### PR TITLE
Update FillInMemoryMap() to Ignore Regions of GCD Memory Type Non-Existent

### DIFF
--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -1301,15 +1301,16 @@ FillInMemoryMap (
                           &OverlapLength,
                           &GcdType
                           );
+      if (GcdType != EfiGcdMemoryTypeNonExistent) {
+        POPULATE_MEMORY_DESCRIPTOR_ENTRY (
+          NewMemoryMapCurrent,
+          StartOfAddressSpace,
+          EfiSizeToPages (OldMemoryMapCurrent->PhysicalStart - StartOfAddressSpace - RemainingLength),
+          GcdTypeToEfiType (&GcdType)
+          );
+        NewMemoryMapCurrent = NEXT_MEMORY_DESCRIPTOR (NewMemoryMapCurrent, *DescriptorSize);
+      }
 
-      POPULATE_MEMORY_DESCRIPTOR_ENTRY (
-        NewMemoryMapCurrent,
-        StartOfAddressSpace,
-        EfiSizeToPages (OldMemoryMapCurrent->PhysicalStart - StartOfAddressSpace - RemainingLength),
-        GcdTypeToEfiType (&GcdType)
-        );
-
-      NewMemoryMapCurrent = NEXT_MEMORY_DESCRIPTOR (NewMemoryMapCurrent, *DescriptorSize);
       StartOfAddressSpace = OldMemoryMapCurrent->PhysicalStart - RemainingLength;
     } while (RemainingLength > 0);
   }
@@ -1323,22 +1324,24 @@ FillInMemoryMap (
       if (NextEntryStart > LastEntryEnd) {
         // Fill in missing region based on the GCD Memory Map
         do {
-          NewMemoryMapCurrent = NEXT_MEMORY_DESCRIPTOR (NewMemoryMapCurrent, *DescriptorSize);
-          OverlapLength       = NextEntryStart - LastEntryEnd;
-          RemainingLength     = GetOverlappingMemorySpaceRegion (
-                                  MemorySpaceMap,
-                                  MemorySpaceMapDescriptorCount,
-                                  &LastEntryEnd,
-                                  &OverlapLength,
-                                  &GcdType
-                                  );
+          OverlapLength   = NextEntryStart - LastEntryEnd;
+          RemainingLength = GetOverlappingMemorySpaceRegion (
+                              MemorySpaceMap,
+                              MemorySpaceMapDescriptorCount,
+                              &LastEntryEnd,
+                              &OverlapLength,
+                              &GcdType
+                              );
+          if (GcdType != EfiGcdMemoryTypeNonExistent) {
+            NewMemoryMapCurrent = NEXT_MEMORY_DESCRIPTOR (NewMemoryMapCurrent, *DescriptorSize);
+            POPULATE_MEMORY_DESCRIPTOR_ENTRY (
+              NewMemoryMapCurrent,
+              LastEntryEnd,
+              EfiSizeToPages (NextEntryStart - LastEntryEnd - RemainingLength),
+              GcdTypeToEfiType (&GcdType)
+              );
+          }
 
-          POPULATE_MEMORY_DESCRIPTOR_ENTRY (
-            NewMemoryMapCurrent,
-            LastEntryEnd,
-            EfiSizeToPages (NextEntryStart - LastEntryEnd - RemainingLength),
-            GcdTypeToEfiType (&GcdType)
-            );
           LastEntryEnd = NextEntryStart - RemainingLength;
         } while (RemainingLength > 0);
       }
@@ -1362,15 +1365,17 @@ FillInMemoryMap (
                           &OverlapLength,
                           &GcdType
                           );
+      if (GcdType != EfiGcdMemoryTypeNonExistent) {
+        POPULATE_MEMORY_DESCRIPTOR_ENTRY (
+          NewMemoryMapCurrent,
+          LastEntryEnd,
+          EfiSizeToPages (EndOfAddressSpace - LastEntryEnd - RemainingLength),
+          GcdTypeToEfiType (&GcdType)
+          );
+        NewMemoryMapCurrent = NEXT_MEMORY_DESCRIPTOR (NewMemoryMapCurrent, *DescriptorSize);
+      }
 
-      POPULATE_MEMORY_DESCRIPTOR_ENTRY (
-        NewMemoryMapCurrent,
-        LastEntryEnd,
-        EfiSizeToPages (EndOfAddressSpace - LastEntryEnd - RemainingLength),
-        GcdTypeToEfiType (&GcdType)
-        );
-      NewMemoryMapCurrent = NEXT_MEMORY_DESCRIPTOR (NewMemoryMapCurrent, *DescriptorSize);
-      LastEntryEnd        = EndOfAddressSpace - RemainingLength;
+      LastEntryEnd = EndOfAddressSpace - RemainingLength;
     } while (RemainingLength > 0);
   }
 


### PR DESCRIPTION
## Description

The FillInMemoryMap() routine which fills in gaps in the EFI memory map based on the GCD memory map. This PR updates the behavior of FillInMemoryMap() to ignore regions not present in the EFI memory map but present in the GCD memory map which are of type EfiGcdMemoryTypeNonExistent.

Platforms don't need to do anything special to integrate this change, but it may solve problems caused by the memory protection initialization routine attempting to set access attributes on memory ranges which aren't configurable via a 4-level page table.

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Comparing the updated EFI memory map with and without the changes.

## Integration Instructions

N/A
