### PR TITLE
Create Github Workflow to publish basetools on release

### DIFF
--- a/.github/workflows/release-basetools.yml
+++ b/.github/workflows/release-basetools.yml
@@ -52,7 +52,14 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
+
+      - name: Install Linux Tools
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get install -y gcc-aarch64-linux-gnu gcc-arm-linux-gnueabi g++-aarch64-linux-gnu g++-arm-linux-gnueabi
+          echo "GCC5_AARCH64_PREFIX=/usr/bin/aarch64-linux-gnu-" >> "$GITHUB_ENV"
+          echo "GCC5_ARM_PREFIX=/usr/bin/arm-linux-gnueabi-" >> "$GITHUB_ENV"
 
       - name: Install Pip Modules
         run: pip install -r pip-requirements.txt --upgrade
@@ -66,12 +73,15 @@ jobs:
       - name: Build Base Tools
         run: python BaseTools/Edk2ToolsBuild.py -t ${{ matrix.tool_chain}} -a ${{ matrix.target }} --skip_path_env
 
-      - name: Upload Build Log
+      - name: Upload Build Logs
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: buildlog-${{ matrix.tool_chain }}-${{ matrix.target }}
-          path: BaseTools/BaseToolsBuild
+          name: logs-${{ matrix.tool_chain }}-${{ matrix.target }}
+          path: |
+            Build/SETUPLOG.txt
+            Build/UPDATE_LOG.txt
+            BaseTools/BaseToolsBuild/BASETOOLS_BUILD.txt
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release-basetools.yml
+++ b/.github/workflows/release-basetools.yml
@@ -1,0 +1,110 @@
+# This workflow automatically publishes the basetools binaries for a given
+# release.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+name: Publish BaseTools
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    name: Build Base Tools
+    strategy:
+      matrix:
+        include:
+          - os: windows-2022
+            tool_chain: VS2022
+            output_dir: "BaseTools\\Bin\\Win32"
+            target: IA32
+
+          - os: windows-2022
+            tool_chain: VS2022
+            output_dir: "BaseTools\\Bin\\Win32"
+            target: ARM
+
+          - os: windows-2022
+            tool_chain: VS2022
+            output_dir: "BaseTools\\Bin\\Win64"
+            target: AARCH64
+
+          - os: ubuntu-22.04
+            tool_chain: GCC5
+            output_dir: "BaseTools/Source/C/bin"
+            target: X64
+
+          - os: ubuntu-22.04
+            tool_chain: GCC5
+            output_dir: "BaseTools/Source/C/bin"
+            target: AARCH64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install Pip Modules
+        run: pip install -r pip-requirements.txt --upgrade
+
+      - name: Stuart Setup
+        run: stuart_setup -c .pytool/CISettings.py
+
+      - name: Stuart Update
+        run: stuart_update -c .pytool/CISettings.py TOOL_CHAIN_TAG=${{ matrix.tool_chain}} -a ${{ matrix.target }}
+
+      - name: Build Base Tools
+        run: python BaseTools/Edk2ToolsBuild.py -t ${{ matrix.tool_chain}} -a ${{ matrix.target }} --skip_path_env
+
+      - name: Upload Build Log
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: buildlog-${{ matrix.tool_chain }}-${{ matrix.target }}
+          path: BaseTools/BaseToolsBuild
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: basetools-${{ matrix.tool_chain }}-${{ matrix.target }}
+          path: ${{ matrix.output_dir }}
+
+  publish:
+    name: Publish Base Tools
+    needs: build
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: ${{ runner.temp }}/artifacts
+
+      - name: Stage Files
+        run: mkdir ${{ runner.temp }}/basetools ;
+          mv ${{ runner.temp }}/artifacts/basetools-GCC5-X64       ${{ runner.temp }}/basetools/Linux-x86 ;
+          mv ${{ runner.temp }}/artifacts/basetools-GCC5-AARCH64   ${{ runner.temp }}/basetools/Linux-ARM-64 ;
+          mv ${{ runner.temp }}/artifacts/basetools-VS2022-IA32    ${{ runner.temp }}/basetools/Windows-x86 ;
+          mv ${{ runner.temp }}/artifacts/basetools-VS2022-ARM     ${{ runner.temp }}/basetools/Windows-ARM ;
+          mv ${{ runner.temp }}/artifacts/basetools-VS2022-AARCH64 ${{ runner.temp }}/basetools/Windows-ARM-64 ;
+
+      - name: Zip Files
+        run: cd ${{ runner.temp }} ; zip -r basetools-${{ github.event.release.tag_name }}.zip basetools/*
+
+      - name: Upload Release Asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload ${{ github.event.release.tag_name }} ${{ runner.temp }}/basetools-*.zip

--- a/BaseTools/Edk2ToolsBuild.py
+++ b/BaseTools/Edk2ToolsBuild.py
@@ -210,20 +210,26 @@ class Edk2ToolsBuild(BaseAbstractInvocable):
                 shell_env.set_shell_var('HOST_ARCH', self.target_arch)
 
                 if "AARCH64" in self.target_arch:
-                    # now check for install dir.  If set then set the Prefix
-                    install_path = shell_environment.GetEnvironment().get_shell_var("GCC5_AARCH64_INSTALL")
+                    prefix = shell_env.get_shell_var("GCC5_AARCH64_PREFIX")
+                    if prefix == None:
+                        # now check for install dir.  If set then set the Prefix
+                        install_path = shell_environment.GetEnvironment().get_shell_var("GCC5_AARCH64_INSTALL")
 
-                    # make GCC5_AARCH64_PREFIX to align with tools_def.txt
-                    prefix = os.path.join(install_path, "bin", "aarch64-none-linux-gnu-")
+                        # make GCC5_AARCH64_PREFIX to align with tools_def.txt
+                        prefix = os.path.join(install_path, "bin", "aarch64-none-linux-gnu-")
+
                     shell_environment.GetEnvironment().set_shell_var("GCC_PREFIX", prefix)
                     TargetInfoArch = "ARM"
 
                 elif "ARM" in self.target_arch:
-                    # now check for install dir.  If set then set the Prefix
-                    install_path = shell_environment.GetEnvironment().get_shell_var("GCC5_ARM_INSTALL")
+                    prefix = shell_env.get_shell_var("GCC5_ARM_PREFIX")
+                    if prefix == None:
+                        # now check for install dir.  If set then set the Prefix
+                        install_path = shell_environment.GetEnvironment().get_shell_var("GCC5_ARM_INSTALL")
 
-                    # make GCC5_ARM_PREFIX to align with tools_def.txt
-                    prefix = os.path.join(install_path, "bin", "arm-none-linux-gnueabihf-")
+                        # make GCC5_ARM_PREFIX to align with tools_def.txt
+                        prefix = os.path.join(install_path, "bin", "arm-none-linux-gnueabihf-")
+
                     shell_environment.GetEnvironment().set_shell_var("GCC_PREFIX", prefix)
                     TargetInfoArch = "ARM"
 


### PR DESCRIPTION
## Description

Create a GitHub Workflow that will build and zip all basetool binaries and attach it to the published release in the format basetools-\<tag\>.zip.

This change is being made to better support no-nuget repo configuration by allowing a web dependency for the MU_BASECORE release assets.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on private fork releases.

## Integration Instructions

N/A
