### PR TITLE
Extend the variable protection exceptions.

### DIFF
--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/TcgMorLockSmm.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/TcgMorLockSmm.c
@@ -348,6 +348,12 @@ SetVariableCheckHandlerMor (
     return EFI_SUCCESS;
   }
 
+  // MU_CHANGE [BEGIN] - Permit deletion when policy is disabled.
+  if (!IsVariablePolicyEnabled() && ((Attributes == 0) || (DataSize == 0))) {
+    return EFI_SUCCESS;
+  }
+  // MU_CHANGE [END]
+
   //
   // MorLock variable
   //

--- a/SecurityPkg/Library/AuthVariableLib/AuthService.c
+++ b/SecurityPkg/Library/AuthVariableLib/AuthService.c
@@ -220,10 +220,15 @@ NeedPhysicallyPresent(
   IN     EFI_GUID       *VendorGuid
   )
 {
-  if ((CompareGuid (VendorGuid, &gEfiSecureBootEnableDisableGuid) && (StrCmp (VariableName, EFI_SECURE_BOOT_ENABLE_NAME) == 0))
-    || (CompareGuid (VendorGuid, &gEfiCustomModeEnableGuid) && (StrCmp (VariableName, EFI_CUSTOM_MODE_NAME) == 0))) {
-    return TRUE;
+  // MU_CHANGE [BEGIN] - If the VariablePolicy engine is disabled, allow
+  //                    deletion of any authenticated variables.
+  if (IsVariablePolicyEnabled()) {
+    if ((CompareGuid (VendorGuid, &gEfiSecureBootEnableDisableGuid) && (StrCmp (VariableName, EFI_SECURE_BOOT_ENABLE_NAME) == 0))
+      || (CompareGuid (VendorGuid, &gEfiCustomModeEnableGuid) && (StrCmp (VariableName, EFI_CUSTOM_MODE_NAME) == 0))) {
+      return TRUE;
+    }
   }
+  // MU_CHANGE [END]
 
   return FALSE;
 }
@@ -845,7 +850,8 @@ ProcessVariable (
              &OrgVariableInfo
              );
 
-  if ((!EFI_ERROR (Status)) && IsDeleteAuthVariable (OrgVariableInfo.Attributes, Data, DataSize, Attributes) && UserPhysicalPresent()) {
+  // MU_CHANGE - If the VariablePolicy engine is disabled, allow deletion of any authenticated variables.
+  if ((!EFI_ERROR (Status)) && IsDeleteAuthVariable (OrgVariableInfo.Attributes, Data, DataSize, Attributes) && (UserPhysicalPresent() || !IsVariablePolicyEnabled())) {
     //
     // Allow the delete operation of common authenticated variable(AT or AW) at user physical presence.
     //


### PR DESCRIPTION
Extend the variable protection exceptions when VariablePolicy is disabled to CustomMode, SecureBootEnable, private AuthenticatedVariables, and MOR variables.