### PR TITLE
Add Initial Support for Dynamic Variable Flash Info in Standalone MM

### DIFF
--- a/MdeModulePkg/Include/Guid/VariableFlashInfo.h
+++ b/MdeModulePkg/Include/Guid/VariableFlashInfo.h
@@ -1,0 +1,34 @@
+/** @file
+  This file defines the GUID and data structure used to pass information about
+  a variable store mapped on flash (i.e. a MMIO firmware volume) to the DXE and MM environment.
+
+  Copyright (c) Microsoft Corporation.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+// MU_CHANGE - WHOLE FILE - TCBZ3479  - Add Variable Flash Information HOB
+
+#ifndef __VARIABLE_FLASH_INFO_H__
+#define __VARIABLE_FLASH_INFO_H__
+
+#define VARIABLE_FLASH_INFO_HOB_GUID \
+  { 0x5d11c653, 0x8154, 0x4ac3, { 0xa8, 0xc2, 0xfb, 0xa2, 0x89, 0x20, 0xfc, 0x90 }}
+
+extern EFI_GUID gVariableFlashInfoHobGuid;
+
+#pragma pack (push, 1)
+
+///
+/// This structure can be used to describe UEFI variable
+/// flash information.
+///
+typedef struct {
+  EFI_PHYSICAL_ADDRESS        BaseAddress;
+  UINT64                      Length;
+} VARIABLE_FLASH_INFO;
+
+#pragma pack (pop)
+
+#endif // __VARIABLE_FLASH_INFO_H__

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -274,6 +274,12 @@
   #  Include/Guid/SmmVariableCommon.h
   gSmmVariableWriteGuid  = { 0x93ba1826, 0xdffb, 0x45dd, { 0x82, 0xa7, 0xe7, 0xdc, 0xaa, 0x3b, 0xbd, 0xf3 }}
 
+  # MU_CHANGE - START - TCBZ3479  - Add Variable Flash Information HOB
+  ## Guid of the variable flash information HOB.
+  #  Include/Guid/VariableFlashInfo.h
+  gVariableFlashInfoHobGuid = { 0x5d11c653, 0x8154, 0x4ac3, { 0xa8, 0xc2, 0xfb, 0xa2, 0x89, 0x20, 0xfc, 0x90 }}
+  # MU_CHANGE - END - TCBZ3479  - Add Variable Flash Information HOB
+
   ## Performance protocol guid that also acts as the performance HOB guid and performance variable GUID
   #  Include/Guid/Performance.h
   gPerformanceProtocolGuid       = { 0x76B6BDFA, 0x2ACD, 0x4462, { 0x9E, 0x3F, 0xCB, 0x58, 0xC9, 0x69, 0xD9, 0x37 } }
@@ -436,7 +442,7 @@
 
   ## Include/Guid/EndofS3Resume.h
   gEdkiiEndOfS3ResumeGuid = { 0x96f5296d, 0x05f7, 0x4f3c, {0x84, 0x67, 0xe4, 0x56, 0x89, 0x0e, 0x0c, 0xb5 } }
-  
+
 ## MSCHANGE BEGIN
   #
   # Guids for NVMe Timeout Events
@@ -2259,7 +2265,7 @@
   ## This dynamic PCD holds the device state bitmap as described in Include/Library/DeviceStateLib.h
   # @Prompt Describes device state
   gEfiMdeModulePkgTokenSpaceGuid.PcdDeviceStateBitmask|0x00000000|UINT32|0x00030009
-  
+
 [PcdsDynamicEx]
   ## This dynamic PCD enables the default variable setting.
   #  Its value is the default store ID value. The default value is zero as Standard default.

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.c
@@ -3659,6 +3659,49 @@ GetHobVariableStore (
   return EFI_SUCCESS;
 }
 
+// MU_CHANGE - START - TCBZ3479 - Add Variable Flash Information HOB
+/**
+  Get the HOB that contains variable flash information.
+
+  @param[out] VariableFlashInfo   Pointer to a pointer to set to the variable flash information structure.
+
+  @retval EFI_SUCCESS             Variable flash information was found successfully.
+  @retval EFI_INVALID_PARAMETER   The VariableFlashInfo pointer given is NULL.
+  @retval EFI_NOT_FOUND           Variable flash information could not be found.
+
+**/
+EFI_STATUS
+GetVariableFlashInfo (
+  OUT VARIABLE_FLASH_INFO       **VariableFlashInfo
+  )
+{
+  EFI_HOB_GUID_TYPE             *GuidHob;
+
+  if (VariableFlashInfo == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  GuidHob = GetFirstGuidHob (&gVariableFlashInfoHobGuid);
+  if (GuidHob == NULL) {
+    return EFI_NOT_FOUND;
+  }
+
+  *VariableFlashInfo = GET_GUID_HOB_DATA (GuidHob);
+
+  //
+  // Assert if more than one variable flash information HOB is present.
+  //
+  DEBUG_CODE (
+    if ((GetNextGuidHob (&gVariableFlashInfoHobGuid, GET_NEXT_HOB (GuidHob)) != NULL)) {
+      DEBUG ((DEBUG_ERROR, "ERROR: Found two variable flash information HOBs\n"));
+      ASSERT (FALSE);
+    }
+  );
+
+  return EFI_SUCCESS;
+}
+// MU_CHANGE - END - TCBZ3479 - Add Variable Flash Information HOB
+
 /**
   Initializes variable store area for non-volatile and volatile variable.
 

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.h
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.h
@@ -31,12 +31,14 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/MemoryAllocationLib.h>
 #include <Library/AuthVariableLib.h>
 #include <Library/VarCheckLib.h>
+#include <Library/SafeIntLib.h>       // MU_CHANGE TCBZ3479 - Add Variable Flash Information HOB
 #include <Guid/GlobalVariable.h>
 #include <Guid/EventGroup.h>
 #include <Guid/VariableFormat.h>
 #include <Guid/SystemNvDataGuid.h>
 #include <Guid/FaultTolerantWrite.h>
 #include <Guid/VarErrorFlag.h>
+#include <Guid/VariableFlashInfo.h>   // MU_CHANGE TCBZ3479 - Add Variable Flash Information HOB
 
 #include "PrivilegePolymorphic.h"
 
@@ -125,6 +127,23 @@ typedef struct {
   CHAR8           Lang[ISO_639_2_ENTRY_SIZE + 1];
   EFI_FIRMWARE_VOLUME_BLOCK_PROTOCOL *FvbInstance;
 } VARIABLE_MODULE_GLOBAL;
+
+// MU_CHANGE - START - TCBZ3479 - Add Variable Flash Information HOB
+/**
+  Get the HOB that contains variable flash information.
+
+  @param[out] VariableFlashInfo   Pointer to a pointer to set to the variable flash information structure.
+
+  @retval EFI_SUCCESS             Variable flash information was found successfully.
+  @retval EFI_INVALID_PARAMETER   The VariableFlashInfo pointer given is NULL.
+  @retval EFI_NOT_FOUND           Variable flash information could not be found.
+
+**/
+EFI_STATUS
+GetVariableFlashInfo (
+  OUT VARIABLE_FLASH_INFO       **VariableFlashInfo
+  );
+// MU_CHANGE - END - TCBZ3479 - Add Variable Flash Information HOB
 
 /**
   Flush the HOB variable to flash.

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableDxe.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableDxe.c
@@ -420,6 +420,7 @@ FtwNotificationEvent (
   EFI_STATUS                              Status;
   EFI_FIRMWARE_VOLUME_BLOCK_PROTOCOL      *FvbProtocol;
   EFI_FAULT_TOLERANT_WRITE_PROTOCOL       *FtwProtocol;
+  VARIABLE_FLASH_INFO                     *VariableFlashInfo;     // MU_CHANGE TCBZ3479 - Add Variable Flash Information HOB
   EFI_PHYSICAL_ADDRESS                    NvStorageVariableBase;
   EFI_GCD_MEMORY_SPACE_DESCRIPTOR         GcdDescriptor;
   EFI_PHYSICAL_ADDRESS                    BaseAddress;
@@ -427,6 +428,7 @@ FtwNotificationEvent (
   EFI_PHYSICAL_ADDRESS                    VariableStoreBase;
   UINT64                                  VariableStoreLength;
   UINTN                                   FtwMaxBlockSize;
+  UINT32                                  NvStorageVariableSize;  // MU_CHANGE TCBZ3479 - Add Variable Flash Information HOB
 
   //
   // Ensure FTW protocol is installed.
@@ -436,13 +438,29 @@ FtwNotificationEvent (
     return ;
   }
 
-  Status = FtwProtocol->GetMaxBlockSize (FtwProtocol, &FtwMaxBlockSize);
+// MU_CHANGE - START - TCBZ3479 - Add Variable Flash Information HOB
+  Status = GetVariableFlashInfo (&VariableFlashInfo);
   if (!EFI_ERROR (Status)) {
-    ASSERT (PcdGet32 (PcdFlashNvStorageVariableSize) <= FtwMaxBlockSize);
+    NvStorageVariableBase = VariableFlashInfo->BaseAddress;
+    Status = SafeUint64ToUint32 (VariableFlashInfo->Length, &NvStorageVariableSize);
+    // This driver currently assumes the size will be UINT32 so only accept
+    // that for now.
+    ASSERT_EFI_ERROR (Status);
   }
 
-  NvStorageVariableBase = NV_STORAGE_VARIABLE_BASE;
+  if (EFI_ERROR (Status)) {
+    NvStorageVariableBase = NV_STORAGE_VARIABLE_BASE;
+    NvStorageVariableSize = PcdGet32 (PcdFlashNvStorageVariableSize);
+  }
+  ASSERT (NvStorageVariableBase != 0);
+
   VariableStoreBase = NvStorageVariableBase + mNvFvHeaderCache->HeaderLength;
+
+  Status = FtwProtocol->GetMaxBlockSize (FtwProtocol, &FtwMaxBlockSize);
+  if (!EFI_ERROR (Status)) {
+    ASSERT (NvStorageVariableSize <= FtwMaxBlockSize);
+  }
+// MU_CHANGE - END - TCBZ3479 - Add Variable Flash Information HOB
 
   //
   // Let NonVolatileVariableBase point to flash variable store base directly after FTW ready.

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
@@ -75,6 +75,7 @@
   VarCheckLib
   VariablePolicyLib
   VariablePolicyHelperLib
+  SafeIntLib                    # MU_CHANGE TCBZ3479 - Add Variable Flash Information HOB
   MemoryTypeInfoSecVarCheckLib  # MU_CHANGE TCBZ1086 - Mitigate potential system brick due to UEFI MemoryTypeInformation var changes
 
 [Protocols]
@@ -117,6 +118,7 @@
   gEfiSystemNvDataFvGuid                        ## CONSUMES             ## GUID
   gEfiEndOfDxeEventGroupGuid                    ## CONSUMES             ## Event
   gEdkiiFaultTolerantWriteGuid                  ## SOMETIMES_CONSUMES   ## HOB
+  gVariableFlashInfoHobGuid                     ## CONSUMES             ## HOB # MU_CHANGE TCBZ3479 - Add Variable Flash Information HOB
 
   ## SOMETIMES_CONSUMES   ## Variable:L"VarErrorFlag"
   ## SOMETIMES_PRODUCES   ## Variable:L"VarErrorFlag"

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.c
@@ -1088,8 +1088,10 @@ SmmFtwNotificationEvent (
   EFI_PHYSICAL_ADDRESS                    VariableStoreBase;
   EFI_SMM_FIRMWARE_VOLUME_BLOCK_PROTOCOL  *FvbProtocol;
   EFI_SMM_FAULT_TOLERANT_WRITE_PROTOCOL   *FtwProtocol;
+  VARIABLE_FLASH_INFO                     *VariableFlashInfo;    // MU_CHANGE TCBZ3479 - Add Variable Flash Information HOB
   EFI_PHYSICAL_ADDRESS                    NvStorageVariableBase;
   UINTN                                   FtwMaxBlockSize;
+  UINT32                                  NvStorageVariableSize; // MU_CHANGE TCBZ3479 - Add Variable Flash Information HOB
 
   if (mVariableModuleGlobal->FvbInstance != NULL) {
     return EFI_SUCCESS;
@@ -1103,13 +1105,27 @@ SmmFtwNotificationEvent (
     return Status;
   }
 
-  Status = FtwProtocol->GetMaxBlockSize (FtwProtocol, &FtwMaxBlockSize);
+// MU_CHANGE - START - TCBZ3479 - Add Variable Flash Information HOB
+  Status = GetVariableFlashInfo (&VariableFlashInfo);
   if (!EFI_ERROR (Status)) {
-    ASSERT (PcdGet32 (PcdFlashNvStorageVariableSize) <= FtwMaxBlockSize);
+    NvStorageVariableBase = VariableFlashInfo->BaseAddress;
+    Status = SafeUint64ToUint32 (VariableFlashInfo->Length, &NvStorageVariableSize);
+    // This driver currently assumes the size will be UINT32 so only accept that for now.
+    ASSERT_EFI_ERROR (Status);
   }
 
-  NvStorageVariableBase = NV_STORAGE_VARIABLE_BASE;
+  if (EFI_ERROR (Status)) {
+    NvStorageVariableBase = NV_STORAGE_VARIABLE_BASE;
+    NvStorageVariableSize = PcdGet32 (PcdFlashNvStorageVariableSize);
+  }
+  ASSERT (NvStorageVariableBase != 0);
   VariableStoreBase = NvStorageVariableBase + mNvFvHeaderCache->HeaderLength;
+
+  Status = FtwProtocol->GetMaxBlockSize (FtwProtocol, &FtwMaxBlockSize);
+  if (!EFI_ERROR (Status)) {
+    ASSERT (NvStorageVariableSize <= FtwMaxBlockSize);
+  }
+// MU_CHANGE - END - TCBZ3479 - Add Variable Flash Information HOB
 
   //
   // Let NonVolatileVariableBase point to flash variable store base directly after FTW ready.

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.inf
@@ -82,6 +82,7 @@
   UefiBootServicesTableLib
   VariablePolicyLib
   VariablePolicyHelperLib
+  SafeIntLib                    # MU_CHANGE TCBZ3479 - Add Variable Flash Information HOB
   AdvLoggerAccessLib                            ## MU_CHANGE
   MemoryTypeInfoSecVarCheckLib  # MU_CHANGE TCBZ1086 - Mitigate potential system brick due to UEFI MemoryTypeInformation var changes
 
@@ -123,6 +124,7 @@
   gSmmVariableWriteGuid                         ## PRODUCES             ## GUID # Install protocol
   gEfiSystemNvDataFvGuid                        ## CONSUMES             ## GUID
   gEdkiiFaultTolerantWriteGuid                  ## SOMETIMES_CONSUMES   ## HOB
+  gVariableFlashInfoHobGuid                     ## CONSUMES             ## HOB  # MU_CHANGE TCBZ3479 - Add Variable Flash Information HOB
 
   ## SOMETIMES_CONSUMES   ## Variable:L"VarErrorFlag"
   ## SOMETIMES_PRODUCES   ## Variable:L"VarErrorFlag"

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
@@ -74,6 +74,7 @@
   HobLib
   MemoryAllocationLib
   MmServicesTableLib
+  SafeIntLib                                   # MU_CHANGE TCBZ3479 - Add Variable Flash Information HOB
   StandaloneMmDriverEntryPoint
   SynchronizationLib
   VarCheckLib
@@ -115,6 +116,7 @@
 
   gEfiSystemNvDataFvGuid                        ## CONSUMES             ## GUID
   gEdkiiFaultTolerantWriteGuid                  ## SOMETIMES_CONSUMES   ## HOB
+  gVariableFlashInfoHobGuid                     ## CONSUMES             ## HOB  # MU_CHANGE TCBZ3479 - Add Variable Flash Information HOB
 
   ## SOMETIMES_CONSUMES   ## Variable:L"VarErrorFlag"
   ## SOMETIMES_PRODUCES   ## Variable:L"VarErrorFlag"


### PR DESCRIPTION
Adds a new GUID that is used to identify a HOB that passes variable
flash information to UEFI variable drivers in HOB consumption phases
such as DXE, Traditional MM, and Standalone MM.

This information was previously passed directly with PCDs such
as EfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableBase
and gEfiMdeModulePkgTokenSpaceGuid.PcdFlashNvStorageVariableSize.
However, the Standalone MM variable driver instance does not have
direct access to the PCD database. Therefore, this HOB will first
be considered as the source for variable flash information and
if platforms do not produce the HOB, reading the information from
the PCDs directly will be a backup to provide backward compatibility.

As a consequence, these changes are backward compatible with existing
platforms. Platform code is expected to produce the variable flash
information HOB if the platform needs dynamic variable flash support in
a Standalone MM environment.