### PR TITLE
[bug] Absolute path support for DscCompleteCheck

### DIFF
--- a/.pytool/Plugin/DscCompleteCheck/DscCompleteCheck.py
+++ b/.pytool/Plugin/DscCompleteCheck/DscCompleteCheck.py
@@ -130,7 +130,8 @@ class DscCompleteCheck(ICiBuildPlugin):
         return overall_status
 
     @staticmethod
-    def _module_in_dsc(inf: str, dsc: DscParser, Edk2pathObj) -> bool:
+    def _module_in_dsc(inf: str, dsc: DscParser, Edk2pathObj: Edk2Path) -> bool:
+
         """Checks if the given module (inf) is in the given dsc.
 
         Args:

--- a/.pytool/Plugin/DscCompleteCheck/DscCompleteCheck.py
+++ b/.pytool/Plugin/DscCompleteCheck/DscCompleteCheck.py
@@ -96,19 +96,9 @@ class DscCompleteCheck(ICiBuildPlugin):
         dp.SetInputVars(environment.GetAllBuildKeyValues())
         dp.ParseFile(wsr_dsc_path)
 
-        def module_in_dsc(inf: str) -> bool:
-            for module_type in (dp.ThreeMods, dp.SixMods, dp.OtherMods):
-                for module in module_type:
-                    if Path(module).is_absolute():
-                        module = Edk2pathObj.GetEdk2RelativePathFromAbsolutePath(module)
-                    if inf in module:
-                        return True
-            return False
-
         # Check if INF in component section
         for INF in INFFiles:
-            if not module_in_dsc(INF):
-
+            if not DscCompleteCheck._module_in_dsc(INF, dp, Edk2pathObj):
                 infp = InfParser().SetBaseAbsPath(Edk2pathObj.WorkspacePath)
                 infp.SetPackagePaths(Edk2pathObj.PackagePathList)
                 infp.ParseFile(INF)
@@ -138,3 +128,23 @@ class DscCompleteCheck(ICiBuildPlugin):
         else:
             tc.SetSuccess()
         return overall_status
+
+    @staticmethod
+    def _module_in_dsc(inf: str, dsc: DscParser, Edk2pathObj) -> bool:
+        """Checks if the given module (inf) is in the given dsc.
+
+        Args:
+            inf (str): The inf file to check for
+            dsc (DscParser): The parsed dsc file.
+            Edk2pathObj (Edk2Path): The path object capturing the workspace and package paths.
+
+        Returns:
+            bool: if the module is in the dsc.
+        """
+        for module_type in (dsc.ThreeMods, dsc.SixMods, dsc.OtherMods):
+            for module in module_type:
+                if Path(module).is_absolute():
+                    module = Edk2pathObj.GetEdk2RelativePathFromAbsolutePath(module)
+                if inf in module:
+                    return True
+        return False

--- a/.pytool/Plugin/DscCompleteCheck/DscCompleteCheck.py
+++ b/.pytool/Plugin/DscCompleteCheck/DscCompleteCheck.py
@@ -9,6 +9,7 @@ from edk2toolext.environment.plugintypes.ci_build_plugin import ICiBuildPlugin
 from edk2toollib.uefi.edk2.parsers.dsc_parser import DscParser
 from edk2toollib.uefi.edk2.parsers.inf_parser import InfParser
 from edk2toolext.environment.var_dict import VarDict
+from pathlib import Path
 
 
 class DscCompleteCheck(ICiBuildPlugin):
@@ -58,7 +59,7 @@ class DscCompleteCheck(ICiBuildPlugin):
                 "DscPath not found in config file.  Nothing to check.")
             return -1
 
-        abs_pkg_path = Edk2pathObj.GetAbsolutePathOnThisSystemFromEdk2RelativePath( # MU_CHANGE
+        abs_pkg_path = Edk2pathObj.GetAbsolutePathOnThisSystemFromEdk2RelativePath(  # MU_CHANGE
             packagename)
         abs_dsc_path = os.path.join(abs_pkg_path, pkgconfig["DscPath"].strip())
         wsr_dsc_path = Edk2pathObj.GetEdk2RelativePathFromAbsolutePath(
@@ -82,7 +83,7 @@ class DscCompleteCheck(ICiBuildPlugin):
                 try:
                     tc.LogStdOut("Ignoring INF {0}".format(a))
                     INFFiles.remove(a)
-                except:
+                except Exception:
                     tc.LogStdError(
                         "DscCompleteCheck.IgnoreInf -> {0} not found in filesystem.  Invalid ignore file".format(a))
                     logging.info(
@@ -95,11 +96,18 @@ class DscCompleteCheck(ICiBuildPlugin):
         dp.SetInputVars(environment.GetAllBuildKeyValues())
         dp.ParseFile(wsr_dsc_path)
 
+        def module_in_dsc(inf: str) -> bool:
+            for module_type in (dp.ThreeMods, dp.SixMods, dp.OtherMods):
+                for module in module_type:
+                    if Path(module).is_absolute():
+                        module = Edk2pathObj.GetEdk2RelativePathFromAbsolutePath(module)
+                    if inf in module:
+                        return True
+            return False
+
         # Check if INF in component section
         for INF in INFFiles:
-            if not any(INF.strip() in x for x in dp.ThreeMods) and \
-               not any(INF.strip() in x for x in dp.SixMods) and \
-               not any(INF.strip() in x for x in dp.OtherMods):
+            if not module_in_dsc(INF):
 
                 infp = InfParser().SetBaseAbsPath(Edk2pathObj.WorkspacePath)
                 infp.SetPackagePaths(Edk2pathObj.PackagePathList)
@@ -119,7 +127,6 @@ class DscCompleteCheck(ICiBuildPlugin):
                     tc.LogStdOut(
                         "Ignoring Library INF due to only supporting type HOST_APPLICATION {0}".format(INF))
                     continue
-
                 logging.critical(INF + " not in " + wsr_dsc_path)
                 tc.LogStdError("{0} not in {1}".format(INF, wsr_dsc_path))
                 overall_status = overall_status + 1

--- a/.pytool/Plugin/DscCompleteCheck/DscCompleteCheck.py
+++ b/.pytool/Plugin/DscCompleteCheck/DscCompleteCheck.py
@@ -10,6 +10,7 @@ from edk2toollib.uefi.edk2.parsers.dsc_parser import DscParser
 from edk2toollib.uefi.edk2.parsers.inf_parser import InfParser
 from edk2toolext.environment.var_dict import VarDict
 from pathlib import Path
+from edk2toollib.uefi.edk2.path_utilities import Edk2Path
 
 
 class DscCompleteCheck(ICiBuildPlugin):


### PR DESCRIPTION
## Description

Fixing a bug to properly read absolute paths in dsc files (on Windows). Absolute paths get introduced when using components within ext_deps and referencing them in the dsc like `$(MY_EXT_DEP_PATH)/MyComponent.inf`. The previous version was checking for `'MyPkg/My_extdep/MyComponent.inf' in 'C:\git\my_repo\MyPkg\My_extdep/MyComponent.inf'` and raising errors even though the component was referenced.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
On Windows:
+ Ran the DscCompleteCheck with components listed in the dsc like `$(MY_EXT_DEP_PATH)/MyComponent.inf`: DscComplete check no longer returns errors
+ Ran the DscCompleteCheck with normal components listed in the dsc: Does not return errors
+ Ran the DscCompleteCheck with normal and ext_dep components left out of the dsc: returned errors about both

## Integration Instructions

N/A
