### PR TITLE
[CHERRY-PICK] xHCI Protocol Speed ID Value (PSIV) Compat and Perf Improvements

### DIFF
--- a/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.c
@@ -471,7 +471,16 @@ XhcGetRootHubPortStatus (
   // For those devices behind hub, we get its attach/detach event by hooking Get_Port_Status request at control transfer for those hub.
   //
   ParentRouteChart.Dword = 0;
-  Status                 = XhcPollPortStatusChange (Xhc, ParentRouteChart, PortNumber, PortStatus); // MU_CHANGE
+  Status                 = XhcPollPortStatusChange (Xhc, ParentRouteChart, PortNumber, PortStatus);
+
+  //
+  // Force resetting the port by clearing the USB_PORT_STAT_C_RESET bit in PortChangeStatus
+  // when XhcPollPortStatusChange fails
+  //
+  if (EFI_ERROR (Status)) {
+    PortStatus->PortChangeStatus &= ~(USB_PORT_STAT_C_RESET);
+    Status                        = EFI_SUCCESS;
+  }
 
 ON_EXIT:
   gBS->RestoreTPL (OldTpl);

--- a/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.c
@@ -405,7 +405,7 @@ XhcGetRootHubPortStatus (
   // Section 7.2 xHCI Support Protocol Capability
   //
   if (PortSpeed > 0) {
-    PortStatus->PortStatus = XhcCheckUsbPortSpeedUsedPsic (Xhc, PortSpeed);
+    PortStatus->PortStatus = XhcCheckUsbPortSpeedUsedPsic (Xhc, PortSpeed, PortNumber);
     // If no match found in ext cap reg, fall back to PORTSC
     if (PortStatus->PortStatus == 0) {
       //

--- a/MdeModulePkg/Bus/Pci/XhciDxe/XhciReg.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/XhciReg.c
@@ -636,6 +636,7 @@ XhcGetSupportedProtocolCapabilityAddr (
   @param  Xhc            The XHCI Instance.
   @param  ExtCapOffset   The USB Major Version in xHCI Support Protocol Capability Field
   @param  PortSpeed      The Port Speed Field in USB PortSc register
+  @param  PortNumber     The Port Number (0-indexed)
 
   @return The Protocol Speed ID (PSI) from xHCI Supported Protocol capability register.
 
@@ -644,12 +645,15 @@ UINT32
 XhciPsivGetPsid (
   IN USB_XHCI_INSTANCE  *Xhc,
   IN UINT32             ExtCapOffset,
-  IN UINT8              PortSpeed
+  IN UINT8              PortSpeed,
+  IN UINT8              PortNumber
   )
 {
   XHC_SUPPORTED_PROTOCOL_DW2                PortId;
   XHC_SUPPORTED_PROTOCOL_PROTOCOL_SPEED_ID  Reg;
   UINT32                                    Count;
+  UINT32                                    MinPortIndex;
+  UINT32                                    MaxPortIndex;
 
   if ((Xhc == NULL) || (ExtCapOffset == 0xFFFFFFFF)) {
     return 0;
@@ -662,6 +666,23 @@ XhciPsivGetPsid (
   // 2. The PSID register boundary should be Base address + PSIC * 0x04
   //
   PortId.Dword = XhcReadExtCapReg (Xhc, ExtCapOffset + XHC_SUPPORTED_PROTOCOL_DW2_OFFSET);
+
+  //
+  // According to XHCI 1.1 spec November 2017, valid values
+  // for CompPortOffset are 1 to CompPortCount - 1.
+  //
+  // PortNumber is zero-indexed, so subtract 1.
+  //
+  if ((PortId.Data.CompPortOffset == 0) || (PortId.Data.CompPortCount == 0)) {
+    return 0;
+  }
+
+  MinPortIndex = PortId.Data.CompPortOffset - 1;
+  MaxPortIndex = MinPortIndex + PortId.Data.CompPortCount - 1;
+
+  if ((PortNumber < MinPortIndex) || (PortNumber > MaxPortIndex)) {
+    return 0;
+  }
 
   for (Count = 0; Count < PortId.Data.Psic; Count++) {
     Reg.Dword = XhcReadExtCapReg (Xhc, ExtCapOffset + XHC_SUPPORTED_PROTOCOL_PSI_OFFSET + (Count << 2));
@@ -676,8 +697,9 @@ XhciPsivGetPsid (
 /**
   Find PortSpeed value match case in XHCI Supported Protocol Capability
 
-  @param  Xhc        The XHCI Instance.
-  @param  PortSpeed  The Port Speed Field in USB PortSc register
+  @param  Xhc         The XHCI Instance.
+  @param  PortSpeed   The Port Speed Field in USB PortSc register
+  @param  PortNumber  The Port Number (0-indexed)
 
   @return The USB Port Speed.
 
@@ -685,7 +707,8 @@ XhciPsivGetPsid (
 UINT16
 XhcCheckUsbPortSpeedUsedPsic (
   IN USB_XHCI_INSTANCE  *Xhc,
-  IN UINT8              PortSpeed
+  IN UINT8              PortSpeed,
+  IN UINT8              PortNumber
   )
 {
   XHC_SUPPORTED_PROTOCOL_PROTOCOL_SPEED_ID  SpField;
@@ -703,7 +726,7 @@ XhcCheckUsbPortSpeedUsedPsic (
   // PortSpeed definition when the Major Revision is 03h.
   //
   if (Xhc->Usb3SupOffset != 0xFFFFFFFF) {
-    SpField.Dword = XhciPsivGetPsid (Xhc, Xhc->Usb3SupOffset, PortSpeed);
+    SpField.Dword = XhciPsivGetPsid (Xhc, Xhc->Usb3SupOffset, PortSpeed, PortNumber);
     if (SpField.Dword != 0) {
       //
       // Found the corresponding PORTSC value in PSIV field of USB3 offset.
@@ -717,7 +740,7 @@ XhcCheckUsbPortSpeedUsedPsic (
   // PortSpeed definition when the Major Revision is 02h.
   //
   if ((UsbSpeedIdMap == 0) && (Xhc->Usb2SupOffset != 0xFFFFFFFF)) {
-    SpField.Dword = XhciPsivGetPsid (Xhc, Xhc->Usb2SupOffset, PortSpeed);
+    SpField.Dword = XhciPsivGetPsid (Xhc, Xhc->Usb2SupOffset, PortSpeed, PortNumber);
     if (SpField.Dword != 0) {
       //
       // Found the corresponding PORTSC value in PSIV field of USB2 offset.

--- a/MdeModulePkg/Bus/Pci/XhciDxe/XhciReg.h
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/XhciReg.h
@@ -621,10 +621,11 @@ XhcGetSupportedProtocolCapabilityAddr (
   );
 
 /**
-  Find SpeedField value match with Port Speed ID value.
+  Find PortSpeed value match case in XHCI Supported Protocol Capability
 
-  @param  Xhc    The XHCI Instance.
-  @param  Speed  The Port Speed filed in USB PortSc register
+  @param  Xhc         The XHCI Instance.
+  @param  PortSpeed   The Port Speed Field in USB PortSc register
+  @param  PortNumber  The Port Number (0-indexed)
 
   @return The USB Port Speed.
 
@@ -632,7 +633,8 @@ XhcGetSupportedProtocolCapabilityAddr (
 UINT16
 XhcCheckUsbPortSpeedUsedPsic (
   IN USB_XHCI_INSTANCE  *Xhc,
-  IN UINT8              Speed
+  IN UINT8              PortSpeed,
+  IN UINT8              PortNumber
   );
 
 #endif


### PR DESCRIPTION
## Description

Fixes #343 

A loss of functionality has been observed on some SKL/KBL systems with the changes currently in mu_basecore release/202208.

Includes 3 patches (cherry picked from edk2) to improve PSIV performance and compatibility.

Read individual commit descriptions for more specific details about each change.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Verified functionality was broken before the change and fixed after the change.

## Integration Instructions

Include the changes in this PR on SKL/KBL systems.