### PR TITLE
Update edk2-pytool-library

### DIFF
--- a/BaseTools/Plugin/WindowsVsToolChain/WindowsVsToolChain.py
+++ b/BaseTools/Plugin/WindowsVsToolChain/WindowsVsToolChain.py
@@ -339,12 +339,17 @@ class WindowsVsToolChain(IUefiBuildPlugin):
         
         if(path is None):
             # Not specified...find latest
-            (rc, path) = FindWithVsWhere(vs_version=vs_version)
-            if rc == 0 and path is not None and os.path.exists(path):
+            try:
+                path = FindWithVsWhere(vs_version=vs_version)
+            except (EnvironmentError, ValueError, RuntimeError) as e:
+                self.Logger.error(str(e))
+                return None
+
+            if path is not None and os.path.exists(path):
                 self.Logger.debug("Found VS instance for %s", vs_version)
             else:
                 self.Logger.error(
-                    "Failed to find VS instance with VsWhere (%d)" % rc)
+                    f"VsWhere successfully executed, but could not find VS instance for {vs_version}.")
         return path
 
     def _get_vc_version(self, path, varname):

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -12,7 +12,7 @@
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 ##
 
-edk2-pytool-library~=0.12.1 # MU_CHANGE
+edk2-pytool-library~=0.13.0 # MU_CHANGE
 edk2-pytool-extensions~=0.21.0 # MU_CHANGE
 edk2-basetools==0.1.24
 antlr4-python3-runtime==4.11.1

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -12,7 +12,7 @@
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 ##
 
-edk2-pytool-library~=0.12.1 # MU_CHANGE
+edk2-pytool-library~=0.13.0 # MU_CHANGE
 edk2-pytool-extensions~=0.21.2 # MU_CHANGE
 edk2-basetools==0.1.24
 antlr4-python3-runtime==4.11.1


### PR DESCRIPTION
## Description

edk2-pytool-library v0.13.0 introduces a breaking change to the function FindWithVsWhere, affecting the WindowsVsToolChain plugin. This commit upgrades edk2-pytool-library and performs necessary integration steps.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
- [ ] Impacts security?
- [X] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Successful CI tests

## Integration Instructions

Upgrade edk2-pytool-library to v0.13.0 or greater.
