### PR TITLE
Adding logging errors to console for SpellCheck and MarkDownLintCheck

### DIFF
--- a/.pytool/Plugin/MarkdownLintCheck/MarkdownLintCheck.py
+++ b/.pytool/Plugin/MarkdownLintCheck/MarkdownLintCheck.py
@@ -144,6 +144,7 @@ class MarkdownLintCheck(ICiBuildPlugin):
         results = self._check_markdown(path_to_check, config_file_path, Ignores)
         for r in results:
             tc.LogStdError(r.strip())
+            logging.error(r.strip())
 
         # add result to test case
         overall_status = len(results)

--- a/.pytool/Plugin/MarkdownLintCheck/MarkdownLintCheck.py
+++ b/.pytool/Plugin/MarkdownLintCheck/MarkdownLintCheck.py
@@ -66,6 +66,9 @@ class MarkdownLintCheck(ICiBuildPlugin):
 
     def RunBuildPlugin(self, packagename, Edk2pathObj, pkgconfig, environment, PLM, PLMHelper, tc, output_stream=None):
         Errors = []
+        audit_only = True
+        if "AuditOnly" in pkgconfig and not pkgconfig["AuditOnly"]:
+            audit_only = False
 
         abs_pkg_path = Edk2pathObj.GetAbsolutePathOnThisSystemFromEdk2RelativePath(
             packagename)
@@ -144,12 +147,13 @@ class MarkdownLintCheck(ICiBuildPlugin):
         results = self._check_markdown(path_to_check, config_file_path, Ignores)
         for r in results:
             tc.LogStdError(r.strip())
-            logging.error(r.strip())
+            if not audit_only:
+                logging.error(r.strip())
 
         # add result to test case
         overall_status = len(results)
         if overall_status != 0:
-            if "AuditOnly" in pkgconfig and pkgconfig["AuditOnly"]:
+            if audit_only:
                 # set as skipped if AuditOnly
                 tc.SetSkipped()
                 return -1

--- a/.pytool/Plugin/MarkdownLintCheck/MarkdownLintCheck.py
+++ b/.pytool/Plugin/MarkdownLintCheck/MarkdownLintCheck.py
@@ -66,9 +66,9 @@ class MarkdownLintCheck(ICiBuildPlugin):
 
     def RunBuildPlugin(self, packagename, Edk2pathObj, pkgconfig, environment, PLM, PLMHelper, tc, output_stream=None):
         Errors = []
-        audit_only = True
-        if "AuditOnly" in pkgconfig and not pkgconfig["AuditOnly"]:
-            audit_only = False
+        audit_only = False
+        if "AuditOnly" in pkgconfig and pkgconfig["AuditOnly"]:
+            audit_only = True
 
         abs_pkg_path = Edk2pathObj.GetAbsolutePathOnThisSystemFromEdk2RelativePath(
             packagename)

--- a/.pytool/Plugin/SpellCheck/SpellCheck.py
+++ b/.pytool/Plugin/SpellCheck/SpellCheck.py
@@ -72,9 +72,9 @@ class SpellCheck(ICiBuildPlugin):
 
     def RunBuildPlugin(self, packagename, Edk2pathObj, pkgconfig, environment, PLM, PLMHelper, tc, output_stream=None):
         Errors = []
-        audit_only = True
-        if "AuditOnly" in pkgconfig and not pkgconfig["AuditOnly"]:
-            audit_only = False
+        audit_only = False
+        if "AuditOnly" in pkgconfig and pkgconfig["AuditOnly"]:
+            audit_only = True
 
         abs_pkg_path = Edk2pathObj.GetAbsolutePathOnThisSystemFromEdk2RelativePath(
             packagename)

--- a/.pytool/Plugin/SpellCheck/SpellCheck.py
+++ b/.pytool/Plugin/SpellCheck/SpellCheck.py
@@ -72,6 +72,9 @@ class SpellCheck(ICiBuildPlugin):
 
     def RunBuildPlugin(self, packagename, Edk2pathObj, pkgconfig, environment, PLM, PLMHelper, tc, output_stream=None):
         Errors = []
+        audit_only = True
+        if "AuditOnly" in pkgconfig and not pkgconfig["AuditOnly"]:
+            audit_only = False
 
         abs_pkg_path = Edk2pathObj.GetAbsolutePathOnThisSystemFromEdk2RelativePath(
             packagename)
@@ -178,7 +181,8 @@ class SpellCheck(ICiBuildPlugin):
             # real error
             EasyFix.append(word.strip().strip("()"))
             Errors.append(r)
-
+            if not audit_only:
+                logging.error(r)
         # Log all errors tc StdError
         for l in Errors:
             tc.LogStdError(l.strip())
@@ -197,7 +201,7 @@ class SpellCheck(ICiBuildPlugin):
         # add result to test case
         overall_status = len(Errors)
         if overall_status != 0:
-            if "AuditOnly" in pkgconfig and pkgconfig["AuditOnly"]:
+            if audit_only:
                 # set as skipped if AuditOnly
                 tc.SetSkipped()
                 return -1


### PR DESCRIPTION
Added lines to log errors to console for SpellCheck (if AuditOnly is False) and MarkDownLintCheck. This change brings these plugins in line with the other CI plugins where errors can be quickly seen in the console instead of digging into the build log.