### PR TITLE
Refactoring infinite boot option retries

### DIFF
--- a/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
+++ b/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
@@ -392,7 +392,6 @@ BootBootOptions (
   //
 
   for (Index = 0; Index < BootOptionCount; Index++) {
-
     //
     // According to EFI Specification, if a load option is not marked
     // as LOAD_OPTION_ACTIVE, the boot manager will not automatically

--- a/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
+++ b/MdeModulePkg/Universal/BdsDxe/BdsEntry.c
@@ -390,17 +390,8 @@ BootBootOptions (
   //
   // Attempt boot each boot option
   //
-  // MU_CHANGE [BEGINS]- Support infinite boot retries
-  for (Index = 0; ; Index++) {
-    if (Index == BootOptionCount) {
-      if (PcdGetBool (PcdSupportInfiniteBootRetries)) {
-        Index = 0;
-      } else {
-        break;
-      }
-    }
 
-    // MU_CHANGE [ENDS]- Support infinite boot retries
+  for (Index = 0; Index < BootOptionCount; Index++) {
 
     //
     // According to EFI Specification, if a load option is not marked
@@ -1125,7 +1116,7 @@ BdsEntry (
         BootSuccess = BootBootOptions (LoadOptions, LoadOptionCount, (BootManagerMenuStatus != EFI_NOT_FOUND) ? &BootManagerMenu : NULL);
         EfiBootManagerFreeLoadOptions (LoadOptions, LoadOptionCount);
       }
-    } while (BootSuccess);
+    } while (BootSuccess || PcdGetBool (PcdSupportInfiniteBootRetries)); // MU_CHANGE add PcdSupportInfiniteBootRetries support
   }
 
   if (BootManagerMenuStatus != EFI_NOT_FOUND) {


### PR DESCRIPTION
## Description

Last revision of infinite boot retries resulted in build errors with VS2022 due to "unreachable code" errors. 

Refactor to move loop to top level function. Refactor of #347 

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Build with VS2022 and PcdSupportInfiniteBootRetries set to TRUE.
Build with VS2022 and PcdSupportInfiniteBootRetries set to FALSE.
Build with GCC5 and PcdSupportInfiniteBootRetries set to TRUE.

## Integration Instructions
N/A