### PR TITLE
MdeModulePkg/UefiBootManagerLib: Fix Previous CodeQL fix

### DIFF
--- a/MdeModulePkg/Library/UefiBootManagerLib/BmConsole.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmConsole.c
@@ -446,6 +446,9 @@ EfiBootManagerUpdateConsoleVariable (
     return EFI_UNSUPPORTED;
   }
 
+  // MU_CHANGE - Initialize variable that might not be updated due to error checking
+  TempNewDevicePath = NULL;
+
   //
   // Delete the ExclusiveDevicePath from current default console
   //


### PR DESCRIPTION
# Preface
Fix code path from lastest round of CodeQl fixes (commit a9342ca) that resulted in an uninitialized variable attempting to be freed. 

## Description
TempNewDevicePath is a local variable that is not initialized. Prior to the last round of CodeQl fixes, the local variable would be assigned a value that is returned from BmDelPartMatchInstance, even if the value was NULL. After CodeQl changes, BmDelPartMatchInstance return value is checked, and the initialization of TempNewDevicePath would not occur.

Freeing of TempNewDevicePath checks if the variable is NULL before attempting to free. In the Linux/GCC5 build, this local variable was not initialized and FreePool was called on an invalid parameter. 

It appears that Windows did not catch this because windows debug builds will zero out local variables when debug mode is enabled. 

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

GCC5 Build under Ubuntu 20.04

## Integration Instructions
N/A