### PR TITLE
SetupBrowserDxe: Initialize the variable 'BrowserStorage'

### DIFF
--- a/MdeModulePkg/Universal/SetupBrowserDxe/IfrParse.c
+++ b/MdeModulePkg/Universal/SetupBrowserDxe/IfrParse.c
@@ -438,8 +438,9 @@ CreateStorage (
   EFI_GUID         *StorageGuid;
   CHAR8            *StorageName;
 
-  UnicodeString = NULL;
-  StorageName   = NULL;
+  UnicodeString  = NULL;
+  StorageName    = NULL;
+  BrowserStorage = NULL; // MU_CHANGE - Initialize variable that might not be updated due to error checking
   switch (StorageType) {
     case EFI_HII_VARSTORE_BUFFER:
       StorageGuid = (EFI_GUID *)(CHAR8 *)&((EFI_IFR_VARSTORE *)OpCodeData)->Guid;

--- a/MdeModulePkg/Universal/SetupBrowserDxe/IfrParse.c
+++ b/MdeModulePkg/Universal/SetupBrowserDxe/IfrParse.c
@@ -535,11 +535,10 @@ ErrorExit:
     FreePool (BrowserStorage);
   }
 
-  if (Storage->ConfigRequest != NULL) {
-    FreePool (Storage->ConfigRequest);
-  }
-
   if (Storage != NULL) {
+    if (Storage->ConfigRequest != NULL) {
+      FreePool (Storage->ConfigRequest);
+    }
     FreePool (Storage);
   }
 

--- a/MdeModulePkg/Universal/SetupBrowserDxe/IfrParse.c
+++ b/MdeModulePkg/Universal/SetupBrowserDxe/IfrParse.c
@@ -539,6 +539,7 @@ ErrorExit:
     if (Storage->ConfigRequest != NULL) {
       FreePool (Storage->ConfigRequest);
     }
+
     FreePool (Storage);
   }
 


### PR DESCRIPTION
# Preface

Fix potential error from CodeQL fixes ([commit df0aadd](https://github.com/microsoft/mu_basecore/commit/df0aadd15f3b5beade40728b87fd0765f58bec5b)) that resulted in an uninitialized variable attempting to be used.

## Description

Initialize the variable 'BrowserStorage' to avoid it's used but uninitialized when the logic route through an if statement.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Built several times with the change locally, and the system boots.

## Integration Instructions

N/A
