### PR TITLE
HostUnitTestCompilerPlugin: enable single module build test execution

### DIFF
--- a/.pytool/Plugin/HostUnitTestCompilerPlugin/HostUnitTestCompilerPlugin.py
+++ b/.pytool/Plugin/HostUnitTestCompilerPlugin/HostUnitTestCompilerPlugin.py
@@ -6,11 +6,12 @@
 
 import logging
 import os
-import re
+import sys
 from edk2toollib.uefi.edk2.parsers.dsc_parser import DscParser
 from edk2toolext.environment.plugintypes.ci_build_plugin import ICiBuildPlugin
+from edk2toolext.environment.plugintypes.uefi_build_plugin import IUefiBuildPlugin
+from edk2toolext.environment.plugin_manager import PluginDescriptor
 from edk2toolext.environment.uefi_build import UefiBuilder
-from edk2toolext import edk2_logging
 from edk2toolext.environment.var_dict import VarDict
 from edk2toollib.utility_functions import GetHostInfo
 
@@ -132,18 +133,31 @@ class HostUnitTestCompilerPlugin(ICiBuildPlugin):
             # Skip if there is no intersection between SUPPORTED_ARCHITECTURES and TARGET_ARCHITECTURES
             if len(set(SUPPORTED_ARCHITECTURES) & set(TARGET_ARCHITECTURES)) == 0:
                 tc.SetSkipped()
-                tc.LogStdError("No supported architecutres to build for host unit tests")
+                tc.LogStdError("No supported architectures to build for host unit tests")
                 return -1
 
         uefiBuilder = UefiBuilder()
         # do all the steps
         # WorkSpace, PackagesPath, PInHelper, PInManager
+        # Skip post build plugins and run only host-based-tests manually
+        sys.argv.append("--SkipPostBuild")
         ret = uefiBuilder.Go(Edk2pathObj.WorkspacePath, os.pathsep.join(Edk2pathObj.PackagePathList), PLMHelper, PLM)
         if ret != 0:  # failure:
             tc.SetFailed("Compile failed for {0}".format(packagename), "Compile_FAILED")
             tc.LogStdError("{0} Compile failed with error code {1} ".format(AP_Path, ret))
             return 1
 
-        else:
-            tc.SetSuccess()
-            return 0
+        def host_test_filter(plugin: PluginDescriptor) -> bool:
+            return plugin.descriptor['scope'] == 'host-based-test'
+
+        build_plugins = PLM.GetPluginsOfClass(IUefiBuildPlugin)
+        host_test_plugins = filter(host_test_filter, build_plugins)
+
+        for plugin in host_test_plugins:
+            if plugin.Obj.do_post_build(uefiBuilder) != 0:
+                tc.SetFailed("Host Based Unit Test failed for {0}".format(packagename), "HostUnitTest_FAILED")
+                tc.LogStdError("Host Based Unit Test failed for {0} ".format(packagename))
+                return 1
+
+        tc.SetSuccess()
+        return 0

--- a/.pytool/Plugin/HostUnitTestCompilerPlugin/HostUnitTestCompilerPlugin.py
+++ b/.pytool/Plugin/HostUnitTestCompilerPlugin/HostUnitTestCompilerPlugin.py
@@ -137,10 +137,11 @@ class HostUnitTestCompilerPlugin(ICiBuildPlugin):
                 return -1
 
         uefiBuilder = UefiBuilder()
+        
         # do all the steps
         # WorkSpace, PackagesPath, PInHelper, PInManager
         # Skip post build plugins and run only host-based-tests manually
-        sys.argv.append("--SkipPostBuild")
+        uefiBuilder.SkipPostBuild = True
         ret = uefiBuilder.Go(Edk2pathObj.WorkspacePath, os.pathsep.join(Edk2pathObj.PackagePathList), PLMHelper, PLM)
         if ret != 0:  # failure:
             tc.SetFailed("Compile failed for {0}".format(packagename), "Compile_FAILED")

--- a/.pytool/Plugin/HostUnitTestCompilerPlugin/Readme.md
+++ b/.pytool/Plugin/HostUnitTestCompilerPlugin/Readme.md
@@ -1,7 +1,10 @@
 # Host UnitTest Compiler Plugin
 
 A CiBuildPlugin that compiles the dsc for host based unit test apps.
-An IUefiBuildPlugin may be attached to this plugin that will run the unit tests and collect the results after successful compilation.
+
+To run the unit tests and collect the results after successful compilation, The
+host UnitTest Compliler Plugin will execute any IUefiBuildPlugin that has the
+scope 'host-based-test'.
 
 ## Configuration
 


### PR DESCRIPTION
## Description

The HostUnitTestComplierPlugin fails to execute unit tests when in single module build mode. Unit tests execution plugins are post build plugins and are skipped for single module builds as post build plugins can assume the entire project has been built, which in the case of a single module build, is not true.

This PR updates the HostUnitTestCompilerPlugin to skip post build scripts in all scenarios, then find and execute only plugins with the host-based-test scope.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

Confirmed successful build and test execution of MU_BASECORE host-based-tests for normal mode and single module build mode

## Integration Instructions

N/A
