### PR TITLE
update conf templates to enable map generation 

### DIFF
--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -282,7 +282,7 @@
 
     <Command>
         $(CARGO) rustc $(CARGO_FLAGS) --manifest-path ${s_path}(+)Cargo.toml -Z unstable-options --target-dir $(CARGO_OUTPUT_DIR) --timings=html
-        $(CP) $(OUTPUT_DIR)(+)x86_64-unknown-uefi(+)$(TARGET)(+)*.a $(OUTPUT_DIR)(+)${s_dir}(+)$(MODULE_NAME)rust.lib
+        $(CP) $(CARGO_BINDIR)(+)*.a $(OUTPUT_DIR)(+)$(MODULE_NAME)rust.lib
 
 [Toml-File.RUST_MODULE]
     <InputFile>
@@ -295,7 +295,7 @@
         # Temporary_Rust_Todo - Remove .efi files to better support Rust incremental build for now.
         $(RM) $(OUTPUT_DIR)(+)*.efi
         $(CARGO) rustc $(CARGO_FLAGS) --bins --manifest-path ${src} -Z unstable-options --target-dir $(CARGO_OUTPUT_DIR) --timings=html -- -C link-arg=/MAP:$(OUTPUT_DIR)(+)$(MODULE_NAME).map
-        $(CP) $(OUTPUT_DIR)(+)x86_64-unknown-uefi(+)$(TARGET)(+)*.efi $(OUTPUT_DIR)(+)$(MODULE_NAME).efi
+        $(CP) $(CARGO_BINDIR)(+)*.efi $(OUTPUT_DIR)(+)$(MODULE_NAME).efi
         $(CP) $(OUTPUT_DIR)(+)$(MODULE_NAME).efi $(BIN_DIR)(+)$(MODULE_NAME).efi
 
 [Device-Tree-Source-File]

--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -3465,20 +3465,33 @@ RELEASE_RVCTCYGWIN_ARM_CC_FLAGS  = "$(CCPATH_FLAG)" $(ARCHCC_FLAGS) $(PLATFORM_F
 ##################
 # RUSTC definitions
 ##################
+*_*_X64_TARGET_TRIPLE = x86_64-unknown-uefi
+*_*_IA32_TARGET_TRIPLE = i686-unknown-uefi
+
 *_*_*_RUSTC_PATH            = rustc
-DEBUG_*_X64_RUSTC_FLAGS     = --edition=2018 --target x86_64-unknown-uefi -C debuginfo=2 --crate-type staticlib
-RELEASE_*_X64_RUSTC_FLAGS   = --edition=2018 --target x86_64-unknown-uefi -C debuginfo=3 --crate-type staticlib
-DEBUG_*_IA32_RUSTC_FLAGS    = --edition=2018 --target i686-unknown-uefi -C debuginfo=2 --crate-type staticlib
-RELEASE_*_IA32_RUSTC_FLAGS  = --edition=2018 --target i686-unknown-uefi -C debuginfo=2 --crate-type staticlib
+DEBUG_*_X64_RUSTC_FLAGS     = --edition=2018 --target $(TARGET_TRIPLE) -C debuginfo=2 --crate-type staticlib
+RELEASE_*_X64_RUSTC_FLAGS   = --edition=2018 --target $(TARGET_TRIPLE) -C debuginfo=3 --crate-type staticlib
+DEBUG_*_IA32_RUSTC_FLAGS    = --edition=2018 --target $(TARGET_TRIPLE) -C debuginfo=2 --crate-type staticlib
+RELEASE_*_IA32_RUSTC_FLAGS  = --edition=2018 --target $(TARGET_TRIPLE) -C debuginfo=2 --crate-type staticlib
+
+# The path to where cargo generated binaries are placed (.efi, .a, .d,)
+DEBUG_VS2019_*_CARGO_BINDIR    = $(OUTPUT_DIR)\$(TARGET_TRIPLE)\debug
+RELEASE_VS2019_*_CARGO_BINDIR  = $(OUTPUT_DIR)\$(TARGET_TRIPLE)\release
+
+DEBUG_VS2022_*_CARGO_BINDIR    = $(OUTPUT_DIR)\$(TARGET_TRIPLE)\debug
+RELEASE_VS2022_*_CARGO_BINDIR  = $(OUTPUT_DIR)\$(TARGET_TRIPLE)\release
+
+DEBUG_GCC5_*_CARGO_BINDIR    = $(OUTPUT_DIR)/$(TARGET_TRIPLE)/debug
+RELEASE_GCC5_*_CARGO_BINDIR  = $(OUTPUT_DIR)/$(TARGET_TRIPLE)/release
 
 ##################
 # CARGO definitions
 ##################
 *_*_*_CARGO_PATH            = cargo
-DEBUG_*_X64_CARGO_FLAGS     = --target x86_64-unknown-uefi
-RELEASE_*_X64_CARGO_FLAGS   = --target x86_64-unknown-uefi --release
-DEBUG_*_IA32_CARGO_FLAGS    = --target i686-unknown-uefi
-RELEASE_*_IA32_CARGO_FLAGS  = --target i686-unknown-uefi   --release
+DEBUG_*_X64_CARGO_FLAGS     = --target $(TARGET_TRIPLE)
+RELEASE_*_X64_CARGO_FLAGS   = --target $(TARGET_TRIPLE) --release
+DEBUG_*_IA32_CARGO_FLAGS    = --target $(TARGET_TRIPLE)
+RELEASE_*_IA32_CARGO_FLAGS  = --target $(TARGET_TRIPLE) --release
 
 *_*_*_CARGOBUILD_NAME	= build
 


### PR DESCRIPTION
## Description

Update conf Templates to enable map generation on for both windows and ubuntu (VS and GCC) for cargo compiled binaries.

## Breaking change?
No

## How This Was Tested

Confirmed map generation on both unbuntu and windows builds.

## Integration Instructions
N/A
