### PR TITLE
MicrocodeMeasurementDxe debug string correction

### DIFF
--- a/UefiCpuPkg/MicrocodeMeasurementDxe/MicrocodeMeasurementDxe.c
+++ b/UefiCpuPkg/MicrocodeMeasurementDxe/MicrocodeMeasurementDxe.c
@@ -238,7 +238,7 @@ MeasureMicrocodePatches (
        TotalMicrocodeSize)
       );
   } else {
-    DEBUG ((DEBUG_ERROR, "ERROR: TpmMeasureAndLogData failed with status %a!\n", Status));
+    DEBUG ((DEBUG_ERROR, "ERROR: TpmMeasureAndLogData failed with status %r!\n", Status));
   }
 
   FreePool (Offsets);

--- a/UefiCpuPkg/MicrocodeMeasurementDxe/MicrocodeMeasurementDxe.c
+++ b/UefiCpuPkg/MicrocodeMeasurementDxe/MicrocodeMeasurementDxe.c
@@ -239,7 +239,6 @@ MeasureMicrocodePatches (
       );
   } else {
     DEBUG ((DEBUG_ERROR, "ERROR: TpmMeasureAndLogData failed with status %r!\n", Status));  // MU_CHANGE
-
   }
 
   FreePool (Offsets);

--- a/UefiCpuPkg/MicrocodeMeasurementDxe/MicrocodeMeasurementDxe.c
+++ b/UefiCpuPkg/MicrocodeMeasurementDxe/MicrocodeMeasurementDxe.c
@@ -238,7 +238,8 @@ MeasureMicrocodePatches (
        TotalMicrocodeSize)
       );
   } else {
-    DEBUG ((DEBUG_ERROR, "ERROR: TpmMeasureAndLogData failed with status %r!\n", Status));
+    DEBUG ((DEBUG_ERROR, "ERROR: TpmMeasureAndLogData failed with status %r!\n", Status));  // MU_CHANGE
+
   }
 
   FreePool (Offsets);


### PR DESCRIPTION
## Description

In a platform with memory protections, the incorrect debug string argument  (%a paired with an EFI_STATUS input) resulted in a CPU exception (based on what was in the uninitialized memory for the string).

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested
After correcting debug string, platform no longer experienced an exception D (General Protection)

## Integration Instructions
N/A