### PR TITLE
Reset USB port during enumeration if GetPortStatus returns device error

### DIFF
--- a/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.c
@@ -458,7 +458,7 @@ XhcGetRootHubPortStatus (
   // For those devices behind hub, we get its attach/detach event by hooking Get_Port_Status request at control transfer for those hub.
   //
   ParentRouteChart.Dword = 0;
-  Status = XhcPollPortStatusChange (Xhc, ParentRouteChart, PortNumber, PortStatus);  // MU_CHANGE
+  Status                 = XhcPollPortStatusChange (Xhc, ParentRouteChart, PortNumber, PortStatus); // MU_CHANGE
 
 ON_EXIT:
   gBS->RestoreTPL (OldTpl);

--- a/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.c
@@ -458,7 +458,7 @@ XhcGetRootHubPortStatus (
   // For those devices behind hub, we get its attach/detach event by hooking Get_Port_Status request at control transfer for those hub.
   //
   ParentRouteChart.Dword = 0;
-  XhcPollPortStatusChange (Xhc, ParentRouteChart, PortNumber, PortStatus);
+  Status = XhcPollPortStatusChange (Xhc, ParentRouteChart, PortNumber, PortStatus);  // MU_CHANGE
 
 ON_EXIT:
   gBS->RestoreTPL (OldTpl);

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbEnumer.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbEnumer.c
@@ -913,7 +913,8 @@ UsbEnumeratePort (
   //
   Status = HubApi->GetPortStatus (HubIf, Port, &PortState);
 
-  if (EFI_ERROR (Status)) {
+  // MU_CHANGE - try a port reset if get port status returns device error
+  if (EFI_ERROR (Status) && (Status != EFI_DEVICE_ERROR)) {
     DEBUG ((DEBUG_ERROR, "UsbEnumeratePort: failed to get state of port %d\n", Port));
     return Status;
   }

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbEnumer.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbEnumer.c
@@ -996,7 +996,8 @@ UsbEnumeratePort (
     //
     DEBUG ((DEBUG_INFO, "UsbEnumeratePort: new device connected at port %d\n", Port));
     if (USB_BIT_IS_SET (PortState.PortChangeStatus, USB_PORT_STAT_C_RESET) &&
-        (Status != EFI_DEVICE_ERROR)) {   // MU_CHANGE
+        (Status != EFI_DEVICE_ERROR))     // MU_CHANGE
+    {
       Status = UsbEnumerateNewDev (HubIf, Port, FALSE);
     } else {
       Status = UsbEnumerateNewDev (HubIf, Port, TRUE);

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbEnumer.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbEnumer.c
@@ -908,12 +908,17 @@ UsbEnumeratePort (
   Child  = NULL;
   HubApi = HubIf->HubApi;
 
+  // MU_CHANGE: Zero out PortState in case GetPortStatus does not set it and we
+  //            continue on the EFI_DEVICE_ERROR path
+  PortState.PortStatus       = 0;
+  PortState.PortChangeStatus = 0;
+
   //
   // Host learns of the new device by polling the hub for port changes.
   //
   Status = HubApi->GetPortStatus (HubIf, Port, &PortState);
 
-  // MU_CHANGE - try a port reset if get port status returns device error
+  // MU_CHANGE - try a port reset if GetPortStatus returns device error
   if (EFI_ERROR (Status) && (Status != EFI_DEVICE_ERROR)) {
     DEBUG ((DEBUG_ERROR, "UsbEnumeratePort: failed to get state of port %d\n", Port));
     return Status;

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbEnumer.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbEnumer.c
@@ -995,7 +995,8 @@ UsbEnumeratePort (
     // Now, new device connected, enumerate and configure the device
     //
     DEBUG ((DEBUG_INFO, "UsbEnumeratePort: new device connected at port %d\n", Port));
-    if (USB_BIT_IS_SET (PortState.PortChangeStatus, USB_PORT_STAT_C_RESET)) {
+    if (USB_BIT_IS_SET (PortState.PortChangeStatus, USB_PORT_STAT_C_RESET) &&
+        (Status != EFI_DEVICE_ERROR)) {   // MU_CHANGE
       Status = UsbEnumerateNewDev (HubIf, Port, FALSE);
     } else {
       Status = UsbEnumerateNewDev (HubIf, Port, TRUE);


### PR DESCRIPTION
During USB device enumeration, issuing a hot reset on a port is skipped if there
is a reset change status already detected on the port. This can happen when
enumerating devices after a host controller soft reset (which drives a hot reset
down the ports).

However, in certain cases an attached device may not be responsive even if the
reset change and connection status bits are set. For e.g., according to xHCI
spec section 4.19.5.1 the port reset change bits can be set when a hot reset
driven on the port transitions to a warm reset and completes with errors. For
such instances it is worthwhile to force a hot reset during enumeration to try
and recover unresponsive devices.

During enumeration check whether querying port status returns EFI_DEVICE_ERROR
and try a port reset if there is a device attached to the port.