### PR TITLE
Updated Uncrustify to pick up Windows-ARM build

### DIFF
--- a/.pytool/Plugin/UncrustifyCheck/uncrustify_ext_dep.yaml
+++ b/.pytool/Plugin/UncrustifyCheck/uncrustify_ext_dep.yaml
@@ -10,7 +10,7 @@
   "type": "nuget",
   "name": "mu-uncrustify-release",
   "source": "https://pkgs.dev.azure.com/projectmu/Uncrustify/_packaging/mu_uncrustify/nuget/v3/index.json",
-  "version": "73.0.4",
+  "version": "73.0.7",
   "flags": ["set_shell_var", "host_specific"],
   "var_name": "UNCRUSTIFY_CI_PATH"
 }


### PR DESCRIPTION
## Description

This change updated the Uncrustify binary to 73.0.7 to pick up release for Windows-ARM builds.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This was tested on Windows-ARM environment building QEMU Q35.

## Integration Instructions

N/A
