### PR TITLE
Set EFI_MEMORY_XP as a required capability for PciHostBridge

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
@@ -545,7 +545,10 @@ InitializePciHostBridge (
         Status = AddMemoryMappedIoSpace (
                    HostAddress,
                    MemApertures[MemApertureIndex]->Limit - MemApertures[MemApertureIndex]->Base + 1,
-                   EFI_MEMORY_UC
+                   // MU_CHANGE START: MMIO ranges should be non-executable
+                   // EFI_MEMORY_UC
+                   EFI_MEMORY_XP | EFI_MEMORY_UC
+                   // MU_CHANGE END
                    );
         ASSERT_EFI_ERROR (Status);
         Status = gDS->SetMemorySpaceAttributes (


### PR DESCRIPTION
## Description

Commit [506f014575bc3473549d06d7d9dff1dea3474183](https://github.com/microsoft/mu_basecore/commit/506f014575bc3473549d06d7d9dff1dea3474183) made MMIO ranges NX. However, it did not set NX as a required capability for MMIO ranges. This caused some platforms to fail to set the region as both NX and UC, which caused a translation fault without UC set. This hung the system.

The suspicion is that other platforms where the above commit was tested did not exercise PCI (as they were using virtio) and so did not attempt to use these MMIO ranges.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on a breaking platform and on QemuQ35 and QemuSbsa, both with and without memory protections enabled.

## Integration Instructions

N/A
