### PR TITLE
MdeModulePkg/Core: Reduce stack cookie value verbosity

### DIFF
--- a/MdeModulePkg/Core/Dxe/Image/Image.c
+++ b/MdeModulePkg/Core/Dxe/Image/Image.c
@@ -926,7 +926,7 @@ CoreLoadPeImage (
   Status = PeCoffLoaderGetSecurityCookieAddress (&Image->ImageContext, &SecurityCookieAddress);
   if (!EFI_ERROR (Status)) {
     InitializeSecurityCookieAddress (SecurityCookieAddress);
-    DEBUG ((DEBUG_INFO | DEBUG_LOAD, "SecurityCookie set to %lld\n", (*SecurityCookieAddress)));
+    DEBUG ((DEBUG_VERBOSE | DEBUG_LOAD, "SecurityCookie set to %lld\n", (*SecurityCookieAddress)));
   }
 
   // END

--- a/MdeModulePkg/Core/PiSmmCore/Dispatcher.c
+++ b/MdeModulePkg/Core/PiSmmCore/Dispatcher.c
@@ -737,7 +737,7 @@ SmmLoadImage (
   Status = PeCoffLoaderGetSecurityCookieAddress (&ImageContext, &SecurityCookieAddress);
   if (!EFI_ERROR (Status)) {
     InitializeSecurityCookieAddress (SecurityCookieAddress);
-    DEBUG ((DEBUG_INFO | DEBUG_LOAD, "SMM SecurityCookie set to %lld\n", (*SecurityCookieAddress)));
+    DEBUG ((DEBUG_VERBOSE | DEBUG_LOAD, "SMM SecurityCookie set to %lld\n", (*SecurityCookieAddress)));
   }
 
   // END


### PR DESCRIPTION
## Description

The message that prints the security cookie value initialized during
PE image load prints about 150 times on some Intel platforms
(depending on DXE/MM module count and cookie config settings).

This information is typically not needed unless specialized debug
related to security cookies is required which is rare. This change
constrains the message to `DEBUG_VERBOSE` (instead of `DEBUG_INFO`)
in addition to `DEBUG_LOAD`.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Before change, log showed stack cookie value and after change it does not
(with `DEBUG_VERBOSE` and `DEBUG_LOAD` not active).

## Integration Instructions

Check if any tools or processes were dependent on the stack cookie value message
and adjust debug print level accordingly if necessary.