### PR TITLE
Remove save-state context after unit test is complete

### DIFF
--- a/UnitTestFrameworkPkg/Library/UnitTestLib/UnitTestLib.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestLib/UnitTestLib.c
@@ -149,6 +149,18 @@ FreeUnitTestFramework (
   IN UNIT_TEST_FRAMEWORK_HANDLE  FrameworkHandle
   )
 {
+  EFI_STATUS Status;
+
+  //
+  // If there is a persisted context, delete it now
+  //
+  if (DoesCacheExist (FrameworkHandle)) {
+    Status = DeleteUnitTestCache (FrameworkHandle);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a - Failed to delete cache file\n", __FUNCTION__));
+    }
+  }
+
   // TODO: Finish this function.
   return EFI_SUCCESS;
 }

--- a/UnitTestFrameworkPkg/Library/UnitTestPersistenceLibNull/UnitTestPersistenceLibNull.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestPersistenceLibNull/UnitTestPersistenceLibNull.c
@@ -73,3 +73,21 @@ LoadUnitTestCache (
 {
   return EFI_UNSUPPORTED;
 }
+
+/**
+  Will delete the cache file associated with an internal Unit Test Framework
+
+  @param[in]  FrameworkHandle  A pointer to the framework that is being persisted.
+
+  @retval  EFI_SUCCESS  Cache file was successfully deleted
+  @retval  Others       Error attempting to delete the cache file
+
+**/
+EFI_STATUS
+EFIAPI
+DeleteUnitTestCache (
+  IN UNIT_TEST_FRAMEWORK_HANDLE  FrameworkHandle
+  )
+{
+  return EFI_UNSUPPORTED;
+}

--- a/UnitTestFrameworkPkg/PrivateInclude/Library/UnitTestPersistenceLib.h
+++ b/UnitTestFrameworkPkg/PrivateInclude/Library/UnitTestPersistenceLib.h
@@ -73,4 +73,19 @@ LoadUnitTestCache (
   OUT UNIT_TEST_SAVE_HEADER       **SaveData
   );
 
+/**
+  Will delete the cache file associated with an internal Unit Test Framework
+
+  @param[in]  FrameworkHandle  A pointer to the framework that is being persisted.
+
+  @retval  EFI_SUCCESS  Cache file was successfully deleted
+  @retval  Others       Error attempting to delete the cache file
+
+**/
+EFI_STATUS
+EFIAPI
+DeleteUnitTestCache (
+  IN UNIT_TEST_FRAMEWORK_HANDLE  FrameworkHandle
+  );
+
 #endif


### PR DESCRIPTION
The current unit test framework leaves behind a save-state cache file after completing unit tests. Subsequent test attempts can cause failures due to consuming old save-state context, unless the file has been manually removed.

This change adds save-state cache file cleanup after unit tests are completed to prevent consumption of older unit test context.