### PR TITLE
[TCBZ2624] Don't require meta files for custom source types

### DIFF
--- a/BaseTools/Source/Python/AutoGen/GenMake.py
+++ b/BaseTools/Source/Python/AutoGen/GenMake.py
@@ -731,7 +731,7 @@ cleanlib:
                     if Dst not in self.ResultFileList:
                         self.ResultFileList.append(Dst)
                     if '%s :' %(Dst) not in self.BuildTargetList:
-                        # MU_CHANGE - Don't require a .map file for custom source types.
+                        # MU_CHANGE - [TCBZ2624] Don't require a .map file for custom source types.
                         # self.BuildTargetList.append("%s : %s" %(Dst,Src))
                         self.BuildTargetList.append("%s :" %(Dst))
                         self.BuildTargetList.append('\t' + self._CP_TEMPLATE_[self._Platform] %{'Src': Src, 'Dst': Dst})

--- a/BaseTools/Source/Python/AutoGen/GenMake.py
+++ b/BaseTools/Source/Python/AutoGen/GenMake.py
@@ -731,7 +731,9 @@ cleanlib:
                     if Dst not in self.ResultFileList:
                         self.ResultFileList.append(Dst)
                     if '%s :' %(Dst) not in self.BuildTargetList:
-                        self.BuildTargetList.append("%s : %s" %(Dst,Src))
+                        # MU_CHANGE - Don't require a .map file for custom source types.
+                        # self.BuildTargetList.append("%s : %s" %(Dst,Src))
+                        self.BuildTargetList.append("%s :" %(Dst))
                         self.BuildTargetList.append('\t' + self._CP_TEMPLATE_[self._Platform] %{'Src': Src, 'Dst': Dst})
 
             FfsCmdList = Cmd[0]


### PR DESCRIPTION
A change in GenMake.py went from this:
```make
$(FFS_OUTPUT_DIR)\$(MODULE_GUID).map :
	if exist $(OUTPUT_DIR)\<some_file>.map $(CP) $(OUTPUT_DIR)\<some_file>.map $(FFS_OUTPUT_DIR)\$(MODULE_GUID).map
```

to this:

```make
$(FFS_OUTPUT_DIR)\$(MODULE_GUID).map : $(OUTPUT_DIR)\<some_file>.map
	if exist $(OUTPUT_DIR)\<some_file>.map $(CP) $(OUTPUT_DIR)\<some_file>.map $(FFS_OUTPUT_DIR)\$(MODULE_GUID).map
```

For custom source files that do not generate maps, the change will fail. The 'if' statement on the second line should be sufficient to cover the "missing file" case without breaking the build.