### PR TITLE
Report more data when a boot option fails.

### DIFF
--- a/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
@@ -1887,7 +1887,22 @@ EfiBootManagerBoot (
       //
       // Report Status Code with the failure status to indicate that the failure to load boot option
       //
-      BmReportLoadFailure (EFI_SW_DXE_BS_EC_BOOT_OPTION_LOAD_ERROR, Status);
+      // MU_CHANGE [BEGIN] - Pass more data about the failing option.
+      // BmReportLoadFailure (EFI_SW_DXE_BS_EC_BOOT_OPTION_LOAD_ERROR, Status);
+      ReportStatusCodeData[0] = (FilePath != NULL) ? (UINTN)FilePath : (UINTN)(BootOption->FilePath);
+      ReportStatusCodeData[1] = Status;
+
+      REPORT_STATUS_CODE_EX (
+        EFI_ERROR_CODE | EFI_ERROR_MINOR,
+        (EFI_SOFTWARE_DXE_BS_DRIVER | EFI_SW_DXE_BS_EC_BOOT_OPTION_LOAD_ERROR),
+        0,
+        NULL,
+        NULL,
+        ReportStatusCodeData,
+        sizeof(ReportStatusCodeData)
+        );
+      // MU_CHANGE [END]
+
       BootOption->Status = Status;
       //
       // Destroy the RAM disk


### PR DESCRIPTION
Restore a prior fix to support reporting more data as part of the RSC when a boot option fails.