### PR TITLE
Fix missing logs from GenMake.py

### DIFF
--- a/BaseTools/Source/Python/AutoGen/GenMake.py
+++ b/BaseTools/Source/Python/AutoGen/GenMake.py
@@ -14,6 +14,7 @@ import sys
 import string
 import re
 import os.path as path
+from Common import EdkLogger
 from Common.LongFilePathSupport import OpenLongFilePath as open
 from Common.MultipleWorkspace import MultipleWorkspace as mws
 from Common.BuildToolError import *

--- a/BaseTools/Source/Python/AutoGen/GenMake.py
+++ b/BaseTools/Source/Python/AutoGen/GenMake.py
@@ -14,7 +14,7 @@ import sys
 import string
 import re
 import os.path as path
-from Common import EdkLogger
+from Common import EdkLogger  # MU_CHANGE
 from Common.LongFilePathSupport import OpenLongFilePath as open
 from Common.MultipleWorkspace import MultipleWorkspace as mws
 from Common.BuildToolError import *


### PR DESCRIPTION
## Description

* EdkLogger logs were not showing up as part of the build log output. Adding the EdkLogger import to GenMake.py fixes the missing log prints.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

* Tested by adding EdkLogger.error and EdkLogger.quiet prints to GenMake.py and verified the output in the platform build log.

## Integration Instructions

N/A
