### PR TITLE
Update FilterMemoryMapAttributes() Interface

### DIFF
--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -1594,23 +1594,17 @@ SeparateImagesInMemoryMap (
 /**
   Applies EFI_MEMORY_ACCESS_MASK to each memory map entry
 
-  @param[in, out] MemoryMapSize     A pointer to the size, in bytes, of the
-                                    MemoryMap buffer. On input, this is the size of
-                                    old MemoryMap before split. The actual buffer
-                                    size of MemoryMap is MemoryMapSize +
-                                    (AdditionalRecordCount * DescriptorSize) calculated
-                                    below. On output, it is the size of new MemoryMap
-                                    after split.
-  @param[in, out] MemoryMap         A pointer to the buffer in which firmware places
-                                    the current memory map.
-  @param[in]      DescriptorSize    Size, in bytes, of an individual EFI_MEMORY_DESCRIPTOR.
+  @param[in]      MemoryMapSize     A pointer to the size, in bytes, of the
+                                    MemoryMap buffer
+  @param[in, out] MemoryMap         A pointer to the buffer containing the memory map
+  @param[in]      DescriptorSize    Size, in bytes, of an individual EFI_MEMORY_DESCRIPTOR
 **/
 STATIC
 VOID
 FilterMemoryMapAttributes (
-  IN OUT UINTN                  *MemoryMapSize,
+  IN CONST UINTN                *MemoryMapSize,
   IN OUT EFI_MEMORY_DESCRIPTOR  *MemoryMap,
-  IN UINTN                      DescriptorSize
+  IN CONST UINTN                *DescriptorSize
   )
 {
   EFI_MEMORY_DESCRIPTOR  *MemoryMapEntry;
@@ -1621,7 +1615,7 @@ FilterMemoryMapAttributes (
 
   while (MemoryMapEntry < MemoryMapEnd) {
     MemoryMapEntry->Attribute &= EFI_MEMORY_ACCESS_MASK;
-    MemoryMapEntry             = NEXT_MEMORY_DESCRIPTOR (MemoryMapEntry, DescriptorSize);
+    MemoryMapEntry             = NEXT_MEMORY_DESCRIPTOR (MemoryMapEntry, *DescriptorSize);
   }
 }
 
@@ -1742,7 +1736,7 @@ GetMemoryMapWithPopulatedAccessAttributes (
   }
 
   // Filter each map entry to only contain access attributes
-  FilterMemoryMapAttributes (MemoryMapSize, *MemoryMap, *DescriptorSize);
+  FilterMemoryMapAttributes (MemoryMapSize, *MemoryMap, DescriptorSize);
 
   // |         |      |      |      |      |      |         |
   // | 4K PAGE | DATA | CODE | DATA | CODE | DATA | 4K PAGE |


### PR DESCRIPTION
## Description

The header description of FilterMemoryMapAttributes() was incorrect and the parameters which shouldn't be changed can be passed as CONST pointers.

## Breaking change?

No

## How This Was Tested

Booting to shell

## Integration Instructions

N/A
