### PR TITLE
Add Volatile Keyword to NVMe CQs and SQs

### DIFF
--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressPassthru.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressPassthru.c
@@ -516,7 +516,7 @@ NvmExpressPassThru (
   EFI_STATUS                     PreviousStatus;
   EFI_PCI_IO_PROTOCOL            *PciIo;
   NVME_SQ                        *Sq;
-  NVME_CQ                        *Cq;
+  volatile NVME_CQ               *Cq;      // MU_CHANGE: Add volatile so that timer loop below is getting updated CQ
   UINT16                         QueueId;
   UINT16                         QueueSize;
   UINT32                         Bytes;

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressPassthru.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressPassthru.c
@@ -940,7 +940,7 @@ NvmExpressPassThru (
       // Dump every completion entry status for debugging.
       //
       DEBUG_CODE_BEGIN ();
-      NvmeDumpStatus ((NVME_CQ)Cq);
+      NvmeDumpStatus (Cq);
       DEBUG_CODE_END ();
     }
 

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressPassthru.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressPassthru.c
@@ -18,7 +18,7 @@
 **/
 VOID
 NvmeDumpStatus (
-  IN NVME_CQ  *Cq
+  IN volatile NVME_CQ  *Cq     // MU_CHANGE: Add volatile keyword to NVME_CQ
   )
 {
   DEBUG ((DEBUG_VERBOSE, "Dump NVMe Completion Entry Status from [0x%x]:\n", Cq));
@@ -515,7 +515,7 @@ NvmExpressPassThru (
   EFI_STATUS                     Status;
   EFI_STATUS                     PreviousStatus;
   EFI_PCI_IO_PROTOCOL            *PciIo;
-  NVME_SQ                        *Sq;
+  volatile NVME_SQ               *Sq;      // MU_CHANGE: Add volatile to ensure HW access
   volatile NVME_CQ               *Cq;      // MU_CHANGE: Add volatile so that timer loop below is getting updated CQ
   UINT16                         QueueId;
   UINT16                         QueueSize;
@@ -668,7 +668,7 @@ NvmExpressPassThru (
   //
   Cq->Pt = Private->Pt[QueueId];
 
-  ZeroMem (Sq, sizeof (NVME_SQ));
+  ZeroMem ((VOID *)Sq, sizeof (NVME_SQ)); // MU_CHANGE: Add volatile keyword to ensure HW access
   Sq->Opc  = (UINT8)Packet->NvmeCmd->Cdw0.Opcode;
   Sq->Fuse = (UINT8)Packet->NvmeCmd->Cdw0.FusedOperation;
   Sq->Cid  = Private->Cid[QueueId]++;
@@ -940,14 +940,14 @@ NvmExpressPassThru (
       // Dump every completion entry status for debugging.
       //
       DEBUG_CODE_BEGIN ();
-      NvmeDumpStatus (Cq);
+      NvmeDumpStatus ((NVME_CQ)Cq);
       DEBUG_CODE_END ();
     }
 
     //
     // Copy the Respose Queue entry for this command to the callers response buffer
     //
-    CopyMem (Packet->NvmeCompletion, Cq, sizeof (EFI_NVM_EXPRESS_COMPLETION));
+    CopyMem (Packet->NvmeCompletion, (VOID *)Cq, sizeof (EFI_NVM_EXPRESS_COMPLETION));  // MU_CHANGE: Add volatile keyword to NVME_CQ
   } else {
     // MS_CHANGE BEGIN UEFI_890
     ReportStatusCode ((EFI_ERROR_MAJOR | EFI_ERROR_CODE), (EFI_IO_BUS_SCSI | EFI_IOB_EC_INTERFACE_ERROR));

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressPassthru.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressPassthru.c
@@ -18,7 +18,7 @@
 **/
 VOID
 NvmeDumpStatus (
-  IN volatile NVME_CQ  *Cq     // MU_CHANGE: Add volatile keyword to NVME_CQ
+  IN NVME_CQ  *Cq
   )
 {
   DEBUG ((DEBUG_VERBOSE, "Dump NVMe Completion Entry Status from [0x%x]:\n", Cq));
@@ -940,7 +940,7 @@ NvmExpressPassThru (
       // Dump every completion entry status for debugging.
       //
       DEBUG_CODE_BEGIN ();
-      NvmeDumpStatus (Cq);
+      NvmeDumpStatus ((NVME_CQ *)Cq); // MU_CHANGE: Add volatile keyword to NVME_CQ
       DEBUG_CODE_END ();
     }
 

--- a/MdeModulePkg/Bus/Pci/NvmExpressPei/NvmExpressPeiPassThru.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressPei/NvmExpressPeiPassThru.c
@@ -115,7 +115,7 @@ NvmeCreatePrpList (
 **/
 EFI_STATUS
 NvmeCheckCqStatus (
-  IN NVME_CQ  *Cq
+  IN volatile NVME_CQ  *Cq  // MU_CHANGE: Add volatile to CQ
   )
 {
   if ((Cq->Sct == 0x0) && (Cq->Sc == 0x0)) {
@@ -617,7 +617,7 @@ NvmePassThruExecute (
   //
   // Copy the Respose Queue entry for this command to the callers response buffer
   //
-  CopyMem (Packet->NvmeCompletion, Cq, sizeof (EFI_NVM_EXPRESS_COMPLETION));
+  CopyMem (Packet->NvmeCompletion, (NVME_CQ *)Cq, sizeof (EFI_NVM_EXPRESS_COMPLETION)); // MU_CHANGE: Add volatile keyword
 
   //
   // Check the NVMe cmd execution result

--- a/MdeModulePkg/Bus/Pci/NvmExpressPei/NvmExpressPeiPassThru.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressPei/NvmExpressPeiPassThru.c
@@ -617,7 +617,7 @@ NvmePassThruExecute (
   //
   // Copy the Respose Queue entry for this command to the callers response buffer
   //
-  CopyMem (Packet->NvmeCompletion, (NVME_CQ *)Cq, sizeof (EFI_NVM_EXPRESS_COMPLETION)); // MU_CHANGE: Add volatile keyword
+  CopyMem (Packet->NvmeCompletion, (VOID *)Cq, sizeof (EFI_NVM_EXPRESS_COMPLETION)); // MU_CHANGE: Add volatile keyword
 
   //
   // Check the NVMe cmd execution result

--- a/MdeModulePkg/Bus/Pci/NvmExpressPei/NvmExpressPeiPassThru.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressPei/NvmExpressPeiPassThru.c
@@ -344,7 +344,7 @@ NvmePassThruExecute (
 {
   EFI_STATUS             Status;
   NVME_SQ                *Sq;
-  NVME_CQ                *Cq;
+  volatile NVME_CQ       *Cq;      // MU_CHANGE: Add volatile so that timer loop below is getting updated CQ
   UINT8                  QueueId;
   UINTN                  SqSize;
   UINTN                  CqSize;

--- a/MdeModulePkg/Bus/Pci/NvmExpressPei/NvmExpressPeiPassThru.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressPei/NvmExpressPeiPassThru.c
@@ -343,7 +343,7 @@ NvmePassThruExecute (
   )
 {
   EFI_STATUS             Status;
-  NVME_SQ                *Sq;
+  volatile NVME_SQ       *Sq;      // MU_CHANGE: Add volatile keyword to ensure HW access
   volatile NVME_CQ       *Cq;      // MU_CHANGE: Add volatile so that timer loop below is getting updated CQ
   UINT8                  QueueId;
   UINTN                  SqSize;
@@ -414,7 +414,7 @@ NvmePassThruExecute (
     return EFI_INVALID_PARAMETER;
   }
 
-  ZeroMem (Sq, sizeof (NVME_SQ));
+  ZeroMem ((VOID *)Sq, sizeof (NVME_SQ));  // MU_CHANGE: Add volatile keyword to ensure HW access
   Sq->Opc  = (UINT8)Packet->NvmeCmd->Cdw0.Opcode;
   Sq->Fuse = (UINT8)Packet->NvmeCmd->Cdw0.FusedOperation;
   Sq->Cid  = Private->Cid[QueueId]++;


### PR DESCRIPTION
## Description

Fixes bug #324. There are two NVMe CQs that get updated by hardware. In these two files, we do not have a volatile keyword on these CQ structs, so when we run them in a loop to check if they have changed, we do not continue to fetch the HW updated queues. Adding the volatile keyword allows us to continue to check the queues during the timer period (otherwise the timer period elapses without being able to operate on queues with descriptors in them.

I checked for other instances of this pattern in the NVMe code that are not reported in this bug, I only found the fixed instances in NvmExpressPassthru.c and NvmExpressPeiPassThru.c. There is a similar if statement in NvmExpress.c, but the CQ gets updated in that loop and this is just a timer callback, process what we found and start the timer again.

This PR also updates SQs to have the volatile keyword, per PR feedback, to ensure that HW accesses are done for each read of the SQ. Current code patterns do not appear to have an issue with reading SQs, but adding the volatile keyword will help ensure that patterns are not introduced that have the same issue as the CQs, as well as maintaining the same pattern with respect to HW queues.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested by bug submitter on an ARM64 platform.

## Integration Instructions

N/A.
