### PR TITLE
Correct placement of DEBUG print

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
@@ -64,12 +64,6 @@ PciDevicePresent (
   // and other purposes.  Skip the device, as all the other data read will be invalid.
   //
   if (!EFI_ERROR (Status) && ((Pci->Hdr).VendorId != 0xffff) && ((Pci->Hdr).VendorId != 0x0001)) {
-    if ((Pci->Hdr).VendorId == 0x0001) {
-      DEBUG ((DEBUG_WARN, "CRS response detected.  Devices that return a CRS response during enumeration are currently ignored\n"));
-    }
-
-    // MU_CHANGE End
-
     //
     // Read the entire config header for the device
     //
@@ -82,7 +76,11 @@ PciDevicePresent (
                                     );
 
     return EFI_SUCCESS;
+  } else if ((Pci->Hdr).VendorId == 0x0001) {
+    DEBUG ((DEBUG_WARN, "CRS response detected.  Devices that return a CRS response during enumeration are currently ignored\n"));
   }
+
+  // MU_CHANGE End
 
   return EFI_NOT_FOUND;
 }

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
@@ -63,21 +63,23 @@ PciDevicePresent (
   // the VendorId may read as 0x0001 when not ready. This value is assigned to the PCI-SIG for this,
   // and other purposes.  Skip the device, as all the other data read will be invalid.
   //
-  if (!EFI_ERROR (Status) && ((Pci->Hdr).VendorId != 0xffff) && ((Pci->Hdr).VendorId != 0x0001)) {
-    //
-    // Read the entire config header for the device
-    //
-    Status = PciRootBridgeIo->Pci.Read (
-                                    PciRootBridgeIo,
-                                    EfiPciWidthUint32,
-                                    Address,
-                                    sizeof (PCI_TYPE00) / sizeof (UINT32),
-                                    Pci
-                                    );
+  if (!EFI_ERROR (Status)) {
+    if (((Pci->Hdr).VendorId != 0xffff) && ((Pci->Hdr).VendorId != 0x0001)) {
+      //
+      // Read the entire config header for the device
+      //
+      Status = PciRootBridgeIo->Pci.Read (
+                                      PciRootBridgeIo,
+                                      EfiPciWidthUint32,
+                                      Address,
+                                      sizeof (PCI_TYPE00) / sizeof (UINT32),
+                                      Pci
+                                      );
 
-    return EFI_SUCCESS;
-  } else if ((Pci->Hdr).VendorId == 0x0001) {
-    DEBUG ((DEBUG_WARN, "CRS response detected.  Devices that return a CRS response during enumeration are currently ignored\n"));
+      return EFI_SUCCESS;
+    } else if ((Pci->Hdr).VendorId == 0x0001) {
+      DEBUG ((DEBUG_WARN, "CRS response detected.  Devices that return a CRS response during enumeration are currently ignored\n"));
+    }
   }
 
   // MU_CHANGE End


### PR DESCRIPTION
# Preface


## Description

DEBUG print is in the wrong place, and is effectively dead code.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?

- [ ] Impacts security?

- [ ] Breaking change?

- [ ] Includes tests?
 
- [ ] Includes documentation?

## How This Was Tested

Ensured that a system that doesn't generate CRS still boots

## Integration Instructions

N/A
