### PR TITLE
LineEndingCheck: Fix bare except

### DIFF
--- a/.pytool/Plugin/LineEndingCheck/LineEndingCheck.py
+++ b/.pytool/Plugin/LineEndingCheck/LineEndingCheck.py
@@ -98,7 +98,7 @@ class LineEndingCheck(ICiBuildPlugin):
                 logging.warning(f"git config core.autocrlf is set to {result} "
                                 f"recommended setting is false "
                                 f"git config --global core.autocrlf false")
-        except:
+        except Exception:
             logging.warning(f"git config core.autocrlf is not set "
                             f"recommended setting is false "
                             f"git config --global core.autocrlf false")


### PR DESCRIPTION
## Description

As specified by the PEP8 standard E722, bare excepts should not be used as they can unintentionally catch some exceptions such as SystemExit, KeyboardInterrupt, and GeneratorExit. This commit Updates the bare exception to catch any `Exception` subclass, which does not include the above listed exception types.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Passes CI

## Integration Instructions

N/A
