### PR TITLE
UefiBootManagerLib: Update assert condition in BmFindBootOptionInVariable()

### DIFF
--- a/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
@@ -147,7 +147,7 @@ BmFindBootOptionInVariable (
   if (OptionNumber == LoadOptionNumberUnassigned) {
     BootOptions = EfiBootManagerGetLoadOptions (&BootOptionCount, LoadOptionTypeBoot);
 
-    if (BootOptions == NULL) {
+    if ((BootOptions == NULL) && (BootOptionCount > 0)) {
       ASSERT (BootOptions != NULL);
       return LoadOptionNumberUnassigned;
     }


### PR DESCRIPTION
## Description

Currently the following assertion is made in
`BmFindBootOptionInVariable()`:

```c
  if (OptionNumber == LoadOptionNumberUnassigned) {
    BootOptions = EfiBootManagerGetLoadOptions (&BootOptionCount, LoadOptionTypeBoot);

    if (BootOptions == NULL) {
      ASSERT (BootOptions != NULL);
      return LoadOptionNumberUnassigned;
    }

    Index = EfiBootManagerFindLoadOption (OptionToFind, BootOptions, BootOptionCount);
```

The reason behind this is to prevent passing a null pointer to
`EfiBootManagerFindLoadOption()`.

However, `EfiBootManagerFindLoadOption()` accepts a null pointer
argument to be passed as the second argument ('Array') as long as
the `Count` argument is `0`.

In that case `LoadOptionNumberUnassigned` will still be returned from
the function but an assert is not necessary.

This change updates the condition to only assert if the pointer is
null and the boot option count is non-zero.

- [ ] Breaking change?
  - Will this change break pre-existing builds or functionality without action being taken?
  **No**

## How This Was Tested

Verified build and boot on Qemu35Pkg.

## Integration Instructions

N/A

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>