### PR TITLE
[TCBZ3891] Use Python 3.10.6+

### DIFF
--- a/.azurepipelines/Ubuntu-PatchCheck.yml
+++ b/.azurepipelines/Ubuntu-PatchCheck.yml
@@ -29,7 +29,7 @@ steps:
 
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: '3.8.x'
+    versionSpec: '>=3.10.6'
     architecture: 'x64'
 
 - script: |

--- a/.azurepipelines/templates/platform-build-run-steps.yml
+++ b/.azurepipelines/templates/platform-build-run-steps.yml
@@ -42,7 +42,7 @@ steps:
 
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: "3.8.x"
+    versionSpec: ">=3.10.6"
     architecture: "x64"
 
 - script: pip install -r pip-requirements.txt --upgrade

--- a/.azurepipelines/templates/pr-gate-steps.yml
+++ b/.azurepipelines/templates/pr-gate-steps.yml
@@ -23,7 +23,7 @@ steps:
 
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: '3.8.x'
+    versionSpec: '>=3.10.6'
     architecture: 'x64'
 
 - script: pip install -r pip-requirements.txt --upgrade


### PR DESCRIPTION
## Description

REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3891

Changes the Python version used in pipelines to 3.10.6 or greater
since that version introduces a fix (bp0-47231) for inconsistent
trailing slashes in tarfile longname directories.

This is required for stuart_update to succeed when handling a
web_dependency (e.g. GCC ARM compilers).

Cc: Sean Brogan <sean.brogan@microsoft.com>
Cc: Bret Barkelew <Bret.Barkelew@microsoft.com>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>

- [ ] Breaking change?
  - Will this change break pre-existing builds or functionality without action being taken?
  **No**

## How This Was Tested

Verified in CI builds

## Integration Instructions

Determine if moving from Python 3.8 to 3.10 impacts any scripts

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>