### PR TITLE
[TCBZ2419] Add PcdProgressBarBackgroundColor to hold the background color of progress bar.

### DIFF
--- a/MdeModulePkg/Library/DisplayUpdateProgressLibGraphics/DisplayUpdateProgressLibGraphics.c
+++ b/MdeModulePkg/Library/DisplayUpdateProgressLibGraphics/DisplayUpdateProgressLibGraphics.c
@@ -75,12 +75,7 @@ const EFI_GRAPHICS_OUTPUT_BLT_PIXEL_UNION  mLogoDetectionColorMask = {
 // Background color of progress bar.  Grey.
 //
 const EFI_GRAPHICS_OUTPUT_BLT_PIXEL_UNION  mProgressBarBackgroundColor = {
-  {
-    0x80,  // Blue
-    0x80,  // Green
-    0x80,  // Red
-    0x00   // Reserved
-  }
+  .Raw = FixedPcdGet32 (PcdProgressBarBackgroundColor)
 };
 
 //

--- a/MdeModulePkg/Library/DisplayUpdateProgressLibGraphics/DisplayUpdateProgressLibGraphics.c
+++ b/MdeModulePkg/Library/DisplayUpdateProgressLibGraphics/DisplayUpdateProgressLibGraphics.c
@@ -75,7 +75,12 @@ const EFI_GRAPHICS_OUTPUT_BLT_PIXEL_UNION  mLogoDetectionColorMask = {
 // Background color of progress bar.  Grey.
 //
 const EFI_GRAPHICS_OUTPUT_BLT_PIXEL_UNION  mProgressBarBackgroundColor = {
-  .Raw = FixedPcdGet32 (PcdProgressBarBackgroundColor)
+  {
+    ((UINT32)FixedPcdGet32 (PcdProgressBarBackgroundColor) >> 0)  & 0xFF, // Blue       // MU_CHANGE
+    ((UINT32)FixedPcdGet32 (PcdProgressBarBackgroundColor) >> 8)  & 0xFF, // Green      // MU_CHANGE
+    ((UINT32)FixedPcdGet32 (PcdProgressBarBackgroundColor) >> 16) & 0xFF, // Red        // MU_CHANGE
+    ((UINT32)FixedPcdGet32 (PcdProgressBarBackgroundColor) >> 24) & 0xFF  // Reserved   // MU_CHANGE
+  }
 };
 
 //

--- a/MdeModulePkg/Library/DisplayUpdateProgressLibGraphics/DisplayUpdateProgressLibGraphics.inf
+++ b/MdeModulePkg/Library/DisplayUpdateProgressLibGraphics/DisplayUpdateProgressLibGraphics.inf
@@ -41,3 +41,6 @@
 [Protocols]
   gEfiGraphicsOutputProtocolGuid  # CONSUMES
   gEdkiiBootLogo2ProtocolGuid     # CONSUMES
+
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdProgressBarBackgroundColor  ## CONSUMES

--- a/MdeModulePkg/Library/DisplayUpdateProgressLibGraphics/DisplayUpdateProgressLibGraphics.inf
+++ b/MdeModulePkg/Library/DisplayUpdateProgressLibGraphics/DisplayUpdateProgressLibGraphics.inf
@@ -42,5 +42,7 @@
   gEfiGraphicsOutputProtocolGuid  # CONSUMES
   gEdkiiBootLogo2ProtocolGuid     # CONSUMES
 
+## MU_CHANGE [BEGIN]
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdProgressBarBackgroundColor  ## CONSUMES
+## MU_CHANGE [END]

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -1593,6 +1593,10 @@
   # @Prompt Enable Capsule On Disk support.
   gEfiMdeModulePkgTokenSpaceGuid.PcdCapsuleOnDiskSupport|FALSE|BOOLEAN|0x0000002d
 
+  ## This PCD holds the background color of progress bar.
+  # @Prompt Describes background color of progress bar.
+  gEfiMdeModulePkgTokenSpaceGuid.PcdProgressBarBackgroundColor|0x00808080|UINT32|0x0000010B
+
 [PcdsPatchableInModule, PcdsDynamic, PcdsDynamicEx]
   ## This PCD defines the Console output row. The default value is 25 according to UEFI spec.
   #  This PCD could be set to 0 then console output would be at max column and max row.

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -1593,9 +1593,16 @@
   # @Prompt Enable Capsule On Disk support.
   gEfiMdeModulePkgTokenSpaceGuid.PcdCapsuleOnDiskSupport|FALSE|BOOLEAN|0x0000002d
 
+  ## MU_CHANGE [BEGIN]
   ## This PCD holds the background color of progress bar.
+  # Bit fields:
+  #   [31:24] - Reserved
+  #   [23:16] - Red
+  #   [15:8]  - Green
+  #   [7:0]   - Blue
   # @Prompt Describes background color of progress bar.
   gEfiMdeModulePkgTokenSpaceGuid.PcdProgressBarBackgroundColor|0x00808080|UINT32|0x0000010B
+  ## MU_CHANGE [END]
 
 [PcdsPatchableInModule, PcdsDynamic, PcdsDynamicEx]
   ## This PCD defines the Console output row. The default value is 25 according to UEFI spec.


### PR DESCRIPTION
Add PcdProgressBarBackgroundColor to hold the background color of progress bar, so that it can be changed in platform config.