### PR TITLE
Bugfix: Move Variables into Memory Map Fill Loop to Handle Side Effects

### DIFF
--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -1276,14 +1276,14 @@ FillInMemoryMap (
   SortMemoryMap (*MemoryMap, *MemoryMapSize, *DescriptorSize);
   SortMemorySpaceMap (MemorySpaceMap, MemorySpaceMapDescriptorCount, MemorySpaceMapDescriptorSize);
 
-  StartOfAddressSpace = MemorySpaceMap[0].BaseAddress;
-  EndOfAddressSpace   = MemorySpaceMap[*MemorySpaceMapDescriptorCount - 1].BaseAddress +
-                        MemorySpaceMap[*MemorySpaceMapDescriptorCount - 1].Length;
-
   AdditionalEntriesCount = 0;
   NewMemoryMapSize       = 0;
   NewMemoryMapStart      = NULL;
   for (LoopIteration = 0; LoopIteration < 2; LoopIteration++) {
+    StartOfAddressSpace = MemorySpaceMap[0].BaseAddress;
+    EndOfAddressSpace   = MemorySpaceMap[*MemorySpaceMapDescriptorCount - 1].BaseAddress +
+                          MemorySpaceMap[*MemorySpaceMapDescriptorCount - 1].Length;
+
     if (LoopIteration == 1) {
       NewMemoryMapSize = *MemoryMapSize + (AdditionalEntriesCount * *DescriptorSize);
       // Allocate a buffer for the new memory map


### PR DESCRIPTION
## Description

Variables StartOfAddressSpace and EndOfAddressSpace are modified within the loop so they need to be reset at the top of each iteration.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Booting to shell

## Integration Instructions

N/A