### PR TITLE
Added check if requested overridevalidation file is not contained in a Package

### DIFF
--- a/BaseTools/Plugin/OverrideValidation/OverrideValidation.py
+++ b/BaseTools/Plugin/OverrideValidation/OverrideValidation.py
@@ -692,7 +692,10 @@ if __name__ == '__main__':
         # Generate and print the override for pasting into the file.
         # Use absolute module path to find package path
         pkg_path = pathtool.GetContainingPackage(Paths.TargetPath)
-        rel_path = Paths.TargetPath[Paths.TargetPath.find(pkg_path):]
+        if pkg_path is not None:
+            rel_path = Paths.TargetPath[Paths.TargetPath.find(pkg_path):]
+        else:
+            rel_path = os.path.relpath (Paths.TargetPath, Paths.WorkSpace)
 
         rel_path = rel_path.replace('\\', '/')
         mod_hash = ModuleHashCal(Paths.TargetPath)

--- a/BaseTools/Plugin/OverrideValidation/OverrideValidation.py
+++ b/BaseTools/Plugin/OverrideValidation/OverrideValidation.py
@@ -695,7 +695,10 @@ if __name__ == '__main__':
         if pkg_path is not None:
             rel_path = Paths.TargetPath[Paths.TargetPath.find(pkg_path):]
         else:
-            rel_path = os.path.relpath (Paths.TargetPath, Paths.WorkSpace)
+            rel_path = pathtool.GetEdk2RelativePathFromAbsolutePath(Paths.TargetPath)
+            if not rel_path:
+                print(f"{Paths.TargetPath} is invalid for this workspace.")
+                sys.exit(1)
 
         rel_path = rel_path.replace('\\', '/')
         mod_hash = ModuleHashCal(Paths.TargetPath)


### PR DESCRIPTION
Fixes #255 

# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

OverrideValidation can run on files that are not contained inside of a Edk2 Package path. These files, when passed to GetContainingPackage(), will return none type.

Adding a check that if the GetContainingPackage returns none type, uses os.path.relpath to get a relative path from the base of the workspace passed into the tool. 

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested locally on a system by passing in "MU_BASECORE/BaseTools/Conf/tools_def.template".

## Integration Instructions

N/A
