### PR TITLE
.azurepipelines: Add support for new artifacts_identifier param

### DIFF
--- a/.azurepipelines/Matrix-Build-Job-Clang.yml
+++ b/.azurepipelines/Matrix-Build-Job-Clang.yml
@@ -68,6 +68,7 @@ jobs:
   steps:
   - template: Steps/PrGate.yml@mu_devops
     parameters:
+      artifacts_identifier: '$(Build.Pkgs) $(Build.Targets)'
       build_archs: ${{ parameters.arch_list }}
       build_pkgs: $(Build.Pkgs)
       build_targets: $(Build.Targets)

--- a/.azurepipelines/Matrix-Build-Job.yml
+++ b/.azurepipelines/Matrix-Build-Job.yml
@@ -78,6 +78,7 @@ jobs:
       displayName: Add User Local Bin to Path
   - template: Steps/PrGate.yml@mu_devops
     parameters:
+      artifacts_identifier: '$(Build.Pkgs) $(Build.Targets)'
       build_archs: ${{ parameters.arch_list }}
       build_pkgs: $(Build.Pkgs)
       build_targets: $(Build.Targets)


### PR DESCRIPTION
## Description

A new identifier can be used to identify published artifacts (as
of mu_devops 2.0.0 release). This change passes the packages and
targets being built to clarify artifact names.

The default value for the identifier is "Artifacts" so that is
what is being used at the moment. For example, build logs are
published under `"Logs Artifacts"`. After this change, the
identifier will be `"Logs <packages> <targets>"`.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [x] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Verified pipeline artifacts are named as expected.

## Integration Instructions

This is considered a "breaking change" because artifacts are accessible via
ADO APIs and can be identified by the artifact name. While it is unlikely any
process is consuming these artifacts based on name, if they are, they will
need to use the new artifact naming convention introduced in this change.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>