### PR TITLE
BaseTools: Simplify Resource-file rule and fix GCC toolchain command

### DIFF
--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -768,29 +768,16 @@
         GenFw -o $(OUTPUT_DIR)(+)$(MODULE_NAME)hii.rc -g $(MODULE_GUID) --hiibinpackage $(HII_BINARY_PACKAGES)
 
 # MU_CHANGE Start
-[Resource-File]
+[Resource-File.UEFI_HII]
     <InputFile>
         *.arc
 
-    <OutputFile.MSFT, OutputFile.INTEL, OutputFile.CLANGPDB>
-        $(OUTPUT_DIR)(+)$(MODULE_NAME)Resource.lib
-
-    <OutputFile.GCC>
-        $(OUTPUT_DIR)(+)$(MODULE_NAME)Resource.rc
-
-    <OutputFile.XCODE, OutputFile.RVCT>
-        $(OUTPUT_DIR)(+)$(MODULE_NAME)Resource.rc
-
-    <Command.MSFT, Command.INTEL, Command.CLANGPDB>
-        "$(RC)" /Fo${dst} ${src}
+    <OutputFile.MSFT, OutputFile.INTEL, OutputFile.GCC, OutputFile.CLANGPDB>
+        $(OUTPUT_DIR)(+)$(MODULE_NAME)Resource.hpk
 
     <Command.GCC>
-        "$(MSRC)" -i ${src} -o ${dst} -Jrc -v
-        # first run the resource compiler, let it know we have an RC file, and tell it know it needs to produce a PECOFF
-        #"$(MSRC)" -i ${src} -o $(OUTPUT_DIR)(+)$(MODULE_NAME)Resource.windres.o -Jrc -Ocoff -v
-        # Then we run object copy to convert the PEX64 that windres produces to the elf64 gcc expects
-        # TODO - figure out the correct output format for the current arch
-        #"$(RC)" -O elf64-x86-64 $(OUTPUT_DIR)(+)$(MODULE_NAME)Resource.windres.o ${dst}
+        # Compile the Resource source .rc to a binary .res file format
+        "$(MSRC)" -i ${src} -o ${dst} -Jrc -Ores -v
 
 [Version-Info-File]
     <InputFile>


### PR DESCRIPTION
This rule contains several issues that causes the VERSIONINFO resource to
not be embedded into the compiled binaries, when using the GCC toolchain.

The problems with the rule when using the GCC toolchain are the following:

* The windres command executed does not contain an --output-format option,
  so the tool tries to guess the format and just generates a .rc file.

* The OutputFile.GCC is set to $(MODULE_NAME)Resource.rc, instead of an
  binary object file that could be included when building the ELF objects.

* The resource is never added to a binary file so is not included in the
  final PE32+ executable binary.

One solution may be to make windres generate a COFF object file and use
the objcopy tool to convert the COFF object file to an ELF object file,
that way the resource would be picked when building the ELF executable.

That is what the commented out commands in the rule attempt to do, but it
won't work since the ELF binary built is a Position Independent Executable
(PIE). The linker then would complain that relocation symbols included in
the ELF object file created by objcopy cannot be used when making a PIE.

Another option is to convert the .rc source resource into a .res binary
format and then embed that in as a section using objcopy --add-section.

And there is already a Hii-Binary-Package.UEFI_HII rule that does exactly
that, it gets hpk files as input and adds the content of those to a .rsrc
section in the binaries. Use that rule instead to avoid duplicated logic.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>