### PR TITLE
Add PEI Memory Bucket Support

### DIFF
--- a/MdeModulePkg/Core/Dxe/DxeMain.h
+++ b/MdeModulePkg/Core/Dxe/DxeMain.h
@@ -49,6 +49,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Protocol/SmmBase2.h>
 #include <Protocol/PeCoffImageEmulator.h>
 #include <Guid/MemoryTypeInformation.h>
+#include <Guid/MemoryTypeStatistics.h>  // MU_CHANGE - Save memory allocations for the PEI memory buckets
 #include <Guid/FirmwareFileSystem2.h>
 #include <Guid/FirmwareFileSystem3.h>
 #include <Guid/HobList.h>
@@ -292,6 +293,20 @@ extern BOOLEAN                                     gLoadFixedAddressCodeMemoryRe
 //
 // Service Initialization Functions
 //
+
+// MU_CHANGE [BEGIN] - Save memory allocations for the PEI memory buckets
+
+/**
+  Called to initialize memory statistics information used during
+  page allocation.
+
+**/
+VOID
+CoreInitializeMemoryStatistics (
+  VOID
+  );
+
+// MU_CHANGE [END] - Save memory allocations for the PEI memory buckets
 
 /**
   Called to initialize the pool.

--- a/MdeModulePkg/Core/Dxe/DxeMain.inf
+++ b/MdeModulePkg/Core/Dxe/DxeMain.inf
@@ -116,6 +116,7 @@
   ## PRODUCES               ## SystemTable
   ## SOMETIMES_CONSUMES     ## HOB
   gEfiMemoryTypeInformationGuid
+  gMemoryTypeStatisticsGuid                     ## CONSUMES # MU_CHANGE - Save memory allocations for the PEI memory buckets
   gEfiEventDxeDispatchGuid                      ## PRODUCES             ## Event
   gLoadFixedAddressConfigurationTableGuid       ## SOMETIMES_PRODUCES   ## SystemTable
   ## PRODUCES   ## Event

--- a/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
+++ b/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
@@ -2263,6 +2263,14 @@ CoreInitializeMemoryServices (
   Hob.Raw = *HobStart;
   ASSERT (GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_HANDOFF);
 
+  // MU_CHANGE [BEGIN] - Save memory allocations for the PEI memory buckets
+  //
+  // Initialize memory statistics information that may be used
+  // for runtime memory bin allocation.
+  //
+  CoreInitializeMemoryStatistics ();
+  // MU_CHANGE [END] - Save memory allocations for the PEI memory buckets
+
   //
   // Initialize the spin locks and maps in the memory services.
   // Also fill in the memory services into the EFI Boot Services Table
@@ -2309,6 +2317,8 @@ CoreInitializeMemoryServices (
   //
   // Include the total memory bin size needed to make sure memory bin could be allocated successfully.
   //
+  // // MU_CHANGE - Save memory allocations for the PEI memory buckets
+  // Todo: Need to adjust the bin allocation to account for pre-allocated bins if provided
   MinimalMemorySizeNeeded = MINIMUM_INITIAL_MEMORY_SIZE + CalculateTotalMemoryBinSizeNeeded ();
 
   //

--- a/MdeModulePkg/Core/Dxe/UnitTest/MemoryProtectionUnitTestHost.inf
+++ b/MdeModulePkg/Core/Dxe/UnitTest/MemoryProtectionUnitTestHost.inf
@@ -177,6 +177,7 @@
   gMuEventPreExitBootServicesGuid
   gDxeMemoryProtectionSettingsGuid
   gMemoryProtectionSpecialRegionHobGuid
+  gMemoryTypeStatisticsGuid
 
 [BuildOptions.Common]
   MSFT:*_*_*_CC_FLAGS = -I$(WORKSPACE)/MdeModulePkg/Core/Dxe

--- a/MdeModulePkg/Core/Pei/Memory/MemoryBuckets.c
+++ b/MdeModulePkg/Core/Pei/Memory/MemoryBuckets.c
@@ -1,0 +1,411 @@
+/**@file
+  This keeps track of the different buckets and the data for the associated HOB.
+
+  This library should not be called by anything outside of the PEI CORE.
+
+  // MU_CHANGE - WHOLE_FILE - Save memory allocations for the PEI memory buckets
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "PeiMain.h"
+#include "MemoryBuckets.h"
+
+// Memory types being kept in buckets in PEI.  Currently only runtime types.
+EFI_MEMORY_TYPE  mMemoryTypes[] = {
+  EfiRuntimeServicesCode,
+  EfiRuntimeServicesData,
+  EfiACPIReclaimMemory,
+  EfiACPIMemoryNVS
+};
+
+/**
+  This function figures out the size of the memory buckets based on the PEI
+  memory bucket PCDs.  If the PCDs are not set by the platform then the memory
+  buckets are disabled.
+
+  @param[in] PrivateData   Pointer to PeiCore's private data structure.
+**/
+UINTN
+EFIAPI
+InitializeMemoryBucketSizes (
+  IN PEI_CORE_INSTANCE  *PrivateData
+  )
+{
+  UINT64                       TotalBucketPages;
+  UINT64                       Index;
+  EFI_HOB_GUID_TYPE            *GuidHob;
+  EFI_MEMORY_TYPE_INFORMATION  *MemInfo;
+
+  TotalBucketPages = 0;
+  GuidHob          = GetFirstGuidHob (&gEfiMemoryTypeInformationGuid);
+
+  if (GuidHob != NULL) {
+    DEBUG ((DEBUG_INFO, "[%a] - The Memory Type Information exists!\n", __FUNCTION__));
+
+    MemInfo = GET_GUID_HOB_DATA (GuidHob);
+
+    for (Index = 0; Index < ARRAY_SIZE (mMemoryTypes); Index++) {
+      PrivateData->PeiMemoryBuckets.RuntimeBuckets[mMemoryTypes[Index]].NumberOfPages = \
+        (UINT64)GetBucketSizeFromMemoryInfoHob (PrivateData, MemInfo, mMemoryTypes[Index]);
+      TotalBucketPages += PrivateData->PeiMemoryBuckets.RuntimeBuckets[mMemoryTypes[Index]].NumberOfPages;
+    }
+  } else {
+    DEBUG ((DEBUG_ERROR, "[%a] - The Memory Type Information doesn't exist!\n", __FUNCTION__));
+  }
+
+  return (UINTN)TotalBucketPages;
+}
+
+/**
+  This function gets the number of pages associated with the memory type
+  that is saved within the MEMORY_TYPE_INFORMATION Hob.
+
+  @param[in] PrivateData   Pointer to PeiCore's private data structure.
+  @param[in] MemInfo       Pointer the the MEMORY_TYPE_INFORMATION object
+                           with the relevant memory bucket sizes.
+  @param[in] MemoryType    The type of memory we are interested in.
+
+  @retval    Returns the number of pages to use for the bucket in the memory
+             memory type inputted.
+**/
+UINT32
+EFIAPI
+GetBucketSizeFromMemoryInfoHob (
+  IN PEI_CORE_INSTANCE            *PrivateData,
+  IN EFI_MEMORY_TYPE_INFORMATION  *MemInfo,
+  IN EFI_MEMORY_TYPE              MemoryType
+  )
+{
+  UINTN  Index;
+
+  for (Index = 0; MemInfo[Index].Type != EfiMaxMemoryType; Index++) {
+    if (MemInfo[Index].Type == (UINT32)MemoryType) {
+      DEBUG ((DEBUG_INFO, "[%a] - Index = %d\n", __FUNCTION__, Index));
+      return MemInfo[Index].NumberOfPages;
+    }
+  }
+
+  DEBUG ((DEBUG_ERROR, "[%a] - The memory type wasn't found in the MEMORY_TYPE_INFORMATION hob!\n", __FUNCTION__));
+
+  return 0;
+}
+
+/**
+  This function initialized the PEI memory buckets.  This should be called
+  when the first memory type being tracked in these buckets is allocated.
+
+      +-----------------------------+  <-- Top of free memory
+      |  Memory Bucket Allocation 1 |
+      +-----------------------------+  <-- Top of free memory + 1st non-zero memory bucket pcd
+      |  Memory Bucket Allocation 2 |
+      +-----------------------------+  <-- Top of free memory + 1st and 2nd non-zero memory bucket pcds
+      |  Memory Bucket Allocation 3 |
+      +-----------------------------+  <-- Top of free memory + 1st, 2nd, 3rd non-zero memory bucket pcds
+      |   . . . . . . . . . . . .   |
+      +-----------------------------+  <-- Top of free memory + 1-n non-zero memory bucket pcds
+      |         FREE MEMORY         |      For PEI allocations all new non bucket free memory starts here.
+      +-----------------------------+
+
+  NOTE: The memory buckets can be created in Pre-mem PEI if runtime pages are
+  allocated in pre-mem PEI.
+
+  @param[in] PrivateData          Pointer to PeiCore's private data structure.
+  @param[in] StartingAddress      The starting address of the memory buckets.
+                                  All of them are contiguous.
+  @param[in] LengthAvailable      Number of bytes available for memory buckets from StartingAddress.
+
+**/
+UINTN
+EFIAPI
+InitializeMemoryBuckets (
+  IN PEI_CORE_INSTANCE     *PrivateData,
+  IN EFI_PHYSICAL_ADDRESS  StartingAddress,
+  IN UINTN                 LengthAvailable
+  )
+{
+  UINTN   Index;
+  UINTN   TotalBucketPages;
+  UINT64  AddressAdjustment;
+
+  for (Index = 0; Index <= EfiMaxMemoryType; Index++) {
+    PrivateData->PeiMemoryBuckets.RuntimeBuckets[Index].BaseAddress          = 0;
+    PrivateData->PeiMemoryBuckets.RuntimeBuckets[Index].MaximumAddress       = (EFI_PHYSICAL_ADDRESS)-1;
+    PrivateData->PeiMemoryBuckets.RuntimeBuckets[Index].CurrentNumberOfPages = 0;
+    PrivateData->PeiMemoryBuckets.RuntimeBuckets[Index].NumberOfPages        = 0;
+    PrivateData->PeiMemoryBuckets.RuntimeBuckets[Index].InformationIndex     = (UINT32)Index;
+    PrivateData->PeiMemoryBuckets.RuntimeBuckets[Index].Special              = TRUE;
+    PrivateData->PeiMemoryBuckets.RuntimeBuckets[Index].Runtime              = TRUE;
+    PrivateData->PeiMemoryBuckets.CurrentTopInBucket[Index]                  = (EFI_PHYSICAL_ADDRESS)-1;
+  }
+
+  TotalBucketPages = InitializeMemoryBucketSizes (PrivateData);
+
+  if (TotalBucketPages > 0) {
+    for (Index = ARRAY_SIZE (mMemoryTypes), AddressAdjustment = 0; Index > 0; Index--) {
+      // Initialize memory locations for buckets
+      PrivateData->PeiMemoryBuckets.RuntimeBuckets[mMemoryTypes[Index-1]].MaximumAddress = \
+        StartingAddress - AddressAdjustment;
+      PrivateData->PeiMemoryBuckets.CurrentTopInBucket[mMemoryTypes[Index-1]] = \
+        StartingAddress - AddressAdjustment;
+      AddressAdjustment += \
+        (PrivateData->PeiMemoryBuckets.RuntimeBuckets[mMemoryTypes[Index-1]].NumberOfPages * EFI_PAGE_SIZE);
+      PrivateData->PeiMemoryBuckets.RuntimeBuckets[mMemoryTypes[Index-1]].BaseAddress = \
+        StartingAddress - AddressAdjustment;
+    }
+
+    PrivateData->PeiMemoryBuckets.RuntimeMemInitialized = TRUE;
+    PrivateData->PeiMemoryBuckets.MemoryBucketsDisabled = FALSE;
+  } else {
+    PrivateData->PeiMemoryBuckets.MemoryBucketsDisabled = TRUE;
+  }
+
+  return TotalBucketPages;
+}
+
+/**
+  This function updates the pointer that keeps track of the start of unused
+  memory in a bucket.
+
+  @param[in] PrivateData   Pointer to PeiCore's private data structure.
+  @param[in] NewTop       The new start of unallocated memory in a bucket.
+  @param[in] MemoryType   The type of memory being updated.
+**/
+VOID
+EFIAPI
+UpdateCurrentBucketTop (
+  IN PEI_CORE_INSTANCE     *PrivateData,
+  IN EFI_PHYSICAL_ADDRESS  NewTop,
+  IN EFI_MEMORY_TYPE       MemoryType
+  )
+{
+  PrivateData->PeiMemoryBuckets.CurrentTopInBucket[MemoryType] = NewTop;
+}
+
+/**
+  This function gets the address of the startfree memory in the bucket
+  specified by MemoryType.
+
+  @param[in] PrivateData   Pointer to PeiCore's private data structure.
+  @param[in] MemoryType   The type of memory we are interested in.
+
+  @retval    Returns an address that points to the start of free memory in a
+             memory bucket that is specified by MemoryType
+**/
+EFI_PHYSICAL_ADDRESS *
+EFIAPI
+GetCurrentBucketTop (
+  IN PEI_CORE_INSTANCE  *PrivateData,
+  IN EFI_MEMORY_TYPE    MemoryType
+  )
+{
+  return &PrivateData->PeiMemoryBuckets.CurrentTopInBucket[MemoryType];
+}
+
+/**
+  This function gets the address of the bottom of the bucket specified by
+  MemoryType.
+
+  @param[in] PrivateData   Pointer to PeiCore's private data structure.
+  @param[in] MemoryType   The type of memory we are interested in.
+
+  @retval    Returns an address that points to the bottom of memory in a
+             memory bucket that is specified by MemoryType
+**/
+EFI_PHYSICAL_ADDRESS *
+EFIAPI
+GetCurrentBucketBottom (
+  IN PEI_CORE_INSTANCE  *PrivateData,
+  IN EFI_MEMORY_TYPE    MemoryType
+  )
+{
+  return &PrivateData->PeiMemoryBuckets.RuntimeBuckets[MemoryType].BaseAddress;
+}
+
+/**
+  Function that returns the address associated with the end of the
+  memory bucket structure.
+
+  @param[in] PrivateData   Pointer to PeiCore's private data structure.
+
+  @retval    The memory address below the memory bucket structure.
+
+**/
+EFI_PHYSICAL_ADDRESS
+EFIAPI
+GetBottomOfBucketsAddress (
+  IN PEI_CORE_INSTANCE  *PrivateData
+  )
+{
+  UINTN                 Index;
+  EFI_PHYSICAL_ADDRESS  *Address;
+
+  for (Index = 0; Index < ARRAY_SIZE (mMemoryTypes); Index++) {
+    if (PrivateData->PeiMemoryBuckets.RuntimeBuckets[mMemoryTypes[Index]].NumberOfPages > 0) {
+      Address = GetCurrentBucketBottom (PrivateData, mMemoryTypes[Index]);
+      if (Address != NULL) {
+        return *Address;
+      }
+
+      ASSERT (Address != NULL);
+    }
+  }
+
+  return 0;
+}
+
+/**
+  This function updates the memory bucket structure to include a new memory allocation.
+
+  @param[in] PrivateData   Pointer to PeiCore's private data structure.
+  @param[in] Pages        The number of pages we are allocating in the bucket.
+  @param[in] MemoryType   The type of memory we are updating in the memory bucket
+                          structure.
+**/
+VOID
+EFIAPI
+UpdateRuntimeMemoryStats (
+  IN PEI_CORE_INSTANCE  *PrivateData,
+  IN UINTN              Pages,
+  IN EFI_MEMORY_TYPE    MemoryType
+  )
+{
+  if (PrivateData->PeiMemoryBuckets.RuntimeBuckets[MemoryType].CurrentNumberOfPages + (UINT64)Pages
+      > PrivateData->PeiMemoryBuckets.RuntimeBuckets[MemoryType].NumberOfPages)
+  {
+    DEBUG ((DEBUG_ERROR, "We have overflowed while allocating PEI pages of index: %d!\n", MemoryType));
+    ASSERT (FALSE);
+    return;
+  }
+
+  PrivateData->PeiMemoryBuckets.RuntimeBuckets[MemoryType].CurrentNumberOfPages = (UINT64)PrivateData->PeiMemoryBuckets.RuntimeBuckets[MemoryType].CurrentNumberOfPages + (UINT64)Pages;
+  UpdateMemoryBucketHob (PrivateData);
+}
+
+/**
+  This function checks to see if the given address lies within the currently defined
+  runtime memory bucket range.
+
+  @param[in] PrivateData   Pointer to PeiCore's private data structure.
+  @param[in] Start   The start of the address we are trying to allocate memory in.
+
+  @retval    TRUE    If the memory address is within the PEI memory bucket region.
+  @retval    FALSE   If the memory address is not within the PEI memory bucket region.
+**/
+BOOLEAN
+EFIAPI
+CheckIfInRuntimeBoundary (
+  IN PEI_CORE_INSTANCE     *PrivateData,
+  IN EFI_PHYSICAL_ADDRESS  Start
+  )
+{
+  // There is no boundary if the buckets are disabled
+  if (!AreMemoryBucketsEnabled (PrivateData)) {
+    return FALSE;
+  }
+
+  if (PrivateData->PeiMemoryBuckets.RuntimeMemInitialized &&
+      ((Start >= GetBottomOfBucketsAddress (PrivateData)) &&
+       (Start <= *GetCurrentBucketTop (PrivateData, EfiACPIMemoryNVS))))
+  {
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+/**
+  Checks if we have initialized PEI memory buckets.
+
+  @param[in] PrivateData   Pointer to PeiCore's private data structure.
+
+  @retval   TRUE   We have initialized PEI memory buckets.
+  @retval   FALSE  We have not initialized PEI memory buckets.
+**/
+BOOLEAN
+EFIAPI
+IsRuntimeMemoryInitialized (
+  IN PEI_CORE_INSTANCE  *PrivateData
+  )
+{
+  return PrivateData->PeiMemoryBuckets.RuntimeMemInitialized;
+}
+
+/**
+  This function checks if the memory type we are allocating is being kept
+  track of within the PEI memory bucket structure.
+
+  @param[in] PrivateData   Pointer to PeiCore's private data structure.
+  @param[in] MemoryType   The type of memory we are interest in allocating.
+
+  @retval    TRUE         The type of memory we are allocating is included
+                          in the PEI memory bucket structure.
+  @retval    FALSE        The type of memory we are allocating is not
+                          included in the PEI memory bucket structure.
+**/
+BOOLEAN
+EFIAPI
+IsRuntimeType (
+  IN PEI_CORE_INSTANCE      *PrivateData,
+  IN       EFI_MEMORY_TYPE  MemoryType
+  )
+{
+  UINTN  Index;
+
+  for (Index = 0; Index < ARRAY_SIZE (mMemoryTypes); Index++) {
+    if (MemoryType == mMemoryTypes[Index]) {
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}
+
+/**
+  Function that checks if PEI memory buckets are enabled.
+
+  @param[in] PrivateData   Pointer to PeiCore's private data structure.
+
+  @retval    TRUE         PEI memory buckets are enabled
+  @retval    FALSE        PEI memory buckets are disabled
+**/
+BOOLEAN
+EFIAPI
+AreMemoryBucketsEnabled (
+  IN PEI_CORE_INSTANCE  *PrivateData
+  )
+{
+  return !PrivateData->PeiMemoryBuckets.MemoryBucketsDisabled;
+}
+
+/**
+  Function that builds and updates the memory bucket hob that will be
+  consumed in DXE.
+
+  @param[in] PrivateData   Pointer to PeiCore's private data structure.
+**/
+VOID
+EFIAPI
+UpdateMemoryBucketHob (
+  IN PEI_CORE_INSTANCE  *PrivateData
+  )
+{
+  EFI_HOB_GUID_TYPE  *GuidHob;
+
+  GuidHob = GetFirstGuidHob (&gMemoryTypeStatisticsGuid);
+  if (GuidHob != NULL) {
+    CopyMem (
+      GET_GUID_HOB_DATA (GuidHob),
+      PrivateData->PeiMemoryBuckets.RuntimeBuckets,
+      (sizeof (PrivateData->PeiMemoryBuckets.RuntimeBuckets))
+      );
+  } else {
+    BuildGuidDataHob (
+      &gMemoryTypeStatisticsGuid,
+      PrivateData->PeiMemoryBuckets.RuntimeBuckets,
+      sizeof (PrivateData->PeiMemoryBuckets.RuntimeBuckets)
+      );
+  }
+}

--- a/MdeModulePkg/Core/Pei/Memory/MemoryBuckets.h
+++ b/MdeModulePkg/Core/Pei/Memory/MemoryBuckets.h
@@ -1,0 +1,257 @@
+/** @file
+  Memory bucket definitions.
+
+  For PEI Core internal use only.
+
+  MU_CHANGE - WHOLE_FILE - Save memory allocations for the PEI memory buckets
+
+  Copyright (C) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef MEMORY_BUCKETS_H_
+#define MEMORY_BUCKETS_H_
+
+#include <PeiMain.h>
+#include <Guid/MemoryTypeStatistics.h>
+#include <Guid/MemoryTypeInformation.h>
+
+/**
+  This function figures out the size of the memory buckets based on the PEI
+  memory bucket PCDs.  If the PCDs are not set by the platform then the memory
+  buckets are disabled.
+
+  @param[in] PrivateData   Pointer to PeiCore's private data structure.
+**/
+UINTN
+EFIAPI
+InitializeMemoryBucketSizes (
+  IN PEI_CORE_INSTANCE  *PrivateData
+  );
+
+/**
+  This function gets the number of pages associated with the memory type
+  that is saved within the MEMORY_TYPE_INFORMATION Hob.
+
+  @param[in] PrivateData   Pointer to PeiCore's private data structure.
+  @param[in] DataSize      The size of the data in the MEMORY_TYPE_INFORMATION
+                           hob.
+  @param[in] MemInfo       Pointer the the MEMORY_TYPE_INFORMATION object
+                           with the relevant memory bucket sizes.
+  @param[in] MemoryType    The type of memory we are interested in.
+
+  @retval    Returns the number of pages to use for the bucket in the memory
+             memory type inputted.
+**/
+UINT32
+EFIAPI
+GetBucketSizeFromMemoryInfoHob (
+  IN PEI_CORE_INSTANCE            *PrivateData,
+  IN EFI_MEMORY_TYPE_INFORMATION  *MemInfo,
+  IN EFI_MEMORY_TYPE              MemoryType
+  );
+
+/**
+  This function initialized the PEI memory buckets.  This should be called
+  when the first memory type being tracked in these buckets is allocated.
+
+      +-----------------------------+  <-- Top of free memory
+      |  Memory Bucket Allocation 1 |
+      +-----------------------------+  <-- Top of free memory + 1st non-zero memory bucket pcd
+      |  Memory Bucket Allocation 2 |
+      +-----------------------------+  <-- Top of free memory + 1st and 2nd non-zero memory bucket pcds
+      |  Memory Bucket Allocation 3 |
+      +-----------------------------+  <-- Top of free memory + 1st, 2nd, 3rd non-zero memory bucket pcds
+      |   . . . . . . . . . . . .   |
+      +-----------------------------+  <-- Top of free memory + 1-n non-zero memory bucket pcds
+      |         FREE MEMORY         |      For PEI allocations all new non bucket free memory starts here.
+      +-----------------------------+
+
+  NOTE: The memory buckets can be created in Pre-mem PEI if runtime pages are
+  allocated in pre-mem PEI.
+
+  @param[in] PrivateData   Pointer to PeiCore's private data structure.
+  @param[in] StartingAddress   The starting address of the memory buckets.
+                               All of them are contiguous.
+**/
+UINTN
+EFIAPI
+InitializeMemoryBuckets (
+  IN PEI_CORE_INSTANCE     *PrivateData,
+  IN EFI_PHYSICAL_ADDRESS  StartingAddress,
+  IN UINTN                 LengthAvailable
+  );
+
+/**
+  This function translates the memory type being allocated into the
+  index that it uses in the memory buckets structure.
+
+  @param[in] MemoryType   The type of memory we are interested in.
+
+  @retval    The index associated with the memory type.
+**/
+UINTN
+EFIAPI
+MemoryTypeToIndex (
+  IN EFI_MEMORY_TYPE  MemoryType
+  );
+
+/**
+  This function updates the pointer that keeps track of the start of unused
+  memory in a bucket.
+
+  @param[in] PrivateData   Pointer to PeiCore's private data structure.
+  @param[in] NewTop       The new start of unallocated memory in a bucket.
+  @param[in] MemoryType   The type of memory being updated.
+**/
+VOID
+EFIAPI
+UpdateCurrentBucketTop (
+  IN PEI_CORE_INSTANCE     *PrivateData,
+  IN EFI_PHYSICAL_ADDRESS  NewTop,
+  IN EFI_MEMORY_TYPE       MemoryType
+  );
+
+/**
+  This function gets the address of the start free memory in the bucket
+  specified by MemoryType.
+
+  @param[in] PrivateData   Pointer to PeiCore's private data structure.
+  @param[in] MemoryType   The type of memory we are interested in.
+
+  @retval    Returns an address that points to the start of free memory in a
+             memory bucket that is specified by MemoryType
+**/
+EFI_PHYSICAL_ADDRESS *
+EFIAPI
+GetCurrentBucketTop (
+  IN PEI_CORE_INSTANCE  *PrivateData,
+  IN EFI_MEMORY_TYPE    MemoryType
+  );
+
+/**
+  This function gets the address of the bottom of the bucket specified by
+  MemoryType.
+
+  @param[in] PrivateData   Pointer to PeiCore's private data structure.
+  @param[in] MemoryType   The type of memory we are interested in.
+
+  @retval    Returns an address that points to the bottom of memory in a
+             memory bucket that is specified by MemoryType
+**/
+EFI_PHYSICAL_ADDRESS *
+EFIAPI
+GetCurrentBucketBottom (
+  IN PEI_CORE_INSTANCE  *PrivateData,
+  IN EFI_MEMORY_TYPE    MemoryType
+  );
+
+/**
+  Function that returns the address associated with the end of the
+  memory bucket structure.
+
+  @param[in] PrivateData   Pointer to PeiCore's private data structure.
+
+  @retval    The memory address below the memory bucket structure.
+
+**/
+EFI_PHYSICAL_ADDRESS
+EFIAPI
+GetBottomOfBucketsAddress (
+  IN PEI_CORE_INSTANCE  *PrivateData
+  );
+
+/**
+  This function updates the memory bucket structure to include a new memory allocation.
+
+  @param[in] PrivateData   Pointer to PeiCore's private data structure.
+  @param[in] Pages        The number of pages we are allocating in the bucket.
+  @param[in] MemoryType   The type of memory we are updating in the memory bucket
+                          structure.
+**/
+VOID
+EFIAPI
+UpdateRuntimeMemoryStats (
+  IN PEI_CORE_INSTANCE  *PrivateData,
+  IN UINTN              Pages,
+  IN EFI_MEMORY_TYPE    MemoryType
+  );
+
+/**
+  This function checks to see if the given address lies within the currently defined
+  runtime memory bucket range.
+
+  @param[in] PrivateData   Pointer to PeiCore's private data structure.
+  @param[in] Start   The start of the address we are trying to allocate memory in.
+
+  @retval    TRUE    If the memory address is within the PEI memory bucket region.
+  @retval    FALSE   If the memory address is not within the PEI memory bucket region.
+**/
+BOOLEAN
+EFIAPI
+CheckIfInRuntimeBoundary (
+  IN PEI_CORE_INSTANCE     *PrivateData,
+  IN EFI_PHYSICAL_ADDRESS  Start
+  );
+
+/**
+  Checks if we have initialized PEI memory buckets.
+
+  @param[in] PrivateData   Pointer to PeiCore's private data structure.
+
+  @retval   TRUE   We have initialized PEI memory buckets.
+  @retval   FALSE  We have not initialized PEI memory buckets.
+**/
+BOOLEAN
+EFIAPI
+IsRuntimeMemoryInitialized (
+  IN PEI_CORE_INSTANCE  *PrivateData
+  );
+
+/**
+  This function checks if the memory type we are allocating is being kept
+  track of within the PEI memory bucket structure.
+
+  @param[in] PrivateData   Pointer to PeiCore's private data structure.
+  @param[in] MemoryType   The type of memory we are interest in allocating.
+
+  @retval    TRUE         The type of memory we are allocating is included
+                          in the PEI memory bucket structure.
+  @retval    FALSE        The type of memory we are allocating is not
+                          included in the PEI memory bucket structure.
+**/
+BOOLEAN
+EFIAPI
+IsRuntimeType (
+  IN PEI_CORE_INSTANCE  *PrivateData,
+  IN EFI_MEMORY_TYPE    MemoryType
+  );
+
+/**
+  Function that checks if PEI memory buckets are enabled.
+
+  @param[in] PrivateData   Pointer to PeiCore's private data structure.
+
+  @retval    TRUE         PEI memory buckets are enabled
+  @retval    FALSE        PEI memory buckets are disabled
+**/
+BOOLEAN
+EFIAPI
+AreMemoryBucketsEnabled (
+  IN PEI_CORE_INSTANCE  *PrivateData
+  );
+
+/**
+  Function that builds and updates the memory bucket hob that will be
+  consumed in DXE.
+
+  @param[in] PrivateData   Pointer to PeiCore's private data structure.
+**/
+VOID
+EFIAPI
+UpdateMemoryBucketHob (
+  IN PEI_CORE_INSTANCE  *PrivateData
+  );
+
+#endif

--- a/MdeModulePkg/Core/Pei/PeiMain.h
+++ b/MdeModulePkg/Core/Pei/PeiMain.h
@@ -43,11 +43,13 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <IndustryStandard/PeImage.h>
 #include <Library/PeiServicesTablePointerLib.h>
 #include <Library/MemoryAllocationLib.h>
-#include <Library/TimerLib.h>       // MS_CHANGE
+#include <Library/TimerLib.h>          // MS_CHANGE
 #include <Guid/FirmwareFileSystem2.h>
 #include <Guid/FirmwareFileSystem3.h>
 #include <Guid/AprioriFileName.h>
 #include <Guid/MigratedFvInfo.h>
+#include <Guid/MemoryTypeStatistics.h>  // MU_CHANGE - Save memory allocations for the PEI memory buckets
+#include <Guid/MemoryTypeInformation.h> // MU_CHANGE - Save memory allocations for the PEI memory buckets
 
 ///
 /// It is an FFS type extension used for PeiFindFileEx. It indicates current
@@ -176,6 +178,17 @@ typedef struct {
   UINTN                   Offset;
   BOOLEAN                 OffsetPositive;
 } HOLE_MEMORY_DATA;
+
+// MU_CHANGE [BEGIN] - Save memory allocations for the PEI memory buckets
+#pragma pack (push, 1)
+typedef struct {
+  EFI_MEMORY_TYPE_STATISTICS    RuntimeBuckets[EfiMaxMemoryType + 1];
+  EFI_PHYSICAL_ADDRESS          CurrentTopInBucket[EfiMaxMemoryType + 1];
+  BOOLEAN                       MemoryBucketsDisabled;
+  BOOLEAN                       RuntimeMemInitialized;
+} PEI_MEMORY_BUCKET_INFORMATION;
+#pragma pack (pop)
+// MU_CHANGE [END] - Save memory allocations for the PEI memory buckets
 
 ///
 /// Forward declaration for PEI_CORE_INSTANCE
@@ -336,6 +349,11 @@ struct _PEI_CORE_INSTANCE {
   DELAYED_DISPATCH_TABLE            *DelayedDispatchTable;    // MS_CHANGE
 
   EFI_PHYSICAL_ADDRESS              PlatformBlob;             // MS_CHANGE  Used by AdvancedLogger
+
+  // MU_CHANGE [BEGIN] - Save memory allocations for the PEI memory buckets
+  // Memory Bucket Variables
+  PEI_MEMORY_BUCKET_INFORMATION     PeiMemoryBuckets;
+  // MU_CHANGE [END] - Save memory allocations for the PEI memory buckets
 };
 
 ///

--- a/MdeModulePkg/Core/Pei/PeiMain.inf
+++ b/MdeModulePkg/Core/Pei/PeiMain.inf
@@ -35,6 +35,8 @@
   Ppi/Ppi.c
   PeiMain/PeiMain.c
   Memory/MemoryServices.c
+  Memory/MemoryBuckets.c   # MU_CHANGE - Added for PEI memory buckets
+  Memory/MemoryBuckets.h   # MU_CHANGE - Added for PEI memory buckets
   Image/Image.c
   Hob/Hob.c
   FwVol/FwVol.c
@@ -81,6 +83,8 @@
   gEdkiiMigratedFvInfoGuid                      ## SOMETIMES_PRODUCES     ## HOB
   gEfiFirmwarePerformanceGuid # MS_CHANGE_161871 - needed to build SEC perf HOB
   gEfiDelayedDispatchTableGuid   # MSCHANGE
+  gEfiMemoryTypeInformationGuid                 ## SOMETIMES_CONSUMES ## HOB # MU_CHANGE  - Save memory allocations for the PEI memory buckets
+  gMemoryTypeStatisticsGuid
 
 [Ppis]
   gEfiPeiStatusCodePpiGuid                      ## SOMETIMES_CONSUMES # PeiReportStatusService is not ready if this PPI doesn't exist

--- a/MdeModulePkg/Include/Guid/MemoryTypeStatistics.h
+++ b/MdeModulePkg/Include/Guid/MemoryTypeStatistics.h
@@ -1,0 +1,31 @@
+/** @file
+
+  GUID and structure for storing memory type statistics.
+  Used for PEI and DXE memory buckets.
+
+  // MU_CHANGE - WHOLE_FILE - Save memory allocations for the PEI memory buckets
+
+  Copyright (C) Microsoft Corporation. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef MEMORY_TYPE_STATISTICS_GUID_H_
+#define MEMORY_TYPE_STATISTICS_GUID_H_
+
+#define MEMORY_TYPE_STATISTICS_GUID \
+  { 0x6146C0D6, 0x8E30, 0x4DC2, { 0xA9, 0xCB, 0x5D, 0x85, 0x10, 0xC4, 0x8B, 0x39 }}
+
+extern EFI_GUID  gMemoryTypeStatisticsGuid;
+
+typedef struct {
+  EFI_PHYSICAL_ADDRESS    BaseAddress;
+  EFI_PHYSICAL_ADDRESS    MaximumAddress;
+  UINT64                  CurrentNumberOfPages;
+  UINT64                  NumberOfPages;
+  UINT32                  InformationIndex;
+  BOOLEAN                 Special;
+  BOOLEAN                 Runtime;
+} EFI_MEMORY_TYPE_STATISTICS;
+
+#endif

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -275,6 +275,12 @@
   #  Include/Guid/MemoryTypeInformation.h
   gEfiMemoryTypeMinimumAllocationGuid = { 0xE4FFE60B, 0x2499, 0x4848, { 0x88, 0x9A, 0xF4, 0x24, 0xC1, 0xC9, 0xC3, 0x47 }}
 
+  # MU_CHANGE [BEGIN] - Save memory allocations for the PEI memory buckets
+  ## Hob and Variable guid specify the platform memory type statistics.
+  #  Include/Guid/MemoryTypeStatistics.h
+  gMemoryTypeStatisticsGuid  = { 0x6146C0D6, 0x8E30, 0x4DC2, { 0xA9, 0xCB, 0x5D, 0x85, 0x10, 0xC4, 0x8B, 0x39 }}
+  # MU_CHANGE [END] - Save memory allocations for the PEI memory buckets
+
   ## Capsule update hob and variable guid
   #  Include/Guid/CapsuleVendor.h
   gEfiCapsuleVendorGuid          = { 0x711C703F, 0xC285, 0x4B10, { 0xA3, 0xB0, 0x36, 0xEC, 0xBD, 0x3C, 0x8B, 0xE2 }}


### PR DESCRIPTION
## Description

Added memory buckets to PEI for all memory types that are allocated
and persist into runtime. This is to reduce memory fragmentation for
memory that is passed into the OS.

This change updates PEI Core to contain "memory bucket" aka "memory
bin" logic that produces a memory type statistics HOB upon runtime
memory type allocation that is consumed by the DXE Core.

These memory buckets are allocated off the PEI heap and used as the
persistent memory location range through OS runtime.

DXE Core will consume the memory type statistics HOB produced if
such a runtime allocation occurs in PEI and use the runtime
memory ranges defined in the HOB for its memory bin locations
instead of allocating new ranges.

As before, the total allocation size per bucket must remain under
the total bucket size to prevent memory from being allocated
outside the PEI bucket range.

Testing has only been done in runtime memory buckets allocated
in post-memory PEI.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

In progress.

## Integration Instructions

N/A

Supersedes #245 and #167 

Co-authored-by: Ken Lautner <klautner@microsoft.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>