### PR TITLE
Bugfix: Special Separation Region Logic Can Cause Duplicate Memory Map Entries

### DIFF
--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -2133,7 +2133,7 @@ SeparateSpecialRegionsInMemoryMap (
     {
       MapEntryStart = (UINTN)MemoryMapEntry->PhysicalStart;
       MapEntryEnd   = (UINTN)MemoryMapEntry->PhysicalStart + (UINTN)EFI_PAGES_TO_SIZE (MemoryMapEntry->NumberOfPages);
-      if ((MapEntryStart <= SpecialRegionStart) && (MapEntryEnd >= SpecialRegionStart)) {
+      if ((MapEntryStart <= SpecialRegionStart) && (MapEntryEnd > SpecialRegionStart)) {
         // Check if some portion of the map entry isn't covered by the special region
         if (MapEntryStart != SpecialRegionStart) {
           // Populate a new descriptor for the region before the special region. This entry can go to the end


### PR DESCRIPTION
## Description

The updated line change is required to ensure the special region we're checking actually overlaps with the memory map entry. A case where the original check would be broken is if the memory map entry ends where the special region starts.

## Breaking change?

No

## How This Was Tested

Checking the update against special region permutations

## Integration Instructions

N/A