### PR TITLE
Improve log messages for DependencyCheck, UncrustifyCheck, and SpellCheck (#115)

### DIFF
--- a/.pytool/Plugin/DependencyCheck/DependencyCheck.py
+++ b/.pytool/Plugin/DependencyCheck/DependencyCheck.py
@@ -108,8 +108,8 @@ class DependencyCheck(ICiBuildPlugin):
                     if mod_specific_key in pkgconfig and p in pkgconfig[mod_specific_key]:
                         continue
 
-                    logging.error("Dependency Check: Invalid Dependency INF: {0} depends on pkg {1}".format(file, p))
-                    tc.LogStdError("Dependency Check: Invalid Dependency INF: {0} depends on pkg {1}".format(file, p))
+                    logging.error(f"Dependency Check: {file} depends on pkg {p} but pkg is not listed in AcceptableDependencies")
+                    tc.LogStdError(f"Dependency Check: {file} depends on pkg {p} but pkg is not listed in AcceptableDependencies")
                     overall_status += 1
 
         # If XML object exists, add results

--- a/.pytool/Plugin/SpellCheck/SpellCheck.py
+++ b/.pytool/Plugin/SpellCheck/SpellCheck.py
@@ -186,13 +186,14 @@ class SpellCheck(ICiBuildPlugin):
         # Helper - Log the syntax needed to add these words to dictionary
         if len(EasyFix) > 0:
             EasyFix = sorted(set(a.lower() for a in EasyFix))
+            logging.error(f'SpellCheck found {len(EasyFix)} failing words. See CI log for details.')
             tc.LogStdOut("\n Easy fix:")
             OneString = "If these are not errors add this to your ci.yaml file.\n"
             OneString += '"SpellCheck": {\n  "ExtendWords": ['
             for a in EasyFix:
                 tc.LogStdOut(f'\n"{a}",')
                 OneString += f'\n    "{a}",'
-            logging.info(OneString.rstrip(",") + '\n  ]\n}')
+            logging.critical(OneString.rstrip(",") + '\n  ]\n}')
 
         # add result to test case
         overall_status = len(Errors)

--- a/.pytool/Plugin/UncrustifyCheck/UncrustifyCheck.py
+++ b/.pytool/Plugin/UncrustifyCheck/UncrustifyCheck.py
@@ -572,26 +572,27 @@ class UncrustifyCheck(ICiBuildPlugin):
         self._formatted_file_error_count = len(formatted_files)
 
         if self._formatted_file_error_count > 0:
-            logging.error(
+            logging.warning(f'Uncrustify found {self._formatted_file_error_count} files with formatting errors')
+            self._tc.LogStdError(f"Uncrustify found {self._formatted_file_error_count} files with formatting errors:\n")
+            logging.critical(
                 "Visit the following instructions to learn "
                 "how to find the detailed formatting errors in Azure "
                 "DevOps CI: "
                 "https://github.com/tianocore/tianocore.github.io/wiki/EDK-II-Code-Formatting#how-to-find-uncrustify-formatting-errors-in-continuous-integration-ci")
-            self._tc.LogStdError("Files with formatting errors:\n")
+            
 
             if self._output_file_diffs:
                 logging.info("Calculating file diffs. This might take a while...")
 
         for formatted_file in formatted_files:
-            pre_formatted_file = formatted_file[:-
-                                                len(UncrustifyCheck.FORMATTED_FILE_EXTENSION)]
-            logging.error(pre_formatted_file)
+            pre_formatted_file = formatted_file[:-len(UncrustifyCheck.FORMATTED_FILE_EXTENSION)]
+
+            self._tc.LogStdError(f"Formatting errors in {os.path.relpath(pre_formatted_file, self._abs_package_path)}\n")
+            logging.info(f"Formatting errors in {os.path.relpath(pre_formatted_file, self._abs_package_path)}")
 
             if (self._output_file_diffs or
                     self._file_template_contents is not None or
                     self._func_template_contents is not None):
-                self._tc.LogStdError(
-                    f"Formatting errors in {os.path.relpath(pre_formatted_file, self._abs_package_path)}\n")
 
                 with open(formatted_file) as ff:
                     formatted_file_text = ff.read()
@@ -612,8 +613,6 @@ class UncrustifyCheck(ICiBuildPlugin):
                             self._tc.LogStdError(line)
 
                         self._tc.LogStdError('\n')
-            else:
-                self._tc.LogStdError(pre_formatted_file)
 
     def _remove_tree(self, dir_path: str, ignore_errors: bool = False) -> None:
         """


### PR DESCRIPTION
## Description

Improve CI log output with more actionable messages, and
downgraded some errors/warnings that should not be treated
as such.

(cherry picked from commit a4322be in release/202202)

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Checked CI plugin results.

## Integration Instructions

N/A