### PR TITLE
Add CodeQL support

### DIFF
--- a/.pytool/Plugin/CodeQL/CodeQlAnalyze_plug_in.yaml
+++ b/.pytool/Plugin/CodeQL/CodeQlAnalyze_plug_in.yaml
@@ -1,0 +1,13 @@
+## @file CodeQlAnalyze_plug_in.py
+#
+# Build plugin used to analyze CodeQL results.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+{
+  "scope": "codeql-analyze",
+  "name": "CodeQL Analyze Plugin",
+  "module": "CodeQlAnalyzePlugin"
+}

--- a/.pytool/Plugin/CodeQL/CodeQlBuildPlugin.py
+++ b/.pytool/Plugin/CodeQL/CodeQlBuildPlugin.py
@@ -1,0 +1,152 @@
+# @file CodeQlBuildPlugin.py
+#
+# A build plugin that produces CodeQL results for the present build.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+import logging
+import os
+import stat
+from common import codeql_plugin
+from pathlib import Path
+
+from edk2toolext import edk2_logging
+from edk2toolext.environment.plugintypes.uefi_build_plugin import \
+    IUefiBuildPlugin
+from edk2toolext.environment.uefi_build import UefiBuilder
+from edk2toollib.uefi.edk2.path_utilities import Edk2Path
+from edk2toollib.utility_functions import GetHostInfo
+
+
+class CodeQlBuildPlugin(IUefiBuildPlugin):
+
+    def do_pre_build(self, builder: UefiBuilder) -> int:
+        """CodeQL pre-build functionality.
+
+        Args:
+            builder (UefiBuilder): A UEFI builder object for this build.
+
+        Returns:
+            int: The plugin return code. Zero indicates the plugin ran
+            successfully. A non-zero value indicates an unexpected error
+            occurred during plugin execution.
+        """
+
+        pp = builder.pp.split(os.pathsep)
+        edk2_path = Edk2Path(builder.ws, pp)
+
+        self.builder = builder
+        self.package = edk2_path.GetContainingPackage(
+                            builder.mws.join(builder.ws,
+                                             builder.env.GetValue(
+                                                "ACTIVE_PLATFORM")))
+        self.target = builder.env.GetValue("TARGET")
+
+        self.codeql_db_path = codeql_plugin.get_codeql_db_path(
+                                builder.ws, self.package, self.target)
+
+        edk2_logging.log_progress(f"{self.package} will be built for CodeQL")
+        edk2_logging.log_progress(f"  CodeQL database will be written to "
+                                  f"{self.codeql_db_path}")
+
+        self.codeql_path = codeql_plugin.get_codeql_cli_path()
+        if not self.codeql_path:
+            logging.critical("CodeQL build enabled but CodeQL CLI application "
+                             "not found.")
+            return -1
+
+        # CodeQL can only generate a database on clean build
+        builder.CleanTree()
+
+        # A build is required to generate a database
+        builder.SkipBuild = False
+
+        # CodeQL CLI does not handle spaces passed in CLI commands well
+        # (perhaps at all) as discussed here:
+        #   1. https://github.com/github/codeql-cli-binaries/issues/73
+        #   2. https://github.com/github/codeql/issues/4910
+        #
+        # Since it's unclear how quotes are handled and may change in the
+        # future, this code is going to use the workaround to place the
+        # command in an executable file that is instead passed to CodeQL.
+        self.codeql_cmd_path = Path(builder.mws.join(
+                                    builder.ws, builder.env.GetValue(
+                                        "BUILD_OUTPUT_BASE"),
+                                    "codeql_build_command"))
+
+        build_params = self._get_build_params()
+
+        codeql_build_cmd = ""
+        if GetHostInfo().os == "Windows":
+            self.codeql_cmd_path = self.codeql_cmd_path.parent / (
+                self.codeql_cmd_path.name + '.bat')
+        elif GetHostInfo().os == "Linux":
+            self.codeql_cmd_path.suffix = self.codeql_cmd_path.parent / (
+                self.codeql_cmd_path.name + '.sh')
+            codeql_build_cmd += f"#!/bin/bash{os.linesep * 2}"
+        codeql_build_cmd += "build " + build_params
+
+        self.codeql_cmd_path.parent.mkdir(exist_ok=True, parents=True)
+        self.codeql_cmd_path.write_text(encoding='utf8', data=codeql_build_cmd)
+
+        if GetHostInfo().os == "Linux":
+            os.chmod(self.codeql_cmd_path,
+                     os.stat(self.codeql_cmd_path).st_mode | stat.S_IEXEC)
+
+        codeql_params = (f'database create {self.codeql_db_path} '
+                         f'--language=cpp '
+                         f'--source-root={builder.ws} '
+                         f'--command={self.codeql_cmd_path}')
+
+        # Set environment variables so the CodeQL build command is picked up
+        # as the active build command.
+        #
+        # Note: Requires recent changes in edk2-pytool-extensions (0.20.0)
+        #       to support reading these variables.
+        builder.env.SetValue(
+            "EDK_BUILD_CMD", self.codeql_path, "Set in CodeQL Build Plugin")
+        builder.env.SetValue(
+            "EDK_BUILD_PARAMS", codeql_params, "Set in CodeQL Build Plugin")
+
+        return 0
+
+    def _get_build_params(self) -> str:
+        """Returns the build command parameters for this build.
+
+        Based on the well-defined `build` command-line parameters.
+
+        Returns:
+            str: A string representing the parameters for the build command.
+        """
+        build_params = f"-p {self.builder.env.GetValue('ACTIVE_PLATFORM')}"
+        build_params += f" -b {self.target}"
+        build_params += f" -t {self.builder.env.GetValue('TOOL_CHAIN_TAG')}"
+
+        max_threads = self.builder.env.GetValue('MAX_CONCURRENT_THREAD_NUMBER')
+        if max_threads is not None:
+            build_params += f" -n {max_threads}"
+
+        rt = self.builder.env.GetValue("TARGET_ARCH").split(" ")
+        for t in rt:
+            build_params += " -a " + t
+
+        if (self.builder.env.GetValue("BUILDREPORTING") == "TRUE"):
+            build_params += (" -y " +
+                             self.builder.env.GetValue("BUILDREPORT_FILE"))
+            rt = self.builder.env.GetValue("BUILDREPORT_TYPES").split(" ")
+            for t in rt:
+                build_params += " -Y " + t
+
+        # add special processing to handle building a single module
+        mod = self.builder.env.GetValue("BUILDMODULE")
+        if (mod is not None and len(mod.strip()) > 0):
+            build_params += " -m " + mod
+            edk2_logging.log_progress("Single Module Build: " + mod)
+
+        build_vars = self.builder.env.GetAllBuildKeyValues(self.target)
+        for key, value in build_vars.items():
+            build_params += " -D " + key + "=" + value
+
+        return build_params

--- a/.pytool/Plugin/CodeQL/CodeQlBuild_plug_in.yaml
+++ b/.pytool/Plugin/CodeQL/CodeQlBuild_plug_in.yaml
@@ -1,0 +1,13 @@
+## @file CodeQlBuild_plug_in.py
+#
+# Build plugin used to produce a CodeQL database from a build.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+{
+  "scope": "codeql-build",
+  "name": "CodeQL Build Plugin",
+  "module": "CodeQlBuildPlugin"
+}

--- a/.pytool/Plugin/CodeQL/MuCodeQlQueries.qls
+++ b/.pytool/Plugin/CodeQL/MuCodeQlQueries.qls
@@ -1,0 +1,53 @@
+---
+- description: Project Mu UEFI (C++) queries
+
+- queries: '.'
+  from: codeql/cpp-queries
+
+# "Core" Queries
+- include:
+    id: cpp/badoverflowguard
+- include:
+    id: cpp/comparison-with-wider-type
+- include:
+    id: cpp/conditionallyuninitializedvariable
+- include:
+    id: cpp/likely-bugs/memory-management/v2/conditionally-uninitialized-variable
+- include:
+    id: cpp/paddingbyteinformationdisclosure
+- include:
+    id: cpp/pointer-overflow-check
+- include:
+    id: cpp/redundant-null-check-param
+- include:
+    id: cpp/unguardednullreturndereference
+- include:
+    id: cpp/uselesstest
+
+# Additional Fundamental Queries Not Originally Run
+- include:
+    id: cpp/infinite-loop-with-unsatisfiable-exit-condition
+- include:
+    id: cpp/infiniteloop
+- include:
+    id: cpp/overflow-buffer
+- include:
+    id: cpp/sizeof/const-int-argument
+- include:
+    id: cpp/sizeof/sizeof-or-operation-as-argument
+
+- include:
+    tags:
+      - "security"
+      - "correctness"
+    severity: "error"
+
+# Specifically hide the results of these.
+- exclude:
+    id: cpp/use-of-goto
+- exclude:
+    id: cpp/weak-crypto/banned-hash-algorithms
+- exclude:
+    id: cpp/weak-crypto/openssl/banned-hash-algorithms
+- exclude:
+    id: cpp/weak-crypto/capi/banned-modes

--- a/.pytool/Plugin/CodeQL/Readme.md
+++ b/.pytool/Plugin/CodeQL/Readme.md
@@ -1,0 +1,288 @@
+# CodeQL Plugin
+
+The set of CodeQL plugins provided include two main plugins:
+
+1. `CodeQlBuildPlugin` - Used to produce a CodeQL database from a build.
+2. `CodeQlAnalyzePlugin` - Used to analyze a CodeQL database.
+
+❗ It is very important to read the Integration Instructions in this file and determine how to best integrate the
+CodeQL plugin into your environment.
+
+Due to the total size of dependencies required to run CodeQL and the flexibility needed by a platform to determine what
+CodeQL queries to run and how to interpret results, a number of configuration options are provided to allow a high
+degree of flexibility during platform integration.
+
+This document is focused on those setting up the CodeQL plugin in their environment. Once setup, end users simply need
+to use their normal build commands and process and CodeQL will be integrated with it. The most relevant section for
+such users is [Local Development Tips](#local-development-tips).
+
+## Table of Contents
+
+1. [Database and Analysis Result Locations](#database-and-analysis-result-locations)
+2. [Global Configuration](#global-configuration)
+3. [Package-Specific Configuration](#package-specific-configuration)
+4. [Integration Instructions](#integration-instructions)
+   - [Integration Step 1 - Choose Scopes](#integration-step-1---choose-scopes)
+   - [Integration Step 2 - Choose CodeQL Queries](#integration-step-2---choose-codeql-queries)
+   - [Integration Step 3 - Determine Global Configuration Values](#integration-step-3---determine-global-configuration-values)
+   - [Integration Step 4 - Determine Package-Specific Configuration Values](#integration-step-4---determine-package-specific-configuration-values)
+   - [Integration Step 5 - Testing](#integration-step-5---testing)
+     - [Scopes Available](#scopes-available)
+5. [High-Level Operation](#high-level-operation)
+   - [CodeQlBuildPlugin](#codeqlbuildplugin)
+   - [CodeQlAnalyzePlugin](#codeqlanalyzeplugin)
+6. [Local Development Tips](#local-development-tips)
+
+## Database and Analysis Result Locations
+
+The CodeQL database is written to a directory unique to the package and target being built:
+
+  `Build/codeql-db-<package>-<target>-<instance>`
+
+For example: `Build/codeql-db-mdemodulepkg-debug-0`
+
+The plugin does not delete or overwrite existing databases, the instance value is simply increased. This is
+because databases are large, take a long time to generate, and are important for reproducing analysis results. The user
+is responsible for deleting database directories when they are no longer needed.
+
+Similarly, analysis results are written to a directory unique to the package and target. For analysis, results are
+stored in individual files so those files are stored in a single directory.
+
+For example, all analysis results for the above package and target will be stored in:
+  `codeql-analysis-mdemodulepkg-debug`
+
+CodeQL results are stored in [SARIF](https://sarifweb.azurewebsites.net/) (Static Analysis Results Interchange Format)
+([CodeQL SARIF documentation](https://codeql.github.com/docs/codeql-cli/sarif-output/)) files. Each SARIF file
+corresponding to a database will be stored in a file with an instance matching the database instance.
+
+For example, the analysis result file for the above database would be stored in this file:
+  `codeql-analysis-mdemodulepkg-debug/codeql-db-mdemodulepkg-debug-0.sarif`
+
+Result files are overwritten. This is because result files are quick to generate and need to represent the latest
+results for the last analysis operation performed. The user is responsible for backing up SARIF result files if they
+need to saved.
+
+## Global Configuration
+
+Global configuration values are specified with build environment variables.
+
+These values are all optional. They provide a convenient mechanism for a build script to set the value for all packages
+built by the script.
+
+- `STUART_CODEQL_AUDIT_ONLY` - If `true` (case insensitive), `CodeQlAnalyzePlugin` will be in audit-only mode. In this
+  mode all CodeQL failures are ignored.
+- `STUART_CODEQL_PATH` - The path to the CodeQL CLI application to use.
+- `STUART_CODEQL_QUERY_SPECIFIERS` - The CodeQL CLI query specifiers to use. See [Running codeql database analyze](https://codeql.github.com/docs/codeql-cli/analyzing-databases-with-the-codeql-cli/#running-codeql-database-analyze)
+  for possible options.
+
+## Package-Specific Configuration
+
+Package-specific configuration values reuse existing package-level configuration approaches to simplify adjusting
+CodeQL plugin behavior per package.
+
+These values are all optional. They provide a convenient mechanism for a package owner to adjust settings specific to
+the package.
+
+``` yaml
+  "CodeQlAnalyze": {
+      "AuditOnly": False,         # Don't fail the build if there are errors. Just log them.
+      "QuerySpecifiers": ""       # Query specifiers to pass to CodeQL CLI.
+  }
+```
+
+## Integration Instructions
+
+First, note that most CodeQL CLI operations will take a long time the first time they are run. This is due to:
+
+1. Downloads - Downloading the CodeQL CLI binary (during `stuart_update`) and downloading CodeQL queries during
+   CodeQL plugin execution
+2. Cache not established - CodeQL CLI caches data as it performs analysis. The first time analysis is performed will
+   take more time than in the future.
+
+Second, these are build plugins. This means a build needs to take place for the plugins to run. This typically happens
+in the following two scenarios:
+
+1. `stuart_build` - A single package is built and the build process is started by the stuart tools.
+2. `stuart_ci_build` - A number of packages may be built and the build process is started by the `CompilerPlugin`.
+
+In any case, each time a package is built, the CodeQL plugins will be run if their scopes are active.
+
+### Integration Step 1 - Choose Scopes
+
+Decide which scopes need to be enabled in your platform, see [Scopes Available](#scopes-available).
+
+Consider using a build profile to enable CodeQL so developers and pipelines can use the profile when they are
+interested in CodeQL results but in other cases they can easily work without CodeQL in the way.
+
+Furthermore, build-script specific command-line parameters might be useful to control CodeQL scopes and other
+behavior.
+
+#### Scopes Available
+
+This CodeQL plugin leverages scopes to control major pieces of functionality. Any combination of scopes can be
+returned from the `GetActiveScopes()` function in the platform settings manager to add and remove functionality.
+
+Plugin scopes:
+
+- `codeql-analyze` - Activate `CodeQlAnalyzePlugin` to perform post-build analysis of the last generated database for
+  the package and target specified.
+- `codeql-build` - Activate `CodeQlBuildPlugin` to hook the firmware build in pre-build such that the build will
+  generate a CodeQL database during build.
+
+In most cases, to perform a full CodeQL run, `codeql-build` should be enabled so a new CodeQL database is generated
+during build and `codeql-analyze` should be be enabled so analysis of that database is performed after the build is
+completed.
+
+External dependency scopes:
+
+- `codeql-ext-dep` - Downloads the cross-platform CodeQL CLI as an external dependency.
+- `codeql-linux-ext-dep` - Downloads the Linux CodeQL CLI as an external dependency.
+- `codeql-windows-ext-dep` - Downloads the Windows CodeQL CLI as an external dependency.
+
+Note, that the CodeQL CLI is large in size. Sizes as of the [v2.11.2 release](https://github.com/github/codeql-cli-binaries/releases/tag/v2.11.2).
+
+| Cross-platform |  Linux | Windows |
+|:--------------:|:------:|:-------:|
+|     934 MB     | 415 MB |  290 MB |
+
+Therefore, the following is recommended:
+
+1. **Ideal** - Create container images for build agents and install the CodeQL CLI for the container OS into the
+   container.
+2. Leverage host-OS detection (e.g. [`GetHostInfo()`](https://github.com/tianocore/edk2-pytool-library/blob/42ad6561af73ba34564f1577f64f7dbaf1d0a5a2/edk2toollib/utility_functions.py#L112))
+to set the scope for the appropriate operating system. This will download the much smaller OS-specific application.
+
+> _NOTE:_ You should never have more than one CodeQL external dependency scope enabled at a time.
+
+### Integration Step 2 - Choose CodeQL Queries
+
+Determine which queries need to be run against packages in your repo. In most cases, the same set of queries will be
+run against all packages. It is also possible to customize the queries run at the package level.
+
+The default set of Project Mu CodeQL queries is specified in the `MuCodeQlQueries.qls` file in this plugin.
+
+> _NOTE:_ The queries in `MuCodeQlQueries.qls` may change at any time. If you do not want these changes to impact
+> your platform, do not relay on option (3).
+
+The plugin decides what queries to run based on the following, in order of preference:
+
+1. Package CI YAML file query specifier
+2. Build environment variable query specifier
+3. Plugin default query set file
+
+For details on how to set (1) and (2), see the Package CI Configuration and Environment Variable sections respectively.
+
+> _NOTE:_ The value specified is directly passed as a `query specifier` to CodeQL CLI. Therefore, the arguments
+> allowed by the `<query-specifiers>` argument of CodeQL CLI are allowed here. See
+> [Running codeql database analyze](https://codeql.github.com/docs/codeql-cli/analyzing-databases-with-the-codeql-cli/#running-codeql-database-analyze).
+
+A likely scenario is that a platform needs to run local/closed source queries in addition to the open-source queries.
+There's various ways to handle that:
+
+1. Create a query specifier that includes all the queries needed, both public and private and use that query specifier,
+   either globally or at package-level.
+
+   For example, at the global level - `STUART_CODEQL_QUERY_SPECIFIERS` = _"Absolute_path_to_AllMyQueries.qls"_
+
+2. Specify a query specifier that includes the closed sources queries and reuse the public query list provided by
+   this plugin.
+
+   For example, at the global level - `STUART_CODEQL_QUERY_SPECIFIERS` = _"Absolute_path_to_MuCodeQlQueries.qls
+   Absolute_path_to_ClosedSourceQueries.qls"_
+
+Refer to the CodeQL documentation noted above on query specifiers to devise other options.
+
+### Integration Step 3 - Determine Global Configuration Values
+
+Review the Environment Variable section to determine which, if any, global values need to be set in your build script.
+
+### Integration Step 4 - Determine Package-Specific Configuration Values
+
+Review the Package CI Configuration section to determine which, if any, global values need to be set in your
+package's CI YAML file.
+
+### Integration Step 5 - Testing
+
+Verify a `stuart_update` and `stuart_build` (or `stuart_ci_build`) command work.
+
+## High-Level Operation
+
+This section summarizes the complete CodeQL plugin flow. This is to help developers understand basic theory of
+operation behind the plugin and can be skipped by anyone not interested in those details.
+
+### CodeQlBuildPlugin
+
+1. Register a pre-build hook
+2. Determine the package and target being built
+3. Determine the best CodeQL CLI path to use
+   - First choice, the `STUART_CODEQL_PATH` environment variable
+     - Note: This is set by the CodeQL CLI external dependency if that is used
+   - Second choice, `codeql` as found on the system path
+4. Determine the directory name for the CodeQL database
+   - Format: `Build/codeql-db-<package>-<target>-<instance>`
+5. Clean the build directory of the active platform and target
+   - CodeQL database generation only works on clean builds
+6. Ensure the "build" step is not skipped as a build is needed to generate a CodeQL database
+7. Build a CodeQL file that wraps around the edk2 build
+   - Written to the package build directory
+     - Example: `Build/MdeModulePkg/VS2022/codeql_build_command.bat`
+8. Set the variables necessary for stuart to call CodeQL CLI during the build phase
+   - Sets `EDK_BUILD_CMD` and `EDK_BUILD_PARAMS`
+
+### CodeQlAnalyzePlugin
+
+1. Register a post-build hook
+2. Determine the package and target being built
+3. Determine the best CodeQL CLI path to use
+   - First choice, the `STUART_CODEQL_PATH` environment variable
+     - Note: This is set by the CodeQL CLI external dependency if that is used
+   - Second choice, `codeql` as found on the system path
+4. Determine the directory name for the most recent CodeQL database
+   - Format: `Build/codeql-db-<package>-<target>-<instance>`
+5. Determine plugin audit status for the given package and target
+   - Check if `AuditOnly` is enabled either globally or for the package
+6. Determine the CodeQL query specifiers to use for the given package and target
+   - First choice, the package CI YAML file value
+   - Second choice, the `STUART_CODEQL_QUERY_SPECIFIERS`
+   - Third choice, use `MuCodeQlQueries.qls` (in the plugin directory)
+7. Run CodeQL CLI to perform database analysis
+8. Parse the analysis SARIF file to determine the number of CodeQL failures
+9. Return the number of failures (or zero if `AuditOnly` is enabled)
+
+## Local Development Tips
+
+This section contains helpful tips to expedite common scenarios when working with CodeQL locally.
+
+1. Pre-build, Build, and Post-Build
+
+   Generating a database requires the pre-build and build steps. Analyzing a database requires the post-build step.
+
+   Therefore, if you are making tweaks that don't affect the build, such as modifying the CodeQL queries used or level
+   of severity reported, you can save time by skipping pre-build and post-build (e.g. `--skipprebuild` and
+   `--skipbuild`).
+
+2. Scopes
+
+   Similar to (1), add/remove `codeql-build` and `codeql-analyze` from the active scopes to save time depending on what
+   you are trying to do.
+
+   If you are focusing on coding, remove the code CodeQL scopes if they are active. If you are ready to check your
+   changes against CodeQL, simply add the scopes back. It is recommended to use build profiles to do this more
+   conveniently.
+
+   If you already have CodeQL CLI enabled, you can remove the `codeql-ext-dep` scope locally. The build will use the
+   `codeql` command on your path.
+
+3. CodeQL Output is in the CI Build Log
+
+   To see exactly which queries CodeQL ran or why it might be taking longer than expected, look in the CI build log
+   (i.e. `Build/CI_BUILDLOG.txt`) where the CodeQL CLI application output is written.
+
+   Search for the text you see in the progress output (e.g. "Analyzing _MdeModulePkg_ (_DEBUG_) CodeQL database at")
+   to jump to the section of the log just before the CodeQL CLI is invoked.
+
+4. Use a SARIF Viewer to Read Results
+
+The [SARIF Viewer extension for VS Code](https://marketplace.visualstudio.com/items?itemName=MS-SarifVSCode.sarif-viewer)
+can open the .sarif file generated by this plugin and allow you to click links directly to the problem area in source
+files.

--- a/.pytool/Plugin/CodeQL/codeqlcli_ext_dep.yaml
+++ b/.pytool/Plugin/CodeQL/codeqlcli_ext_dep.yaml
@@ -1,0 +1,26 @@
+## @file codeqlcli_ext_dep.yaml
+#
+# Downloads the CodeQL Command-Line Interface (CLI) application that support Linux, Windows, and Mac OS X.
+#
+# This download is very large but conveniently provides support for all operating systems. Use it if you
+# need CodeQL CLI support without concern for the host operating system.
+#
+# In an environment where a platform might build in different operating systems, it is recommended to set
+# the scope for the appropriate CodeQL external dependency based on the host operating system being used.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+{
+  "scope": "codeql-ext-dep",
+  "type": "web",
+  "name": "codeql_cli",
+  "source": "https://github.com/github/codeql-cli-binaries/releases/download/v2.11.2/codeql.zip",
+  "version": "2.11.2",
+  "sha256": "3ffa99df6752cda7ada25828df3f165df03b6ee4ca9c68405a38c3b54129ce40",
+  "compression_type": "zip",
+  "internal_path": "/codeql/",
+  "flags": ["set_shell_var", ],
+  "var_name": "STUART_CODEQL_PATH"
+}

--- a/.pytool/Plugin/CodeQL/codeqlcli_linux_ext_dep.yaml
+++ b/.pytool/Plugin/CodeQL/codeqlcli_linux_ext_dep.yaml
@@ -1,0 +1,24 @@
+## @file codeqlcli_linux_ext_dep.yaml
+#
+# Downloads the Linux CodeQL Command-Line Interface (CLI) application.
+#
+# This download only supports Linux. In an environment where a platform might build in different operating
+# systems, it is recommended to set the scope for the appropriate CodeQL external dependency based on the
+# host operating system being used.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+{
+  "scope": "codeql-linux-ext-dep",
+  "type": "web",
+  "name": "codeql_linux_cli",
+  "source": "https://github.com/github/codeql-cli-binaries/releases/download/v2.11.2/codeql-linux64.zip",
+  "version": "2.11.2",
+  "sha256": "a9b735d7ef9cc4a8cdf3a67b7018fe741078605cec273e1514a497353e31d2b8",
+  "compression_type": "zip",
+  "internal_path": "/codeql/",
+  "flags": ["set_shell_var", ],
+  "var_name": "STUART_CODEQL_PATH"
+}

--- a/.pytool/Plugin/CodeQL/codeqlcli_windows_ext_dep.yaml
+++ b/.pytool/Plugin/CodeQL/codeqlcli_windows_ext_dep.yaml
@@ -1,0 +1,24 @@
+## @file codeqlcli_windows_ext_dep.yaml
+#
+# Downloads the Windows CodeQL Command-Line Interface (CLI) application.
+#
+# This download only supports Windows. In an environment where a platform might build in different operating
+# systems, it is recommended to set the scope for the appropriate CodeQL external dependency based on the
+# host operating system being used.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+{
+  "scope": "codeql-windows-ext-dep",
+  "type": "web",
+  "name": "codeql_windows_cli",
+  "source": "https://github.com/github/codeql-cli-binaries/releases/download/v2.11.2/codeql-win64.zip",
+  "version": "2.11.2",
+  "sha256": "aa886ffdf7ef5c0471ed5eeee115a5114a0f292da81ad15025d4889b1ff0fd41",
+  "compression_type": "zip",
+  "internal_path": "/codeql/",
+  "flags": ["set_shell_var", ],
+  "var_name": "STUART_CODEQL_PATH"
+}

--- a/.pytool/Plugin/CodeQL/common/codeql_plugin.py
+++ b/.pytool/Plugin/CodeQL/common/codeql_plugin.py
@@ -1,0 +1,74 @@
+# @file codeql_plugin.py
+#
+# Common logic shared across the CodeQL plugin.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+import os
+import shutil
+from os import PathLike
+
+from edk2toollib.utility_functions import GetHostInfo
+
+
+def get_codeql_db_path(workspace: PathLike, package: str, target: str,
+                       new_path: bool = True) -> str:
+    """Return the CodeQL database path for this build.
+
+    Args:
+        workspace (PathLike): The workspace path.
+        package (str): The package name (e.g. "MdeModulePkg")
+        target (str): The target (e.g. "DEBUG")
+        new_path (bool, optional): Whether to create a new database path or
+                                   return an existing path. Defaults to True.
+
+    Returns:
+        str: The absolute path to the CodeQL database directory.
+    """
+    codeql_db_dir_name = "codeql-db-" + package + "-" + target
+    codeql_db_dir_name = codeql_db_dir_name.lower()
+    codeql_db_path = os.path.join("Build", codeql_db_dir_name)
+    codeql_db_path = os.path.join(workspace, codeql_db_path)
+
+    i = 0
+    while os.path.isdir(f"{codeql_db_path + '-%s' % i}"):
+        i += 1
+
+    if not new_path:
+        if i == 0:
+            return None
+        else:
+            i -= 1
+
+    return codeql_db_path + f"-{i}"
+
+
+def get_codeql_cli_path() -> str:
+    """Return the current CodeQL CLI path.
+
+    Returns:
+        str: The absolute path to the CodeQL CLI application to use for
+             this build.
+    """
+    # The CodeQL executable path can be passed via the
+    # STUART_CODEQL_PATH environment variable (to override with a
+    # custom value for this run) or read from the system path.
+    codeql_path = None
+
+    if "STUART_CODEQL_PATH" in os.environ:
+        codeql_path = os.environ["STUART_CODEQL_PATH"]
+
+        if GetHostInfo().os == "Windows":
+            codeql_path = os.path.join(codeql_path, "codeql.exe")
+        else:
+            codeql_path = os.path.join(codeql_path, "codeql")
+
+        if not os.path.isfile(codeql_path):
+            codeql_path = None
+
+    if not codeql_path:
+        codeql_path = shutil.which("codeql")
+
+    return codeql_path

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -12,8 +12,8 @@
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 ##
 
-edk2-pytool-library~=0.11.6 # MU_CHANGE
-edk2-pytool-extensions~=0.17.2 # MU_CHANGE
+edk2-pytool-library~=0.12.1 # MU_CHANGE
+edk2-pytool-extensions~=0.20.0 # MU_CHANGE
 edk2-basetools==0.1.24
 antlr4-python3-runtime==4.7.1
 regex


### PR DESCRIPTION
## Description

Adds a CodeQL plugin that supports CodeQL in the build system.

1. CodeQlBuildPlugin - Generates a CodeQL database for a given build.
2. CodeQlAnalyzePlugin - Analyzes a CodeQL database and interprets results.
3. External dependencies - Assist with downloading the CodeQL CLI and making it available to the CodeQL plugins.
4. MuCodeQlQueries.qls - A Project Mu CodeQL query set run against Project Mu code.
5. Readme.md - A comprehensive readme file to help:
   - Platform integrators understand how to configure the plugin
   - Developers understand how to modify the plugin
   - Users understand how to use the plugin

Read Readme.md for additional details.

- [ ] Breaking change?
  - Will this change break pre-existing builds or functionality without action being taken?
  **No**

## How This Was Tested

1. Verified CodeQlBuildPlugin generates a CodeQL database against every mu_basecore package
2. Verified all configuration options in CodeQlBuildPlugin work
3. Verified CodeQlAnalyzePlugin produces a SARIF result file as expected
4. Verified all configuration options in CodeQlAnalyzePlugin work
5. Verified SARIF results are read correctly
6. Verified all external Web dependencies work

## Integration Instructions

Read the Readme.md file added in this change.

Note: The plugin will be used to enable CodeQL in this repo in a separate, future
change after some additional CodeQL fixes have gone into the repo.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>