### PR TITLE
Fixing bug with newer versions of markdownlint

### DIFF
--- a/.pytool/Plugin/MarkdownLintCheck/MarkdownLintCheck.py
+++ b/.pytool/Plugin/MarkdownLintCheck/MarkdownLintCheck.py
@@ -102,6 +102,9 @@ class MarkdownLintCheck(ICiBuildPlugin):
         # Get relative path for the root of package to use with ignore and path parameters
         relpath = os.path.relpath(abs_pkg_path)
 
+        # Newer versions of markdownlint don't understand backslashes
+        relpath = relpath.replace(os.path.sep, '/')
+
         #
         # check for any package specific ignore patterns defined by package config
         #


### PR DESCRIPTION
## Description
Fixed a bug with the MarkdownLintCheck plugin where with newer versions of the tool the plugin would pass when there were markdown issues. Newer versions of `markdownlint` (in this case `0.34.0`) no longer understand backslashes in the `<files|directories|globs>` parameter; including backslashes in that parameter results in the tool printing the help text and returning 0. This change removes the backslashes from that parameter to fix the plugin.


- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested
On Windows 11 with Node v16.15.0:
+ with markdownlint v0.34.0: ran stuart_ci_build on my pkgs and observed the MarkdownLintCheck plugin failed when markdown issues, succeeded when no markdown issues.
+ with markdownlint v0.31.1 (version known to not have this issue): ran stuart_ci_build on my pkgs and observed the MarkdownLintCheck plugin failed when markdown issues, succeeded when no markdown issues.

## Integration Instructions
N/A
