### PR TITLE
Add debug messages for DHCP state changes, Tftp progress, and PxeBc progress.

### DIFF
--- a/NetworkPkg/Dhcp4Dxe/Dhcp4Impl.c
+++ b/NetworkPkg/Dhcp4Dxe/Dhcp4Impl.c
@@ -788,13 +788,13 @@ EfiDhcp4Start (
   DhcpSb = Instance->Service;
 
   if (DhcpSb->DhcpState == Dhcp4Stopped) {
-    DEBUG ((DEBUG_NET, "%a: failed, in stopped state.\n", __FUNCTION__));
+    DEBUG ((DEBUG_NET | DEBUG_ERROR, "%a: failed, in stopped state.\n", __FUNCTION__));
     Status = EFI_NOT_STARTED;
     goto ON_ERROR;
   }
 
   if ((DhcpSb->DhcpState != Dhcp4Init) && (DhcpSb->DhcpState != Dhcp4InitReboot)) {
-    DEBUG ((DEBUG_NET, "%a: failed, !Init and !InitReboot state.\n", __FUNCTION__));
+    DEBUG ((DEBUG_NET | DEBUG_ERROR, "%a: failed, !Init and !InitReboot state.\n", __FUNCTION__));
     Status = EFI_ALREADY_STARTED;
     goto ON_ERROR;
   }

--- a/NetworkPkg/Dhcp4Dxe/Dhcp4Impl.c
+++ b/NetworkPkg/Dhcp4Dxe/Dhcp4Impl.c
@@ -788,11 +788,13 @@ EfiDhcp4Start (
   DhcpSb = Instance->Service;
 
   if (DhcpSb->DhcpState == Dhcp4Stopped) {
+    DEBUG ((DEBUG_NET, "%a: failed, in stopped state.\n", __FUNCTION__));
     Status = EFI_NOT_STARTED;
     goto ON_ERROR;
   }
 
   if ((DhcpSb->DhcpState != Dhcp4Init) && (DhcpSb->DhcpState != Dhcp4InitReboot)) {
+    DEBUG ((DEBUG_NET, "%a: failed, !Init and !InitReboot state.\n", __FUNCTION__));
     Status = EFI_ALREADY_STARTED;
     goto ON_ERROR;
   }
@@ -903,11 +905,13 @@ EfiDhcp4RenewRebind (
   DhcpSb = Instance->Service;
 
   if (DhcpSb->DhcpState == Dhcp4Stopped) {
+    DEBUG ((DEBUG_NET, "%a: failed, Dhcp4Stopped.\n", __FUNCTION__));
     Status = EFI_NOT_STARTED;
     goto ON_EXIT;
   }
 
   if (DhcpSb->DhcpState != Dhcp4Bound) {
+    DEBUG ((DEBUG_NET, "%a: failed, !Dhcp4Bound.\n", __FUNCTION__));
     Status = EFI_ACCESS_DENIED;
     goto ON_EXIT;
   }
@@ -1016,6 +1020,7 @@ EfiDhcp4Release (
   DhcpSb = Instance->Service;
 
   if ((DhcpSb->DhcpState != Dhcp4InitReboot) && (DhcpSb->DhcpState != Dhcp4Bound)) {
+    DEBUG ((DEBUG_NET, "%a: failed, !InitReboot and !Bound.\n", __FUNCTION__));
     Status = EFI_ACCESS_DENIED;
     goto ON_EXIT;
   }
@@ -1084,6 +1089,8 @@ EfiDhcp4Stop (
   DhcpSb = Instance->Service;
 
   DhcpCleanLease (DhcpSb);
+
+  DEBUG ((DEBUG_NET, "%a: new state is Dhcp4Stopped.\n", __FUNCTION__));
 
   DhcpSb->DhcpState    = Dhcp4Stopped;
   DhcpSb->ServiceState = DHCP_UNCONFIGED;

--- a/NetworkPkg/Dhcp4Dxe/Dhcp4Io.c
+++ b/NetworkPkg/Dhcp4Dxe/Dhcp4Io.c
@@ -900,7 +900,7 @@ DhcpHandleReboot (
 
   Status = DhcpCallUser (DhcpSb, Dhcp4RcvdAck, Packet, NULL);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_NET, "%a: Error from CallUser.\n", __FUNCTION__));
+    DEBUG ((DEBUG_NET, "%a: Error from CallUser - %r.\n", __FUNCTION__, Status));
     goto ON_EXIT;
   }
 

--- a/NetworkPkg/Dhcp4Dxe/Dhcp4Io.c
+++ b/NetworkPkg/Dhcp4Dxe/Dhcp4Io.c
@@ -917,7 +917,7 @@ DhcpHandleReboot (
   DhcpSb->Selected = Packet;
   Status           = DhcpLeaseAcquired (DhcpSb);
   if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_NET, "%a: Error from LeaseAcquired.\n", __FUNCTION__));
+    DEBUG ((DEBUG_NET, "%a: Error from LeaseAcquired - %r.\n", __FUNCTION__, Status));
     return Status;
   }
 

--- a/NetworkPkg/Dhcp4Dxe/Dhcp4Io.c
+++ b/NetworkPkg/Dhcp4Dxe/Dhcp4Io.c
@@ -39,7 +39,7 @@ DhcpInitRequest (
     Status = DhcpSendMessage (DhcpSb, NULL, NULL, DHCP_MSG_DISCOVER, NULL);
 
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_NET, "%a: SendError, new state is Dhcp4Init. Code=%r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_NET | DEBUG_ERROR, "%a: SendError, new state is Dhcp4Init. Code=%r\n", __FUNCTION__, Status));
       DhcpSb->DhcpState = Dhcp4Init;
       return Status;
     }
@@ -48,7 +48,7 @@ DhcpInitRequest (
     Status = DhcpSendMessage (DhcpSb, NULL, NULL, DHCP_MSG_REQUEST, NULL);
 
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_NET, "%a: SendError, new state is Dhcp4InitReboot. Code-%r\n", __FUNCTION__, Status));
+      DEBUG ((DEBUG_NET | DEBUG_ERROR, "%a: SendError, new state is Dhcp4InitReboot. Code-%r\n", __FUNCTION__, Status));
       DhcpSb->DhcpState = Dhcp4InitReboot;
       return Status;
     }

--- a/NetworkPkg/Dhcp4Dxe/Dhcp4Io.c
+++ b/NetworkPkg/Dhcp4Dxe/Dhcp4Io.c
@@ -1421,7 +1421,7 @@ DhcpRetransmit (
 
   ASSERT (DhcpSb->LastPacket != NULL);
 
-  DEBUG ((DEBUG_NET, "%a:\n", __FUNCTION__));
+  DEBUG ((DEBUG_NET, "%a: Entry...\n", __FUNCTION__));
 
   //
   // For REQUEST message in Dhcp4Requesting state, do not change the secs fields.

--- a/NetworkPkg/Dhcp4Dxe/Dhcp4Io.c
+++ b/NetworkPkg/Dhcp4Dxe/Dhcp4Io.c
@@ -39,7 +39,7 @@ DhcpInitRequest (
     Status = DhcpSendMessage (DhcpSb, NULL, NULL, DHCP_MSG_DISCOVER, NULL);
 
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_NET, "%a: SendError, new state is Dhcp4Init.\n", __FUNCTION__));
+      DEBUG ((DEBUG_NET, "%a: SendError, new state is Dhcp4Init. Code=%r\n", __FUNCTION__, Status));
       DhcpSb->DhcpState = Dhcp4Init;
       return Status;
     }
@@ -48,7 +48,7 @@ DhcpInitRequest (
     Status = DhcpSendMessage (DhcpSb, NULL, NULL, DHCP_MSG_REQUEST, NULL);
 
     if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_NET, "%a: SendError, new state is Dhcp4InitReboot.\n", __FUNCTION__));
+      DEBUG ((DEBUG_NET, "%a: SendError, new state is Dhcp4InitReboot. Code-%r\n", __FUNCTION__, Status));
       DhcpSb->DhcpState = Dhcp4InitReboot;
       return Status;
     }

--- a/NetworkPkg/Dhcp4Dxe/Dhcp4Io.c
+++ b/NetworkPkg/Dhcp4Dxe/Dhcp4Io.c
@@ -431,7 +431,6 @@ DhcpCleanLease (
   IN DHCP_SERVICE  *DhcpSb
   )
 {
-
   DEBUG ((DEBUG_NET, "%a: Setting state to Init.\n", __FUNCTION__));
 
   DhcpSb->DhcpState  = Dhcp4Init;
@@ -576,8 +575,6 @@ DhcpEndSession (
   IN EFI_STATUS    Status
   )
 {
-
-
   if (DHCP_CONNECTED (DhcpSb->DhcpState)) {
     DEBUG ((DEBUG_NET, "%a: AddressLost.\n", __FUNCTION__));
     DhcpCallUser (DhcpSb, Dhcp4AddressLost, NULL, NULL);
@@ -884,7 +881,7 @@ DhcpHandleReboot (
     DhcpSb->ClientAddr = 0;
     DEBUG ((DEBUG_NET, "%a: NAK received, going to Init\n", __FUNCTION__));
 
-    DhcpSb->DhcpState  = Dhcp4Init;
+    DhcpSb->DhcpState = Dhcp4Init;
 
     Status = DhcpInitRequest (DhcpSb);
     goto ON_EXIT;

--- a/NetworkPkg/Dhcp4Dxe/Dhcp4Io.c
+++ b/NetworkPkg/Dhcp4Dxe/Dhcp4Io.c
@@ -88,6 +88,8 @@ DhcpCallUser (
     *NewPacket = NULL;
   }
 
+  DEBUG ((DEBUG_NET, "%a: Calling user code with DhcpState=%d.\n", __FUNCTION__, Event));
+
   //
   // If user doesn't provide the call back function, return the value
   // that directs the client to continue the normal process.
@@ -104,8 +106,6 @@ DhcpCallUser (
 
     return EFI_SUCCESS;
   }
-
-  DEBUG ((DEBUG_NET, "%a: Calling user code with DhcpState=%d.\n", __FUNCTION__, DhcpSb->DhcpState));
 
   Status = Config->Dhcp4Callback (
                      &DhcpSb->ActiveChild->Dhcp4Protocol,

--- a/NetworkPkg/Mtftp4Dxe/Mtftp4Impl.c
+++ b/NetworkPkg/Mtftp4Dxe/Mtftp4Impl.c
@@ -492,6 +492,8 @@ Mtftp4Start (
   //
   Token->Status = EFI_NOT_READY;
 
+  DEBUG ((DEBUG_NET, "%a: Starting request, type=%d\n", __FUNCTION__, (UINT32)Operation));
+
   //
   // Build and send an initial requests
   //
@@ -637,6 +639,8 @@ EfiMtftp4Configure (
     return EFI_INVALID_PARAMETER;
   }
 
+  DEBUG ((DEBUG_NET, "%a: Entry\n", __FUNCTION__));
+
   Instance = MTFTP4_PROTOCOL_FROM_THIS (This);
 
   if (ConfigData == NULL) {
@@ -692,6 +696,8 @@ EfiMtftp4Configure (
 
     gBS->RestoreTPL (OldTpl);
   }
+
+  DEBUG ((DEBUG_NET, "%a: Exit Success\n", __FUNCTION__));
 
   return EFI_SUCCESS;
 }
@@ -794,6 +800,8 @@ EfiMtftp4ReadFile (
   IN EFI_MTFTP4_TOKEN     *Token
   )
 {
+  DEBUG ((DEBUG_NET, "%a: Entry\n", __FUNCTION__));
+
   return Mtftp4Start (This, Token, EFI_MTFTP4_OPCODE_RRQ);
 }
 
@@ -854,6 +862,8 @@ EfiMtftp4WriteFile (
   IN EFI_MTFTP4_TOKEN     *Token
   )
 {
+  DEBUG ((DEBUG_NET, "%a: Entry\n", __FUNCTION__));
+
   return Mtftp4Start (This, Token, EFI_MTFTP4_OPCODE_WRQ);
 }
 
@@ -923,6 +933,8 @@ EfiMtftp4ReadDirectory (
   IN EFI_MTFTP4_TOKEN     *Token
   )
 {
+  DEBUG ((DEBUG_NET, "%a: Entry\n", __FUNCTION__));
+
   return Mtftp4Start (This, Token, EFI_MTFTP4_OPCODE_DIR);
 }
 

--- a/NetworkPkg/Mtftp4Dxe/Mtftp4Rrq.c
+++ b/NetworkPkg/Mtftp4Dxe/Mtftp4Rrq.c
@@ -1,4 +1,4 @@
-F/** @file
+/** @file
   Routines to process Rrq (download).
 
 (C) Copyright 2014 Hewlett-Packard Development Company, L.P.<BR>

--- a/NetworkPkg/Mtftp4Dxe/Mtftp4Rrq.c
+++ b/NetworkPkg/Mtftp4Dxe/Mtftp4Rrq.c
@@ -1,4 +1,4 @@
-/** @file
+F/** @file
   Routines to process Rrq (download).
 
 (C) Copyright 2014 Hewlett-Packard Development Company, L.P.<BR>
@@ -48,6 +48,8 @@ Mtftp4RrqStart (
   )
 {
   EFI_STATUS  Status;
+
+  DEBUG ((DEBUG_NET, "%a: Entry\n", __FUNCTION__));
 
   //
   // The valid block number range are [1, 0xffff]. For example:
@@ -273,6 +275,7 @@ Mtftp4RrqHandleData (
   Status = Mtftp4RrqSaveBlock (Instance, Packet, Len);
 
   if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_NET, "%a: Error = %r\n", __FUNCTION__, Status));
     return Status;
   }
 
@@ -429,6 +432,7 @@ Mtftp4RrqConfigMcastPort (
   Status = McastIo->Protocol.Udp4->Configure (McastIo->Protocol.Udp4, &UdpConfig);
 
   if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_NET, "%a: Error = %r\n", __FUNCTION__, Status));
     return Status;
   }
 
@@ -448,6 +452,7 @@ Mtftp4RrqConfigMcastPort (
                                        );
 
     if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_NET, "%a: Error2 = %r\n", __FUNCTION__, Status));
       McastIo->Protocol.Udp4->Configure (McastIo->Protocol.Udp4, NULL);
       return Status;
     }
@@ -527,6 +532,8 @@ Mtftp4RrqHandleOack (
         );
     }
 
+    DEBUG ((DEBUG_NET, "%a: TFTP ERROR(%d) = %r\n", __FUNCTION__, __LINE__, Status));
+
     return EFI_TFTP_ERROR;
   }
 
@@ -545,6 +552,8 @@ Mtftp4RrqHandleOack (
           EFI_MTFTP4_ERRORCODE_ILLEGAL_OPERATION,
           (UINT8 *)"Illegal multicast setting"
           );
+
+        DEBUG ((DEBUG_NET, "%a: TFTP ERROR(%d) = %r\n", __FUNCTION__, __LINE__, Status));
 
         return EFI_TFTP_ERROR;
       }
@@ -591,6 +600,8 @@ Mtftp4RrqHandleOack (
           EFI_MTFTP4_ERRORCODE_ACCESS_VIOLATION,
           (UINT8 *)"Failed to create socket to receive multicast packet"
           );
+
+        DEBUG ((DEBUG_NET, "%a: TFTP ERROR(%d) = %r\n", __FUNCTION__, __LINE__, Status));
 
         return Status;
       }
@@ -669,6 +680,7 @@ Mtftp4RrqInput (
 
   if (EFI_ERROR (IoStatus)) {
     Status = IoStatus;
+    DEBUG ((DEBUG_NET, "%a: TFTP ERROR(%d) = %r\n", __FUNCTION__, __LINE__, Status));
     goto ON_EXIT;
   }
 
@@ -744,6 +756,8 @@ Mtftp4RrqInput (
           );
       }
 
+      DEBUG ((DEBUG_NET, "%a: TFTP ERROR(%d) = %r\n", __FUNCTION__, __LINE__, Status));
+
       Status = EFI_ABORTED;
       goto ON_EXIT;
     }
@@ -797,6 +811,8 @@ ON_EXIT:
       Status = UdpIoRecvDatagram (Instance->UnicastPort, Mtftp4RrqInput, Instance, 0);
     }
   }
+
+  DEBUG ((DEBUG_NET, "%a: Completed=%d. Code=%r\n", __FUNCTION__, Completed, Status));
 
   if (EFI_ERROR (Status) || Completed) {
     Mtftp4CleanOperation (Instance, Status);

--- a/NetworkPkg/Mtftp4Dxe/Mtftp4Wrq.c
+++ b/NetworkPkg/Mtftp4Dxe/Mtftp4Wrq.c
@@ -465,6 +465,8 @@ ON_EXIT:
     Status = UdpIoRecvDatagram (Instance->UnicastPort, Mtftp4WrqInput, Instance, 0);
   }
 
+  DEBUG ((DEBUG_NET, "%a: Completed=%d. Code=%r\n", __FUNCTION__, Completed, Status));
+
   //
   // Status may have been updated by UdpIoRecvDatagram
   //
@@ -495,6 +497,8 @@ Mtftp4WrqStart (
 {
   EFI_STATUS  Status;
 
+  DEBUG ((DEBUG_NET, "%a: Entry\n", __FUNCTION__));
+
   //
   // The valid block number range are [0, 0xffff]. For example:
   // the client sends an WRQ request to the server, the server
@@ -504,12 +508,14 @@ Mtftp4WrqStart (
   Status = Mtftp4InitBlockRange (&Instance->Blocks, 0, 0xffff);
 
   if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_NET, "%a: TFTP ERROR(%d) = %r\n", __FUNCTION__, __LINE__, Status));
     return Status;
   }
 
   Status = Mtftp4SendRequest (Instance);
 
   if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_NET, "%a: TFTP ERROR(%d) = %r\n", __FUNCTION__, __LINE__, Status));
     return Status;
   }
 

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcBoot.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcBoot.c
@@ -1219,6 +1219,7 @@ PxeBcLoadBootFile (
   // Begin to download the bootfile if everything is ready.
   //
   AsciiPrint ("\n Downloading NBP file...\n");
+  DEBUG ((DEBUG_NET, "%a:  Downloading NBP file...\n", __FUNCTION__));
   if (PxeBcMode->UsingIpv6) {
     Status = PxeBcReadBootFileList (
                Private,
@@ -1243,6 +1244,8 @@ PxeBcLoadBootFile (
 ON_EXIT:
   *BufferSize = (UINTN)CurrentSize;
   PxeBcUninstallCallback (Private, NewMakeCallback);
+
+  DEBUG ((DEBUG_NET, "%a:  Complete, code = %r\n", __FUNCTION__, Status));
 
   if (Status == EFI_SUCCESS) {
     AsciiPrint ("\n  NBP file downloaded successfully.\n");

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcImpl.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcImpl.c
@@ -2375,6 +2375,8 @@ EfiPxeLoadFile (
   EFI_STATUS                  Status;
   EFI_STATUS                  MediaStatus;
 
+  DEBUG ((DEBUG_NET, "%a: Entry\n", __FUNCTION__));
+
   if ((This == NULL) || (BufferSize == NULL) || (FilePath == NULL) || !IsDevicePathEnd (FilePath)) {
     return EFI_INVALID_PARAMETER;
   }
@@ -2383,6 +2385,7 @@ EfiPxeLoadFile (
   // Only support BootPolicy
   //
   if (!BootPolicy) {
+    DEBUG ((DEBUG_NET, "%a: !BootPolicy\n", __FUNCTION__));
     return EFI_UNSUPPORTED;
   }
 
@@ -2398,6 +2401,7 @@ EfiPxeLoadFile (
   MediaStatus = EFI_SUCCESS;
   NetLibDetectMediaWaitTimeout (Private->Controller, PXEBC_CHECK_MEDIA_WAITING_TIME, &MediaStatus);
   if (MediaStatus != EFI_SUCCESS) {
+    DEBUG ((DEBUG_NET, "%a: No Media\n", __FUNCTION__));
     return EFI_NO_MEDIA;
   }
 
@@ -2448,6 +2452,8 @@ EfiPxeLoadFile (
       Private->Dhcp4->Configure (Private->Dhcp4, NULL);
     }
   }
+
+  DEBUG ((DEBUG_NET, "%a: Completed, Code = %r\n", __FUNCTION__, Status));
 
   return Status;
 }


### PR DESCRIPTION
## Description

Add DEBUG message to Dhcp4Dxe

- [ No] Breaking change?
  - Will this change break pre-existing builds or functionality without action being taken?

## How This Was Tested

Not tested

## Integration Instructions

To only get the DHCP debug messages, edit your platform build .dsc to add the debug flag to

Current:
NetworkPkg/Dhcp4Dxe/Dhcp4Dxe.inf

To get the new DEBUG_NET messages from Dhcp4Dxe:
  NetworkPkg/Dhcp4Dxe/Dhcp4Dxe.inf {
    <PcdsPatchableInModule>
      gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel|0x80084246
    <PcdsFixedAtBuild>
      gEfiMdePkgTokenSpaceGuid.PcdFixedDebugPrintErrorLevel|0x80084246
}
