### PR TITLE
Add Logic to Merge the Memory Map by Attributes

### DIFF
--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -2186,7 +2186,7 @@ SetAccessAttributesInMemoryMap (
 }
 
 /**
-  Merge continous memory map entries with the same attributes.
+  Merge contiguous memory map entries with the same attributes.
 
   @param  MemoryMap              A pointer to the memory map
   @param  MemoryMapSize          A pointer to the size, in bytes, of the
@@ -2207,6 +2207,10 @@ MergeMemoryMapByAttribute (
   UINT64                 MemoryBlockLength;
   EFI_MEMORY_DESCRIPTOR  *NewMemoryMapEntry;
   EFI_MEMORY_DESCRIPTOR  *NextMemoryMapEntry;
+
+  if ((MemoryMap == NULL) || (MemoryMapSize == NULL) || (DescriptorSize == NULL)) {
+    return;
+  }
 
   MemoryMapEntry    = MemoryMap;
   NewMemoryMapEntry = MemoryMap;


### PR DESCRIPTION
## Description

To reduce the number of calls to SetMemoryAttributes(), merge contiguous memory map entries by only attribute instead of by attribute and type.

## Breaking change?
No

## How This Was Tested

Inspecting the merge and booting with added protections

## Integration Instructions

N/A
