### PR TITLE
Check Page Table on Protection Policy Application

### DIFF
--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
@@ -1564,7 +1564,7 @@ ApplyMemoryProtectionPolicy (
     Status = MemoryAttributeProtocol->GetMemoryAttributes (
                                         MemoryAttributeProtocol,
                                         Memory,
-                                        EFI_SIZE_TO_PAGES (Length),
+                                        Length,
                                         &OldAttributes
                                         );
 

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
@@ -1485,8 +1485,6 @@ ApplyMemoryProtectionPolicy (
   UINT64  OldAttributes;
   UINT64  NewAttributes;
 
-  EFI_STATUS  Status; // MU_CHANGE
-
   //
   // The policy configured in Dxe NX Protection Policy // MU_CHANGE
   // does not apply to allocations performed in SMM mode.
@@ -1561,14 +1559,9 @@ ApplyMemoryProtectionPolicy (
   // attributes from the page table to see if they are consistent. If they are not consistent,
   // GetMemoryAttributes() will return an error.
   if (MemoryAttributeProtocol != NULL) {
-    Status = MemoryAttributeProtocol->GetMemoryAttributes (
-                                        MemoryAttributeProtocol,
-                                        Memory,
-                                        Length,
-                                        &OldAttributes
-                                        );
-
-    if (!EFI_ERROR (Status) && (OldAttributes == NewAttributes)) {
+    if (!EFI_ERROR (MemoryAttributeProtocol->GetMemoryAttributes (MemoryAttributeProtocol, Memory, Length, &OldAttributes)) &&
+        (OldAttributes == NewAttributes))
+    {
       return EFI_SUCCESS;
     }
   }


### PR DESCRIPTION
## Description

This update checks the page table before calling SetMemoryAttributes() to avoid a TLB and cache flush if it's unnecessary. A subtle and unresolved bug can cause the pages being allocated/freed to not have consistent attributes which can cause unpredictable issues. Instead of calling SetMemoryAttributes() on every allocate and free, check the page table to see if the attributes across the region are consistent and the call to SetMemoryAttributes() is necessary. This update will reap similar performance benefits to the same call we added in CoreInternalFreePages() because the number of times where we actually need to call SetMemoryAttributes() is small and branch prediction will expedite the most common result.

## Breaking change?

No

## How This Was Tested

Booting to shell

## Integration Instructions

N/A
