### PR TITLE
Add support for HTTP error 429

### DIFF
--- a/NetworkPkg/Library/DxeHttpLib/DxeHttpLib.c
+++ b/NetworkPkg/Library/DxeHttpLib/DxeHttpLib.c
@@ -2072,6 +2072,8 @@ HttpMappingToStatusCode (
       return HTTP_STATUS_416_REQUESTED_RANGE_NOT_SATISFIED;
     case 417:
       return HTTP_STATUS_417_EXPECTATION_FAILED;
+    case 429:                                    // MU_CHANGE
+      return HTTP_STATUS_429_TOO_MANY_REQUESTS;  // MU_CHANGE
     case 500:
       return HTTP_STATUS_500_INTERNAL_SERVER_ERROR;
     case 501:


### PR DESCRIPTION
## Description

HTTP status codes have to be explicitly specified in DxeHttpLib in order to be supported.  Intune may return 429 to throttle requests.

- [ No] Breaking change?
  - Will this change break pre-existing builds or functionality without action being taken?

## How This Was Tested

Compiled.

## Integration Instructions

N/A
