### PR TITLE
Add Logic to Support Special Region Exceptions

### DIFF
--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -1931,6 +1931,7 @@ SeparateImagesInMemoryMap (
 
   @retval         EFI_SUCCESS                     Memory map has been split
   @retval         EFI_NOT_FOUND                   Unable to find a special region
+  @retval         EFI_INVALID_PARAMETER           An input was NULL
 **/
 STATIC
 EFI_STATUS
@@ -1946,6 +1947,13 @@ SeparateSpecialRegionsInMemoryMap (
   LIST_ENTRY                                   *SpecialRegionEntryLink;
   MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY  *SpecialRegionEntry;
   UINTN                                        SpecialRegionStart, SpecialRegionEnd, MapEntryStart, MapEntryEnd;
+
+  if ((MemoryMapSize == NULL) || (MemoryMap == NULL) ||
+      (DescriptorSize == NULL) || (BufferSize == NULL) ||
+      (SpecialRegionList == NULL))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
 
   MemoryMapEntry = MemoryMap;
   MemoryMapEnd   = (EFI_MEMORY_DESCRIPTOR *)((UINT8 *)MemoryMap + *MemoryMapSize);

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -1968,15 +1968,15 @@ SeparateSpecialRegionsInMemoryMap (
                            MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY_SIGNATURE
                            );
 
-    SpecialRegionStart = SpecialRegionEntry->SpecialRegion.Start;
-    SpecialRegionEnd   = SpecialRegionEntry->SpecialRegion.Start + SpecialRegionEntry->SpecialRegion.Length;
+    SpecialRegionStart = (UINTN)SpecialRegionEntry->SpecialRegion.Start;
+    SpecialRegionEnd   = (UINTN)SpecialRegionEntry->SpecialRegion.Start + (UINTN)SpecialRegionEntry->SpecialRegion.Length;
 
     while ((MemoryMapEntry < MemoryMapEnd) &&
            (SpecialRegionStart < SpecialRegionEnd) &&
            (((UINTN)MapEntryInsert + *DescriptorSize) > *BufferSize))
     {
-      MapEntryStart = MemoryMapEntry->PhysicalStart;
-      MapEntryEnd   = MemoryMapEntry->PhysicalStart + EFI_PAGES_TO_SIZE (MemoryMapEntry->NumberOfPages);
+      MapEntryStart = (UINTN)MemoryMapEntry->PhysicalStart;
+      MapEntryEnd   = (UINTN)MemoryMapEntry->PhysicalStart + (UINTN)EFI_PAGES_TO_SIZE (MemoryMapEntry->NumberOfPages);
       if ((MapEntryStart <= SpecialRegionStart) && (MapEntryEnd >= SpecialRegionStart)) {
         // Check if some portion of the map entry isn't covered by the special region
         if (MapEntryStart != SpecialRegionStart) {
@@ -2047,7 +2047,7 @@ SeparateSpecialRegionsInMemoryMap (
   }
 
   // if we've created new records, sort the map
-  if (MapEntryInsert > MapEntryEnd) {
+  if ((UINTN)MapEntryInsert > (UINTN)MapEntryEnd) {
     // Sort from low to high
     SortMemoryMap (
       MemoryMap,
@@ -2240,12 +2240,12 @@ RemoveAttributesOfNonProtectedImageRanges (
                                 IMAGE_PROPERTIES_RECORD_SIGNATURE
                                 );
 
-    NonProtectedStart = NonProtectedImageRecord->ImageBase;
-    NonProtectedEnd   = NonProtectedImageRecord->ImageBase + NonProtectedImageRecord->ImageSize;
+    NonProtectedStart = (UINTN)NonProtectedImageRecord->ImageBase;
+    NonProtectedEnd   = (UINTN)NonProtectedImageRecord->ImageBase + (UINTN)NonProtectedImageRecord->ImageSize;
 
     while ((MemoryMapEntry < MemoryMapEnd) && (NonProtectedStart < NonProtectedEnd)) {
-      MapEntryStart = MemoryMapEntry->PhysicalStart;
-      MapEntryEnd   = MemoryMapEntry->PhysicalStart +  EFI_PAGES_TO_SIZE (MemoryMapEntry->NumberOfPages);
+      MapEntryStart = (UINTN)MemoryMapEntry->PhysicalStart;
+      MapEntryEnd   = (UINTN)MemoryMapEntry->PhysicalStart +  (UINTN)EFI_PAGES_TO_SIZE (MemoryMapEntry->NumberOfPages);
 
       if ((NonProtectedStart == MapEntryStart)) {
         if (MemoryMapEntry->VirtualStart != SPECIAL_REGION_PATTERN) {

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -1917,7 +1917,7 @@ SeparateImagesInMemoryMap (
 
 /**
   Split memory map descriptors based on the input special region list. After the function, one or more memory map
-  descriptors will divide evenly into every special region so attributes can be targetted at those regions. Every
+  descriptors will divide evenly into every special region so attributes can be targeted at those regions. Every
   descriptor covered by a special region will have its virtual address set to SPECIAL_REGION_PATTERN.
 
   @param[in, out] MemoryMapSize                   IN:   The size, in bytes, of the old memory map before the split
@@ -1926,14 +1926,13 @@ SeparateImagesInMemoryMap (
   @param[in, out] MemoryMap                       IN:   A pointer to the buffer containing a sorted memory map
                                                   OUT:  A pointer to the updated memory map
   @param[in]      DescriptorSize                  The size, in bytes, of an individual EFI_MEMORY_DESCRIPTOR
-  @param[in]      ExpandedMemMapSize              The size, in bytes, of the full memory map buffer
+  @param[in]      BufferSize                      The size, in bytes, of the full memory map buffer
   @param[in]      SpecialRegionList               List of special regions to separate
 
   @retval         EFI_SUCCESS                     Memory map has been split
   @retval         EFI_NOT_FOUND                   Unable to find a special region
   @retval         EFI_INVALID_PARAMETER           An input was NULL
 **/
-STATIC
 EFI_STATUS
 SeparateSpecialRegionsInMemoryMap (
   IN OUT      UINTN                  *MemoryMapSize,
@@ -1990,7 +1989,7 @@ SeparateSpecialRegionsInMemoryMap (
           MapEntryInsert->Attribute = MemoryMapEntry->Attribute;
 
           // Update this descriptor to start at the special region start
-          MemoryMapEntry->NumberOfPages -= MapEntryInsert->NumberOfPages; // BEEBE TODO: Underflow cases?
+          MemoryMapEntry->NumberOfPages -= MapEntryInsert->NumberOfPages;
           MemoryMapEntry->PhysicalStart  = SpecialRegionStart;
           MapEntryStart                  = SpecialRegionStart;
 


### PR DESCRIPTION
## Description

Add logic to update the memory map attributes based on special memory regions when calling GetMemoryMapWithPopulatedAccessAttributes(). This will enable platforms to specify regions of memory which require special attributes.

## Breaking change?
No

## How This Was Tested

Booting to shell with special regions, a mix of protected and unprotected images, and debug memory protections

## Integration Instructions

N/A
