### PR TITLE
Update MuBuild and Config Validation to use Edk2Path object

### DIFF
--- a/UefiBuild/MuBuild/ConfigValidator.py
+++ b/UefiBuild/MuBuild/ConfigValidator.py
@@ -73,7 +73,8 @@ Example MU CONFIG FILE
 
 
 #Checks the top level MU Config
-def check_mu_confg(config,workspace,pluginList):
+def check_mu_confg(config,edk2path,pluginList):
+    workspace = edk2path.WorkspacePath
     def _mu_error(message):
         raise Exception("Mu Config Error: {0}".format(message))
 
@@ -92,10 +93,10 @@ def check_mu_confg(config,workspace,pluginList):
             return False
     
     def _check_packages(packages,name):
-        for package in packages:            
-            path = os.path.join(workspace,package)
-            if not os.path.isdir(path):
-                _mu_error("{0} isn't a valid package to build".format(path))
+        for package in packages:
+            path = edk2path.GetAbsolutePathOnThisSytemFromEdk2RelativePath(package)
+            if path is None or not os.path.isdir(path):
+                _mu_error("{0} isn't a valid package to build".format(package))
         return True
 
     def _is_valid_arch(targets,name):

--- a/UefiBuild/MuBuild/MuBuild.py
+++ b/UefiBuild/MuBuild/MuBuild.py
@@ -202,7 +202,7 @@ if __name__ == '__main__':
     pluginList = pluginManager.GetPluginsOfClass(PluginManager.IMuBuildPlugin)
     
     # Check to make sure our configuration is valid
-    ConfigValidator.check_mu_confg(mu_config,WORKSPACE_PATH,pluginList)
+    ConfigValidator.check_mu_confg(mu_config,edk2path,pluginList)
 
     for pkgToRunOn in packageList:
         #


### PR DESCRIPTION
Current config validation fails when workspace and package root is not the same directory because a packages path is not accounted for.