### PR TITLE
.github/dependabot.yml: Remove submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,13 +18,6 @@ updates:
     commit-message:
       prefix: "pip"
 
-  - package-ecosystem: "gitsubmodule"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "submodule"
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Description

After reviewing the submodule updates enabled by the dependabot
change in 6e67d80, we've decided there is more risk than upside
in deviating too far from the submodule versions used in edk2.

Therefore, this change disables submodule updates to prevent them
from being shown in the future.

- [ ] Breaking change?
  - Will this change break pre-existing builds or functionality without action being taken?
  **No**

## How This Was Tested

Verified changes in another repo.

## Integration Instructions

N/A - Impacts local submodule management in this repo.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>