### PR TITLE
build_rule.template: Add timing report to cargo build command

### DIFF
--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -281,7 +281,7 @@
         $(OUTPUT_DIR)(+)$(MODULE_NAME)rust.lib
 
     <Command>
-        $(CARGO) build $(CARGO_FLAGS) --manifest-path ${s_path}(+)Cargo.toml -Z unstable-options --out-dir $(CARGO_OUTPUT_DIR) --target-dir $(CARGO_OUTPUT_DIR)
+        $(CARGO) build $(CARGO_FLAGS) --manifest-path ${s_path}(+)Cargo.toml -Z unstable-options --out-dir $(CARGO_OUTPUT_DIR) --target-dir $(CARGO_OUTPUT_DIR) --timings=html
         $(CP) $(OUTPUT_DIR)(+)${s_dir}(+)*.a $(OUTPUT_DIR)(+)${s_dir}(+)$(MODULE_NAME)rust.lib
 
 [Toml-File.RUST_MODULE]
@@ -294,7 +294,7 @@
     <Command>
         # Temporary_Rust_Todo - Remove .efi files to better support Rust incremental build for now.
         $(RM) $(OUTPUT_DIR)(+)*.efi
-        $(CARGO) build $(CARGO_FLAGS) --manifest-path ${src} -Z unstable-options --out-dir $(CARGO_OUTPUT_DIR) --target-dir $(CARGO_OUTPUT_DIR)
+        $(CARGO) build $(CARGO_FLAGS) --manifest-path ${src} -Z unstable-options --out-dir $(CARGO_OUTPUT_DIR) --target-dir $(CARGO_OUTPUT_DIR) --timings=html
         $(CP) $(OUTPUT_DIR)(+)${s_dir}(+)*.efi $(OUTPUT_DIR)(+)$(MODULE_NAME).efi
         $(CP) $(OUTPUT_DIR)(+)$(MODULE_NAME).efi $(BIN_DIR)(+)$(MODULE_NAME).efi
         # Temporary_Rust_Todo - Create fake map file to prevent build error. Revisit and generate actual map file.


### PR DESCRIPTION
## Description

Outputs compilation timing information so we can track data across
changes and gain more insight into overall build time.

Reports can be found in a "cargo-timings" directory in the module
"OUTPUT" directory.

More information: https://doc.rust-lang.org/beta/cargo/reference/timings.html#reporting-build-timings

- [ ] Breaking change?
  - Will this change break pre-existing builds or functionality without action being taken?
  **No**

## How This Was Tested

Verified HTML report generated after change.

## Integration Instructions

N/A

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>