### PR TITLE
Generalize List Functions in MemoryProtectionSupport

### DIFF
--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -276,7 +276,7 @@ extern LIST_ENTRY  mGcdMemorySpaceMap;
   @param[in] EntryToInsert              Pointer to the list entry to insert into List
   @param[in] ComparisonOffset           Offset of the field to compare each list entry against relative to the
                                         list entry pointer
-  @param[in] ComparisonOffset           Offset of the signature to compare each list entry against relative to the
+  @param[in] SignatureOffset            Offset of the signature to compare each list entry against relative to the
                                         list entry pointer
   @param[in] Signature                  Signature to compare for each list entry. If this is zero, no signature check
                                         will be performed
@@ -346,7 +346,7 @@ OrderedInsertUint64Comparison (
                                               into the input List
   @param[in] ComparisonOffset                 Offset of the field to compare each list entry against relative to the
                                               list entry pointer
-  @param[in] ComparisonOffset                 Offset of the signature to compare each list entry against relative to the
+  @param[in] SignatureOffset                  Offset of the signature to compare each list entry against relative to the
                                               list entry pointer
   @param[in] Signature                        Signature to compare for each list entry. If this is zero,
                                               no signature check will be performed
@@ -412,7 +412,7 @@ OrderedInsertArrayUint64Comparison (
                                               LIST_ENTRY* merged into ListToMergeInto
   @param[in] ComparisonOffset                 Offset of the field to compare each list entry against relative to the
                                               list entry pointer
-  @param[in] ComparisonOffset                 Offset of the signature to compare each list entry against relative to the
+  @param[in] SignatureOffset                  Offset of the signature to compare each list entry against relative to the
                                               list entry pointer
   @param[in] Signature                        Signature to compare for each list entry. If this is zero,
                                               no signature check will be performed

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -282,8 +282,7 @@ extern LIST_ENTRY  mGcdMemorySpaceMap;
                                         will be performed
 
   @retval EFI_SUCCESS                   EntryToInsert was inserted into List
-  @retval EFI_INVALID_PARAMETER         ImageRecordList or ImageRecordToInsertLink were NULL, or a signature
-                                        check failed
+  @retval EFI_INVALID_PARAMETER         List or EntryToInsert were NULL, or a signature check failed
 **/
 STATIC
 EFI_STATUS

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -591,14 +591,7 @@ CollectSpecialRegionHobs (
     NewSpecialRegion->SpecialRegion.Length        = ALIGN_VALUE (HobSpecialRegion->Length, EFI_PAGE_SIZE);
     NewSpecialRegion->SpecialRegion.EfiAttributes = HobSpecialRegion->EfiAttributes & EFI_MEMORY_ACCESS_MASK;
     NewSpecialRegion->Signature                   = MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY_SIGNATURE;
-
-    OrderedInsertUint64Comparison (
-      &mSpecialMemoryRegionsPrivate.SpecialRegionList,
-      &NewSpecialRegion->Link,
-      OFFSET_OF (MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY, SpecialRegion) + OFFSET_OF (MEMORY_PROTECTION_SPECIAL_REGION, Start) - OFFSET_OF (MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY, Link),
-      OFFSET_OF (MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY, Signature) - OFFSET_OF (MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY, Link),
-      MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY_SIGNATURE
-      );
+    InsertHeadList (&mSpecialMemoryRegionsPrivate.SpecialRegionList, &NewSpecialRegion->Link);
     mSpecialMemoryRegionsPrivate.Count++;
 
     GuidHob = GetNextGuidHob (&gMemoryProtectionSpecialRegionHobGuid, GET_NEXT_HOB (GuidHob));
@@ -718,13 +711,7 @@ AddSpecialRegion (
   SpecialRegionEntry->SpecialRegion.Start         = ALIGN_ADDRESS (Start);
   SpecialRegionEntry->SpecialRegion.Length        = ALIGN_VALUE (Length, EFI_PAGE_SIZE);
   SpecialRegionEntry->SpecialRegion.EfiAttributes = Attributes & EFI_MEMORY_ACCESS_MASK;
-  OrderedInsertUint64Comparison (
-    &mSpecialMemoryRegionsPrivate.SpecialRegionList,
-    &SpecialRegionEntry->Link,
-    OFFSET_OF (MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY, SpecialRegion) + OFFSET_OF (MEMORY_PROTECTION_SPECIAL_REGION, Start) - OFFSET_OF (MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY, Link),
-    OFFSET_OF (MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY, Signature) - OFFSET_OF (MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY, Link),
-    MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY_SIGNATURE
-    );
+  InsertTailList (&mSpecialMemoryRegionsPrivate.SpecialRegionList, &SpecialRegionEntry->Link);
   mSpecialMemoryRegionsPrivate.Count++;
 
   return EFI_SUCCESS;


### PR DESCRIPTION
## Description

Instead of making multiple ordered insert functions for each type containing the input list entry pointer, inserts can be done generically by the type being compared and the offsets of the relevant signature and value being compared. This PR updates the OrderedInsert, MergeList, and OrderedInsertArray functions to be agnostic to the struct type containing the list entry provided the struct contains at least the value which is being compared.

This PR also updates the interface of what was MergeImagePropertiesRecordLists() and is now MergeListsUint64Comparison() to be passed a triple pointer so the array can be allocated within the function instead of requiring the allocation to occur before the function call.

## Breaking change?
No

## How This Was Tested

Comparing the function output against the previous behavior

## Integration Instructions

N/A
