### PR TITLE
Add CodeQL build plugin

### DIFF
--- a/.pytool/Plugin/CodeQlBuildPlugin/CodeQlBuildPlugin.py
+++ b/.pytool/Plugin/CodeQlBuildPlugin/CodeQlBuildPlugin.py
@@ -1,0 +1,43 @@
+# @file CodeQlBuildPlugin.py
+#
+# A build plugin that produces CodeQL results for the present build.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+import os
+
+from edk2toolext.environment.plugintypes.uefi_build_plugin import \
+    IUefiBuildPlugin                                               # noqa: E402
+from edk2toolext.environment.uefi_build import UefiBuilder         # noqa: E402
+from edk2toollib.uefi.edk2.path_utilities import Edk2Path          # noqa: E402
+
+
+class CodeQlBuildPlugin(IUefiBuildPlugin):
+
+    def do_pre_build(self, builder: UefiBuilder) -> int:
+        """CodeQL pre-build functionality.
+
+        Args:
+            builder (UefiBuilder): A UEFI builder object for this build.
+
+        Returns:
+            int: The number of debug macro errors found. Zero indicates the
+            check either did not run or no errors were found.
+        """
+        pp = builder.pp.split(os.pathsep)
+        edk2 = Edk2Path(builder.ws, pp)
+        package = edk2.GetContainingPackage(
+                            builder.mws.join(builder.ws,
+                                             builder.env.GetValue(
+                                                "ACTIVE_PLATFORM")))
+        target = builder.env.GetValue("TARGET")
+
+        codeql_db_dir_name = "codeql-db-" + package + "-" + target
+        codeql_db_dir_name = codeql_db_dir_name.lower()
+
+        codeql_db_path = os.path.join("Build", codeql_db_dir_name)
+        builder.EnableCodeQl(codeql_db_path)
+
+        return 0

--- a/.pytool/Plugin/CodeQlBuildPlugin/CodeQlBuild_plug_in.yaml
+++ b/.pytool/Plugin/CodeQlBuildPlugin/CodeQlBuild_plug_in.yaml
@@ -1,0 +1,12 @@
+## @file
+# Build plugin used to include CodeQL results with build results.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+{
+  "scope": "codeql",
+  "name": "CodeQL Build Plugin",
+  "module": "CodeQlBuildPlugin"
+}

--- a/.pytool/Plugin/CodeQlBuildPlugin/Readme.md
+++ b/.pytool/Plugin/CodeQlBuildPlugin/Readme.md
@@ -1,0 +1,12 @@
+# CodeQL Build Plugin
+
+This build plugin generates a CodeQL database of the package being built.
+
+## Usage
+
+The plugin is activated by including the `codeql` scope in the list of active scopes.
+
+Once active, the plugin will set up CodeQL tracing of the `build` command such that build output is captured into a
+CodeQL database that is in a directory unique to the package and target being built:
+
+  `Build/codeql-db-<package>-<target>`


### PR DESCRIPTION
## Description

Adds a plugin that can generate a CodeQL database for a package
being built.

The plugin is activated with the "codeql" scope.

It is primarily intended to be used in CI environments where
stuart_ci_build is used rather than a platform build with
stuart_build. However, it is useful for generating a large number
of CodeQL databases quickly in any case.

- [ ] Breaking change?
  - Will this change break pre-existing builds or functionality without action being taken?
  **No**

## How This Was Tested

Verified build plugin generates CodeQL databases as expected when enabled.

Verified no impact when disabled.

## Integration Instructions

No special integration required. Usage instructions in:
  .pytool/Plugin/CodeQlBuildPlugin/Readme.md

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>