### PR TITLE
Modifies DxeCapsuleProcessLib so that UpdateImageProgress() returns sucess

### DIFF
--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLib.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLib.c
@@ -179,12 +179,14 @@ UpdateImageProgress (
     }
   }
 
+//MU_CHANGE - Return success on Progress Display Error to allow capsule to proceed in the face of progress errors.
   Status = DisplayUpdateProgress (Completion, Color);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_WARN, "DisplayUpdateProgress returned %r\n", Status));
   }
 
   return EFI_SUCCESS;
+//MU_CHANGE - Return success on Progress Display Error to allow capsule to proceed in the face of progress errors.END
 }
 
 /**

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLib.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLib.c
@@ -180,8 +180,8 @@ UpdateImageProgress (
   }
 
   Status = DisplayUpdateProgress (Completion, Color);
-  if (EFI_ERROR(Status)) {
-    DEBUG((DEBUG_WARN, "DisplayUpdateProgress returned %r\n", Status));
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_WARN, "DisplayUpdateProgress returned %r\n", Status));
   }
 
   return EFI_SUCCESS;

--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLib.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleProcessLib.c
@@ -180,8 +180,11 @@ UpdateImageProgress (
   }
 
   Status = DisplayUpdateProgress (Completion, Color);
+  if (EFI_ERROR(Status)) {
+    DEBUG((DEBUG_WARN, "DisplayUpdateProgress returned %r\n", Status));
+  }
 
-  return Status;
+  return EFI_SUCCESS;
 }
 
 /**

--- a/Readme.rst
+++ b/Readme.rst
@@ -31,7 +31,7 @@ Breaking Changes-dev
 Main Changes-dev
 ----------------
 
-- None
+- Modifies DxeCapsuleProcessLib so that UpdateImageProgress() returns success even if DisplayUpdateProgress() returns EFI_ERROR. This allows capsule update to proceed even if there are errors in the progress reporting.
 
 Bug Fixes-dev
 -------------


### PR DESCRIPTION
Modifies DxeCapsuleProcessLib so that UpdateImageProgress() returns sucess even if DisplayUpdateProgress() returns EFI_ERROR.

This allows capsule update to proceed even if there are errors in the progress reporting.