### PR TITLE
python: resolve parser deprecation warnings

### DIFF
--- a/.pytool/Plugin/CompilerPlugin/CompilerPlugin.py
+++ b/.pytool/Plugin/CompilerPlugin/CompilerPlugin.py
@@ -74,9 +74,7 @@ class CompilerPlugin(ICiBuildPlugin):
         self._env.SetValue("ACTIVE_PLATFORM", AP_Path, "Set in Compiler Plugin")
 
         # Parse DSC to check for SUPPORTED_ARCHITECTURES
-        dp = DscParser()
-        dp.SetBaseAbsPath(Edk2pathObj.WorkspacePath)
-        dp.SetPackagePaths(Edk2pathObj.PackagePathList)
+        dp = DscParser().SetEdk2Path(Edk2pathObj)
         # MU_CHANGE [BEGIN] - Enable CompilerPlugin to pass through BuildVars
         build_target = self._env.GetValue("TARGET")
         dp.SetInputVars(self._env.GetAllBuildKeyValues(build_target))

--- a/.pytool/Plugin/DependencyCheck/DependencyCheck.py
+++ b/.pytool/Plugin/DependencyCheck/DependencyCheck.py
@@ -92,8 +92,8 @@ class DependencyCheck(ICiBuildPlugin):
 
         # For each INF file
         for file in INFFiles:
-            logging.debug("Parsing " + file)
             ip = InfParser().SetEdk2Path(Edk2pathObj)
+            logging.debug("Parsing " + file)
             ip.ParseFile(file)
 
             if("MODULE_TYPE" not in ip.Dict):

--- a/.pytool/Plugin/DependencyCheck/DependencyCheck.py
+++ b/.pytool/Plugin/DependencyCheck/DependencyCheck.py
@@ -92,9 +92,9 @@ class DependencyCheck(ICiBuildPlugin):
 
         # For each INF file
         for file in INFFiles:
-            ip = InfParser().SetEdk2Path(Edk2pathObj)
+            ip = InfParser()
             logging.debug("Parsing " + file)
-            ip.ParseFile(file)
+            ip.SetEdk2Path(Edk2pathObj).ParseFile(file)
 
             if("MODULE_TYPE" not in ip.Dict):
                 tc.LogStdOut("Ignoring INF. Missing key for MODULE_TYPE {0}".format(file))

--- a/.pytool/Plugin/DependencyCheck/DependencyCheck.py
+++ b/.pytool/Plugin/DependencyCheck/DependencyCheck.py
@@ -93,7 +93,8 @@ class DependencyCheck(ICiBuildPlugin):
         # For each INF file
         for file in INFFiles:
             logging.debug("Parsing " + file)
-            ip = InfParser().SetEdk2Path(Edk2pathObj).ParseFile(file)
+            ip = InfParser().SetEdk2Path(Edk2pathObj)
+            ip.ParseFile(file)
 
             if("MODULE_TYPE" not in ip.Dict):
                 tc.LogStdOut("Ignoring INF. Missing key for MODULE_TYPE {0}".format(file))

--- a/.pytool/Plugin/DependencyCheck/DependencyCheck.py
+++ b/.pytool/Plugin/DependencyCheck/DependencyCheck.py
@@ -8,7 +8,6 @@ import logging
 import os
 from edk2toolext.environment.plugintypes.ci_build_plugin import ICiBuildPlugin
 from edk2toollib.uefi.edk2.parsers.inf_parser import InfParser
-from edk2toollib.uefi.edk2.path_utilities import Edk2Path
 from edk2toolext.environment.var_dict import VarDict
 
 

--- a/.pytool/Plugin/DependencyCheck/DependencyCheck.py
+++ b/.pytool/Plugin/DependencyCheck/DependencyCheck.py
@@ -8,6 +8,7 @@ import logging
 import os
 from edk2toolext.environment.plugintypes.ci_build_plugin import ICiBuildPlugin
 from edk2toollib.uefi.edk2.parsers.inf_parser import InfParser
+from edk2toollib.uefi.edk2.path_utilities import Edk2Path
 from edk2toolext.environment.var_dict import VarDict
 
 
@@ -92,9 +93,8 @@ class DependencyCheck(ICiBuildPlugin):
 
         # For each INF file
         for file in INFFiles:
-            ip = InfParser()
             logging.debug("Parsing " + file)
-            ip.SetBaseAbsPath(Edk2pathObj.WorkspacePath).SetPackagePaths(Edk2pathObj.PackagePathList).ParseFile(file)
+            ip = InfParser().SetEdk2Path(Edk2pathObj).ParseFile(file)
 
             if("MODULE_TYPE" not in ip.Dict):
                 tc.LogStdOut("Ignoring INF. Missing key for MODULE_TYPE {0}".format(file))

--- a/.pytool/Plugin/DscCompleteCheck/DscCompleteCheck.py
+++ b/.pytool/Plugin/DscCompleteCheck/DscCompleteCheck.py
@@ -91,17 +91,14 @@ class DscCompleteCheck(ICiBuildPlugin):
                         "DscCompleteCheck.IgnoreInf -> {0} not found in filesystem.  Invalid ignore file".format(a))
 
         # DSC Parser
-        dp = DscParser()
-        dp.SetBaseAbsPath(Edk2pathObj.WorkspacePath)
-        dp.SetPackagePaths(Edk2pathObj.PackagePathList)
+        dp = DscParser().SetEdk2Path(Edk2pathObj)
         dp.SetInputVars(environment.GetAllBuildKeyValues())
         dp.ParseFile(wsr_dsc_path)
 
         # Check if INF in component section
         for INF in INFFiles:
             if not DscCompleteCheck._module_in_dsc(INF, dp, Edk2pathObj):
-                infp = InfParser().SetBaseAbsPath(Edk2pathObj.WorkspacePath)
-                infp.SetPackagePaths(Edk2pathObj.PackagePathList)
+                infp = InfParser().SetEdk2Path(Edk2pathObj)
                 infp.ParseFile(INF)
                 if("MODULE_TYPE" not in infp.Dict):
                     tc.LogStdOut(

--- a/.pytool/Plugin/HostUnitTestCompilerPlugin/HostUnitTestCompilerPlugin.py
+++ b/.pytool/Plugin/HostUnitTestCompilerPlugin/HostUnitTestCompilerPlugin.py
@@ -122,9 +122,7 @@ class HostUnitTestCompilerPlugin(ICiBuildPlugin):
                 raise RuntimeError("Can't Change TARGET_ARCH as required")
 
         # Parse DSC to check for SUPPORTED_ARCHITECTURES
-        dp = DscParser()
-        dp.SetBaseAbsPath(Edk2pathObj.WorkspacePath)
-        dp.SetPackagePaths(Edk2pathObj.PackagePathList)
+        dp = DscParser().SetEdk2Path(Edk2pathObj)
         dp.ParseFile(AP_Path)
         if "SUPPORTED_ARCHITECTURES" in dp.LocalVars:
             SUPPORTED_ARCHITECTURES = dp.LocalVars["SUPPORTED_ARCHITECTURES"].split('|')

--- a/.pytool/Plugin/HostUnitTestDscCompleteCheck/HostUnitTestDscCompleteCheck.py
+++ b/.pytool/Plugin/HostUnitTestDscCompleteCheck/HostUnitTestDscCompleteCheck.py
@@ -92,9 +92,7 @@ class HostUnitTestDscCompleteCheck(ICiBuildPlugin):
                         "HostUnitTestDscCompleteCheck.IgnoreInf -> {0} not found in filesystem.  Invalid ignore file".format(a))
 
         # DSC Parser
-        dp = DscParser()
-        dp.SetBaseAbsPath(Edk2pathObj.WorkspacePath)
-        dp.SetPackagePaths(Edk2pathObj.PackagePathList)
+        dp = DscParser().SetEdk2Path(Edk2pathObj)
         dp.SetInputVars(environment.GetAllBuildKeyValues())
         dp.ParseFile(wsr_dsc_path)
 
@@ -104,8 +102,7 @@ class HostUnitTestDscCompleteCheck(ICiBuildPlugin):
                not any(INF.strip() in x for x in dp.SixMods) and \
                not any(INF.strip() in x for x in dp.OtherMods):
 
-                infp = InfParser().SetBaseAbsPath(Edk2pathObj.WorkspacePath)
-                infp.SetPackagePaths(Edk2pathObj.PackagePathList)
+                infp = InfParser().SetEdk2Path(Edk2pathObj)
                 infp.ParseFile(INF)
                 if("MODULE_TYPE" not in infp.Dict):
                     tc.LogStdOut(

--- a/.pytool/Plugin/ImageValidation/ImageValidation.py
+++ b/.pytool/Plugin/ImageValidation/ImageValidation.py
@@ -82,10 +82,10 @@ class ImageValidation(IUefiBuildPlugin):
             return 0
 
         # parse the DSC and the FDF
-        dsc_parser.SetBaseAbsPath(ws).SetPackagePaths(pp)
+        dsc_parser.SetEdk2Path(edk2)
         dsc_parser.SetInputVars(thebuilder.env.GetAllBuildKeyValues()).ParseFile(
             ActiveDsc)  # parse the DSC for build vars
-        fdf_parser.SetBaseAbsPath(ws).SetPackagePaths(pp)
+        fdf_parser.SetEdk2Path(edk2)
         fdf_parser.SetInputVars(dsc_parser.LocalVars).ParseFile(
             ActiveFdf)  # give FDF parser the vars from DSC
 

--- a/.pytool/Plugin/LibraryClassCheck/LibraryClassCheck.py
+++ b/.pytool/Plugin/LibraryClassCheck/LibraryClassCheck.py
@@ -73,8 +73,7 @@ class LibraryClassCheck(ICiBuildPlugin):
             return -1
 
         # Get all include folders
-        dec = DecParser()
-        dec.SetBaseAbsPath(Edk2pathObj.WorkspacePath).SetPackagePaths(Edk2pathObj.PackagePathList)
+        dec = DecParser().SetEdk2Path(Edk2pathObj)
         dec.ParseFile(wsr_dec_path)
 
         AllHeaderFiles = []

--- a/BaseTools/Plugin/BmpCheck/BmpCheckPlugin.py
+++ b/BaseTools/Plugin/BmpCheck/BmpCheckPlugin.py
@@ -134,9 +134,9 @@ class BmpCheckPlugin(IUefiBuildPlugin):
                 self.logger.info("No FDF found- BMP check skipped")
                 return 0
             # parse the DSC and the FDF
-            dp.SetBaseAbsPath(ws).SetPackagePaths(pp)
+            dp.SetEdk2Path(edk2)
             dp.SetInputVars(thebuilder.env.GetAllBuildKeyValues()).ParseFile(ActiveDsc)  # parse the DSC for build vars
-            fp.SetBaseAbsPath(ws).SetPackagePaths(pp)
+            fp.SetEdk2Path(edk2)
             fp.SetInputVars(dp.LocalVars).ParseFile(ActiveFdf)  # give FDF parser the vars from DSC
 
             # for each FV section in the DSC

--- a/BaseTools/Plugin/OverrideValidation/OverrideValidation.py
+++ b/BaseTools/Plugin/OverrideValidation/OverrideValidation.py
@@ -458,7 +458,7 @@ try:
             logging.debug("Parse Active Platform DSC file")
             input_vars = thebuilder.env.GetAllBuildKeyValues()
             input_vars["TARGET"] = thebuilder.env.GetValue("TARGET")
-            dscp = DscParser().SetBaseAbsPath(thebuilder.ws).SetPackagePaths(thebuilder.pp.split(os.pathsep)).SetInputVars(input_vars)
+            dscp = DscParser().SetEdk2Path(Edk2Path(thebuilder.ws, thebuilder.pp.split(os.pathsep))).SetInputVars(input_vars)
             plat_dsc = thebuilder.env.GetValue("ACTIVE_PLATFORM")
             if (plat_dsc is None):
                 return InfFileList


### PR DESCRIPTION
## Description

base_parser.py:BaseParser -  `SetBaseAbsPath()` and `SetPackagePaths()` have been deprecated in favor of `SetEdk2Path()`.

This deprecation is to improve performance when parsing files. Originally the class instantiated it's own Edk2Path object, which is an expensive operation as it parses the workspace to confirm Packages Path and Package validity. While this is not noticed for a single call, typically the parsers are used to parse multiple files at once. 

This change allows (and eventually enforces) that the Edk2Path object be passed to the parser rather than instantiated each time, so that only one Edk2Path object is created for `N` number of file parses.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Passes CI

## Integration Instructions

N/A
