### PR TITLE
Set mDxePcdDbSize equal to mDxePcdDbBinary->LengthForAllSkus

### DIFF
--- a/MdeModulePkg/Universal/PCD/Dxe/Service.c
+++ b/MdeModulePkg/Universal/PCD/Dxe/Service.c
@@ -744,8 +744,8 @@ LocateExPcdBinary (
     ASSERT (FALSE);
   }
 
-  mDxePcdDbSize =  mDxePcdDbBinary->Length + mDxePcdDbBinary->LengthForAllSkus;   // MU_CHANGE
-                                                                                  // MU_CHANGE
+  mDxePcdDbSize = mDxePcdDbBinary->LengthForAllSkus;  // MU_CHANGE
+                                                      // MU_CHANGE
   return mDxePcdDbBinary;
 }
 


### PR DESCRIPTION
The proper size calculation for mDxePcdDbSize should be equal to the total size of mDxePcdDbBinary. The LengthForAllSkus represents this total size of the binary. This can be seen by comparing DxePcdDatabaseBinarySize to mDxePcdDbSize.

While this isn't a breaking bug, it could allow for SkuId searches to index past the mDxePcdDbBinary.
```
  //
  // Find the delta data for DXE DB
  //
  Index    = (mPcdDatabase.DxeDb->Length + 7) & (~7);
  SkuDelta = NULL;
  while (Index < mDxePcdDbSize) {
    SkuDelta = (PCD_DATABASE_SKU_DELTA *) ((UINT8 *) mDxePcdDbBinary + Index);
    if (SkuDelta->SkuId == SkuId && SkuDelta->SkuIdCompared == 0) {
      break;
    }
    Index = (Index + SkuDelta->Length + 7) & (~7);
  }
```
Where Index is allowed to iterate through available SkuIds of mDxePcdDbBinary.
