### PR TITLE
Bugfix: Update device path type check when searching for startup.nsh

### DIFF
--- a/ShellPkg/Application/Shell/Shell.c
+++ b/ShellPkg/Application/Shell/Shell.c
@@ -1260,7 +1260,7 @@ LocateStartupScript (
 
     InternalEfiShellSetEnv (L"homefilesystem", StartupScriptPath, TRUE);
     // MU_CHANGE START: Ensure FileDevicePath is a FILEPATH_DEVICE_PATH prior to accessing PathName
-    if ((FileDevicePath->Type == MEDIA_VENDOR_DP) && (FileDevicePath->SubType == MEDIA_FILEPATH_DP)) {
+    if ((FileDevicePath->Type == MEDIA_DEVICE_PATH) && (FileDevicePath->SubType == MEDIA_FILEPATH_DP)) {
       StartupScriptPath = StrnCatGrow (&StartupScriptPath, &Size, ((FILEPATH_DEVICE_PATH *)FileDevicePath)->PathName, 0);
       PathRemoveLastItem (StartupScriptPath);
     } else {


### PR DESCRIPTION
## Description

Fixes #298 

PR #292 had the incorrect Type for a Filepath Device Path.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

N/A

## Integration Instructions

N/A
