### PR TITLE
Use Cargo make for building rust packages

### DIFF
--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -281,7 +281,7 @@
         $(OUTPUT_DIR)(+)$(MODULE_NAME)rust.lib
 
     <Command>
-        $(CARGO) rustc $(CARGO_FLAGS) --manifest-path ${s_path}(+)Cargo.toml -Z unstable-options --target-dir $(CARGO_OUTPUT_DIR) --timings=html
+        $(CARGO) $(CARGOMAKE_BUILD) $(MODULE_NAME)
         $(CP) $(CARGO_BINDIR)(+)*.a $(OUTPUT_DIR)(+)$(MODULE_NAME)rust.lib
 
 [Toml-File.RUST_MODULE]
@@ -294,9 +294,10 @@
     <Command>
         # Temporary_Rust_Todo - Remove .efi files to better support Rust incremental build for now.
         $(RM) $(OUTPUT_DIR)(+)*.efi
-        $(CARGO) rustc $(CARGO_FLAGS) --bins --manifest-path ${src} -Z unstable-options --target-dir $(CARGO_OUTPUT_DIR) --timings=html -- -C link-arg=/MAP:$(OUTPUT_DIR)(+)$(MODULE_NAME).map
-        $(CP) $(CARGO_BINDIR)(+)*.efi $(OUTPUT_DIR)(+)$(MODULE_NAME).efi
-        $(CP) $(OUTPUT_DIR)(+)$(MODULE_NAME).efi $(BIN_DIR)(+)$(MODULE_NAME).efi
+        $(CARGO) $(CARGOMAKE_BUILD) $(MODULE_NAME)
+        $(CP) $(CARGO_BINDIR)(+)$(MODULE_NAME).map $(OUTPUT_DIR)(+)$(MODULE_NAME).map
+        $(CP) $(CARGO_BINDIR)(+)$(MODULE_NAME).efi $(OUTPUT_DIR)(+)$(MODULE_NAME).efi
+        $(CP) $(CARGO_BINDIR)(+)$(MODULE_NAME).efi $(BIN_DIR)(+)$(MODULE_NAME).efi
 
 [Device-Tree-Source-File]
     <InputFile>

--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -3488,9 +3488,15 @@ RELEASE_*_*_CARGOMAKE_BUILD  = make --cwd ENV(WORKSPACE) -p release -e TARGET_TR
 # CARGO definitions
 ##################
 # The path to where cargo generated binaries are placed (.efi, .a, .d,)
-*_VS2019_*_CARGO_BINDIR  = ENV(WORKSPACE)\target\$(TARGET_TRIPLE)\$(TARGET)
-*_VS2022_*_CARGO_BINDIR  = ENV(WORKSPACE)\target\$(TARGET_TRIPLE)\$(TARGET)
-*_GCC5_*_CARGO_BINDIR    = ENV(WORKSPACE)/target/$(TARGET_TRIPLE)/$(TARGET)
+DEBUG_VS2019_*_CARGO_BINDIR  = ENV(WORKSPACE)\target\$(TARGET_TRIPLE)\debug
+RELEASE_VS2019_*_CARGO_BINDIR  = ENV(WORKSPACE)\target\$(TARGET_TRIPLE)\release
+
+DEBUG_VS2022_*_CARGO_BINDIR  = ENV(WORKSPACE)\target\$(TARGET_TRIPLE)\debug
+RELEASE_VS2022_*_CARGO_BINDIR  = ENV(WORKSPACE)\target\$(TARGET_TRIPLE)\release
+
+DEBUG_GCC5_*_CARGO_BINDIR    = ENV(WORKSPACE)/target/$(TARGET_TRIPLE)/debug
+RELEASE_GCC5_*_CARGO_BINDIR    = ENV(WORKSPACE)/target/$(TARGET_TRIPLE)/release
+
 *_*_*_CARGO_PATH         = cargo
 
 #################

--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -3474,26 +3474,24 @@ RELEASE_*_X64_RUSTC_FLAGS   = --edition=2018 --target $(TARGET_TRIPLE) -C debugi
 DEBUG_*_IA32_RUSTC_FLAGS    = --edition=2018 --target $(TARGET_TRIPLE) -C debuginfo=2 --crate-type staticlib
 RELEASE_*_IA32_RUSTC_FLAGS  = --edition=2018 --target $(TARGET_TRIPLE) -C debuginfo=2 --crate-type staticlib
 
-# The path to where cargo generated binaries are placed (.efi, .a, .d,)
-DEBUG_VS2019_*_CARGO_BINDIR    = $(OUTPUT_DIR)\$(TARGET_TRIPLE)\debug
-RELEASE_VS2019_*_CARGO_BINDIR  = $(OUTPUT_DIR)\$(TARGET_TRIPLE)\release
+##########################
+# CARGO MAKE definitions #
+##########################
+*_VS2019_*_CARGOMAKE_BUILDFLAGS  = "-Zunstable-options --timings=html --bins -- -C link-arg=/MAP:$(CARGO_BINDIR)\$(MODULE_NAME).map"
+*_VS2022_*_CARGOMAKE_BUILDFLAGS  = "-Zunstable-options --timings=html --bins -- -C link-arg=/MAP:$(CARGO_BINDIR)\$(MODULE_NAME).map"
+*_GCC5_*_CARGOMAKE_BUILDFLAGS  = "-Zunstable-options --timings=html --bins -- -C link-arg=/MAP:$(CARGO_BINDIR)/$(MODULE_NAME).map"
 
-DEBUG_VS2022_*_CARGO_BINDIR    = $(OUTPUT_DIR)\$(TARGET_TRIPLE)\debug
-RELEASE_VS2022_*_CARGO_BINDIR  = $(OUTPUT_DIR)\$(TARGET_TRIPLE)\release
-
-DEBUG_GCC5_*_CARGO_BINDIR    = $(OUTPUT_DIR)/$(TARGET_TRIPLE)/debug
-RELEASE_GCC5_*_CARGO_BINDIR  = $(OUTPUT_DIR)/$(TARGET_TRIPLE)/release
+DEBUG_*_*_CARGOMAKE_BUILD    = make --cwd ENV(WORKSPACE) -p development -e TARGET_TRIPLE=$(TARGET_TRIPLE) -e BUILD_FLAGS=$(CARGOMAKE_BUILDFLAGS) build
+RELEASE_*_*_CARGOMAKE_BUILD  = make --cwd ENV(WORKSPACE) -p release -e TARGET_TRIPLE=$(TARGET_TRIPLE) -e BUILD_FLAGS=$(CARGOMAKE_BUILDFLAGS) build
 
 ##################
 # CARGO definitions
 ##################
-*_*_*_CARGO_PATH            = cargo
-DEBUG_*_X64_CARGO_FLAGS     = --target $(TARGET_TRIPLE)
-RELEASE_*_X64_CARGO_FLAGS   = --target $(TARGET_TRIPLE) --release
-DEBUG_*_IA32_CARGO_FLAGS    = --target $(TARGET_TRIPLE)
-RELEASE_*_IA32_CARGO_FLAGS  = --target $(TARGET_TRIPLE) --release
-
-*_*_*_CARGOBUILD_NAME	= build
+# The path to where cargo generated binaries are placed (.efi, .a, .d,)
+*_VS2019_*_CARGO_BINDIR  = ENV(WORKSPACE)\target\$(TARGET_TRIPLE)\$(TARGET)
+*_VS2022_*_CARGO_BINDIR  = ENV(WORKSPACE)\target\$(TARGET_TRIPLE)\$(TARGET)
+*_GCC5_*_CARGO_BINDIR    = ENV(WORKSPACE)/target/$(TARGET_TRIPLE)/$(TARGET)
+*_*_*_CARGO_PATH         = cargo
 
 #################
 # Build rule order


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

Updates the build_rule and tools_def file to use cargo make when building rust packages. Users can manually run the same cargo make commands when developing a package, which is much simpler to execute, while also ensuring that "If it works for them, it will work for the build system".

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Verify successful build DEBUG/RELASE on Windows, Ubuntu.

## Integration Instructions

Cargo make must now be installed
