### PR TITLE
Standardize behavior when VariablePolicy is disabled.

### DIFF
--- a/MdeModulePkg/Include/Protocol/VariablePolicy.h
+++ b/MdeModulePkg/Include/Protocol/VariablePolicy.h
@@ -114,7 +114,6 @@ EFI_STATUS
   @retval     EFI_INVALID_PARAMETER   NewPolicy is NULL or is internally inconsistent.
   @retval     EFI_ALREADY_STARTED     An identical matching policy already exists.
   @retval     EFI_WRITE_PROTECTED     The interface has been locked until the next reboot.
-  @retval     EFI_UNSUPPORTED         Policy enforcement has been disabled. No reason to add more policies.
   @retval     EFI_ABORTED             A calculation error has prevented this function from completing.
   @retval     EFI_OUT_OF_RESOURCES    Cannot grow the table to hold any more policies.
 

--- a/MdeModulePkg/Library/UefiVariablePolicyLib/UefiVariablePolicyLib.c
+++ b/MdeModulePkg/Library/UefiVariablePolicyLib/UefiVariablePolicyLib.c
@@ -369,9 +369,6 @@ RegisterVariablePolicy (
   if (mInterfaceLocked) {
     return EFI_WRITE_PROTECTED;
   }
-  if (mProtectionDisabled) {
-    return EFI_UNSUPPORTED;
-  }
 
   if (!IsValidVariablePolicyStructure( NewPolicy )) {
     return EFI_INVALID_PARAMETER;

--- a/MdeModulePkg/Library/UefiVariablePolicyLib/UefiVariablePolicyUnitTest/UefiVariablePolicyUnitTest.inf
+++ b/MdeModulePkg/Library/UefiVariablePolicyLib/UefiVariablePolicyUnitTest/UefiVariablePolicyUnitTest.inf
@@ -47,7 +47,6 @@
 [Packages]
   MdePkg/MdePkg.dec
   UnitTestPkg/UnitTestPkg.dec
-  FutureMdePkg/FutureMdePkg.dec
   MdeModulePkg/MdeModulePkg.dec
   CmockaHostUnitTestPkg/CmockaHostUnitTestPkg.dec
 


### PR DESCRIPTION
Remove the unnecessary error when registering a VariablePolicy after policy enforcement has been disabled.

Add tests for this and other errors when booting with VariablePolicy disabled.