### PR TITLE
Add extra RestoreTpl() call in DiskIo to maintain TPL raise/restore symmetry

### DIFF
--- a/MdeModulePkg/Universal/Disk/DiskIoDxe/DiskIo.c
+++ b/MdeModulePkg/Universal/Disk/DiskIoDxe/DiskIo.c
@@ -847,6 +847,7 @@ DiskIo2ReadWriteDisk (
   DISK_IO_SUBTASK         *Subtask;
   DISK_IO2_TASK           *Task;
   EFI_TPL                 OldTpl;
+  EFI_TPL                 OldTpl1; // MU_CHANGE - TPL Symmetry
   BOOLEAN                 Blocking;
   BOOLEAN                 SubtaskBlocking;
   LIST_ENTRY              *SubtasksPtr;
@@ -977,7 +978,7 @@ DiskIo2ReadWriteDisk (
     }
   }
 
-  gBS->RaiseTPL (TPL_NOTIFY);
+  OldTpl1 = gBS->RaiseTPL (TPL_NOTIFY); // MU_CHANGE - TPL symmetry
 
   //
   // Remove all the remaining subtasks when failure.
@@ -1012,6 +1013,7 @@ DiskIo2ReadWriteDisk (
     FreePool (Task);
   }
 
+  gBS->RestoreTPL (OldTpl1); // MU_CHANGE TPL Symmetry
   gBS->RestoreTPL (OldTpl);
 
   return Status;


### PR DESCRIPTION
## Description

Adds a call to RestoreTpl() in DiskIo2ReadWriteDisk(). While the current implementation does not technically violate spec on raise/restore TPL, this extra call ensures symmetry between RaiseTpl and RestoreTpl calls, which makes analysis of TPL correctness simpler and permits certain non-standard TPL usages that some platforms require.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Booted a system using this driver for disk access, observed that symmetry between Raise/Restore TPL was maintained as expected.

## Integration Instructions

N/A