### PR TITLE
Restore BSP Exception Stack Initialization

### DIFF
--- a/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
+++ b/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
@@ -244,6 +244,7 @@ DxeMain (
   EFI_VECTOR_HANDOFF_INFO       *VectorInfoList;
   EFI_VECTOR_HANDOFF_INFO       *VectorInfo;
   VOID                          *EntryPoint;
+  VOID                          *Ptr; // MU_CHANGE
 
   //
   // Setup the default exception handlers
@@ -260,10 +261,17 @@ DxeMain (
   //
   // Setup Stack Guard
   //
-  // MU_CHANGE START
+  // MU_CHANGE START: Check Memory Protection HOB
   // if (PcdGetBool (PcdCpuStackGuard)) {
-  //  Status = InitializeSeparateExceptionStacks (NULL, NULL);
-  //  ASSERT_EFI_ERROR (Status);
+  Ptr = GetFirstGuidHob (&gDxeMemoryProtectionSettingsGuid);
+  if ((Ptr != NULL) &&
+      (*((UINT8 *)GET_GUID_HOB_DATA (Ptr)) == (UINT8)DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION) &&
+      ((DXE_MEMORY_PROTECTION_SETTINGS *)GET_GUID_HOB_DATA (Ptr))->CpuStackGuard)
+  {
+    Status = InitializeSeparateExceptionStacks (NULL, NULL);
+    ASSERT_EFI_ERROR (Status);
+  }
+
   // }
   // MU_CHANGE END
 

--- a/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
+++ b/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
@@ -244,7 +244,7 @@ DxeMain (
   EFI_VECTOR_HANDOFF_INFO       *VectorInfoList;
   EFI_VECTOR_HANDOFF_INFO       *VectorInfo;
   VOID                          *EntryPoint;
-  VOID                          *Ptr; // MU_CHANGE
+  EFI_HOB_GUID_TYPE             *GuidHob2; // MU_CHANGE
 
   //
   // Setup the default exception handlers
@@ -263,10 +263,10 @@ DxeMain (
   //
   // MU_CHANGE START: Check Memory Protection HOB
   // if (PcdGetBool (PcdCpuStackGuard)) {
-  Ptr = GetFirstGuidHob (&gDxeMemoryProtectionSettingsGuid);
-  if ((Ptr != NULL) &&
-      (*((UINT8 *)GET_GUID_HOB_DATA (Ptr)) == (UINT8)DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION) &&
-      ((DXE_MEMORY_PROTECTION_SETTINGS *)GET_GUID_HOB_DATA (Ptr))->CpuStackGuard)
+  GuidHob2 = GetFirstGuidHob (&gDxeMemoryProtectionSettingsGuid);
+  if ((GuidHob2 != NULL) &&
+      (((DXE_MEMORY_PROTECTION_SETTINGS *)GET_GUID_HOB_DATA (GuidHob2))->StructVersion == (UINT8)DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION) &&
+      ((DXE_MEMORY_PROTECTION_SETTINGS *)GET_GUID_HOB_DATA (GuidHob2))->CpuStackGuard)
   {
     Status = InitializeSeparateExceptionStacks (NULL, NULL);
     ASSERT_EFI_ERROR (Status);


### PR DESCRIPTION
## Description

The BSP switch stack initialization was lost during the 202208 integration.

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Booting to shell

## Integration Instructions

N/A
