### PR TITLE
Updated pipelines to only run CI and PR gates on release/202208 and r…

### DIFF
--- a/.azurepipelines/Ubuntu-CLANGPDB.yml
+++ b/.azurepipelines/Ubuntu-CLANGPDB.yml
@@ -8,7 +8,8 @@
 # MU_CHANGE BEGIN
 trigger:
 - dev/*
-- release/*
+- release/202208
+- release/202202
 
 schedules:
 - cron: "30 9 * * 0,3"  # Sun/Wed at 2:30AM Pacific
@@ -16,12 +17,14 @@ schedules:
   branches:
     include:
     - dev/*
-    - release/*
+    - release/202208
+    - release/202202
   always: true          # Always build, even if no changes
 
 pr:
 - dev/*
-- release/*
+- release/202208
+- release/202202
 # MU_CHANGE END
 
 jobs:

--- a/.azurepipelines/Ubuntu-GCC5.yml
+++ b/.azurepipelines/Ubuntu-GCC5.yml
@@ -8,7 +8,8 @@
 # MU_CHANGE [BEGIN]
 trigger:
 - dev/*
-- release/*
+- release/202208
+- release/202202
 
 schedules:
 - cron: "30 9 * * 0,3"  # Sun/Wed at 2:30AM Pacific
@@ -16,12 +17,14 @@ schedules:
   branches:
     include:
     - dev/*
-    - release/*
+    - release/202208
+    - release/202202
   always: true          # Always build, even if no changes
 
 pr:
 - dev/*
-- release/*
+- release/202208
+- release/202202
 # MU_CHANGE [END]
 
 jobs:

--- a/.azurepipelines/Ubuntu-PatchCheck.yml
+++ b/.azurepipelines/Ubuntu-PatchCheck.yml
@@ -17,7 +17,8 @@ trigger: none
 # MU_CHANGE [BEGIN]
 pr:
 - dev/*
-- release/*
+- release/202208
+- release/202202
 # MU_CHANGE [END]
 
 pool:

--- a/.azurepipelines/Windows-CLANGPDB.yml
+++ b/.azurepipelines/Windows-CLANGPDB.yml
@@ -7,7 +7,8 @@
 # MU_CHANGE BEGIN
 trigger:
 - dev/*
-- release/*
+- release/202208
+- release/202202
 
 schedules:
 - cron: "0 8 * * 0,3"   # Sun/Wed at 1AM Pacific
@@ -15,12 +16,14 @@ schedules:
   branches:
     include:
     - dev/*
-    - release/*
+    - release/202208
+    - release/202202
   always: true          # Always build, even if no changes
 
 pr:
 - dev/*
-- release/*
+- release/202208
+- release/202202
 # MU_CHANGE END
 
 jobs:

--- a/.azurepipelines/Windows-VS2022.yml
+++ b/.azurepipelines/Windows-VS2022.yml
@@ -7,7 +7,8 @@
 # MU_CHANGE [BEGIN]
 trigger:
 - dev/*
-- release/*
+- release/202208
+- release/202202
 
 schedules:
 - cron: "0 8 * * 0,3"   # Sun/Wed at 1AM Pacific
@@ -15,12 +16,14 @@ schedules:
   branches:
     include:
     - dev/*
-    - release/*
+    - release/202208
+    - release/202202
   always: true          # Always build, even if no changes
 
 pr:
 - dev/*
-- release/*
+- release/202208
+- release/202202
 # MU_CHANGE [END]
 
 jobs:


### PR DESCRIPTION
## Description

Updated pipelines to only run CI and PR gates on release/202208 and release/202202"

- [ ] Breaking change?
  No.

## How This Was Tested

Pipelines passed.

## Integration Instructions

N/A
