### PR TITLE
[SMM_PAGING]Add reboot instrumentation for SMM test 

### DIFF
--- a/UefiCpuPkg/PiSmmCpuDxeSmm/X64/PageTbl.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/X64/PageTbl.c
@@ -1086,8 +1086,10 @@ SmiPFHandler (
       DEBUG_CODE (
         DumpModuleInfoByIp ((UINTN)SystemContext.SystemContextX64->Rip);
       );
-      CpuDeadLoop ();
-      goto Exit;
+      // MSCHANGE - Allow system to reset instead of halt in test mode.
+      goto HaltOrReboot;
+      //CpuDeadLoop ();
+      //goto Exit;
     }
   }
 

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/X64/PageTbl.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/X64/PageTbl.c
@@ -1086,7 +1086,7 @@ SmiPFHandler (
       DEBUG_CODE (
         DumpModuleInfoByIp ((UINTN)SystemContext.SystemContextX64->Rip);
       );
-      // MSCHANGE - Allow system to reset instead of halt in test mode.
+      // MU_CHANGE - Allow system to reset instead of halt in test mode.
       goto HaltOrReboot;
       //CpuDeadLoop ();
       //goto Exit;


### PR DESCRIPTION
Adding reboot support to a previously uninstrumented failure case in SmiPFHandler. Extends 9465636faae18bb1a919ce4533bde7fbacb5b373