### PR TITLE
Edk2ToolsBuild.py: set arch to host arch if not specified on linux

### DIFF
--- a/BaseTools/Edk2ToolsBuild.py
+++ b/BaseTools/Edk2ToolsBuild.py
@@ -203,6 +203,7 @@ class Edk2ToolsBuild(BaseAbstractInvocable):
             # MU_CHANGE STARTs: Specify target architecture
             # Note: This HOST_ARCH is in respect to the BUILT base tools, not the host arch where
             # this script is BUILDING the base tools.
+            HostInfo = GetHostInfo()
             prefix = None
             TargetInfoArch = None
             if self.target_arch is not None:
@@ -228,11 +229,12 @@ class Edk2ToolsBuild(BaseAbstractInvocable):
 
                 else:
                     TargetInfoArch = "x86"
-
+            else:
+                self.target_arch = HostInfo.arch
+                TargetInfoArch = HostInfo.arch
             # Otherwise, the built binary arch will be consistent with the host system
 
             # Added logic to support cross compilation scenarios
-            HostInfo = GetHostInfo()
             if TargetInfoArch != HostInfo.arch:
                 # this is defaulting to the version that comes with Ubuntu 20.04
                 ver = shell_environment.GetBuildVars().GetValue("LIBUUID_VERSION", "2.34")


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

The -a <ARCH> command line options should be optional, defaulting to IA32 on windows or the host arch on linux, however this scenario fails on linux systems as the arch is not set to the host's architecture. This PR adds this logic.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

<_Please describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
