### PR TITLE
Activate Improved Memory Protection Init Functionality

### DIFF
--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -2518,7 +2518,7 @@ GetMemoryMapWithPopulatedAccessAttributes (
   EFI_STATUS  Status;
   UINTN       AdditionalRecordCount, NumMemoryMapDescriptors, NumBitmapEntries, \
               NumMemorySpaceMapDescriptors, MemorySpaceMapDescriptorSize, MapKey, \
-              ExpandedMemoryMapSize, MemorySpaceMapSize, BitmapIndex;
+              ExpandedMemoryMapSize, BitmapIndex;
   UINT32                           DescriptorVersion;
   UINT8                            *Bitmap                    = NULL;
   EFI_MEMORY_DESCRIPTOR            *ExpandedMemoryMap         = NULL;
@@ -2580,7 +2580,6 @@ GetMemoryMapWithPopulatedAccessAttributes (
   }
 
   MemorySpaceMapDescriptorSize = sizeof (EFI_GCD_MEMORY_SPACE_DESCRIPTOR);
-  MemorySpaceMapSize           = sizeof (EFI_GCD_MEMORY_SPACE_DESCRIPTOR) * NumMemorySpaceMapDescriptors;
 
   // Fill in the memory map with regions described in the GCD memory map but not the EFI memory map
   Status = FillInMemoryMap (

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -2521,10 +2521,10 @@ GetMemoryMapWithPopulatedAccessAttributes (
               ExpandedMemoryMapSize, MemorySpaceMapSize, BitmapIndex;
   UINT32                           DescriptorVersion;
   UINT8                            *Bitmap                    = NULL;
-  EFI_MEMORY_DESCRIPTOR            *ExpandedMemMap            = NULL;
+  EFI_MEMORY_DESCRIPTOR            *ExpandedMemoryMap         = NULL;
   LIST_ENTRY                       *MergedImageList           = NULL;
   LIST_ENTRY                       **ArrayOfListEntryPointers = NULL;
-  EFI_GCD_MEMORY_SPACE_DESCRIPTOR  *MemSpaceMap               = NULL;
+  EFI_GCD_MEMORY_SPACE_DESCRIPTOR  *MemorySpaceMap            = NULL;
 
   if ((MemoryMapSize == NULL) || (MemoryMap == NULL) ||
       (*MemoryMap != NULL) || (DescriptorSize == NULL))
@@ -2572,7 +2572,7 @@ GetMemoryMapWithPopulatedAccessAttributes (
   // Filter each map entry to only contain access attributes
   FilterMemoryMapAttributes (MemoryMapSize, *MemoryMap, DescriptorSize);
 
-  Status = CoreGetMemorySpaceMap (&NumMemorySpaceMapDescriptors, &MemSpaceMap);
+  Status = CoreGetMemorySpaceMap (&NumMemorySpaceMapDescriptors, &MemorySpaceMap);
 
   if (EFI_ERROR (Status)) {
     ASSERT_EFI_ERROR (Status);
@@ -2588,7 +2588,7 @@ GetMemoryMapWithPopulatedAccessAttributes (
              MemoryMap,
              DescriptorSize,
              &NumMemorySpaceMapDescriptors,
-             MemSpaceMap,
+             MemorySpaceMap,
              &MemorySpaceMapDescriptorSize
              );
 
@@ -2620,18 +2620,18 @@ GetMemoryMapWithPopulatedAccessAttributes (
                           (mNonProtectedImageRangesPrivate.NonProtectedImageCount * 3);
 
   ExpandedMemoryMapSize = (*MemoryMapSize * 2) + ((*DescriptorSize) * AdditionalRecordCount);
-  ExpandedMemMap        = AllocatePool (ExpandedMemoryMapSize);
+  ExpandedMemoryMap     = AllocatePool (ExpandedMemoryMapSize);
 
-  if (ExpandedMemMap == NULL) {
+  if (ExpandedMemoryMap == NULL) {
     Status = EFI_OUT_OF_RESOURCES;
     ASSERT_EFI_ERROR (Status);
     goto Cleanup;
   }
 
-  CopyMem (ExpandedMemMap, *MemoryMap, *MemoryMapSize);
+  CopyMem (ExpandedMemoryMap, *MemoryMap, *MemoryMapSize);
   FreePool (*MemoryMap);
 
-  *MemoryMap = ExpandedMemMap;
+  *MemoryMap = ExpandedMemoryMap;
 
   DEBUG_CODE (
     DEBUG ((DEBUG_INFO, "---Currently Protected Images---\n"));

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -2592,10 +2592,7 @@ GetMemoryMapWithPopulatedAccessAttributes (
              &MemorySpaceMapDescriptorSize
              );
 
-  if (EFI_ERROR (Status)) {
-    ASSERT_EFI_ERROR (Status);
-    goto Cleanup;
-  }
+  ASSERT_EFI_ERROR (Status);
 
   // |         |      |      |      |      |      |         |
   // | 4K PAGE | DATA | CODE | DATA | CODE | DATA | 4K PAGE |
@@ -2721,11 +2718,8 @@ GetMemoryMapWithPopulatedAccessAttributes (
                OFFSET_OF (IMAGE_PROPERTIES_RECORD, Signature) - OFFSET_OF (IMAGE_PROPERTIES_RECORD, Link),
                IMAGE_PROPERTIES_RECORD_SIGNATURE
                );
-    if (EFI_ERROR (Status)) {
-      ASSERT_EFI_ERROR (Status);
-      goto Cleanup;
-    }
 
+    ASSERT_EFI_ERROR (Status);
     FreePool (ArrayOfListEntryPointers);
   }
 
@@ -2735,10 +2729,7 @@ GetMemoryMapWithPopulatedAccessAttributes (
   // Set the bits in the bitmap to mark that the corresponding memory descriptor
   // has been set based on the memory protection policy and special regions
   Status = SyncBitmap (MemoryMapSize, *MemoryMap, DescriptorSize, Bitmap);
-  if (EFI_ERROR (Status)) {
-    ASSERT_EFI_ERROR (Status);
-    goto Cleanup;
-  }
+  ASSERT_EFI_ERROR (Status);
 
   // Remove the access attributes from descriptors which correspond to nonprotected images
   if (mNonProtectedImageRangesPrivate.NonProtectedImageCount > 0) {
@@ -2757,10 +2748,7 @@ GetMemoryMapWithPopulatedAccessAttributes (
   // Set the access attributes of descriptor ranges which have not been checked
   // against our memory protection policy
   Status = SetAccessAttributesInMemoryMap (MemoryMapSize, *MemoryMap, DescriptorSize, Bitmap);
-  if (EFI_ERROR (Status)) {
-    ASSERT_EFI_ERROR (Status);
-    goto Cleanup;
-  }
+  ASSERT_EFI_ERROR (Status);
 
   DEBUG_CODE (
     DEBUG ((DEBUG_INFO, "---Final Bitmap---\n"));

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -2652,16 +2652,16 @@ GetMemoryMapWithPopulatedAccessAttributes (
   }
   // If both protected and non-protected images are loaded, merge the two lists
   else {
-    MergedImageList          = &mImagePropertiesPrivate.ImageRecordList;
-    Status = MergeListsUint64Comparison (
-               MergedImageList,
-               &mNonProtectedImageRangesPrivate.NonProtectedImageList,
-               &mNonProtectedImageRangesPrivate.NonProtectedImageCount,
-               &ArrayOfListEntryPointers,
-               OFFSET_OF (IMAGE_PROPERTIES_RECORD, ImageBase) - OFFSET_OF (IMAGE_PROPERTIES_RECORD, Link),
-               OFFSET_OF (IMAGE_PROPERTIES_RECORD, Signature) - OFFSET_OF (IMAGE_PROPERTIES_RECORD, Link),
-               IMAGE_PROPERTIES_RECORD_SIGNATURE
-               );
+    MergedImageList = &mImagePropertiesPrivate.ImageRecordList;
+    Status          = MergeListsUint64Comparison (
+                        MergedImageList,
+                        &mNonProtectedImageRangesPrivate.NonProtectedImageList,
+                        &mNonProtectedImageRangesPrivate.NonProtectedImageCount,
+                        &ArrayOfListEntryPointers,
+                        OFFSET_OF (IMAGE_PROPERTIES_RECORD, ImageBase) - OFFSET_OF (IMAGE_PROPERTIES_RECORD, Link),
+                        OFFSET_OF (IMAGE_PROPERTIES_RECORD, Signature) - OFFSET_OF (IMAGE_PROPERTIES_RECORD, Link),
+                        IMAGE_PROPERTIES_RECORD_SIGNATURE
+                        );
 
     if (EFI_ERROR (Status)) {
       ASSERT_EFI_ERROR (Status);

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -2505,7 +2505,7 @@ RemoveAttributesOfNonProtectedImageRanges (
 
   @retval         EFI_SUCCESS             The memory map was returned in the MemoryMap buffer
   @retval         EFI_OUT_OF_RESOURCES    Failed to allocate memory
-  @retval         Other                   One of the supportion functions failed
+  @retval         Other                   One of the supporting functions failed
 **/
 EFI_STATUS
 EFIAPI
@@ -2573,25 +2573,23 @@ GetMemoryMapWithPopulatedAccessAttributes (
   FilterMemoryMapAttributes (MemoryMapSize, *MemoryMap, DescriptorSize);
 
   Status = CoreGetMemorySpaceMap (&NumMemorySpaceMapDescriptors, &MemorySpaceMap);
-
-  if (EFI_ERROR (Status)) {
-    ASSERT_EFI_ERROR (Status);
-    goto Cleanup;
-  }
-
-  MemorySpaceMapDescriptorSize = sizeof (EFI_GCD_MEMORY_SPACE_DESCRIPTOR);
-
-  // Fill in the memory map with regions described in the GCD memory map but not the EFI memory map
-  Status = FillInMemoryMap (
-             MemoryMapSize,
-             MemoryMap,
-             DescriptorSize,
-             &NumMemorySpaceMapDescriptors,
-             MemorySpaceMap,
-             &MemorySpaceMapDescriptorSize
-             );
-
   ASSERT_EFI_ERROR (Status);
+
+  if (MemorySpaceMap != NULL) {
+    MemorySpaceMapDescriptorSize = sizeof (EFI_GCD_MEMORY_SPACE_DESCRIPTOR);
+
+    // Fill in the memory map with regions described in the GCD memory map but not the EFI memory map
+    Status = FillInMemoryMap (
+               MemoryMapSize,
+               MemoryMap,
+               DescriptorSize,
+               &NumMemorySpaceMapDescriptors,
+               MemorySpaceMap,
+               &MemorySpaceMapDescriptorSize
+               );
+
+    ASSERT_EFI_ERROR (Status);
+  }
 
   // |         |      |      |      |      |      |         |
   // | 4K PAGE | DATA | CODE | DATA | CODE | DATA | 4K PAGE |


### PR DESCRIPTION
## Description

This update activates all the added memory protection logic to ensure when the CPU architecture protocol is installed, we can create a clear understanding of the state of memory and maximize paging protections based on the memory protection policy for the boot.

## Breaking change?
Yes

## How This Was Tested

Booting to OS on Q35 using various memory protection configuration presets.

## Integration Instructions

Any platform which requires special permissions for a particular memory region will need to add a memory protection special region by either building a memory protection special region HOB in PEI or utilizing the memory protection special region protocol in DXE before the CPU architecture protocol is installed.

Here are some cases where you might want to create a special region:

1. You're using FSP API mode and need to thunk back into a 32-bit image which may have NX applied based on its memory type
2. You allocated memory in DXE before the CPU architecture protocol was installed and need that memory to have particular attributes not in line with the attributes which would be applied based on its memory type.
3. There is an executing region of memory not loaded using the PE loader which cannot have its access attributes updated without disabling paging.