### PR TITLE
Plugin/CodeQL: Fix query specifier assignment

### DIFF
--- a/.pytool/Plugin/CodeQL/CodeQlAnalyzePlugin.py
+++ b/.pytool/Plugin/CodeQL/CodeQlAnalyzePlugin.py
@@ -105,7 +105,8 @@ class CodeQlAnalyzePlugin(IUefiBuildPlugin):
         # by setting the value in the STUART_CODEQL_QUERY_SPECIFIERS
         # environment variable.
         if not query_specifiers:
-            builder.env.GetValue("STUART_CODEQL_QUERY_SPECIFIERS")
+            query_specifiers = builder.env.GetValue(
+                                "STUART_CODEQL_QUERY_SPECIFIERS")
 
         # Use this plugins query set file as the default fallback if it is
         # not overridden. It is possible the file is not present if modified


### PR DESCRIPTION
## Description

The `query_specifiers` variable should be assigned to the
`STUART_CODEQL_QUERY_SPECIFIERS` environment value if it is present.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Verified a query set specified in `STUART_CODEQL_QUERY_SPECIFIERS`
was used as expected.

## Integration Instructions

N/A

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>