### PR TITLE
CodeQlFilters.yml: Add UefiDevicePathLib filters

### DIFF
--- a/CodeQlFilters.yml
+++ b/CodeQlFilters.yml
@@ -10,6 +10,9 @@
 
 {
   "Filters": [
+    "-MdePkg/Library/UefiDevicePathLib/DevicePathFromText.c:SM02311",
+    "-MdePkg/Library/UefiDevicePathLib/DevicePathUtilities.c:SM02311",
+    "-MdePkg/Library/UefiDevicePathLibDevicePathProtocol/UefiDevicePathLib.c:SM02311",
     "-MdeModulePkg/Universal/Disk/UdfDxe/FileName.c:cpp/uselesstest",
     "-MdeModulePkg/Universal/EbcDxe/EbcDebugger/EdbSupportString.c:cpp/uselesstest",
     "-MdeModulePkg/Universal/Disk/UdfDxe/FileSystemOperations.c:cpp/uselesstest",


### PR DESCRIPTION
## Description

These filters are needed to avoid SM02311 from being reported in
many packages.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Verified CodeQL results are filtered according to this change.

## Integration Instructions

N/A - It is recommended to include these filters in a repo that consumes mu_basecore
and runs CodeQL.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>