### PR TITLE
CompilerPlugin: Fix typo

### DIFF
--- a/.pytool/Plugin/CompilerPlugin/CompilerPlugin.py
+++ b/.pytool/Plugin/CompilerPlugin/CompilerPlugin.py
@@ -89,7 +89,7 @@ class CompilerPlugin(ICiBuildPlugin):
             # Skip if there is no intersection between SUPPORTED_ARCHITECTURES and TARGET_ARCHITECTURES
             if len(set(SUPPORTED_ARCHITECTURES) & set(TARGET_ARCHITECTURES)) == 0:
                 tc.SetSkipped()
-                tc.LogStdError("No supported architecutres to build")
+                tc.LogStdError("No supported architectures to build")
                 return -1
 
         uefiBuilder = UefiBuilder()


### PR DESCRIPTION
## Description

Change "architecutres" to "architectures".

Given more importance to fix since this is text that users or scripts
may search for to find errors in output.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

N/A - Manually confirmed spelling change

## Integration Instructions

Update any tools that may have searched for the text with the typo.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>