### PR TITLE
Plugin/CodeQL: Linux fixes

### DIFF
--- a/.pytool/Plugin/CodeQL/CodeQlBuildPlugin.py
+++ b/.pytool/Plugin/CodeQL/CodeQlBuildPlugin.py
@@ -6,6 +6,7 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 
+import glob
 import logging
 import os
 import stat
@@ -99,7 +100,7 @@ class CodeQlBuildPlugin(IUefiBuildPlugin):
                 self.codeql_cmd_path = self.codeql_cmd_path.parent / (
                     self.codeql_cmd_path.name + '.bat')
             elif GetHostInfo().os == "Linux":
-                self.codeql_cmd_path.suffix = self.codeql_cmd_path.parent / (
+                self.codeql_cmd_path = self.codeql_cmd_path.parent / (
                     self.codeql_cmd_path.name + '.sh')
                 codeql_build_cmd += f"#!/bin/bash{os.linesep * 2}"
             codeql_build_cmd += "build " + build_params
@@ -110,6 +111,9 @@ class CodeQlBuildPlugin(IUefiBuildPlugin):
             if GetHostInfo().os == "Linux":
                 os.chmod(self.codeql_cmd_path,
                         os.stat(self.codeql_cmd_path).st_mode | stat.S_IEXEC)
+                for f in glob.glob(os.path.join(
+                    os.path.dirname(self.codeql_path), '**/*'), recursive=True):
+                        os.chmod(f, os.stat(f).st_mode | stat.S_IEXEC)
 
             codeql_params = (f'database create {self.codeql_db_path} '
                             f'--language=cpp '


### PR DESCRIPTION
## Description

Fixes #363 

1. Removes assignment to `suffix` (which does not have a setter)
2. Adds owner execution permission to files in the CodeQL CLI ext dep

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Test in TianoCore [Fedora 37 Dev container](https://github.com/tianocore/containers/pkgs/container/containers%2Ffedora-37-dev) `3b3eb8f`.

## Integration Instructions

Use this change if using the CodeQL plugin on Linux hosts.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>