### PR TITLE
Increase Temp Buffer Size in FillMemoryMap() Routine

### DIFF
--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -1280,7 +1280,7 @@ FillInMemoryMap (
   NewMemoryMapStart = NULL;
 
   // Quadruple the size of the input memory map to accomodate extra entries
-  NewMemoryMapStart = AllocatePool ((*MemoryMapSize * 4) + *DescriptorSize);
+  NewMemoryMapStart = AllocatePool (*MemoryMapSize * 4);
 
   if (NewMemoryMapStart == NULL) {
     return EFI_OUT_OF_RESOURCES;

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -1279,8 +1279,8 @@ FillInMemoryMap (
 
   NewMemoryMapStart = NULL;
 
-  // Double the size of the memory map for the worst case of every entry being non-contiguous
-  NewMemoryMapStart = AllocatePool ((*MemoryMapSize * 2) + (*DescriptorSize * 2));
+  // Quadruple the size of the input memory map to accomodate extra entries
+  NewMemoryMapStart = AllocatePool ((*MemoryMapSize * 4) + *DescriptorSize);
 
   if (NewMemoryMapStart == NULL) {
     return EFI_OUT_OF_RESOURCES;


### PR DESCRIPTION
## Description

Platforms with many differences between the EFI and GCD memory maps can overflow the temp buffer allocated at the start of FillInMemoryMap(). This PR updates the size of the temp buffer to be quadruple the size of the input EFI memory map to accommodate extra entries. At the end of the routine, the contents of the temp buffer are copied into a new buffer which is strictly the required size and the temp buffer is freed.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Booting to shell

## Integration Instructions

N/A
