### PR TITLE
Add DEBUG_CLEAR_MEMORY_ENABLED to Necessary Conditions for Clearing Attributes on Page Free

### DIFF
--- a/MdeModulePkg/Core/Dxe/Mem/Page.c
+++ b/MdeModulePkg/Core/Dxe/Mem/Page.c
@@ -1567,10 +1567,10 @@ CoreInternalFreePages (
   UINTN       Alignment;
   BOOLEAN     IsGuarded;
 
-  // MU_CHANGE Start: Unprotect page(s) before free
+  // MU_CHANGE Start: Unprotect page(s) before free if the memory will be cleared on free
   UINT64  Attributes;
 
-  if (MemoryAttributeProtocol != NULL) {
+  if (DebugClearMemoryEnabled () && (MemoryAttributeProtocol != NULL)) {
     Status = MemoryAttributeProtocol->GetMemoryAttributes (MemoryAttributeProtocol, Memory, EFI_PAGES_TO_SIZE (NumberOfPages), &Attributes);
 
     if ((Attributes & EFI_MEMORY_RO) || (Attributes & EFI_MEMORY_RP) || (Status == EFI_NO_MAPPING)) {


### PR DESCRIPTION
## Description

To ensure we don't fault when trying to free a page, a process was added to check the attributes of the page being freed. The potential fault is only a concern if DEBUG_PROPERTY_DEBUG_CLEAR_MEMORY_ENABLED is active, so add a check to that property as a necessary condition for clearing the access attributes.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Running the MemoryAttributeProtocolFuncTestApp on SBSA and Q35 with DEBUG_PROPERTY_DEBUG_CLEAR_MEMORY_ENABLED active and inactive

## Integration Instructions

N/A
