### PR TITLE
Fix Incorrect Variable Check in SeparateSpecialRegionsInMemoryMap()

### DIFF
--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -2046,7 +2046,7 @@ SeparateSpecialRegionsInMemoryMap (
   }
 
   // if we've created new records, sort the map
-  if ((UINTN)MapEntryInsert > (UINTN)MapEntryEnd) {
+  if ((UINTN)MapEntryInsert > (UINTN)MemoryMapEnd) {
     // Sort from low to high
     SortMemoryMap (
       MemoryMap,


### PR DESCRIPTION
## Description

The variable used to check if we added entries to the memory map should be MemoryMapEnd, not MapEntryEnd.

## Breaking change?
No

## How This Was Tested

Testing special regions

## Integration Instructions

N/A
