### PR TITLE
Remove requirement on the deprecated compiled capsule tools.

### DIFF
--- a/BaseTools/Plugin/Edk2ToolHelper/Edk2ToolHelper.py
+++ b/BaseTools/Plugin/Edk2ToolHelper/Edk2ToolHelper.py
@@ -6,6 +6,7 @@ from MuPythonLibrary.UtilityFunctions import RunPythonScript
 from MuPythonLibrary.UtilityFunctions import CatalogSignWithSignTool
 import shutil
 import datetime
+from Common.Edk2.Capsule.FmpPayloadHeader  import FmpPayloadHeaderClass
 
 
 class Edk2ToolHelper(PluginManager.IUefiHelperPlugin):
@@ -59,6 +60,20 @@ class Edk2ToolHelper(PluginManager.IUefiHelperPlugin):
     ##
     @staticmethod
     def PackageMsFmpHeader(InputBin, OutputBin, VersionInt, LsvInt, DepList = []):
+        # TODO: Crash if deps are passed. Return a useful error.
+
+        # Attempt to write the payload to the file.
+        # This would normally
+        with open(InputBin, 'rb') as in_file:
+            payload_data = in_file.read()
+
+            fmp_header = FmpPayloadHeaderClass()
+            fmp_header.FwVersion              = VersionInt
+            fmp_header.LowestSupportedVersion = LsvInt
+            fmp_header.Payload                = payload_data
+
+            # Result = FmpPayloadHeader.Encode ()
+
         logging.debug("CapsulePackage: Fmp Header")
         params = "-o " + OutputBin
         params = params + " --version " + hex(VersionInt).rstrip("L")

--- a/BaseTools/Plugin/Edk2ToolHelper/Edk2ToolHelper.py
+++ b/BaseTools/Plugin/Edk2ToolHelper/Edk2ToolHelper.py
@@ -1,12 +1,14 @@
 from MuEnvironment import PluginManager
 import logging
 import os
+import uuid
 from MuPythonLibrary.UtilityFunctions import RunCmd
 from MuPythonLibrary.UtilityFunctions import RunPythonScript
 from MuPythonLibrary.UtilityFunctions import CatalogSignWithSignTool
 import shutil
 import datetime
 from Common.Edk2.Capsule.FmpPayloadHeader  import FmpPayloadHeaderClass
+from Common.Uefi.Capsule.FmpCapsuleHeader  import FmpCapsuleHeaderClass
 
 
 class Edk2ToolHelper(PluginManager.IUefiHelperPlugin):
@@ -60,7 +62,20 @@ class Edk2ToolHelper(PluginManager.IUefiHelperPlugin):
     ##
     @staticmethod
     def PackageMsFmpHeader(InputBin, OutputBin, VersionInt, LsvInt, DepList = []):
-        # TODO: Crash if deps are passed. Return a useful error.
+        # NOTE: Crash if deps are passed. Return a useful error.
+        # Currently not ported to the new tooling.
+        if len(DepList) > 0:
+            raise RuntimeError("PackageMsFmpHeader has not been ported to support dependencies yet!")
+
+        #append depedency if supplied
+        # for dep in DepList:
+        #     depGuid = dep[0]
+        #     depIndex = int(dep[1])
+        #     depMinVer = hex(dep[2])
+        #     depFlag = hex(dep[3])
+        #     logging.debug("Adding a Dependency:\n\tFMP Guid: %s \nt\tFmp Descriptor Index: %d \n\tFmp DepVersion: %s \n\tFmp Flags: %s\n" % (depGuid, depIndex, depMinVer, depFlag))
+        #     params += " --dep " + depGuid + " " + str(depIndex) + " " + depMinVer + " " + depFlag
+        #     raise Exception("GenMsPayloadHeader Failed with errorcode %d" % ret)
 
         # Attempt to write the payload to the file.
         # This would normally
@@ -72,25 +87,10 @@ class Edk2ToolHelper(PluginManager.IUefiHelperPlugin):
             fmp_header.LowestSupportedVersion = LsvInt
             fmp_header.Payload                = payload_data
 
-            # Result = FmpPayloadHeader.Encode ()
+            with open(OutputBin, 'wb') as out_file:
+                out_file.write(fmp_header.Encode())
 
-        logging.debug("CapsulePackage: Fmp Header")
-        params = "-o " + OutputBin
-        params = params + " --version " + hex(VersionInt).rstrip("L")
-        params = params + " --lsv " + hex(LsvInt)
-        params = params + " -p " + InputBin + " -v"
-        #append depedency if supplied
-        for dep in DepList:
-            depGuid = dep[0]
-            depIndex = int(dep[1])
-            depMinVer = hex(dep[2])
-            depFlag = hex(dep[3])
-            logging.debug("Adding a Dependency:\n\tFMP Guid: %s \nt\tFmp Descriptor Index: %d \n\tFmp DepVersion: %s \n\tFmp Flags: %s\n" % (depGuid, depIndex, depMinVer, depFlag))
-            params += " --dep " + depGuid + " " + str(depIndex) + " " + depMinVer + " " + depFlag
-        ret = RunCmd("genmspayloadheader.exe", params)
-        if(ret != 0):
-            raise Exception("GenMsPayloadHeader Failed with errorcode %d" % ret)
-        return ret
+        return 0
 
     ##
     # Function to create binary wrapped with FmpImage Auth using input supplied
@@ -161,13 +161,16 @@ class Edk2ToolHelper(PluginManager.IUefiHelperPlugin):
 
     @staticmethod
     def PackageFmpCapsuleHeader(InputBin, OutputBin, FmpGuid):
-        logging.debug("CapsulePackage: Fmp Capsule Header")
-        params = "-o " + OutputBin
-        params = params + " -p " + InputBin + " " + FmpGuid + " 1 0 -V"
-        ret = RunCmd("genfmpcap.exe", params)
-        if(ret != 0):
-            raise Exception("GenFmpCap Failed with errorcode" % ret)
-        return ret
+        with open(InputBin, 'rb') as in_file:
+            capsule_data = in_file.read()
+
+            fmp_capsule = FmpCapsuleHeaderClass()
+            fmp_capsule.AddPayload(uuid.UUID(FmpGuid), capsule_data)
+
+            with open(OutputBin, 'wb') as out_file:
+                out_file.write(fmp_capsule.Encode())
+
+        return 0
 
     @staticmethod
     def PackageCapsuleHeader(InputBin, OutputBin, FmpDeviceGuid=None):

--- a/BaseTools/Source/Python/Common/Edk2/Capsule/FmpPayloadHeader.py
+++ b/BaseTools/Source/Python/Common/Edk2/Capsule/FmpPayloadHeader.py
@@ -25,31 +25,6 @@ def _SIGNATURE_32 (A, B, C, D):
 def _SIGNATURE_32_TO_STRING (Signature):
     return struct.pack ("<I", Signature).decode ()
 
-# typedef struct {
-#   UINT32 Identifier;
-#   UINT32 HeaderSize;
-#   UINT32 FwVersion;
-#   UINT32 LowestSupportedVersion;
-#   // FW_DEPENDENCY DependencyList[];
-# } MS_FMP_PAYLOAD_HEADER;
-
-# typedef struct {
-#   EFI_GUID FmpInstance;
-#   UINT32   MiniumVersionInSystem;
-#   UINT8    ImageIndex;  //matches the descriptor index
-#   UINT8    Reserved;
-#   UINT16   Flags;
-# } FW_DEPENDENCY;
-
-# #pragma pack()
-
-# // Flags to describe the expected dependency behaviour 
-
-# //dependency must be in system.  Default is only if FMP instance present in system. 
-# #define MS_FW_DEPENDENCY_FLAG_REQUIRED                  0x0001
-# //version must match exactly.  Default is greater than or equal.
-# #define MS_FW_DEPENDENCY_FLAG_MATCH_EXACT_VERSION       0x0002
-
 class FmpPayloadHeaderClass (object):
     #
     # typedef struct {

--- a/BaseTools/Source/Python/Common/Edk2/Capsule/FmpPayloadHeader.py
+++ b/BaseTools/Source/Python/Common/Edk2/Capsule/FmpPayloadHeader.py
@@ -25,6 +25,31 @@ def _SIGNATURE_32 (A, B, C, D):
 def _SIGNATURE_32_TO_STRING (Signature):
     return struct.pack ("<I", Signature).decode ()
 
+# typedef struct {
+#   UINT32 Identifier;
+#   UINT32 HeaderSize;
+#   UINT32 FwVersion;
+#   UINT32 LowestSupportedVersion;
+#   // FW_DEPENDENCY DependencyList[];
+# } MS_FMP_PAYLOAD_HEADER;
+
+# typedef struct {
+#   EFI_GUID FmpInstance;
+#   UINT32   MiniumVersionInSystem;
+#   UINT8    ImageIndex;  //matches the descriptor index
+#   UINT8    Reserved;
+#   UINT16   Flags;
+# } FW_DEPENDENCY;
+
+# #pragma pack()
+
+# // Flags to describe the expected dependency behaviour 
+
+# //dependency must be in system.  Default is only if FMP instance present in system. 
+# #define MS_FW_DEPENDENCY_FLAG_REQUIRED                  0x0001
+# //version must match exactly.  Default is greater than or equal.
+# #define MS_FW_DEPENDENCY_FLAG_MATCH_EXACT_VERSION       0x0002
+
 class FmpPayloadHeaderClass (object):
     #
     # typedef struct {

--- a/Readme.rst
+++ b/Readme.rst
@@ -26,7 +26,7 @@ Branch Changes - release/201903
 Breaking Changes-dev
 --------------------
 
-- None
+- Edk2ToolHelper no longer has logic for dependencies. This is easily replaced, but convenient to leave out while GenerateCapsule is being refactored to remove reliance on older compiled tools.
 
 Main Changes-dev
 ----------------


### PR DESCRIPTION
The GenMsPayloadHeader and GenFmpCap tools were removed from source in 201808, but carried as binaries. Now that the binaries have also been removed, change Edk2ToolHelper plugin to use the standard Python classes to build the capsule headers.

This is a step towards refactoring all capsule tooling to use standard rather than proprietary solutions.