### PR TITLE
Merge Image Record Lists Before Breaking up the Memory Map

### DIFF
--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -1958,9 +1958,6 @@ GetMemoryMapWithPopulatedAccessAttributes (
   // has been set based on the memory protection policy
   SyncBitmap (MemoryMapSize, *MemoryMap, DescriptorSize, Bitmap);
   
-  DEBUG((DEBUG_INFO, "%a:%d - bitmap after sync\n", __FUNCTION__, __LINE__));
-  DumpBitmap (Bitmap, NumberOfBitmapEntries);
-
   DEBUG_CODE (
     DEBUG ((DEBUG_INFO, "---Memory Map With Separated Image Descriptors---\n"));
     DumpMemoryMap (MemoryMapSize, *MemoryMap, DescriptorSize);

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -1890,7 +1890,6 @@ GetMemoryMapWithPopulatedAccessAttributes (
     ASSERT_EFI_ERROR (Status);
   }
 
-  // Split PE code/data if firmware volume image protection is active
   SeparateImagesInMemoryMap (MemoryMapSize, *MemoryMap, *DescriptorSize, MergedImageList, AdditionalRecordCount);
 
   if (ArrayOfListEntryPointers != NULL) {

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -581,6 +581,7 @@ OrderedInsertImagePropertiesRecordArray (
                                               ListToBeMergedCount was zero
   @retval other                               Return value of OrderedInsertImageRecordListEntry()
 **/
+STATIC
 EFI_STATUS
 MergeImagePropertiesRecordLists (
   IN  LIST_ENTRY  *ListToMergeInto,


### PR DESCRIPTION
## Description

Now that we allow for protected and non-protected image lists, we need to merge them together (if necessary) before passing them into the memory map breakup logic. This will enable images to be loaded and non-protected without affecting our more general NX protection policy and any future mitigations we may add.

## Breaking change?
No

## How This Was Tested

Forcing a split between protected and nonprotected images and booting to shell to examine the outcome of the memory map breakup logic

## Integration Instructions

N/A
