### PR TITLE
[REBASE && FF] Improve Security of MP Buffers and MMIO Ranges

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
@@ -551,10 +551,13 @@ InitializePciHostBridge (
         Status = gDS->SetMemorySpaceAttributes (
                         HostAddress,
                         MemApertures[MemApertureIndex]->Limit - MemApertures[MemApertureIndex]->Base + 1,
-                        EFI_MEMORY_UC
+                        // MU_CHANGE START: MMIO ranges should be non-executable
+                        // EFI_MEMORY_UC
+                        EFI_MEMORY_XP | EFI_MEMORY_UC
+                        // MU_CHANGE END
                         );
         if (EFI_ERROR (Status)) {
-          DEBUG ((DEBUG_WARN, "PciHostBridge driver failed to set EFI_MEMORY_UC to MMIO aperture - %r.\n", Status));
+          DEBUG ((DEBUG_WARN, "PciHostBridge driver failed to set EFI_MEMORY_XP and EFI_MEMORY_UC to MMIO aperture - %r.\n", Status));
         }
 
         if (ResourceAssigned) {

--- a/UefiCpuPkg/Library/MpInitLib/DxeMpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/DxeMpLib.c
@@ -40,21 +40,21 @@ volatile UINT32   mNumberToFinish = 0;
 // Begin wakeup buffer allocation below 0x88000
 //
 STATIC EFI_PHYSICAL_ADDRESS  mSevEsDxeWakeupBuffer = 0x88000;
-// MU_CHANGE START: Update to enable removal of NX attribute from buffer
+// MU_CHANGE START: Update to enable removal of NX attribute and application of RO
 
 /**
-  Remove NX attribute from Buffer
+  Remove NX attribute from Buffer and apply RO to Buffer
 
   @param[in]  Buffer      Buffer whose attributes will be altered
   @param[in]  Size        Size of the buffer
 
-  @retval EFI_SUCCESS             NX attribute removed
+  @retval EFI_SUCCESS             NX attribute removed, RO attribute applied
   @retval EFI_INVALID_PARAMETER   Buffer is not page-aligned or Buffer is 0 or Size of buffer
                                   is not page-aligned
-  @retval Other                   Return value of LocateProtocol or ClearMemoryAttributes
+  @retval Other                   Return value of LocateProtocol, ClearMemoryAttributes, or SetMemoryAttributes
 **/
 EFI_STATUS
-BufferRemoveNoExecute (
+BufferRemoveNoExecuteSetReadOnly (
   IN EFI_PHYSICAL_ADDRESS  Buffer,
   IN UINTN                 Size
   )
@@ -76,6 +76,18 @@ BufferRemoveNoExecute (
     DEBUG ((DEBUG_INFO, "%a - Unable to locate Memory Attribute Protocol\n", __FUNCTION__));
     ASSERT_EFI_ERROR (Status);
     return Status;
+  }
+
+  Status = MemoryAttribute->SetMemoryAttributes (
+                              MemoryAttribute,
+                              Buffer,
+                              Size,
+                              EFI_MEMORY_RO
+                              );
+
+  if EFI_ERROR (Status) {
+    DEBUG ((DEBUG_INFO, "%a - Unable to apply RO attribute to buffer\n", __FUNCTION__));
+    ASSERT_EFI_ERROR (Status);
   }
 
   Status = MemoryAttribute->ClearMemoryAttributes (
@@ -237,14 +249,9 @@ AllocateCodeBuffer (
                         EFI_SIZE_TO_PAGES (BufferSize),
                         &StartAddress
                         );
-  // MU_CHANGE START: NX is applied to the allocated buffer - call function to remove that attribute
-  if (EFI_ERROR (Status) ||
-      EFI_ERROR (BufferRemoveNoExecute (StartAddress, ALIGN_VALUE (BufferSize, EFI_PAGE_SIZE))))
-  {
+  if (EFI_ERROR (Status)) {
     StartAddress = 0;
   }
-
-  // MU_CHANGE END
 
   return (UINTN)StartAddress;
 }

--- a/UefiCpuPkg/Library/MpInitLib/MpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/MpLib.c
@@ -1930,7 +1930,7 @@ MpInitLibInitialize (
     ApResetVectorSizeAbove1Mb
     );
   DEBUG ((DEBUG_INFO, "AP Vector: non-16-bit = %p/%x\n", CpuMpData->WakeupBufferHigh, ApResetVectorSizeAbove1Mb));
-
+  BufferRemoveNoExecuteSetReadOnly (CpuMpData->WakeupBufferHigh, ALIGN_VALUE (ApResetVectorSizeAbove1Mb, EFI_PAGE_SIZE));
   //
   // Enable the local APIC for Virtual Wire Mode.
   //

--- a/UefiCpuPkg/Library/MpInitLib/MpLib.h
+++ b/UefiCpuPkg/Library/MpInitLib/MpLib.h
@@ -842,4 +842,24 @@ SevSnpCreateAP (
   IN INTN         ProcessorNumber
   );
 
+// MU_CHANGE START: Update to enable removal of NX attribute and application of RO
+
+/**
+  Remove NX attribute from Buffer and apply RO to Buffer
+
+  @param[in]  Buffer      Buffer whose attributes will be altered
+  @param[in]  Size        Size of the buffer
+
+  @retval EFI_SUCCESS             NX attribute removed, RO attribute applied
+  @retval EFI_INVALID_PARAMETER   Buffer is not page-aligned or Buffer is 0 or Size of buffer
+                                  is not page-aligned
+  @retval Other                   Return value of LocateProtocol, ClearMemoryAttributes, or SetMemoryAttributes
+**/
+EFI_STATUS
+BufferRemoveNoExecuteSetReadOnly (
+  IN EFI_PHYSICAL_ADDRESS  Buffer,
+  IN UINTN                 Size
+  );
+
+// MU_CHANGE END
 #endif

--- a/UefiCpuPkg/Library/MpInitLib/PeiMpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/PeiMpLib.c
@@ -40,6 +40,30 @@ EFI_PEI_NOTIFY_DESCRIPTOR  mS3SmmInitDoneNotifyDesc = {
   NotifyOnS3SmmInitDonePpi
 };
 
+// MU_CHANGE START: Update to enable removal of NX attribute and application of RO
+
+/**
+  Remove NX attribute from Buffer and apply RO to Buffer
+
+  @param[in]  Buffer      Buffer whose attributes will be altered
+  @param[in]  Size        Size of the buffer
+
+  @retval EFI_SUCCESS             NX attribute removed, RO attribute applied
+  @retval EFI_INVALID_PARAMETER   Buffer is not page-aligned or Buffer is 0 or Size of buffer
+                                  is not page-aligned
+  @retval Other                   Return value of LocateProtocol, ClearMemoryAttributes, or SetMemoryAttributes
+**/
+EFI_STATUS
+BufferRemoveNoExecuteSetReadOnly (
+  IN EFI_PHYSICAL_ADDRESS  Buffer,
+  IN UINTN                 Size
+  )
+{
+  return EFI_SUCCESS;
+}
+
+// MU_CHANGE END
+
 /**
   S3 SMM Init Done notification function.
 


### PR DESCRIPTION
## Description

To pass the DXE paging audit, no ranges should be R/W/X. These updates secure some failing buffers.

## Breaking change?

No

## How This Was Tested

- Booting to the OS and running the paging audit app on Q35

## Integration Instructions

N/A
