### PR TITLE
enable rustc compiled binaries map generation

### DIFF
--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -281,8 +281,8 @@
         $(OUTPUT_DIR)(+)$(MODULE_NAME)rust.lib
 
     <Command>
-        $(CARGO) build $(CARGO_FLAGS) --manifest-path ${s_path}(+)Cargo.toml -Z unstable-options --out-dir $(CARGO_OUTPUT_DIR) --target-dir $(CARGO_OUTPUT_DIR) --timings=html
-        $(CP) $(OUTPUT_DIR)(+)${s_dir}(+)*.a $(OUTPUT_DIR)(+)${s_dir}(+)$(MODULE_NAME)rust.lib
+        $(CARGO) build $(CARGO_FLAGS) --manifest-path ${s_path}(+)Cargo.toml -Z unstable-options --target-dir $(CARGO_OUTPUT_DIR) --timings=html
+        $(CP) $(OUTPUT_DIR)(+)x86_64-unknown-uefi(+)$(TARGET)(+)*.a $(OUTPUT_DIR)(+)${s_dir}(+)$(MODULE_NAME)rust.lib
 
 [Toml-File.RUST_MODULE]
     <InputFile>
@@ -294,8 +294,8 @@
     <Command>
         # Temporary_Rust_Todo - Remove .efi files to better support Rust incremental build for now.
         $(RM) $(OUTPUT_DIR)(+)*.efi
-        $(CARGO) build $(CARGO_FLAGS) --manifest-path ${src} -Z unstable-options --out-dir $(CARGO_OUTPUT_DIR) --target-dir $(CARGO_OUTPUT_DIR) --timings=html
-        $(CP) $(OUTPUT_DIR)(+)${s_dir}(+)*.efi $(OUTPUT_DIR)(+)$(MODULE_NAME).efi
+        $(CARGO) build $(CARGO_FLAGS) --manifest-path ${src} -Z unstable-options --target-dir $(CARGO_OUTPUT_DIR) --timings=html
+        $(CP) $(OUTPUT_DIR)(+)x86_64-unknown-uefi(+)$(TARGET)(+)*.efi $(OUTPUT_DIR)(+)$(MODULE_NAME).efi
         $(CP) $(OUTPUT_DIR)(+)$(MODULE_NAME).efi $(BIN_DIR)(+)$(MODULE_NAME).efi
         # Temporary_Rust_Todo - Create fake map file to prevent build error. Revisit and generate actual map file.
         $(CP) $(OUTPUT_DIR)(+)$(MODULE_NAME).efi $(OUTPUT_DIR)(+)$(MODULE_NAME).map

--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -281,7 +281,7 @@
         $(OUTPUT_DIR)(+)$(MODULE_NAME)rust.lib
 
     <Command>
-        $(CARGO) build $(CARGO_FLAGS) --manifest-path ${s_path}(+)Cargo.toml -Z unstable-options --target-dir $(CARGO_OUTPUT_DIR) --timings=html
+        $(CARGO) rustc $(CARGO_FLAGS) --manifest-path ${s_path}(+)Cargo.toml -Z unstable-options --target-dir $(CARGO_OUTPUT_DIR) --timings=html
         $(CP) $(OUTPUT_DIR)(+)x86_64-unknown-uefi(+)$(TARGET)(+)*.a $(OUTPUT_DIR)(+)${s_dir}(+)$(MODULE_NAME)rust.lib
 
 [Toml-File.RUST_MODULE]
@@ -294,11 +294,9 @@
     <Command>
         # Temporary_Rust_Todo - Remove .efi files to better support Rust incremental build for now.
         $(RM) $(OUTPUT_DIR)(+)*.efi
-        $(CARGO) build $(CARGO_FLAGS) --manifest-path ${src} -Z unstable-options --target-dir $(CARGO_OUTPUT_DIR) --timings=html
+        $(CARGO) rustc $(CARGO_FLAGS) --bins --manifest-path ${src} -Z unstable-options --target-dir $(CARGO_OUTPUT_DIR) --timings=html -- -C link-arg=/MAP:$(OUTPUT_DIR)(+)$(MODULE_NAME).map
         $(CP) $(OUTPUT_DIR)(+)x86_64-unknown-uefi(+)$(TARGET)(+)*.efi $(OUTPUT_DIR)(+)$(MODULE_NAME).efi
         $(CP) $(OUTPUT_DIR)(+)$(MODULE_NAME).efi $(BIN_DIR)(+)$(MODULE_NAME).efi
-        # Temporary_Rust_Todo - Create fake map file to prevent build error. Revisit and generate actual map file.
-        $(CP) $(OUTPUT_DIR)(+)$(MODULE_NAME).efi $(OUTPUT_DIR)(+)$(MODULE_NAME).map
 
 [Device-Tree-Source-File]
     <InputFile>


### PR DESCRIPTION
## Description

This PR does two things, and the PRs will not be squashed.

1. Removes the use of --out-dir. --out-dir moves only the compiled binary to the specified directory while all other build artifacts stay in the source directory, which we generally try and avoid. Keep --target-dir as it not only moves the compiled binary, but all build artifacts. 
2. add the linker arg /MAP to generate a map file. The map is currently mangled, which by default, should be demangled, so that will require additional research.

- Breaking change?
No

## How This Was Tested

Confirmed build and boot for DEBUG, RELEASE

## Integration Instructions

Update MU_BASECORE submodule
