### PR TITLE
Update __security_check_cookie_Failure to Emit 0x40 Interrupt

### DIFF
--- a/MdePkg/Library/BaseBinSecurityLibRng/X64/security_check_cookie.asm
+++ b/MdePkg/Library/BaseBinSecurityLibRng/X64/security_check_cookie.asm
@@ -17,7 +17,7 @@ __security_check_cookie PROC PUBLIC
     ret
 
 __security_check_cookie_Failure:
-    int     3
+    int     2ch
     ret
 __security_check_cookie ENDP
 

--- a/MdePkg/Library/BaseBinSecurityLibRng/X64/security_check_cookie.asm
+++ b/MdePkg/Library/BaseBinSecurityLibRng/X64/security_check_cookie.asm
@@ -17,7 +17,7 @@ __security_check_cookie PROC PUBLIC
     ret
 
 __security_check_cookie_Failure:
-    int     2ch
+    int     40h
     ret
 __security_check_cookie ENDP
 


### PR DESCRIPTION
## Description

Stack Cookie failures will cause a 0x40 interrupt. The intel software development manual states interrupts 0-32 are predefined and our use of interrupt 64 is an arbitrary choice.

## Breaking change?

No

## How This Was Tested

Enabling stack cookies on Q35

## Integration Instructions

N/A