### PR TITLE
Remove .cargo/config.toml file

### DIFF
--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -281,7 +281,7 @@
         $(OUTPUT_DIR)(+)$(MODULE_NAME)rust.lib
 
     <Command>
-        $(CARGO) rustc $(CARGO_FLAGS) --manifest-path ${s_path}(+)Cargo.toml -Z unstable-options --target-dir $(CARGO_OUTPUT_DIR) --timings=html
+        $(CARGO) rustc $(CARGO_FLAGS) --manifest-path ${s_path}(+)Cargo.toml $(RUST_ZFLAGS) --target-dir $(CARGO_OUTPUT_DIR) --timings=html
         $(CP) $(CARGO_BINDIR)(+)*.a $(OUTPUT_DIR)(+)$(MODULE_NAME)rust.lib
 
 [Toml-File.RUST_MODULE]
@@ -294,7 +294,7 @@
     <Command>
         # Temporary_Rust_Todo - Remove .efi files to better support Rust incremental build for now.
         $(RM) $(OUTPUT_DIR)(+)*.efi
-        $(CARGO) rustc $(CARGO_FLAGS) --bins --manifest-path ${src} -Z unstable-options --target-dir $(CARGO_OUTPUT_DIR) --timings=html -- -C link-arg=/MAP:$(OUTPUT_DIR)(+)$(MODULE_NAME).map
+        $(CARGO) rustc $(CARGO_FLAGS) --bins --manifest-path ${src} $(RUST_ZFLAGS) --target-dir $(CARGO_OUTPUT_DIR) --timings=html -- -C link-arg=/MAP:$(OUTPUT_DIR)(+)$(MODULE_NAME).map
         $(CP) $(CARGO_BINDIR)(+)*.efi $(OUTPUT_DIR)(+)$(MODULE_NAME).efi
         $(CP) $(OUTPUT_DIR)(+)$(MODULE_NAME).efi $(BIN_DIR)(+)$(MODULE_NAME).efi
 

--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -3468,6 +3468,8 @@ RELEASE_RVCTCYGWIN_ARM_CC_FLAGS  = "$(CCPATH_FLAG)" $(ARCHCC_FLAGS) $(PLATFORM_F
 *_*_X64_TARGET_TRIPLE = x86_64-unknown-uefi
 *_*_IA32_TARGET_TRIPLE = i686-unknown-uefi
 
+*_*_*_RUST_ZFLAGS = -Z unstable-options -Z build-std=core,compiler_builtins,alloc -Z build-std-features=compiler-builtins-mem
+
 *_*_*_RUSTC_PATH            = rustc
 DEBUG_*_X64_RUSTC_FLAGS     = --edition=2018 --target $(TARGET_TRIPLE) -C debuginfo=2 --crate-type staticlib
 RELEASE_*_X64_RUSTC_FLAGS   = --edition=2018 --target $(TARGET_TRIPLE) -C debuginfo=3 --crate-type staticlib


### PR DESCRIPTION
Previously Z flags were set in the projects .cargo/config.toml file. This file has been deleted as it forced host target builds (for tests) to use compiler flags meant for target based builds. To ensure the flags continue to be used during target builds, they are added to the build command itself.

## Description

<_Please include a description of the change and why this change was made._>

- [ ] Breaking change?
  - Will this change break pre-existing builds or functionality without action being taken?

## How This Was Tested

<_Please describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
