### PR TITLE
Set MMIO NX Based on Memory Protection Policy

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
@@ -557,6 +557,7 @@ InitializePciHostBridge (
         if (gDxeMps.NxProtectionPolicy.Fields.EfiMemoryMappedIO != 0) {
           Attributes |= EFI_MEMORY_XP;
         }
+
         Status = gDS->SetMemorySpaceAttributes (
                         HostAddress,
                         MemApertures[MemApertureIndex]->Limit - MemApertures[MemApertureIndex]->Base + 1,

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
@@ -536,6 +536,11 @@ InitializePciHostBridge (
 
     for (MemApertureIndex = 0; MemApertureIndex < ARRAY_SIZE (MemApertures); MemApertureIndex++) {
       if (MemApertures[MemApertureIndex]->Base <= MemApertures[MemApertureIndex]->Limit) {
+        // MU_CHANGE START: Set MMIO ranges to be non-executable if protection policy dictates
+        if (gDxeMps.NxProtectionPolicy.Fields.EfiMemoryMappedIO != 0) {
+          Attributes |= EFI_MEMORY_XP;
+        }
+
         //
         // Base and Limit in PCI_ROOT_BRIDGE_APERTURE are device address.
         // For GCD resource manipulation, we need to use host address.
@@ -547,16 +552,10 @@ InitializePciHostBridge (
         Status = AddMemoryMappedIoSpace (
                    HostAddress,
                    MemApertures[MemApertureIndex]->Limit - MemApertures[MemApertureIndex]->Base + 1,
-                   // MU_CHANGE START: MMIO ranges should be non-executable
                    // EFI_MEMORY_UC
-                   EFI_MEMORY_XP | EFI_MEMORY_UC
-                   // MU_CHANGE END
+                   Attributes
                    );
         ASSERT_EFI_ERROR (Status);
-        // MU_CHANGE START: Set MMIO ranges to be non-executable if protection policy dictates
-        if (gDxeMps.NxProtectionPolicy.Fields.EfiMemoryMappedIO != 0) {
-          Attributes |= EFI_MEMORY_XP;
-        }
 
         Status = gDS->SetMemorySpaceAttributes (
                         HostAddress,

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
@@ -10,6 +10,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include "PciHostBridge.h"
 #include "PciRootBridge.h"
 #include "PciHostResource.h"
+#include <Library/DxeMemoryProtectionHobLib.h>
 
 EFI_CPU_IO2_PROTOCOL  *mCpuIo;
 
@@ -450,6 +451,7 @@ InitializePciHostBridge (
   BOOLEAN                   ResourceAssigned;
   LIST_ENTRY                *Link;
   UINT64                    HostAddress;
+  UINT64                    Attributes = EFI_MEMORY_UC; // MU_CHANGE
 
   RootBridges = PciHostBridgeGetRootBridges (&RootBridgeCount);
   if ((RootBridges == NULL) || (RootBridgeCount == 0)) {
@@ -551,14 +553,17 @@ InitializePciHostBridge (
                    // MU_CHANGE END
                    );
         ASSERT_EFI_ERROR (Status);
+        // MU_CHANGE START: Set MMIO ranges to be non-executable if protection policy dictates
+        if (gDxeMps.NxProtectionPolicy.Fields.EfiMemoryMappedIO != 0) {
+          Attributes |= EFI_MEMORY_XP;
+        }
         Status = gDS->SetMemorySpaceAttributes (
                         HostAddress,
                         MemApertures[MemApertureIndex]->Limit - MemApertures[MemApertureIndex]->Base + 1,
-                        // MU_CHANGE START: MMIO ranges should be non-executable
                         // EFI_MEMORY_UC
-                        EFI_MEMORY_XP | EFI_MEMORY_UC
-                        // MU_CHANGE END
+                        Attributes
                         );
+        // MU_CHANGE END
         if (EFI_ERROR (Status)) {
           DEBUG ((DEBUG_WARN, "PciHostBridge driver failed to set EFI_MEMORY_XP and EFI_MEMORY_UC to MMIO aperture - %r.\n", Status));
         }

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridgeDxe.inf
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridgeDxe.inf
@@ -41,6 +41,7 @@
   TimerLib
   PcdLib                                          ## MU_CHANGE
   ReportStatusCodeLib                             ## MU_CHANGE
+  DxeMemoryProtectionHobLib                       ## MU_CHANGE
 
 [FeaturePcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdRequireIommu  ## MU_CHANGE


### PR DESCRIPTION
## Description

We currently apply NX to MMIO ranges converted during PciHostBridge initialiation. This update makes NX application dependent upon the memory protection policy.

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Booting to shell

## Integration Instructions

N/A