### PR TITLE
Handle Special Region Overlap

### DIFF
--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -517,7 +517,7 @@ MergeOverlappingSpecialRegions (
   IN LIST_ENTRY  *SpecialRegionList
   )
 {
-  LIST_ENTRY                                   *BackLink, *ForwardLink, *TempLink;
+  LIST_ENTRY                                   *BackLink, *ForwardLink;
   MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY  *BackEntry, *ForwardEntry, *NewEntry;
   EFI_PHYSICAL_ADDRESS                         BackStart, BackEnd, ForwardStart, ForwardEnd;
 
@@ -555,11 +555,9 @@ MergeOverlappingSpecialRegions (
         // If the attributes are the same between both entries, just expand BackEntry and delete ForwardEntry
         if (BackEntry->SpecialRegion.EfiAttributes == ForwardEntry->SpecialRegion.EfiAttributes) {
           BackEntry->SpecialRegion.Length = ForwardEnd - BackStart;
-          TempLink                        = ForwardLink;
-          ForwardLink                     = ForwardLink->ForwardLink;
-          RemoveEntryList (TempLink);
+          ForwardLink                     = ForwardLink->BackLink;
+          RemoveEntryList (ForwardLink->ForwardLink);
           FreePool (ForwardEntry);
-          continue;
         }
         // If BackEntry subsumes ForwardEntry, we need to create a new list entry to split BackEntry
         else if (CHECK_SUBSUMPTION (BackStart, BackEnd, ForwardStart, ForwardEnd)) {

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -51,6 +51,18 @@ EFI_MEMORY_ATTRIBUTE_PROTOCOL  *MemoryAttributeProtocol = NULL;
 
 #define SPECIAL_REGION_PATTERN  7732426 // 7-(S) 7-(P) 3-(E) 2-(C) 4-(I) 2-(A) 6-(L)
 
+// TRUE if A and B have overlapping intervals
+#define CHECK_OVERLAP(AStart, AEnd, BStart, BEnd) \
+  ((AStart <= BStart && AEnd > BStart) || \
+  (BStart <= AStart && BEnd > AStart))
+
+// TRUE if A interval subsumes B interval
+#define CHECK_SUBSUMPTION(AStart, AEnd, BStart, BEnd) \
+  ((AStart < BStart) && (AEnd > BEnd))
+
+// TRUE if A is a subset of B
+#define CHECK_SUBSET(A, B)  ((A | B) == B)
+
 /**
   Swap two image records.
 
@@ -491,6 +503,164 @@ MergeListsUint64Comparison (
 // ---------------------------------------
 
 /**
+  Walk through the input special region list to combine overlapping intervals.
+
+  @param[in]  SpecialRegionList      Pointer to the head of the list
+
+  @retval     EFI_INVALID_PARAMTER  SpecialRegionList was NULL
+  @retval     EFI_OUT_OF_RESOURCES  Failed to allocate memory
+  @retval     EFI_SUCCESS           Input special region list was merged
+**/
+STATIC
+EFI_STATUS
+MergeOverlappingSpecialRegions (
+  IN LIST_ENTRY  *SpecialRegionList
+  )
+{
+  LIST_ENTRY                                   *BackLink, *ForwardLink;
+  MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY  *BackEntry, *ForwardEntry, *NewEntry;
+  EFI_PHYSICAL_ADDRESS                         BackStart, BackEnd, ForwardStart, ForwardEnd;
+
+  if (SpecialRegionList == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  BackLink = SpecialRegionList->ForwardLink;
+
+  while (BackLink != SpecialRegionList) {
+    BackEntry = CR (
+                  BackLink,
+                  MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY,
+                  Link,
+                  MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY_SIGNATURE
+                  );
+
+    BackStart = BackEntry->SpecialRegion.Start;
+    BackEnd   = BackEntry->SpecialRegion.Start + BackEntry->SpecialRegion.Length;
+
+    ForwardLink = BackLink->ForwardLink;
+    while (ForwardLink != SpecialRegionList) {
+      ForwardEntry = CR (
+                       ForwardLink,
+                       MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY,
+                       Link,
+                       MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY_SIGNATURE
+                       );
+
+      ForwardStart = ForwardEntry->SpecialRegion.Start;
+      ForwardEnd   = ForwardEntry->SpecialRegion.Start + ForwardEntry->SpecialRegion.Length;
+
+      // If BackEntry and ForwardEntry overlap
+      if (CHECK_OVERLAP (BackStart, BackEnd, ForwardStart, ForwardEnd)) {
+        // If the attributes are the same between both entries, just expand BackEntry and delete ForwardEntry
+        if (BackEntry->SpecialRegion.EfiAttributes == ForwardEntry->SpecialRegion.EfiAttributes) {
+          BackEntry->SpecialRegion.Length = ForwardEnd - BackStart;
+          RemoveEntryList (ForwardLink);
+          FreePool (ForwardEntry);
+        }
+        // If BackEntry subsumes ForwardEntry, we need to create a new list entry to split BackEntry
+        else if (CHECK_SUBSUMPTION (BackStart, BackEnd, ForwardStart, ForwardEnd)) {
+          NewEntry = AllocatePool (sizeof (MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY));
+
+          if (NewEntry == NULL) {
+            return EFI_OUT_OF_RESOURCES;
+          }
+
+          BackEntry->SpecialRegion.Length = ForwardStart - BackStart;
+          InitializeListHead (&NewEntry->Link);
+          NewEntry->Signature                   = MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY_SIGNATURE;
+          NewEntry->SpecialRegion.EfiAttributes = BackEntry->SpecialRegion.EfiAttributes;
+          NewEntry->SpecialRegion.Start         = ForwardEnd;
+          NewEntry->SpecialRegion.Length        = BackEnd - ForwardEnd;
+          OrderedInsertUint64Comparison (
+            SpecialRegionList,
+            &NewEntry->Link,
+            OFFSET_OF (MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY, SpecialRegion) + OFFSET_OF (MEMORY_PROTECTION_SPECIAL_REGION, Start) - OFFSET_OF (MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY, Link),
+            OFFSET_OF (MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY, Signature) - OFFSET_OF (MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY, Link),
+            MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY_SIGNATURE
+            );
+
+          ForwardLink = &NewEntry->Link;
+          break;
+        }
+        // If BackEntry does not subsume FrontEntry, we can trim each entry
+        //
+        // If ForwardEntry has more strict attributes, trim BackEntry
+        else if (CHECK_SUBSET (BackEntry->SpecialRegion.EfiAttributes, ForwardEntry->SpecialRegion.EfiAttributes)) {
+          BackEntry->SpecialRegion.Length = ForwardStart - BackStart;
+        }
+        // If BackEntry has more strict attributes, trim ForwardEntry
+        else {
+          ForwardEntry->SpecialRegion.Start = BackEnd;
+        }
+      } else {
+        // No overlap
+        break;
+      }
+
+      ForwardLink = ForwardLink->ForwardLink;
+    }
+
+    BackLink    = ForwardLink;
+    ForwardLink = BackLink->ForwardLink;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Check if the input SpecialRegion conflicts with any special regions in the input SpecialRegionList. SpecialRegion
+  conflicts if the interval overlaps with another interval in SpecialRegionList AND the attributes of
+  SpecialRegion are not a subset of the attributes of the region with which it overlaps.
+
+  @param[in]  SpecialRegion       The special region to check against all special regions in SpecialRegionList
+  @param[in]  SpecialRegionList   The list of special regions to check against the input SpecialRegion
+
+  @retval     TRUE                SpecialRegion conflicts with a special region in SpecialRegionList
+  @retval     FALSE               SpecialRegion does not conflict with a special region in SpecialRegionList
+**/
+STATIC
+BOOLEAN
+DoesSpecialRegionConflict (
+  IN MEMORY_PROTECTION_SPECIAL_REGION  *SpecialRegion,
+  IN LIST_ENTRY                        *SpecialRegionList
+  )
+{
+  LIST_ENTRY                                   *SpecialRegionListLink;
+  MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY  *SpecialRegionListEntry;
+  BOOLEAN                                      OverlapCheck, SubsetCheck;
+  EFI_PHYSICAL_ADDRESS                         InputStart, InputEnd, ListEntryStart, ListEntryEnd;
+
+  InputStart = SpecialRegion->Start;
+  InputEnd   = SpecialRegion->Start + SpecialRegion->Length;
+
+  SpecialRegionListLink = SpecialRegionList->ForwardLink;
+
+  while (SpecialRegionListLink != SpecialRegionList) {
+    SpecialRegionListEntry = CR (
+                               SpecialRegionListLink,
+                               MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY,
+                               Link,
+                               MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY_SIGNATURE
+                               );
+
+    ListEntryStart = SpecialRegionListEntry->SpecialRegion.Start;
+    ListEntryEnd   = SpecialRegionListEntry->SpecialRegion.Start + SpecialRegionListEntry->SpecialRegion.Length;
+
+    OverlapCheck = CHECK_OVERLAP (InputStart, InputEnd, ListEntryStart, ListEntryEnd);
+    SubsetCheck  = CHECK_SUBSET (SpecialRegion->EfiAttributes, SpecialRegionListEntry->SpecialRegion.EfiAttributes);
+
+    if (OverlapCheck && !SubsetCheck) {
+      return TRUE;
+    }
+
+    SpecialRegionListLink = SpecialRegionListLink->ForwardLink;
+  }
+
+  return FALSE;
+}
+
+/**
   Copy the HOB MEMORY_PROTECTION_SPECIAL_REGION entries into a local list
 
   @retval EFI_SUCCESS           HOB Entries successfully copied
@@ -502,15 +672,30 @@ CollectSpecialRegionHobs (
   VOID
   )
 {
-  EFI_HOB_GUID_TYPE                            *GuidHob          = NULL;
-  MEMORY_PROTECTION_SPECIAL_REGION             *HobSpecialRegion = NULL;
-  MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY  *NewSpecialRegion = NULL;
+  EFI_HOB_GUID_TYPE                            *GuidHob                  = NULL;
+  MEMORY_PROTECTION_SPECIAL_REGION             *HobSpecialRegion         = NULL;
+  MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY  *NewSpecialRegion         = NULL;
+  MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY  *OverlappingSpecialRegion = NULL;
 
   GuidHob = GetFirstGuidHob (&gMemoryProtectionSpecialRegionHobGuid);
 
   while (GuidHob != NULL) {
-    HobSpecialRegion = (MEMORY_PROTECTION_SPECIAL_REGION *)GET_GUID_HOB_DATA (GuidHob);
-    NewSpecialRegion = AllocateCopyPool (sizeof (MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY), HobSpecialRegion);
+    HobSpecialRegion         = (MEMORY_PROTECTION_SPECIAL_REGION *)GET_GUID_HOB_DATA (GuidHob);
+    OverlappingSpecialRegion = NULL;
+    if (DoesSpecialRegionConflict (HobSpecialRegion, &mSpecialMemoryRegionsPrivate.SpecialRegionList)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a - Special region 0x%llx - 0x%llx conflicts with another special region!\n",
+        __FUNCTION__,
+        HobSpecialRegion->Start,
+        HobSpecialRegion->Start + HobSpecialRegion->Length
+        ));
+      ASSERT (FALSE);
+      GuidHob = GetNextGuidHob (&gMemoryProtectionSpecialRegionHobGuid, GET_NEXT_HOB (GuidHob));
+      continue;
+    }
+
+    NewSpecialRegion = AllocatePool (sizeof (MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY));
 
     if (NewSpecialRegion == NULL) {
       DEBUG ((
@@ -536,6 +721,8 @@ CollectSpecialRegionHobs (
 
     GuidHob = GetNextGuidHob (&gMemoryProtectionSpecialRegionHobGuid, GET_NEXT_HOB (GuidHob));
   }
+
+  MergeOverlappingSpecialRegions (&mSpecialMemoryRegionsPrivate.SpecialRegionList);
 
   return EFI_SUCCESS;
 }
@@ -622,7 +809,8 @@ GetSpecialRegions (
                                   and which should be active if the region was reported after initialization.
 
   @retval   EFI_SUCCESS           SpecialRegion was successfully added
-  @retval   EFI_INVALID_PARAMTER  Length is zero
+  @retval   EFI_INVALID_PARAMTER  Length is zero or the input region overlaps with an
+                                  existing special region
   @retval   EFI_OUT_OF_RESOURCES  Failed to allocate memory
 **/
 EFI_STATUS
@@ -649,6 +837,20 @@ AddSpecialRegion (
   SpecialRegionEntry->SpecialRegion.Start         = ALIGN_ADDRESS (Start);
   SpecialRegionEntry->SpecialRegion.Length        = ALIGN_VALUE (Length, EFI_PAGE_SIZE);
   SpecialRegionEntry->SpecialRegion.EfiAttributes = Attributes & EFI_MEMORY_ACCESS_MASK;
+
+  if (DoesSpecialRegionConflict (&SpecialRegionEntry->SpecialRegion, &mSpecialMemoryRegionsPrivate.SpecialRegionList)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a - Special region 0x%llx - 0x%llx conflicts with an existing special region!\n",
+      __FUNCTION__,
+      SpecialRegionEntry->SpecialRegion.Start,
+      SpecialRegionEntry->SpecialRegion.Start + SpecialRegionEntry->SpecialRegion.Length
+      ));
+    ASSERT (FALSE);
+    FreePool (SpecialRegionEntry);
+    return EFI_INVALID_PARAMETER;
+  }
+
   OrderedInsertUint64Comparison (
     &mSpecialMemoryRegionsPrivate.SpecialRegionList,
     &SpecialRegionEntry->Link,
@@ -657,6 +859,7 @@ AddSpecialRegion (
     MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY_SIGNATURE
     );
   mSpecialMemoryRegionsPrivate.Count++;
+  MergeOverlappingSpecialRegions (&mSpecialMemoryRegionsPrivate.SpecialRegionList);
 
   return EFI_SUCCESS;
 }

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -675,13 +675,11 @@ CollectSpecialRegionHobs (
   EFI_HOB_GUID_TYPE                            *GuidHob                  = NULL;
   MEMORY_PROTECTION_SPECIAL_REGION             *HobSpecialRegion         = NULL;
   MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY  *NewSpecialRegion         = NULL;
-  MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY  *OverlappingSpecialRegion = NULL;
 
   GuidHob = GetFirstGuidHob (&gMemoryProtectionSpecialRegionHobGuid);
 
   while (GuidHob != NULL) {
     HobSpecialRegion         = (MEMORY_PROTECTION_SPECIAL_REGION *)GET_GUID_HOB_DATA (GuidHob);
-    OverlappingSpecialRegion = NULL;
     if (DoesSpecialRegionConflict (HobSpecialRegion, &mSpecialMemoryRegionsPrivate.SpecialRegionList)) {
       DEBUG ((
         DEBUG_ERROR,

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -517,7 +517,7 @@ MergeOverlappingSpecialRegions (
   IN LIST_ENTRY  *SpecialRegionList
   )
 {
-  LIST_ENTRY                                   *BackLink, *ForwardLink;
+  LIST_ENTRY                                   *BackLink, *ForwardLink, *TempLink;
   MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY  *BackEntry, *ForwardEntry, *NewEntry;
   EFI_PHYSICAL_ADDRESS                         BackStart, BackEnd, ForwardStart, ForwardEnd;
 
@@ -555,8 +555,9 @@ MergeOverlappingSpecialRegions (
         // If the attributes are the same between both entries, just expand BackEntry and delete ForwardEntry
         if (BackEntry->SpecialRegion.EfiAttributes == ForwardEntry->SpecialRegion.EfiAttributes) {
           BackEntry->SpecialRegion.Length = ForwardEnd - BackStart;
+          TempLink                        = ForwardLink;
           ForwardLink                     = ForwardLink->ForwardLink;
-          RemoveEntryList (ForwardLink);
+          RemoveEntryList (TempLink);
           FreePool (ForwardEntry);
           continue;
         }

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -672,14 +672,14 @@ CollectSpecialRegionHobs (
   VOID
   )
 {
-  EFI_HOB_GUID_TYPE                            *GuidHob                  = NULL;
-  MEMORY_PROTECTION_SPECIAL_REGION             *HobSpecialRegion         = NULL;
-  MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY  *NewSpecialRegion         = NULL;
+  EFI_HOB_GUID_TYPE                            *GuidHob          = NULL;
+  MEMORY_PROTECTION_SPECIAL_REGION             *HobSpecialRegion = NULL;
+  MEMORY_PROTECTION_SPECIAL_REGION_LIST_ENTRY  *NewSpecialRegion = NULL;
 
   GuidHob = GetFirstGuidHob (&gMemoryProtectionSpecialRegionHobGuid);
 
   while (GuidHob != NULL) {
-    HobSpecialRegion         = (MEMORY_PROTECTION_SPECIAL_REGION *)GET_GUID_HOB_DATA (GuidHob);
+    HobSpecialRegion = (MEMORY_PROTECTION_SPECIAL_REGION *)GET_GUID_HOB_DATA (GuidHob);
     if (DoesSpecialRegionConflict (HobSpecialRegion, &mSpecialMemoryRegionsPrivate.SpecialRegionList)) {
       DEBUG ((
         DEBUG_ERROR,

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -609,7 +609,7 @@ MergeOverlappingSpecialRegions (
 }
 
 /**
-  Check if the input SpecialRegion conflicts with any special regions in the input SpecialRegionList. SpecialRegion
+  Check if the input SpecialRegion conflicts with any special regions in the input SpecialRegionList. The SpecialRegion
   conflicts if the interval overlaps with another interval in SpecialRegionList AND the attributes of
   SpecialRegion are not a subset of the attributes of the region with which it overlaps.
 


### PR DESCRIPTION
## Description

This update handles the case where a caller tries to add a special region which is partially or completely already present in the special region list. The overlapping special region will be allowed into the list if it does not conflict with the existing special regions. A special region conflicts if it overlaps with an existing interval and its attributes are not a subset of the attributes of the existing interval.

## Breaking change?
No

## How This Was Tested

Testing various interval combinations

## Integration Instructions

N/A
