### PR TITLE
BaseTools: Work around array.array.tostring() removal in python 3.9

### DIFF
--- a/BaseTools/Source/Python/AutoGen/UniClassObject.py
+++ b/BaseTools/Source/Python/AutoGen/UniClassObject.py
@@ -152,7 +152,7 @@ class Ucs2Codec(codecs.Codec):
 
 TheUcs2Codec = Ucs2Codec()
 def Ucs2Search(name):
-    if name == 'ucs-2':
+    if name in ['ucs-2', 'ucs_2']:
         return codecs.CodecInfo(
             name=name,
             encode=TheUcs2Codec.encode,

--- a/BaseTools/Source/Python/Common/Misc.py
+++ b/BaseTools/Source/Python/Common/Misc.py
@@ -1635,7 +1635,7 @@ class PeImageClass():
         ByteArray = array.array('B')
         ByteArray.fromfile(PeObject, 4)
         # PE signature should be 'PE\0\0'
-        if ByteArray.tostring() != b'PE\0\0':
+        if ByteArray.tolist() != [ord('P'), ord('E'), 0, 0]:
             self.ErrorInfo = self.FileName + ' has no valid PE signature PE00'
             return
 

--- a/BaseTools/Source/Python/Common/Misc.py
+++ b/BaseTools/Source/Python/Common/Misc.py
@@ -1155,13 +1155,11 @@ def ParseFieldValue (Value):
         if Value[0] == '"' and Value[-1] == '"':
             Value = Value[1:-1]
         try:
-            Value = str(uuid.UUID(Value).bytes_le)
-            if Value.startswith("b'"):
-                Value = Value[2:-1]
-            Value = "'" + Value + "'"
+            Value = uuid.UUID(Value).bytes_le
+            ValueL, ValueH = struct.unpack('2Q', Value)
+            Value = (ValueH << 64 ) | ValueL
         except ValueError as Message:
             raise BadExpression(Message)
-        Value, Size = ParseFieldValue(Value)
         return Value, 16
     if Value.startswith('L"') and Value.endswith('"'):
         # Unicode String

--- a/BaseTools/Source/Python/GenFds/GenFdsGlobalVariable.py
+++ b/BaseTools/Source/Python/GenFds/GenFdsGlobalVariable.py
@@ -27,10 +27,11 @@ from Common.TargetTxtClassObject import TargetTxtDict
 from Common.ToolDefClassObject import ToolDefDict
 from AutoGen.BuildEngine import ToolBuildRule
 import Common.DataType as DataType
-from Common.Misc import PathClass
+from Common.Misc import PathClass,CreateDirectory
 from Common.LongFilePathSupport import OpenLongFilePath as open
 from Common.MultipleWorkspace import MultipleWorkspace as mws
 import Common.GlobalData as GlobalData
+from Common.BuildToolError import *
 
 ## Global variables
 #
@@ -463,12 +464,28 @@ class GenFdsGlobalVariable:
                     GenFdsGlobalVariable.SecCmdList.append(' '.join(Cmd).strip())
             else:
                 SectionData = array('B', [0, 0, 0, 0])
-                SectionData.fromstring(Ui.encode("utf_16_le"))
+                SectionData.fromlist(array('B',Ui.encode('utf-16-le')).tolist())
                 SectionData.append(0)
                 SectionData.append(0)
                 Len = len(SectionData)
                 GenFdsGlobalVariable.SectionHeader.pack_into(SectionData, 0, Len & 0xff, (Len >> 8) & 0xff, (Len >> 16) & 0xff, 0x15)
-                SaveFileOnChange(Output, SectionData.tostring())
+
+
+                DirName = os.path.dirname(Output)
+                if not CreateDirectory(DirName):
+                    EdkLogger.error(None, FILE_CREATE_FAILURE, "Could not create directory %s" % DirName)
+                else:
+                    if DirName == '':
+                        DirName = os.getcwd()
+                    if not os.access(DirName, os.W_OK):
+                        EdkLogger.error(None, PERMISSION_FAILURE, "Do not have write permission on directory %s" % DirName)
+
+                try:
+                    with open(Output, "wb") as Fd:
+                        SectionData.tofile(Fd)
+                        Fd.flush()
+                except IOError as X:
+                    EdkLogger.error(None, FILE_CREATE_FAILURE, ExtraData='IOError %s' % X)
 
         elif Ver:
             Cmd += ("-n", Ver)


### PR DESCRIPTION
Backport python 3.9 support from:
20b292d0cdf7dce58d824fdf9ab1613c2a1ad2ec
43bec9ea3d56f3662ede78023baa2a791b66acac
5d8648345cd9ad729837118c731063c59edea192
b0ae13e45a74d495b06da22db834e97170e19f68
-----------
In python3, array.array.tostring() was a compat alias for tobytes().
tostring() was removed in python 3.9.

Convert this to use tolist() which should be valid for all python
versions.

This fixes this build error on python3.9:

(Python 3.9.0b5 on linux) Traceback (most recent call last):
  File "/root/edk2/edk2-edk2-stable202002/BaseTools/BinWrappers/PosixLike/../../Source/Python/Trim/Trim.py", line 593, in Main
    GenerateVfrBinSec(CommandOptions.ModuleName, CommandOptions.DebugDir, CommandOptions.OutputFile)
  File "/root/edk2/edk2-edk2-stable202002/BaseTools/BinWrappers/PosixLike/../../Source/Python/Trim/Trim.py", line 449, in GenerateVfrBinSec
    VfrUniOffsetList = GetVariableOffset(MapFileName, EfiFileName, VfrNameList)
  File "/root/edk2/edk2-edk2-stable202002/BaseTools/Source/Python/Common/Misc.py", line 88, in GetVariableOffset
    return _parseForGCC(lines, efifilepath, varnames)
  File "/root/edk2/edk2-edk2-stable202002/BaseTools/Source/Python/Common/Misc.py", line 151, in _parseForGCC
    efisecs = PeImageClass(efifilepath).SectionHeaderList
  File "/root/edk2/edk2-edk2-stable202002/BaseTools/Source/Python/Common/Misc.py", line 1638, in __init__
    if ByteArray.tostring() != b'PE\0\0':
AttributeError: 'array.array' object has no attribute 'tostring'
-------------
BaseTools: Fix the issue caused by tostring() removal on Py39

    REF: https://bugzilla.tianocore.org/show_bug.cgi?id=3136

    Python 3.9 remove the array.array.tostring and
    array.array.fromstring() function. This patch
    is to use other method to replace tostring() and
    fromstring()
------------------------
    BaseTools: fix ucs-2 lookup on python 3.9

    python3.9 changed/fixed codec.register behavior to always replace
    hyphen with underscore for passed in codec names:

      https://bugs.python.org/issue37751

    So the custom Ucs2Search needs to be adapted to handle 'ucs_2' in
    addition to existing 'ucs-2' for back compat.

    This fixes test failures on python3.9, example:

    ======================================================================
    FAIL: testUtf16InUniFile (CheckUnicodeSourceFiles.Tests)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/builddir/build/BUILD/edk2-edk2-stable202002/BaseTools/Source/Python/AutoGen/UniClassObject.py", line 375, in PreProcess
        FileIn = UniFileClassObject.OpenUniFile(LongFilePath(File.Path))
      File "/builddir/build/BUILD/edk2-edk2-stable202002/BaseTools/Source/Python/AutoGen/UniClassObject.py", line 303, in OpenUniFile
        UniFileClassObject.VerifyUcs2Data(FileIn, FileName, Encoding)
      File "/builddir/build/BUILD/edk2-edk2-stable202002/BaseTools/Source/Python/AutoGen/UniClassObject.py", line 312, in VerifyUcs2Data
        Ucs2Info = codecs.lookup('ucs-2')
    LookupError: unknown encoding: ucs-2
---------------
[TCBZ3136] Fix Python 3.9 bugs