### PR TITLE
BaseTools: Remove leading zeroes in NuGet versions

### DIFF
--- a/BaseTools/Bin/basetoolsbin_ext_dep.yaml
+++ b/BaseTools/Bin/basetoolsbin_ext_dep.yaml
@@ -12,7 +12,7 @@
   "type": "nuget",
   "name": "Mu-Basetools",
   "source": "https://api.nuget.org/v3/index.json",
-  "version": "2022.02.1",
+  "version": "2022.2.1",
   "flags": ["set_shell_var", "set_path", "host_specific"],
   "var_name": "EDK_TOOLS_BIN"
 }

--- a/BaseTools/Bin/nasm_ext_dep.yaml
+++ b/BaseTools/Bin/nasm_ext_dep.yaml
@@ -13,6 +13,6 @@
   "type": "nuget",
   "name": "mu_nasm",
   "source": "https://api.nuget.org/v3/index.json",
-  "version": "2.15.05",
+  "version": "2.15.5",
   "flags": ["set_path", "host_specific"]
 }

--- a/CryptoPkg/Driver/Bin/BaseCryptoDriver_ext_dep.json
+++ b/CryptoPkg/Driver/Bin/BaseCryptoDriver_ext_dep.json
@@ -3,7 +3,7 @@
     "type": "nuget",
     "name": "edk2-basecrypto-driver-bin",
     "source": "https://pkgs.dev.azure.com/projectmu/mu/_packaging/Mu-Public/nuget/v3/index.json",
-    "version": "2022.02.2",
+    "version": "2022.2.2",
     "flags": ["set_build_var"],
     "var_name": "CRYPTO_BINARY_EXTDEP_PATH"
   }


### PR DESCRIPTION
## Description

When a formal semantic version validator is run against these versions
they are recognized as being invalid due to the leading zero in the patch
which is not allowed per the Semantic Versioning Specification:

https://semver.org/#spec-item-2

The NuGet Gallery already reports the version without the leading zero:

- https://www.nuget.org/packages/mu_nasm/2.15.5
- https://www.nuget.org/packages/Mu-Basetools/2022.2.1
- https://dev.azure.com/projectmu/mu/_artifacts/feed/Basetools-Binary/NuGet/Mu-Basetools/versions/2022.2.1

This change simply removes the leading zero to prevent code such as
https://pypi.org/project/semantic-version/ from reporting a version error.

- [ ] Breaking change?
  - Will this change break pre-existing builds or functionality without action being taken?
  **No**

## How This Was Tested

Verified NuGet packages download the version is not reported as being invalid.

## Integration Instructions

If consumers have similarly versioned packages, they might also need to remove
leading zeroes.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>