### PR TITLE
Add the Interrupt Entry Code to the Special Region List

### DIFF
--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeCpuExceptionHandlerLib.inf
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeCpuExceptionHandlerLib.inf
@@ -64,3 +64,10 @@
   DebugLib
   VmgExitLib
   DxeMemoryProtectionHobLib ## MU_CHANGE
+
+## MU_CHANGE START: Add protocol used for declaring regions of memory
+##                  which should have specific attributes applied during
+##                  memory protection initialization.
+[Protocols]
+  gMemoryProtectionSpecialRegionProtocolGuid
+# MU_CHANGE END

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeException.c
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeException.c
@@ -183,8 +183,8 @@ InitializeCpuInterruptHandlers (
                   );
   ASSERT (!EFI_ERROR (Status) && InterruptEntryCode != NULL);
 
-  ASSERT_EFI_ERROR (gBS->LocateProtocol (&gMemoryProtectionSpecialRegionProtocolGuid, NULL, (VOID **)&SpecialRegionProtocol));
-
+  Status = gBS->LocateProtocol (&gMemoryProtectionSpecialRegionProtocolGuid, NULL, (VOID **)&SpecialRegionProtocol);
+  ASSERT_EFI_ERROR (Status);
   // MU_CHANGE: Ensure this region has read-only applied during memory protection initialization
   if (SpecialRegionProtocol != NULL) {
     Status = SpecialRegionProtocol->AddSpecialRegion (

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeException.c
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeException.c
@@ -188,7 +188,7 @@ InitializeCpuInterruptHandlers (
   // MU_CHANGE: Ensure this region has read-only applied during memory protection initialization
   if (SpecialRegionProtocol != NULL) {
     Status = SpecialRegionProtocol->AddSpecialRegion (
-                                      (EFI_PHYSICAL_ADDRESS)InterruptEntryCode,
+                                      (EFI_PHYSICAL_ADDRESS)(UINTN)InterruptEntryCode,
                                       ALIGN_VALUE (TemplateMap.ExceptionStubHeaderSize * CPU_INTERRUPT_NUM, EFI_PAGE_SIZE),
                                       EFI_MEMORY_RO
                                       );

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeException.c
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeException.c
@@ -12,7 +12,8 @@
 #include <Library/MemoryAllocationLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 
-#include <Library/DxeMemoryProtectionHobLib.h> // MU_CHANGE
+#include <Library/DxeMemoryProtectionHobLib.h>              // MU_CHANGE
+#include <Protocol/MemoryProtectionSpecialRegionProtocol.h> // MU_CHANGE
 
 CONST UINTN  mDoFarReturnFlag = 0;
 
@@ -92,16 +93,17 @@ InitializeCpuInterruptHandlers (
   IN EFI_VECTOR_HANDOFF_INFO  *VectorInfo OPTIONAL
   )
 {
-  EFI_STATUS                      Status;
-  IA32_IDT_GATE_DESCRIPTOR        *IdtTable;
-  IA32_DESCRIPTOR                 IdtDescriptor;
-  UINTN                           IdtEntryCount;
-  EXCEPTION_HANDLER_TEMPLATE_MAP  TemplateMap;
-  UINTN                           Index;
-  UINTN                           InterruptEntry;
-  UINT8                           *InterruptEntryCode;
-  RESERVED_VECTORS_DATA           *ReservedVectors;
-  EFI_CPU_INTERRUPT_HANDLER       *ExternalInterruptHandler;
+  EFI_STATUS                                 Status;
+  IA32_IDT_GATE_DESCRIPTOR                   *IdtTable;
+  IA32_DESCRIPTOR                            IdtDescriptor;
+  UINTN                                      IdtEntryCount;
+  EXCEPTION_HANDLER_TEMPLATE_MAP             TemplateMap;
+  UINTN                                      Index;
+  UINTN                                      InterruptEntry;
+  UINT8                                      *InterruptEntryCode;
+  RESERVED_VECTORS_DATA                      *ReservedVectors;
+  EFI_CPU_INTERRUPT_HANDLER                  *ExternalInterruptHandler;
+  MEMORY_PROTECTION_SPECIAL_REGION_PROTOCOL  *SpecialRegionProtocol = NULL;
 
   // MU_CHANGE START: Update ReservedVectors allocation to be page instead of pool
   // Status = gBS->AllocatePool (
@@ -179,8 +181,22 @@ InitializeCpuInterruptHandlers (
                   EFI_SIZE_TO_PAGES (TemplateMap.ExceptionStubHeaderSize * CPU_INTERRUPT_NUM),
                   (EFI_PHYSICAL_ADDRESS *)(UINTN)&InterruptEntryCode
                   );
-  // MU_CHANGE END
   ASSERT (!EFI_ERROR (Status) && InterruptEntryCode != NULL);
+
+  ASSERT_EFI_ERROR (gBS->LocateProtocol (&gMemoryProtectionSpecialRegionProtocolGuid, NULL, (VOID **)&SpecialRegionProtocol));
+
+  // MU_CHANGE: Ensure this region has read-only applied during memory protection initialization
+  if (SpecialRegionProtocol != NULL) {
+    Status = SpecialRegionProtocol->AddSpecialRegion (
+                                      (EFI_PHYSICAL_ADDRESS)InterruptEntryCode,
+                                      ALIGN_VALUE (TemplateMap.ExceptionStubHeaderSize * CPU_INTERRUPT_NUM, EFI_PAGE_SIZE),
+                                      EFI_MEMORY_RO
+                                      );
+
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  // MU_CHANGE END
 
   InterruptEntry = (UINTN)InterruptEntryCode;
   for (Index = 0; Index < CPU_INTERRUPT_NUM; Index++) {


### PR DESCRIPTION
## Description

The interrupt entry code should have RO applied, but if attributes are applied based on the memory type then NX would be applied. Adding the range to the special region list will result in RO being applied during memory protection initialization.

## Breaking change?
No

## How This Was Tested

Booting to Windows

## Integration Instructions

N/A
