### PR TITLE
CodeQLAnalyzePlugin: Look for filter patterns in "Filters"

### DIFF
--- a/.pytool/Plugin/CodeQL/CodeQlAnalyzePlugin.py
+++ b/.pytool/Plugin/CodeQL/CodeQlAnalyzePlugin.py
@@ -177,13 +177,13 @@ class CodeQlAnalyzePlugin(IUefiBuildPlugin):
                         f"CodeQL analysis is incomplete.")
                     return -1
 
-        if plugin_data and "Patterns" in plugin_data:
-            if type(plugin_data["Patterns"]) is not list:
+        if plugin_data and "Filters" in plugin_data:
+            if type(plugin_data["Filters"]) is not list:
                 logging.critical(
                     "CodeQL pattern data must be a list of strings. "
                     "CodeQL analysis is incomplete.")
                 return -1
-            filter_pattern_data.extend(plugin_data["Patterns"])
+            filter_pattern_data.extend(plugin_data["Filters"])
 
         if filter_pattern_data:
             logging.info("Applying CodeQL SARIF result filters.")


### PR DESCRIPTION
## Description

Users can specify filter patterns to include/exclude files from
specific CodeQL rules as described in the CodeQL plugin readme:

https://github.com/microsoft/mu_basecore/blob/release/202208/.pytool/Plugin/CodeQL/Readme.md

The key for the list of pattern strings was intended to be "Filters"
and that is what is used for global filter files. This change updates
CI YAML files to also use "Fitlers" for consistency.

Any platform CI YAML files currently using "Patterns" needs to switch
to "Filters" when integrating this change.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [x] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Verified a CI YAML file has filters applied that are described in a "Filters"
section.

## Integration Instructions

If filter patterns are applied in any CI YAML files in the repository, update the
`"Patterns"` key to instead be `"Filters"`.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>