### PR TITLE
CodeQL plugin filter support [Rebase & FF]

### DIFF
--- a/.pytool/Plugin/CodeQL/CodeQlAnalyzePlugin.py
+++ b/.pytool/Plugin/CodeQL/CodeQlAnalyzePlugin.py
@@ -11,6 +11,7 @@ import logging
 import os
 import yaml
 
+from analyze import analyze_filter
 from common import codeql_plugin
 
 from edk2toolext import edk2_logging
@@ -80,6 +81,7 @@ class CodeQlAnalyzePlugin(IUefiBuildPlugin):
         query_specifiers = None
         package_config_file = Path(os.path.join(
                                 self.package_path, self.package + ".ci.yaml"))
+        plugin_data = None
         if package_config_file.is_file():
             with open(package_config_file, 'r') as cf:
                 package_config_file_data = yaml.safe_load(cf)
@@ -138,6 +140,58 @@ class CodeQlAnalyzePlugin(IUefiBuildPlugin):
             logging.critical(f"The sarif file {self.codeql_sarif_path} was "
                              f"not created. Analysis cannot continue.")
             return -1
+
+        filter_pattern_data = []
+        global_filter_file_value = builder.env.GetValue(
+                                    "STUART_CODEQL_FILTER_FILES")
+        if global_filter_file_value:
+            global_filter_files = global_filter_file_value.strip().split(',')
+            global_filter_files = [Path(f) for f in global_filter_files]
+
+            for global_filter_file in global_filter_files:
+                if global_filter_file.is_file():
+                    with open(global_filter_file, 'r') as ff:
+                        global_filter_file_data = yaml.safe_load(ff)
+                        if "Filters" in global_filter_file_data:
+                            current_pattern_data = \
+                                global_filter_file_data["Filters"]
+                            if type(current_pattern_data) is not list:
+                                logging.critical(
+                                    f"CodeQL pattern data must be a list of "
+                                    f"strings. Data in "
+                                    f"{str(global_filter_file.resolve())} is "
+                                    f"invalid. CodeQL analysis is incomplete.")
+                                return -1
+                            filter_pattern_data += current_pattern_data
+                        else:
+                            logging.critical(
+                                f"CodeQL global filter file "
+                                f"{str(global_filter_file.resolve())} is  "
+                                f"malformed. Missing Filters section. CodeQL "
+                                f"analysis is incomplete.")
+                            return -1
+                else:
+                    logging.critical(
+                        f"CodeQL global filter file "
+                        f"{str(global_filter_file.resolve())} was not found. "
+                        f"CodeQL analysis is incomplete.")
+                    return -1
+
+        if plugin_data and "Patterns" in plugin_data:
+            if type(plugin_data["Patterns"]) is not list:
+                logging.critical(
+                    "CodeQL pattern data must be a list of strings. "
+                    "CodeQL analysis is incomplete.")
+                return -1
+            filter_pattern_data.extend(plugin_data["Patterns"])
+
+        if filter_pattern_data:
+            logging.info("Applying CodeQL SARIF result filters.")
+            analyze_filter.filter_sarif(
+                self.codeql_sarif_path,
+                self.codeql_sarif_path,
+                filter_pattern_data,
+                split_lines=False)
 
         with open(self.codeql_sarif_path, 'r') as sf:
             sarif_file_data = json.load(sf)

--- a/.pytool/Plugin/CodeQL/Readme.md
+++ b/.pytool/Plugin/CodeQL/Readme.md
@@ -32,17 +32,19 @@ such users is [Local Development Tips](#local-development-tips).
 1. [Database and Analysis Result Locations](#database-and-analysis-result-locations)
 2. [Global Configuration](#global-configuration)
 3. [Package-Specific Configuration](#package-specific-configuration)
-4. [Integration Instructions](#integration-instructions)
+4. [Filter Patterns](#filter-patterns)
+5. [Integration Instructions](#integration-instructions)
    - [Integration Step 1 - Choose Scopes](#integration-step-1---choose-scopes)
+     - [Scopes Available](#scopes-available)
    - [Integration Step 2 - Choose CodeQL Queries](#integration-step-2---choose-codeql-queries)
    - [Integration Step 3 - Determine Global Configuration Values](#integration-step-3---determine-global-configuration-values)
    - [Integration Step 4 - Determine Package-Specific Configuration Values](#integration-step-4---determine-package-specific-configuration-values)
    - [Integration Step 5 - Testing](#integration-step-5---testing)
-     - [Scopes Available](#scopes-available)
-5. [High-Level Operation](#high-level-operation)
+   - [Integration Step 6 - Define Inclusion and Exclusion Filter Patterns](#integration-step-6---define-inclusion-and-exclusion-filter-patterns)
+6. [High-Level Operation](#high-level-operation)
    - [CodeQlBuildPlugin](#codeqlbuildplugin)
    - [CodeQlAnalyzePlugin](#codeqlanalyzeplugin)
-6. [Local Development Tips](#local-development-tips)
+7. [Local Development Tips](#local-development-tips)
 
 ## Database and Analysis Result Locations
 
@@ -85,6 +87,26 @@ built by the script.
 - `STUART_CODEQL_PATH` - The path to the CodeQL CLI application to use.
 - `STUART_CODEQL_QUERY_SPECIFIERS` - The CodeQL CLI query specifiers to use. See [Running codeql database analyze](https://codeql.github.com/docs/codeql-cli/analyzing-databases-with-the-codeql-cli/#running-codeql-database-analyze)
   for possible options.
+- `STUART_CODEQL_FILTER_FILES` - The path to "filter" files that contains filter patterns as described in
+  [Filter Patterns](#filter-patterns).
+  - More than one file may be specified by separating each absolute file path with a comma.
+    - This might be useful to reference a global filter file from an upstream repo and also include a global filter
+      file for the local repo.
+    - Filters are concatenated in the order of files in the variable. Patterns in later files can override patterns
+      in earlier files.
+  - The file only needs to contain a list of filter pattern strings under a `"Filters"` key. For example:
+
+    ```yaml
+      {
+        "Filters": [
+          "<pattern-line-1>",
+          "<pattern-line-2>"
+        ]
+      }
+      ...
+    ```
+
+    Comments are allowed in the filter files and begin with `#` (like a normal YAML file).
 
 ## Package-Specific Configuration
 
@@ -98,8 +120,57 @@ the package.
   "CodeQlAnalyze": {
       "AuditOnly": False,         # Don't fail the build if there are errors. Just log them.
       "QuerySpecifiers": ""       # Query specifiers to pass to CodeQL CLI.
+      "Filters": ""               # Inclusion/exclusion filters
   }
 ```
+
+> _NOTE:_ If a global filter set is provided via `STUART_CODEQL_FILTER_FILES` and a package has a package-specific
+> list, then the package-specific filter list (in a package CI YAML file) is appended onto the global filter list and
+> may be used to override settings in the global list.
+
+The format used to specify items in `"Filters"` is specified in [Filter Patterns](#filter-patterns).
+
+## Filter Patterns
+
+As you inspect results, you may want to include or exclude certain sets of results. For example, exclude some files by
+file path entirely or adjust the CodeQL rule applied to a certain file. This plugin reuses logic from a popular
+GitHub Action called [`filter-sarif`](https://github.com/advanced-security/filter-sarif) to allow filtering as part of
+the plugin analysis process.
+
+If any results are excluded using filters, the results are removed from the SARIF file. This allows the exclude results
+seen locally to exactly match the results on the CI server.
+
+Read the ["Patterns"](https://github.com/advanced-security/filter-sarif#patterns) section there for more details. The
+patterns section is also copied below with some updates to make the information more relevant for an edk2 codebase
+for convenience.
+
+Each pattern line is of the form:
+
+```plaintext
+[+/-]<file pattern>[:<rule pattern>]
+```
+
+For example:
+
+```yaml
+-**/*Test*.c:**             # exclusion pattern: remove all alerts from all test files
+-**/*Test*.c                # ditto, short form of the line above
++**/*.c:cpp/infiniteloop    # inclusion pattern: This line has precedence over the first two
+                            # and thus "allow lists" alerts of type "cpp/infiniteloop"
+**/*.c:cpp/infiniteloop     # ditto, the "+" in inclusion patterns is optional
+**                          # allow all alerts in all files (reverses all previous lines)
+```
+
+- The path separator character in patterns is always `/`, independent of the platform the code is running on and
+  independent of the paths in the SARIF file.
+- `*` matches any character, except a path separator
+- `**` matches any character and is only allowed between path separators, e.g. `/**/file.txt`, `**/file.txt` or `**`.
+  NOT allowed: `**.txt`, `/etc**`
+- The rule pattern is optional. If omitted, it will apply to alerts of all types.
+- Subsequent lines override earlier ones. By default all alerts are included.
+- If you need to use the literals `+`, `-`, `\` or `:` in your pattern, you can escape them with `\`, e.g.
+  `\-this/is/an/inclusion/file/pattern\:with-a-semicolon:and/a/rule/pattern/with/a/\\/backslash`. For `+` and `-`, this
+  is only necessary if they appear at the beginning of the pattern line.
 
 ## Integration Instructions
 
@@ -215,6 +286,11 @@ package's CI YAML file.
 ### Integration Step 5 - Testing
 
 Verify a `stuart_update` and `stuart_build` (or `stuart_ci_build`) command work.
+
+### Integration Step 6 - Define Inclusion and Exclusion Filter Patterns
+
+After reviewing the test results from Step 5, determine if you need to apply any filters as described in
+[Filter Patterns](#filter-patterns).
 
 ## High-Level Operation
 

--- a/.pytool/Plugin/CodeQL/Readme.md
+++ b/.pytool/Plugin/CodeQL/Readme.md
@@ -1,9 +1,20 @@
 # CodeQL Plugin
 
-The set of CodeQL plugins provided include two main plugins:
+The set of CodeQL plugins provided include two main plugins that seamlessly integrate into a Stuart build environment:
 
 1. `CodeQlBuildPlugin` - Used to produce a CodeQL database from a build.
 2. `CodeQlAnalyzePlugin` - Used to analyze a CodeQL database.
+
+While CodeQL can be run in a CI environment with other approaches. This plugin offers the following advantages:
+
+1. Provides exactly the same results locally as on a CI server.
+2. Integrates very well into VS Code.
+3. Very simple to use - just use normal Stuart update and build commands.
+4. Very simple to understand - minimally wraps the official CodeQL CLI.
+5. Very simple to integrate - works like any other Stuart build plugin.
+   - Integration is usually just a few lines of code.
+6. Portable - not tied to Azure DevOps specific, GitHub specific, or other host infrastructure.
+7. Versioned - the query and filters are versioned in source control so easy to find and track.
 
 ❗ It is very important to read the Integration Instructions in this file and determine how to best integrate the
 CodeQL plugin into your environment.

--- a/.pytool/Plugin/CodeQL/analyze/analyze_filter.py
+++ b/.pytool/Plugin/CodeQL/analyze/analyze_filter.py
@@ -1,0 +1,176 @@
+# @file analyze_filter.py
+#
+# Filters results in a SARIF file.
+#
+# Based on code in:
+#   https://github.com/advanced-security/filter-sarif
+#
+# Specifically:
+#   https://github.com/advanced-security/filter-sarif/blob/main/filter_sarif.py
+#
+# That code is licensed under:
+#            Apache License
+#      Version 2.0, January 2004
+#   http://www.apache.org/licenses/
+#
+# View the full and complete license as provided by that repository here:
+#   https://github.com/advanced-security/filter-sarif/blob/main/LICENSE
+#
+# This file has been altered from its original form.
+#
+# It primarily contains modifications made to integrate with the CodeQL plugin.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+import json
+import logging
+import re
+from os import PathLike
+from typing import Iterable, List, Tuple
+
+from analyze.globber import match
+
+
+def _match_path_and_rule(
+    path: str, rule: str, patterns: Iterable[str]) -> bool:
+    """Returns whether a given path matches a given rule.
+
+    Args:
+        path (str): A file path string.
+        rule (str): A rule file path string.
+        patterns (Iterable[str]): An iterable of pattern strings.
+
+    Returns:
+        bool: True if the path matches a rule. Otherwise, False.
+    """
+    result = True
+    for s, fp, rp in patterns:
+        if match(rp, rule) and match(fp, path):
+            result = s
+    return result
+
+
+def _parse_pattern(line: str) -> Tuple[str]:
+    """Parses a given pattern line.
+
+    Args:
+        line (str): The line string that contains the rule.
+
+    Returns:
+        Tuple[str]: The parsed sign, file pattern, and rule pattern from the
+                    line.
+    """
+    sep_char = ':'
+    esc_char = '\\'
+    file_pattern = ''
+    rule_pattern = ''
+    seen_separator = False
+    sign = True
+
+    # inclusion or exclusion pattern?
+    u_line = line
+    if line:
+        if line[0] == '-':
+            sign = False
+            u_line = line[1:]
+        elif line[0] == '+':
+            u_line = line[1:]
+
+    i = 0
+    while i < len(u_line):
+        c = u_line[i]
+        i = i + 1
+        if c == sep_char:
+            if seen_separator:
+                raise Exception(
+                    'Invalid pattern: "' + line + '" Contains more than one '
+                    'separator!')
+            seen_separator = True
+            continue
+        elif c == esc_char:
+            next_c = u_line[i] if (i < len(u_line)) else None
+            if next_c in ['+' , '-', esc_char, sep_char]:
+                i = i + 1
+                c = next_c
+        if seen_separator:
+            rule_pattern = rule_pattern + c
+        else:
+            file_pattern = file_pattern + c
+
+    if not rule_pattern:
+        rule_pattern = '**'
+
+    return sign, file_pattern, rule_pattern
+
+
+def filter_sarif(input_sarif: PathLike,
+                 output_sarif: PathLike,
+                 patterns: List[str],
+                 split_lines: bool) -> None:
+    """Filters a SARIF file with a given set of filter patterns.
+
+    Args:
+        input_sarif (PathLike): Input SARIF file path.
+        output_sarif (PathLike): Output SARIF file path.
+        patterns (PathLike): List of filter pattern strings.
+        split_lines (PathLike): Whether to split lines in individual patterns.
+    """
+    if split_lines:
+        tmp = []
+        for p in patterns:
+            tmp = tmp + re.split('\r?\n', p)
+        patterns = tmp
+
+    patterns = [_parse_pattern(p) for p in patterns if p]
+
+    logging.debug('Given patterns:')
+    for s, fp, rp in patterns:
+        logging.debug(
+            'files: {file_pattern}    rules: {rule_pattern} ({sign})'.format(
+                file_pattern=fp,
+                rule_pattern=rp,
+                sign='positive' if s else 'negative'))
+
+    with open(input_sarif, 'r') as f:
+        s = json.load(f)
+
+    for run in s.get('runs', []):
+        if run.get('results', []):
+            new_results = []
+            for r in run['results']:
+                if r.get('locations', []):
+                    new_locations = []
+                    for l in r['locations']:
+                        # TODO: The uri field is optional. We might have to
+                        #       fetch the actual uri from "artifacts" via
+                        #       "index"
+                        # (see https://github.com/microsoft/sarif-tutorials/blob/main/docs/2-Basics.md#-linking-results-to-artifacts)
+                        uri = l.get(
+                                    'physicalLocation', {}).get(
+                                        'artifactLocation', {}).get(
+                                            'uri', None)
+
+                        # TODO: The ruleId field is optional and potentially
+                        #       ambiguous. We might have to fetch the actual
+                        #       ruleId from the rule metadata via the ruleIndex
+                        #       field.
+                        # (see https://github.com/microsoft/sarif-tutorials/blob/main/docs/2-Basics.md#rule-metadata)
+                        ruleId = r['ruleId']
+
+                        if (uri is None or
+                            _match_path_and_rule(uri, ruleId, patterns)):
+                            new_locations.append(l)
+                    r['locations'] = new_locations
+                    if new_locations:
+                        new_results.append(r)
+                else:
+                    # locations array doesn't exist or is empty, so we can't
+                    # match on anything. Therefore, we include the result in
+                    # the output.
+                    new_results.append(r)
+            run['results'] = new_results
+
+    with open(output_sarif, 'w') as f:
+        json.dump(s, f, indent=2)

--- a/.pytool/Plugin/CodeQL/analyze/globber.py
+++ b/.pytool/Plugin/CodeQL/analyze/globber.py
@@ -1,0 +1,132 @@
+# @file globber.py
+#
+# Provides global functionality for use by the CodeQL plugin.
+#
+# Copyright 2019 Jaakko Kangasharju
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file has been altered from its original form.
+#
+# Based on code in:
+#   https://github.com/advanced-security/filter-sarif
+#
+# Specifically:
+#   https://github.com/advanced-security/filter-sarif/blob/main/filter_sarif.py
+#
+# That code is licensed under:
+#            Apache License
+#      Version 2.0, January 2004
+#   http://www.apache.org/licenses/
+#
+# This file has been altered from its original form. Primarily modifications
+# made to integrate with the CodeQL plugin.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+import re
+
+_double_star_after_invalid_regex = re.compile(r'[^/\\]\*\*')
+_double_star_first_before_invalid_regex = re.compile('^\\*\\*[^/]')
+_double_star_middle_before_invalid_regex = re.compile(r'[^\\]\*\*[^/]')
+
+
+def _match_component(pattern_component, file_name_component):
+    if len(pattern_component) == 0 and len(file_name_component) == 0:
+        return True
+    elif len(pattern_component) == 0:
+        return False
+    elif len(file_name_component) == 0:
+        return pattern_component == '*'
+    elif pattern_component[0] == '*':
+        return (_match_component(pattern_component, file_name_component[1:]) or
+                _match_component(pattern_component[1:], file_name_component))
+    elif pattern_component[0] == '?':
+        return _match_component(pattern_component[1:], file_name_component[1:])
+    elif pattern_component[0] == '\\':
+        return (len(pattern_component) >= 2 and
+                pattern_component[1] == file_name_component[0] and
+                _match_component(
+                    pattern_component[2:], file_name_component[1:]))
+    elif pattern_component[0] != file_name_component[0]:
+        return False
+    else:
+        return _match_component(pattern_component[1:], file_name_component[1:])
+
+
+def _match_components(pattern_components, file_name_components):
+    if len(pattern_components) == 0 and len(file_name_components) == 0:
+        return True
+    if len(pattern_components) == 0:
+        return False
+    if len(file_name_components) == 0:
+        return len(pattern_components) == 1 and pattern_components[0] == '**'
+    if pattern_components[0] == '**':
+        return (_match_components(pattern_components, file_name_components[1:])
+                or _match_components(
+                    pattern_components[1:], file_name_components))
+    else:
+        return (
+            _match_component(
+                pattern_components[0], file_name_components[0]) and
+            _match_components(
+                pattern_components[1:], file_name_components[1:]))
+
+
+def match(pattern: str, file_name: str):
+    """Match a glob pattern against a file name.
+
+    Glob pattern matching is for file names, which do not need to exist as
+    files on the file system.
+
+    A file name is a sequence of directory names, possibly followed by the name
+    of a file, with the components separated by a path separator. A glob
+    pattern is similar, except it may contain special characters: A '?' matches
+    any character in a name. A '*' matches any sequence of characters (possibly
+    empty) in a name. Both of these match only within a single component, i.e.,
+    they will not match a path separator. A component in a pattern may also be
+    a literal '**', which matches zero or more components in the complete file
+    name. A backslash '\\' in a pattern acts as an escape character, and
+    indicates that the following character is to be matched literally, even if
+    it is a special character.
+
+    Args:
+        pattern (str): The pattern to match. The path separator in patterns is
+                       always '/'.
+        file_name (str): The file name to match against. The path separator in
+                         file names is the platform separator
+
+    Returns:
+        bool: True if the pattern matches, False otherwise.
+    """
+    if (_double_star_after_invalid_regex.search(pattern) is not None or
+        _double_star_first_before_invalid_regex.search(
+            pattern) is not None or
+        _double_star_middle_before_invalid_regex.search(pattern) is not None):
+        raise ValueError(
+            '** in {} not alone between path separators'.format(pattern))
+
+    pattern = pattern.rstrip('/')
+    file_name = file_name.rstrip('/')
+
+    while '**/**' in pattern:
+        pattern = pattern.replace('**/**', '**')
+
+    pattern_components = pattern.split('/')
+
+    # We split on '\' as well as '/' to support unix and windows-style paths
+    file_name_components = re.split(r'[\\/]', file_name)
+
+    return _match_components(pattern_components, file_name_components)


### PR DESCRIPTION
## Description

**Updates readme as of this change**

```
Plugin/CodeQL: Add plugin advantages to readme

Updates the beginning of the readme file to describe the advantages
of the plugin for new readers.
```

**Adds filtering support to the CodeQL plugin**

```
Adds the ability to filter issues with filter patterns defined in
an arbitrary number of YAML files and/or at individual package level
with a section in the package CI YAML file.

Further details are available in the Readme.md file.
```

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- Verified functionality with no filtering (no regression)
- Verified filter all rules in a file
- Verified filter specific rules in a file
- Verified filter against multiple files
- Verified filter file
- Verified multiple filter files
- Verified multiple filter files + filters in package CI YAML file
- Verified malformed filter files report errors

## Integration Instructions

View the instructions in `.pytool/Plugin/CodeQL/Readme.md` in this change.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>