### PR TITLE
[TCBZ3662]Fix a missing parameter in DEBUG print in XhciInitializeDeviceSlot()

### DIFF
--- a/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
@@ -2299,7 +2299,7 @@ XhcInitializeDeviceSlot (
     DEBUG ((EFI_D_INFO, "    Address %d assigned successfully\n", DeviceAddress));
     Xhc->UsbDevContext[SlotId].XhciDevAddr = DeviceAddress;
   } else {
-    DEBUG ((DEBUG_INFO, "    Address %d assigned unsuccessfully\n"));
+    DEBUG ((DEBUG_INFO, "    Slot %d address not assigned successfully. Status=%r\n", SlotId, Status)); //MU_CHANGE - TCBZ3662
     XhcDisableSlotCmd (Xhc, SlotId);
   }
 


### PR DESCRIPTION
Fix a debug print in XhciSched that specified a parameter in the format string but did not supply the actual parameter. 