### PR TITLE
CodeQL Fixes - Second Pass

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciLib.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciLib.c
@@ -1823,7 +1823,7 @@ PciProgramResizableBar (
                                     );
   ASSERT_EFI_ERROR (Status);
 
-  for (Index = 0; Index < ResizableBarNumber; Index++) {
+  for (Index = 0; (UINTN)Index < ResizableBarNumber; Index++) {
     //
     // When the bit of Capabilities Set, indicates that the Function supports
     // operating with the BAR sized to (2^Bit) MB.

--- a/MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDisk.c
+++ b/MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDisk.c
@@ -2566,7 +2566,7 @@ ScsiDiskInquiryDevice (
         //
         // Locate the code for the Block Limits VPD page
         //
-        for (Index = 0; Index < PageLength; Index++) {
+        for (Index = 0; (UINTN)Index < PageLength; Index++) {
           //
           // Sanity check
           //

--- a/MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThruHci.c
+++ b/MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThruHci.c
@@ -405,7 +405,7 @@ UfsInitUtpPrdt (
   Remaining    = Buffer;
   PrdtNumber   = (UINTN)DivU64x32 ((UINT64)BufferSize + UFS_MAX_DATA_LEN_PER_PRD - 1, UFS_MAX_DATA_LEN_PER_PRD);
 
-  for (PrdtIndex = 0; PrdtIndex < PrdtNumber; PrdtIndex++) {
+  for (PrdtIndex = 0; (UINTN)PrdtIndex < PrdtNumber; PrdtIndex++) {
     if (RemainingLen < UFS_MAX_DATA_LEN_PER_PRD) {
       Prdt[PrdtIndex].DbCount = (UINT32)RemainingLen - 1;
     } else {

--- a/MdeModulePkg/Core/Dxe/Hand/Handle.c
+++ b/MdeModulePkg/Core/Dxe/Hand/Handle.c
@@ -1166,16 +1166,7 @@ Done:
     // Keep Interface unmodified in case of any Error
     // except EFI_ALREADY_STARTED and EFI_UNSUPPORTED.
     //
-    if (!EFI_ERROR (Status) || (Status == EFI_ALREADY_STARTED)) {
-      //
-      // According to above logic, if 'Prot' is NULL, then the 'Status' must be
-      // EFI_UNSUPPORTED. Here the 'Status' is not EFI_UNSUPPORTED, so 'Prot'
-      // must be not NULL.
-      //
-      // The ASSERT here is for addressing a false positive NULL pointer
-      // dereference issue raised from static analysis.
-      //
-      ASSERT (Prot != NULL);
+    if ((!EFI_ERROR (Status) || (Status == EFI_ALREADY_STARTED)) && (Prot != NULL)) {
       //
       // EFI_ALREADY_STARTED is not an error for bus driver.
       // Return the corresponding protocol interface.

--- a/MdeModulePkg/Core/Pei/FwVol/FwVol.c
+++ b/MdeModulePkg/Core/Pei/FwVol/FwVol.c
@@ -338,7 +338,7 @@ FindFileEx (
   FileOffset = (UINT32)((UINT8 *)FfsFileHeader - (UINT8 *)FwVolHeader);
   ASSERT (FileOffset <= 0xFFFFFFFF);
 
-  while (FileOffset < (FvLength - sizeof (EFI_FFS_FILE_HEADER))) {
+  while ((UINTN)FileOffset < (UINTN)(FvLength - sizeof (EFI_FFS_FILE_HEADER))) {
     //
     // Get FileState which is the highest bit of the State
     //

--- a/MdeModulePkg/Library/SmmLockBoxLib/SmmLockBoxMmLib.c
+++ b/MdeModulePkg/Library/SmmLockBoxLib/SmmLockBoxMmLib.c
@@ -506,7 +506,11 @@ SaveLockBox (
     ));
 
   LockBoxQueue = InternalGetLockBoxQueue ();
-  ASSERT (LockBoxQueue != NULL);
+  if (LockBoxQueue == NULL) {
+    ASSERT (LockBoxQueue != NULL);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
   InsertTailList (LockBoxQueue, &LockBox->Link);
 
   //
@@ -840,6 +844,7 @@ RestoreLockBox (
   @retval RETURN_SUCCESS            the information is restored successfully.
   @retval RETURN_NOT_STARTED        it is too early to invoke this interface
   @retval RETURN_UNSUPPORTED        the service is not supported by implementaion.
+  @retval RETURN_OUT_OF_RESOURCES   noT enough resourceS to save the information.
 **/
 RETURN_STATUS
 EFIAPI
@@ -854,7 +859,10 @@ RestoreAllLockBoxInPlace (
   DEBUG ((DEBUG_INFO, "SmmLockBoxSmmLib RestoreAllLockBoxInPlace - Enter\n"));
 
   LockBoxQueue = InternalGetLockBoxQueue ();
-  ASSERT (LockBoxQueue != NULL);
+  if (LockBoxQueue == NULL) {
+    ASSERT (LockBoxQueue != NULL);
+    return EFI_OUT_OF_RESOURCES;
+  }
 
   //
   // Restore all, Buffer and Length MUST be NULL

--- a/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
@@ -2304,12 +2304,20 @@ BmEnumerateBootOptions (
       }
 
       Description = BmGetBootDescription (Handles[Index]);
+      if (Description == NULL) {
+        continue;
+      }
+
       BootOptions = ReallocatePool (
                       sizeof (EFI_BOOT_MANAGER_LOAD_OPTION) * (*BootOptionCount),
                       sizeof (EFI_BOOT_MANAGER_LOAD_OPTION) * (*BootOptionCount + 1),
                       BootOptions
                       );
-      ASSERT (BootOptions != NULL);
+      if (BootOptions == NULL) {
+        ASSERT (BootOptions != NULL);
+        FreePool (Description);
+        continue;
+      }
 
       Status = EfiBootManagerInitializeLoadOption (
                  &BootOptions[(*BootOptionCount)++],
@@ -2355,12 +2363,20 @@ BmEnumerateBootOptions (
     }
 
     Description = BmGetBootDescription (Handles[Index]);
+    if (Description == NULL) {
+      continue;
+    }
+
     BootOptions = ReallocatePool (
                     sizeof (EFI_BOOT_MANAGER_LOAD_OPTION) * (*BootOptionCount),
                     sizeof (EFI_BOOT_MANAGER_LOAD_OPTION) * (*BootOptionCount + 1),
                     BootOptions
                     );
-    ASSERT (BootOptions != NULL);
+    if (BootOptions == NULL) {
+      ASSERT (BootOptions != NULL);
+      FreePool (Description);
+      continue;
+    }
 
     Status = EfiBootManagerInitializeLoadOption (
                &BootOptions[(*BootOptionCount)++],
@@ -2399,12 +2415,20 @@ BmEnumerateBootOptions (
     }
 
     Description = BmGetBootDescription (Handles[Index]);
+    if (Description == NULL) {
+      continue;
+    }
+
     BootOptions = ReallocatePool (
                     sizeof (EFI_BOOT_MANAGER_LOAD_OPTION) * (*BootOptionCount),
                     sizeof (EFI_BOOT_MANAGER_LOAD_OPTION) * (*BootOptionCount + 1),
                     BootOptions
                     );
-    ASSERT (BootOptions != NULL);
+    if (BootOptions == NULL) {
+      ASSERT (BootOptions != NULL);
+      FreePool (Description);
+      continue;
+    }
 
     Status = EfiBootManagerInitializeLoadOption (
                &BootOptions[(*BootOptionCount)++],

--- a/MdeModulePkg/Library/UefiBootManagerLib/BmConsole.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmConsole.c
@@ -484,17 +484,19 @@ EfiBootManagerUpdateConsoleVariable (
     }
   }
 
-  //
-  // Finally, Update the variable of the default console by NewDevicePath
-  //
-  Status = gRT->SetVariable (
-                  mConVarName[ConsoleType],
-                  &gEfiGlobalVariableGuid,
-                  EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS
-                  | ((ConsoleType < ConInDev) ? EFI_VARIABLE_NON_VOLATILE : 0),
-                  GetDevicePathSize (NewDevicePath),
-                  NewDevicePath
-                  );
+  if (NewDevicePath != NULL) {
+    //
+    // Finally, Update the variable of the default console by NewDevicePath
+    //
+    Status = gRT->SetVariable (
+                    mConVarName[ConsoleType],
+                    &gEfiGlobalVariableGuid,
+                    EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS
+                    | ((ConsoleType < ConInDev) ? EFI_VARIABLE_NON_VOLATILE : 0),
+                    GetDevicePathSize (NewDevicePath),
+                    NewDevicePath
+                    );
+  }
 
   if (VarConsole == NewDevicePath) {
     if (VarConsole != NULL) {

--- a/MdeModulePkg/Library/UefiBootManagerLib/BmLoadOption.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmLoadOption.c
@@ -454,6 +454,9 @@ EfiBootManagerSortLoadOptionVariable (
   UINT16                        *OptionOrder;
 
   LoadOption = EfiBootManagerGetLoadOptions (&LoadOptionCount, OptionType);
+  if (LoadOption == NULL) {
+    return;
+  }
 
   //
   // Insertion sort algorithm

--- a/MdeModulePkg/Library/UefiBootManagerLib/BmMisc.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmMisc.c
@@ -57,7 +57,10 @@ BmDelPartMatchInstance (
       }
     }
 
-    FreePool (Instance);
+    if (Instance != NULL) {
+      FreePool (Instance);
+    }
+
     Instance      = GetNextDevicePathInstance (&Multi, &InstanceSize);
     InstanceSize -= END_DEVICE_PATH_LENGTH;
   }

--- a/MdeModulePkg/Library/UefiHiiLib/HiiLib.c
+++ b/MdeModulePkg/Library/UefiHiiLib/HiiLib.c
@@ -1216,7 +1216,7 @@ ValidateQuestionFromVfr (
   // Check IFR value is in block data, then Validate Value
   //
   PackageOffset = sizeof (EFI_HII_PACKAGE_LIST_HEADER);
-  while (PackageOffset < PackageListLength) {
+  while ((UINTN)PackageOffset < PackageListLength) {
     CopyMem (&PackageHeader, (UINT8 *)HiiPackageList + PackageOffset, sizeof (PackageHeader));
 
     //

--- a/MdeModulePkg/Universal/Acpi/AcpiTableDxe/AmlNamespace.c
+++ b/MdeModulePkg/Universal/Acpi/AcpiTableDxe/AmlNamespace.c
@@ -32,7 +32,7 @@ AmlConstructNodeList (
   @param[in]    Parent               AML parent node list.
   @param[in]    AmlByteEncoding      AML Byte Encoding.
 
-  @return       AML Node.
+  @return       AML Node or NULL if insufficient resources to allocate a buffer
 **/
 EFI_AML_NODE_LIST *
 AmlCreateNode (
@@ -44,7 +44,10 @@ AmlCreateNode (
   EFI_AML_NODE_LIST  *AmlNodeList;
 
   AmlNodeList = AllocatePool (sizeof (*AmlNodeList));
-  ASSERT (AmlNodeList != NULL);
+  if (AmlNodeList == NULL) {
+    ASSERT (AmlNodeList != NULL);
+    return NULL;
+  }
 
   AmlNodeList->Signature = EFI_AML_NODE_LIST_SIGNATURE;
   CopyMem (AmlNodeList->Name, NameSeg, AML_NAME_SEG_SIZE);

--- a/MdeModulePkg/Universal/Acpi/AcpiTableDxe/AmlString.c
+++ b/MdeModulePkg/Universal/Acpi/AcpiTableDxe/AmlString.c
@@ -379,7 +379,7 @@ AmlUpperCaseCopyMem (
 
   @param[in]    AslPath     ASL name.
 
-  @return AmlName
+  @return AmlName or NULL if insufficient resources to allocate a buffer
 **/
 UINT8 *
 AmlNameFromAslName (
@@ -401,7 +401,10 @@ AmlNameFromAslName (
   }
 
   AmlPath = AllocatePool (TotalLength);
-  ASSERT (AmlPath != NULL);
+  if (AmlPath == NULL) {
+    ASSERT (AmlPath != NULL);
+    return NULL;
+  }
 
   AmlBuffer = AmlPath;
   Buffer    = AslPath;

--- a/MdeModulePkg/Universal/Console/GraphicsConsoleDxe/GraphicsConsole.c
+++ b/MdeModulePkg/Universal/Console/GraphicsConsoleDxe/GraphicsConsole.c
@@ -463,7 +463,7 @@ GraphicsConsoleControllerDriverStart (
       //
       MaxMode = Private->GraphicsOutput->Mode->MaxMode;
 
-      for (ModeIndex = 0; ModeIndex < MaxMode; ModeIndex++) {
+      for (ModeIndex = 0; (UINTN)ModeIndex < MaxMode; ModeIndex++) {
         Status = Private->GraphicsOutput->QueryMode (
                                             Private->GraphicsOutput,
                                             ModeIndex,

--- a/MdeModulePkg/Universal/Disk/PartitionDxe/Mbr.c
+++ b/MdeModulePkg/Universal/Disk/PartitionDxe/Mbr.c
@@ -359,7 +359,7 @@ PartitionInstallMbrChildHandles (
       if (ExtMbrStartingLba == 0) {
         break;
       }
-    } while (ExtMbrStartingLba  < ParentHdDev.PartitionSize);
+    } while ((UINT64)ExtMbrStartingLba  < ParentHdDev.PartitionSize);
   }
 
 Done:

--- a/MdeModulePkg/Universal/FaultTolerantWritePei/FaultTolerantWritePei.c
+++ b/MdeModulePkg/Universal/FaultTolerantWritePei/FaultTolerantWritePei.c
@@ -102,7 +102,7 @@ FtwGetLastWriteRecord (
   //
   // Try to find the last write record "that has not completed"
   //
-  for (Index = 0; Index < FtwWriteHeader->NumberOfWrites; Index += 1) {
+  for (Index = 0; (UINT64)Index < FtwWriteHeader->NumberOfWrites; Index += 1) {
     if (FtwRecord->DestinationComplete != FTW_VALID_STATE) {
       //
       // The last write record is found

--- a/MdeModulePkg/Universal/HiiDatabaseDxe/Font.c
+++ b/MdeModulePkg/Universal/HiiDatabaseDxe/Font.c
@@ -412,7 +412,7 @@ GlyphToBlt (
   // The glyph's upper left hand corner pixel is the most significant bit of the
   // first bitmap byte.
   //
-  for (Ypos = 0; Ypos < Cell->Height && (((UINT32)Ypos + YposOffset) < RowHeight); Ypos++) {
+  for (Ypos = 0; Ypos < Cell->Height && ((UINTN)((UINT32)Ypos + YposOffset) < RowHeight); Ypos++) {
     OffsetY = BITMAP_LEN_1_BIT (Cell->Width, Ypos);
 
     //
@@ -420,7 +420,7 @@ GlyphToBlt (
     //
     for (Xpos = 0; Xpos < Cell->Width / 8; Xpos++) {
       Data = *(GlyphBuffer + OffsetY + Xpos);
-      for (Index = 0; Index < 8 && (((UINT32)Xpos * 8 + Index + Cell->OffsetX) < RowWidth); Index++) {
+      for (Index = 0; Index < 8 && ((UINTN)((UINT32)Xpos * 8 + Index + Cell->OffsetX) < RowWidth); Index++) {
         if ((Data & (1 << (8 - Index - 1))) != 0) {
           BltBuffer[Ypos * ImageWidth + Xpos * 8 + Index] = Foreground;
         } else {
@@ -436,7 +436,7 @@ GlyphToBlt (
       // There are some padding bits in this byte. Ignore them.
       //
       Data = *(GlyphBuffer + OffsetY + Xpos);
-      for (Index = 0; Index < Cell->Width % 8 && (((UINT32)Xpos * 8 + Index + Cell->OffsetX) < RowWidth); Index++) {
+      for (Index = 0; Index < (UINT16)(Cell->Width % 8) && ((UINTN)((UINT32)Xpos * 8 + Index + Cell->OffsetX) < RowWidth); Index++) {
         if ((Data & (1 << (8 - Index - 1))) != 0) {
           BltBuffer[Ypos * ImageWidth + Xpos * 8 + Index] = Foreground;
         } else {

--- a/MdeModulePkg/Universal/HiiDatabaseDxe/Image.c
+++ b/MdeModulePkg/Universal/HiiDatabaseDxe/Image.c
@@ -300,7 +300,7 @@ Output1bitPixel (
       // Padding bits in this byte should be ignored.
       //
       Byte = *(Data + OffsetY + Xpos);
-      for (Index = 0; Index < Image->Width % 8; Index++) {
+      for (Index = 0; (UINT16)Index < (UINT16)(Image->Width % 8); Index++) {
         if ((Byte & (1 << (8 - Index - 1))) != 0) {
           CopyMem (&BitMapPtr[Ypos * Image->Width + Xpos * 8 + Index], &PaletteValue[1], sizeof (*BitMapPtr));
         } else {

--- a/MdeModulePkg/Universal/PCD/Pei/Pcd.c
+++ b/MdeModulePkg/Universal/PCD/Pei/Pcd.c
@@ -574,7 +574,7 @@ PeiPcdSetSku (
   }
 
   SkuIdTable = (SKU_ID *)((UINT8 *)PeiPcdDb + PeiPcdDb->SkuIdTableOffset);
-  for (Index = 0; Index < SkuIdTable[0]; Index++) {
+  for (Index = 0; (UINT64)Index < SkuIdTable[0]; Index++) {
     if (SkuId == SkuIdTable[Index + 1]) {
       DEBUG ((DEBUG_INFO, "PcdPei - SkuId is found in SkuId table.\n"));
       break;

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariablePolicySmmDxe.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariablePolicySmmDxe.c
@@ -478,6 +478,8 @@ InternalProtocolGetVariablePolicyInfo (
   UINTN                                  BufferSize;
   UINTN                                  VariableNameSize;
 
+  PolicyHeader = NULL;
+
   if ((VariableName == NULL) || (VendorGuid == NULL) || (VariablePolicy == NULL)) {
     return EFI_INVALID_PARAMETER;
   }
@@ -611,7 +613,11 @@ InternalProtocolGetVariablePolicyInfo (
 Done:
   ReleaseLockOnlyAtBootTime (&mMmCommunicationLock);
 
-  return (EFI_ERROR (Status)) ? Status : PolicyHeader->Result;
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  return (PolicyHeader != NULL) ? PolicyHeader->Result : EFI_SUCCESS;
 }
 
 /**

--- a/MdePkg/Library/BasePeCoffLib/BasePeCoff.c
+++ b/MdePkg/Library/BasePeCoffLib/BasePeCoff.c
@@ -101,7 +101,7 @@ PeCoffLoaderGetPeHeader (
   UINTN                     Size;
   UINTN                     ReadSize;
   UINT32                    SectionHeaderOffset;
-  UINT32                    Index;
+  UINTN                     Index;
   UINT32                    HeaderWithoutDataDir;
   CHAR8                     BufferData;
   UINTN                     NumberOfSections;

--- a/MdePkg/Library/UefiDevicePathLib/DevicePathFromText.c
+++ b/MdePkg/Library/UefiDevicePathLib/DevicePathFromText.c
@@ -3807,18 +3807,31 @@ UefiDevicePathLibConvertTextToDevicePath (
   }
 
   DevicePath = (EFI_DEVICE_PATH_PROTOCOL *)AllocatePool (END_DEVICE_PATH_LENGTH);
-  ASSERT (DevicePath != NULL);
+  if (DevicePath == NULL) {
+    ASSERT (DevicePath != NULL);
+    return NULL;
+  }
+
   SetDevicePathEndNode (DevicePath);
 
   DevicePathStr = UefiDevicePathLibStrDuplicate (TextDevicePath);
+  if (DevicePathStr == NULL) {
+    return NULL;
+  }
 
   Str = DevicePathStr;
   while ((DeviceNodeStr = GetNextDeviceNodeStr (&Str, &IsInstanceEnd)) != NULL) {
     DeviceNode = UefiDevicePathLibConvertTextToDeviceNode (DeviceNodeStr);
 
     NewDevicePath = AppendDevicePathNode (DevicePath, DeviceNode);
-    FreePool (DevicePath);
-    FreePool (DeviceNode);
+    if (DevicePath != NULL) {
+      FreePool (DevicePath);
+    }
+
+    if (DeviceNode != NULL) {
+      FreePool (DeviceNode);
+    }
+
     DevicePath = NewDevicePath;
 
     if (IsInstanceEnd) {
@@ -3828,8 +3841,14 @@ UefiDevicePathLibConvertTextToDevicePath (
       DeviceNode->SubType = END_INSTANCE_DEVICE_PATH_SUBTYPE;
 
       NewDevicePath = AppendDevicePathNode (DevicePath, DeviceNode);
-      FreePool (DevicePath);
-      FreePool (DeviceNode);
+      if (DevicePath != NULL) {
+        FreePool (DevicePath);
+      }
+
+      if (DeviceNode != NULL) {
+        FreePool (DeviceNode);
+      }
+
       DevicePath = NewDevicePath;
     }
   }

--- a/StandaloneMmPkg/Library/FvLib/FvLib.c
+++ b/StandaloneMmPkg/Library/FvLib/FvLib.c
@@ -167,7 +167,7 @@ FfsFindNextFile (
 
   FileOffset = (UINT32)((UINT8 *)FfsFileHeader - (UINT8 *)FwVolHeader);
 
-  while (FileOffset < (FvLength - sizeof (EFI_FFS_FILE_HEADER))) {
+  while ((UINT64)FileOffset < (FvLength - sizeof (EFI_FFS_FILE_HEADER))) {
     //
     // Get FileState which is the highest bit of the State
     //

--- a/UefiCpuPkg/Library/MpInitLib/PeiMpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/PeiMpLib.c
@@ -239,7 +239,7 @@ GetWakeupBuffer (
           WakeupBufferEnd = BASE_1MB;
         }
 
-        while (WakeupBufferEnd > WakeupBufferSize) {
+        while (WakeupBufferEnd > (UINT64)WakeupBufferSize) {
           //
           // Wakeup buffer should be aligned on 4KB
           //

--- a/UefiCpuPkg/Library/MtrrLib/MtrrLib.c
+++ b/UefiCpuPkg/Library/MtrrLib/MtrrLib.c
@@ -1627,8 +1627,8 @@ MtrrLibCalculateMtrrs (
   }
 
   for (TypeCount = 2; TypeCount <= 3; TypeCount++) {
-    for (Start = 0; Start < VertexCount; Start++) {
-      for (Stop = Start + 2; Stop < VertexCount; Stop++) {
+    for (Start = 0; (UINT32)Start < VertexCount; Start++) {
+      for (Stop = Start + 2; (UINT32)Stop < VertexCount; Stop++) {
         ASSERT (Vertices[Stop].Address > Vertices[Start].Address);
         Length = Vertices[Stop].Address - Vertices[Start].Address;
         if (Length > Vertices[Start].Alignment) {
@@ -2063,13 +2063,13 @@ MtrrLibSetMemoryRanges (
   //
   BiggestScratchSize = 0;
 
-  for (Index = 0; Index < RangeCount;) {
+  for (Index = 0; (UINTN)Index < RangeCount;) {
     Base0 = Ranges[Index].BaseAddress;
 
     //
     // Full step is optimal
     //
-    while (Index < RangeCount) {
+    while ((UINTN)Index < RangeCount) {
       ASSERT (Ranges[Index].BaseAddress == Base0);
       Alignment = MtrrLibBiggestAlignment (Base0, A0);
       while (Base0 + Alignment <= Ranges[Index].BaseAddress + Ranges[Index].Length) {
@@ -2117,7 +2117,7 @@ MtrrLibSetMemoryRanges (
     CompatibleTypes = MtrrLibGetCompatibleTypes (&Ranges[Index], RangeCount - Index);
 
     End = Index; // End points to last one that matches the CompatibleTypes.
-    while (End + 1 < RangeCount) {
+    while ((UINTN)(End + 1) < RangeCount) {
       if (((1 << Ranges[End + 1].Type) & CompatibleTypes) == 0) {
         break;
       }
@@ -2133,7 +2133,7 @@ MtrrLibSetMemoryRanges (
     // Base1 may not in Ranges[End]. Update End to the range Base1 belongs to.
     //
     End = Index;
-    while (End + 1 < RangeCount) {
+    while ((UINTN)(End + 1) < RangeCount) {
       if (Base1 <= Ranges[End + 1].BaseAddress) {
         break;
       }


### PR DESCRIPTION
## Description

Makes changes to comply with alerts raised by CodeQL.

A prior pass with a subset of queries used here was already done so this is mostly addressing
issues discovered by enabling a few new queries.

Most of the issues here fall into the following two categories:

1. Potential use of uninitialized pointer
2. Inconsistent integer width used in loop comparison

- [ ] Breaking change?
  - Will this change break pre-existing builds or functionality without action being taken?
  **No** - Should just be refactoring to address alerts

## How This Was Tested

1. Verified CI build
2. Verified boot to EFI shell on QemuQ35Pkg

## Integration Instructions

N/A

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>