### PR TITLE
Remove unnecessary TPL restore call

### DIFF
--- a/MdeModulePkg/Core/Dxe/Image/Image.c
+++ b/MdeModulePkg/Core/Dxe/Image/Image.c
@@ -1768,7 +1768,10 @@ CoreStartImage (
   // Image has completed.  Verify the tpl is the same
   //
   ASSERT (Image->Tpl == gEfiCurrentTpl);
-  // CoreRestoreTpl (Image->Tpl); //MU_CHANGE - remove unecessary TPL restore.
+  if (Image->Tpl != gEfiCurrentTpl) {
+    // MU_CHANGE - reduce TPL restore
+    CoreRestoreTpl (Image->Tpl);
+  } // MU_CHANGE - reduce TPL restore
 
   CoreFreePool (Image->JumpBuffer);
 

--- a/MdeModulePkg/Core/Dxe/Image/Image.c
+++ b/MdeModulePkg/Core/Dxe/Image/Image.c
@@ -1768,7 +1768,7 @@ CoreStartImage (
   // Image has completed.  Verify the tpl is the same
   //
   ASSERT (Image->Tpl == gEfiCurrentTpl);
-  CoreRestoreTpl (Image->Tpl);
+  // CoreRestoreTpl (Image->Tpl); //MU_CHANGE - remove unecessary TPL restore.
 
   CoreFreePool (Image->JumpBuffer);
 


### PR DESCRIPTION
## Description

Comments out a redundant call to RestoreTpl(). While this does not technically violate spec on raise/restore TPL, TPL should already be at the specified level. This extra call introduces an asymmetry between RaiseTpl and RestoreTpl calls, which makes analysis of TPL correctness more difficult and hampers certain non-standard TPL usages that some platforms require. 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Booted and observed no un-intended side effects w.r.t. TPL with this modification. Added test instrumentation to verify that TPL is always already at the desired state prior to this call being executed.

## Integration Instructions

N/A