### PR TITLE
Handling the continue cases for BDS retry

### DIFF
--- a/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
+++ b/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
@@ -391,7 +391,7 @@ BootBootOptions (
   // Attempt boot each boot option
   //
   // MU_CHANGE [BEGINS]- Support infinite boot retries
-  for (Index = 0;; Index++) {
+  for (Index = 0; ; Index++) {
     if (Index == BootOptionCount) {
       if (PcdGetBool (PcdSupportInfiniteBootRetries)) {
         Index = 0;
@@ -399,6 +399,7 @@ BootBootOptions (
         break;
       }
     }
+
     // MU_CHANGE [ENDS]- Support infinite boot retries
 
     //

--- a/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
+++ b/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
@@ -396,7 +396,6 @@ BootBootOptions (
       if (PcdGetBool (PcdSupportInfiniteBootRetries)) {
         // Resetting index back to -1 so loop increment will result in Index 0 for next iteration
         Index = 0;
-        DEBUG ((DEBUG_ERROR, "%a HEre: Wrap around!!! %d\n", __FUNCTION__, __LINE__));
       } else {
         break;
       }

--- a/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
+++ b/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
@@ -394,7 +394,6 @@ BootBootOptions (
   for (Index = 0;; Index++) {
     if (Index == BootOptionCount) {
       if (PcdGetBool (PcdSupportInfiniteBootRetries)) {
-        // Resetting index back to -1 so loop increment will result in Index 0 for next iteration
         Index = 0;
       } else {
         break;

--- a/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
+++ b/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
@@ -390,7 +390,19 @@ BootBootOptions (
   //
   // Attempt boot each boot option
   //
-  for (Index = 0; Index < BootOptionCount; Index++) {
+  // MU_CHANGE [BEGINS]- Support infinite boot retries
+  for (Index = 0;; Index++) {
+    if (Index == BootOptionCount) {
+      if (PcdGetBool (PcdSupportInfiniteBootRetries)) {
+        // Resetting index back to -1 so loop increment will result in Index 0 for next iteration
+        Index = 0;
+        DEBUG ((DEBUG_ERROR, "%a HEre: Wrap around!!! %d\n", __FUNCTION__, __LINE__));
+      } else {
+        break;
+      }
+    }
+    // MU_CHANGE [ENDS]- Support infinite boot retries
+
     //
     // According to EFI Specification, if a load option is not marked
     // as LOAD_OPTION_ACTIVE, the boot manager will not automatically
@@ -439,13 +451,6 @@ BootBootOptions (
       //  Changes for PcdSupportInfiniteBootRetries are meant to minimize upkeep in mu repos.
       //   If/when upstreaming this change, refactoring calling loop in BdsEntry() would be
       //   better location.
-    }
-
-    if (PcdGetBool (PcdSupportInfiniteBootRetries)) {
-      if (Index == (BootOptionCount - 1)) {
-        // Resetting index back to -1 so loop increment will result in Index 0 for next iteration
-        Index = (UINTN)-1;
-      }
     }
 
     // MU_CHANGE [END]- Support infinite boot retries


### PR DESCRIPTION
## Description

The original change (https://github.com/microsoft/mu_basecore/pull/347) will not handle the use case when the last entry in the BootOptions being inactive, and the loop will break in one of the "continue" cases.

This change will ensure that continue statements redirect control to logic for handling infinite retry attempt support.

Fixes https://github.com/microsoft/mu_basecore/issues/368.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This is tested on FVP based virtual platform.

## Integration Instructions

N/A
