### PR TITLE
Update Stack Cookie Vector to Fixed PCD

### DIFF
--- a/MdePkg/Library/BaseBinSecurityLibRng/BaseBinSecurityLibRng.inf
+++ b/MdePkg/Library/BaseBinSecurityLibRng/BaseBinSecurityLibRng.inf
@@ -32,4 +32,7 @@
   DebugLib
   BaseLib
   RngLib
+  PcdLib
 
+[FixedPcd]
+  gEfiMdePkgTokenSpaceGuid.PcdStackCookieExceptionVector

--- a/MdePkg/Library/BaseBinSecurityLibRng/X64/security_check_cookie.asm
+++ b/MdePkg/Library/BaseBinSecurityLibRng/X64/security_check_cookie.asm
@@ -17,7 +17,7 @@ __security_check_cookie PROC PUBLIC
     ret
 
 __security_check_cookie_Failure:
-    int     40h
+    int     FixedPcdGet8 (PcdStackCookieExceptionVector)
     ret
 __security_check_cookie ENDP
 

--- a/MdePkg/MdePkg.dec
+++ b/MdePkg/MdePkg.dec
@@ -2238,6 +2238,11 @@
   # @Prompt Speculation Barrier Type.
   gEfiMdePkgTokenSpaceGuid.PcdSpeculationBarrierType|0x01|UINT8|0x30001018
 
+  ## MU_CHANGE START: Add Stack Cookie Exception Vector
+  ## This PCD specifies the interrupt vector for stack cookie check failures
+  gEfiMdePkgTokenSpaceGuid.PcdStackCookieExceptionVector|0x42|UINT8|0x30001019
+  ## MU_CHANGE END
+
 [PcdsFixedAtBuild,PcdsPatchableInModule]
   ## Indicates the maximum length of unicode string used in the following
   #  BaseLib functions: StrLen(), StrSize(), StrCmp(), StrnCmp(), StrCpy(), StrnCpy()<BR><BR>


### PR DESCRIPTION
## Description

To enable more easily setting the stack cookie failure vector, update the check to reference a fixed at build PCD in MdePkg. The interrupt vector value default is now 0x42 instead of 0x40 to avoid conflicting with the HPET interrupt vector.

## Breaking change?

No

## How This Was Tested

Triggering the interrupt on Q35

## Integration Instructions

Platforms can update the value by setting the PcdStackCookieExceptionVector PCD in their platform DSC file.