### PR TITLE
Add basic wrappers to the Policy Library

### DIFF
--- a/PolicyServicePkg/Include/Library/PolicyLib.h
+++ b/PolicyServicePkg/Include/Library/PolicyLib.h
@@ -1,13 +1,13 @@
 /** @file
-  Definitions for the verified policy libraries.
+  Definitions for the policy libraries.
 
   Copyright (c) Microsoft Corporation
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
-#ifndef _VERIFIED_POLICY_H_
-#define _VERIFIED_POLICY_H_
+#ifndef _POLICY_LIB_H_
+#define _POLICY_LIB_H_
 
 #define VERIFIED_POLICY_LIB_VERSION  1
 
@@ -23,6 +23,66 @@ typedef struct _VERIFIED_POLICY_HEADER {
 #pragma pack()
 
 typedef VERIFIED_POLICY_HEADER VERIFIED_POLICY_DESCRIPTOR;
+
+/**
+  Creates or updates a policy in the policy store. Will notify any applicable
+  callbacks.
+
+  @param[in]  PolicyGuid          The uniquely identifying GUID for the policy.
+  @param[in]  Attributes          Attributes of the policy to be set.
+  @param[in]  Policy              The policy data buffer. This buffer will be
+                                  copied into the data store.
+  @param[in]  PolicySize          The size of the provided policy data.
+
+  @retval   EFI_SUCCESS           Policy was created or updated.
+  @retval   EFI_ACCESS_DENIED     Policy was already finalized prior to this call.
+  @retval   EFI_OUT_OF_RESOURCES  Failed to allocate space for policy structures.
+**/
+EFI_STATUS
+EFIAPI
+SetPolicy (
+  IN CONST EFI_GUID  *PolicyGuid,
+  IN UINT64          Attributes,
+  IN VOID            *Policy,
+  IN UINT16          PolicySize
+  );
+
+/**
+  Retrieves the policy descriptor, buffer, and size for a given policy GUID.
+
+  @param[in]      PolicyGuid        The GUID of the policy being retrieved.
+  @param[out]     Attributes        The attributes of the stored policy.
+  @param[out]     Policy            The buffer where the policy data is copied.
+  @param[in,out]  PolicySize        The size of the stored policy data buffer.
+                                    On output, contains the size of the stored policy.
+
+  @retval   EFI_SUCCESS           The policy was retrieved.
+  @retval   EFI_BUFFER_TOO_SMALL  The provided buffer size was too small.
+  @retval   EFI_NOT_FOUND         The policy does not exist.
+**/
+EFI_STATUS
+EFIAPI
+GetPolicy (
+  IN CONST EFI_GUID  *PolicyGuid,
+  OUT UINT64         *Attributes OPTIONAL,
+  OUT VOID           *Policy,
+  IN OUT UINT16      *PolicySize
+  );
+
+/**
+  Removes a policy from the policy store. The policy will be removed from the store
+  and freed if possible.
+
+  @param[in]  PolicyGuid        The GUID of the policy being retrieved.
+
+  @retval   EFI_SUCCESS         The policy was removed.
+  @retval   EFI_NOT_FOUND       The policy does not exist.
+**/
+EFI_STATUS
+EFIAPI
+RemovePolicy (
+  IN CONST EFI_GUID  *PolicyGuid
+  );
 
 /**
   Retrieves a verified policy of the given type from the policy store.

--- a/PolicyServicePkg/Library/DxePolicyLib/DxePolicy.c
+++ b/PolicyServicePkg/Library/DxePolicyLib/DxePolicy.c
@@ -12,7 +12,7 @@
 #include <Library/BaseLib.h>
 
 #include <Protocol/Policy.h>
-#include <Library/VerifiedPolicy.h>
+#include <Library/PolicyLib.h>
 
 #include "../PolicyLibCommon.h"
 

--- a/PolicyServicePkg/Library/MmPolicyLib/MmPolicy.c
+++ b/PolicyServicePkg/Library/MmPolicyLib/MmPolicy.c
@@ -12,7 +12,7 @@
 #include <Library/BaseLib.h>
 
 #include <Protocol/MmPolicy.h>
-#include <Library/VerifiedPolicy.h>
+#include <Library/PolicyLib.h>
 
 #include "../PolicyLibCommon.h"
 

--- a/PolicyServicePkg/Library/PeiPolicyLib/PeiPolicy.c
+++ b/PolicyServicePkg/Library/PeiPolicyLib/PeiPolicy.c
@@ -12,7 +12,7 @@
 #include <Library/PeiServicesLib.h>
 
 #include <Ppi/Policy.h>
-#include <Library/VerifiedPolicy.h>
+#include <Library/PolicyLib.h>
 
 #include "../PolicyLibCommon.h"
 

--- a/PolicyServicePkg/Library/PolicyLibCommon.c
+++ b/PolicyServicePkg/Library/PolicyLibCommon.c
@@ -12,10 +12,103 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/MemoryAllocationLib.h>
 
-#include <Library/VerifiedPolicy.h>
+#include <Library/PolicyLib.h>
 #include <PolicyInterface.h>
 
 #include "../PolicyLibCommon.h"
+
+/**
+  Creates or updates a policy in the policy store. Will notify any applicable
+  callbacks.
+
+  @param[in]  PolicyGuid          The uniquely identifying GUID for the policy.
+  @param[in]  Attributes          Attributes of the policy to be set.
+  @param[in]  Policy              The policy data buffer. This buffer will be
+                                  copied into the data store.
+  @param[in]  PolicySize          The size of the provided policy data.
+
+  @retval   EFI_SUCCESS           Policy was created or updated.
+  @retval   EFI_ACCESS_DENIED     Policy was already finalized prior to this call.
+  @retval   EFI_OUT_OF_RESOURCES  Failed to allocate space for policy structures.
+**/
+EFI_STATUS
+EFIAPI
+SetPolicy (
+  IN CONST EFI_GUID  *PolicyGuid,
+  IN UINT64          Attributes,
+  IN VOID            *Policy,
+  IN UINT16          PolicySize
+  )
+{
+  POLICY_INTERFACE  *PolicyService;
+  EFI_STATUS        Status;
+
+  Status = GetPolicyInterface (&PolicyService);
+  if (!EFI_ERROR (Status)) {
+    Status = PolicyService->SetPolicy (PolicyGuid, Attributes, Policy, PolicySize);
+  }
+
+  return Status;
+}
+
+/**
+  Retrieves the policy descriptor, buffer, and size for a given policy GUID.
+
+  @param[in]      PolicyGuid        The GUID of the policy being retrieved.
+  @param[out]     Attributes        The attributes of the stored policy.
+  @param[out]     Policy            The buffer where the policy data is copied.
+  @param[in,out]  PolicySize        The size of the stored policy data buffer.
+                                    On output, contains the size of the stored policy.
+
+  @retval   EFI_SUCCESS           The policy was retrieved.
+  @retval   EFI_BUFFER_TOO_SMALL  The provided buffer size was too small.
+  @retval   EFI_NOT_FOUND         The policy does not exist.
+**/
+EFI_STATUS
+EFIAPI
+GetPolicy (
+  IN CONST EFI_GUID  *PolicyGuid,
+  OUT UINT64         *Attributes OPTIONAL,
+  OUT VOID           *Policy,
+  IN OUT UINT16      *PolicySize
+  )
+{
+  POLICY_INTERFACE  *PolicyService;
+  EFI_STATUS        Status;
+
+  Status = GetPolicyInterface (&PolicyService);
+  if (!EFI_ERROR (Status)) {
+    Status = PolicyService->GetPolicy (PolicyGuid, Attributes, Policy, PolicySize);
+  }
+
+  return Status;
+}
+
+/**
+  Removes a policy from the policy store. The policy will be removed from the store
+  and freed if possible.
+
+  @param[in]  PolicyGuid        The GUID of the policy being retrieved.
+
+  @retval   EFI_SUCCESS         The policy was removed.
+  @retval   EFI_NOT_FOUND       The policy does not exist.
+**/
+EFI_STATUS
+EFIAPI
+RemovePolicy (
+  IN CONST EFI_GUID  *PolicyGuid
+  )
+{
+  POLICY_INTERFACE  *PolicyService;
+  EFI_STATUS        Status;
+
+  Status = GetPolicyInterface (&PolicyService);
+  if (!EFI_ERROR (Status)) {
+    Status = PolicyService->RemovePolicy (PolicyGuid);
+  }
+
+  return Status;
+}
 
 /**
   Retrieves a verified policy of the given type from the policy store.

--- a/PolicyServicePkg/PolicyService/DxeMm/PolicyCommon.c
+++ b/PolicyServicePkg/PolicyService/DxeMm/PolicyCommon.c
@@ -82,7 +82,7 @@ CheckPolicyExists (
 **/
 EFI_STATUS
 EFIAPI
-GetPolicy (
+CommonGetPolicy (
   IN CONST EFI_GUID  *PolicyGuid,
   OUT UINT64         *Attributes OPTIONAL,
   OUT VOID           *Policy,
@@ -201,7 +201,7 @@ IngestPoliciesFromHob (
 **/
 EFI_STATUS
 EFIAPI
-RemovePolicy (
+CommonRemovePolicy (
   IN CONST EFI_GUID  *PolicyGuid
   )
 {
@@ -243,7 +243,7 @@ RemovePolicy (
 **/
 EFI_STATUS
 EFIAPI
-SetPolicy (
+CommonSetPolicy (
   IN CONST EFI_GUID  *PolicyGuid,
   IN UINT64          Attributes,
   IN VOID            *Policy,

--- a/PolicyServicePkg/PolicyService/DxeMm/PolicyCommon.h
+++ b/PolicyServicePkg/PolicyService/DxeMm/PolicyCommon.h
@@ -57,7 +57,7 @@ typedef struct _POLICY_ENTRY {
 **/
 EFI_STATUS
 EFIAPI
-SetPolicy (
+CommonSetPolicy (
   IN CONST EFI_GUID  *PolicyGuid,
   IN UINT64          Attributes,
   IN VOID            *Policy,
@@ -79,7 +79,7 @@ SetPolicy (
 **/
 EFI_STATUS
 EFIAPI
-GetPolicy (
+CommonGetPolicy (
   IN CONST EFI_GUID  *PolicyGuid,
   OUT UINT64         *Attributes OPTIONAL,
   OUT VOID           *Policy,
@@ -97,7 +97,7 @@ GetPolicy (
 **/
 EFI_STATUS
 EFIAPI
-RemovePolicy (
+CommonRemovePolicy (
   IN CONST EFI_GUID  *PolicyGuid
   );
 

--- a/PolicyServicePkg/PolicyService/DxeMm/PolicyDxe.c
+++ b/PolicyServicePkg/PolicyService/DxeMm/PolicyDxe.c
@@ -16,9 +16,9 @@ STATIC EFI_LOCK    mPolicyListLock = EFI_INITIALIZE_LOCK_VARIABLE (TPL_NOTIFY);
 STATIC EFI_HANDLE  mImageHandle    = NULL;
 
 POLICY_PROTOCOL  mPolicyProtocol = {
-  SetPolicy,
-  GetPolicy,
-  RemovePolicy
+  CommonSetPolicy,
+  CommonGetPolicy,
+  CommonRemovePolicy
 };
 
 /**

--- a/PolicyServicePkg/PolicyService/DxeMm/PolicyMm.c
+++ b/PolicyServicePkg/PolicyService/DxeMm/PolicyMm.c
@@ -14,9 +14,9 @@
 STATIC EFI_HANDLE  mProtocolHandle = NULL;
 
 MM_POLICY_PROTOCOL  mPolicyProtocol = {
-  SetPolicy,
-  GetPolicy,
-  RemovePolicy
+  CommonSetPolicy,
+  CommonGetPolicy,
+  CommonRemovePolicy
 };
 
 /**

--- a/PolicyServicePkg/PolicyServicePkg.dec
+++ b/PolicyServicePkg/PolicyServicePkg.dec
@@ -16,7 +16,7 @@
   Include
 
 [LibraryClasses]
-  PolicyLib|Include/Library/VerifiedPolicy.h
+  PolicyLib|Include/Library/PolicyLib.h
 
 [Guids]
   ## GUID used for storing policy data in HOB.

--- a/PolicyServicePkg/Samples/PolicyDefinitions/PolicyDataStructGFX.h
+++ b/PolicyServicePkg/Samples/PolicyDefinitions/PolicyDataStructGFX.h
@@ -13,7 +13,7 @@
 #ifndef __POLICY_DATA_STRUCT_GFX_H__
 #define __POLICY_DATA_STRUCT_GFX_H__
 
-#include <Library/VerifiedPolicy.h>
+#include <Library/PolicyLib.h>
 
 #pragma pack(1)
 
@@ -23,16 +23,16 @@
 
 
 typedef struct {
-  
+
   /* Power state of GFX port 0 */
   UINT16                      Power_State_Port_0;
-  
+
   /* Power state of GFX port 1 */
   UINT16                      Power_State_Port_1;
-  
+
   /* Flag to skip this controller or not */
   UINT16                      Skip_Check_0;
-  
+
   /* Flag to skip this controller or not */
   UINT16                      Skip_Check_1;
 

--- a/PolicyServicePkg/Test/UnitTest/PolicyTest/PolicyLibTestCommon.c
+++ b/PolicyServicePkg/Test/UnitTest/PolicyTest/PolicyLibTestCommon.c
@@ -130,6 +130,48 @@ BasicVerifiedPolicyTest (
 }
 
 /**
+  Tests the basic test scenario.
+
+  @param[in]  Context                     Unused.
+
+  @retval   UNIT_TEST_PASSED              Test passed.
+  @retval   UNIT_TEST_ERROR_TEST_FAILED   Test failed.
+**/
+UNIT_TEST_STATUS
+EFIAPI
+BasicPolicyTest (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+
+{
+  EFI_STATUS      Status;
+  UINT8           TestData[16] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+  UINT8           ReadData[16] = { 0 };
+  UINT16          PolicySize;
+  CONST EFI_GUID  PolicyGuid = {
+    0x30c24026, 0xee8f, 0x494a, { 0x92, 0x48, 0xc0, 0x05, 0x28, 0xc6, 0x7f, 0x5b }
+  };
+
+  PolicySize = sizeof (ReadData);
+  Status     = GetPolicy (&PolicyGuid, NULL, &ReadData[0], &PolicySize);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_NOT_FOUND);
+
+  Status = SetPolicy (&PolicyGuid, 0, &TestData[0], sizeof (TestData));
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+
+  Status = GetPolicy (&PolicyGuid, NULL, &ReadData[0], &PolicySize);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+  UT_ASSERT_MEM_EQUAL (&TestData[0], &ReadData[0], sizeof (TestData));
+
+  Status = RemovePolicy (&PolicyGuid);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_SUCCESS);
+  Status = RemovePolicy (&PolicyGuid);
+  UT_ASSERT_STATUS_EQUAL (Status, EFI_NOT_FOUND);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
   Add the common policy library tests.
 
   @param[in]  Framework       The test framework to add the common policy
@@ -160,6 +202,7 @@ PolicyLibCommonCreateTests (
     return Status;
   }
 
+  AddTestCase (LibCommonTests, "Tests the basic policy lib interfaces", "BasicPolicyTest", BasicPolicyTest, NULL, NULL, NULL);
   AddTestCase (LibCommonTests, "Test basic verified policy creation", "BasicVerifiedPolicyTest", BasicVerifiedPolicyTest, NULL, NULL, NULL);
   AddTestCase (LibCommonTests, "Test change of major version", "MajorVersionChangeTest", MajorVersionChangeTest, NULL, NULL, NULL);
 

--- a/PolicyServicePkg/Test/UnitTest/PolicyTest/PolicyLibTestCommon.c
+++ b/PolicyServicePkg/Test/UnitTest/PolicyTest/PolicyLibTestCommon.c
@@ -14,7 +14,7 @@
 #include <Library/BaseMemoryLib.h>
 
 #include <PolicyInterface.h>
-#include <Library/VerifiedPolicy.h>
+#include <Library/PolicyLib.h>
 #include <Library/UnitTestLib.h>
 
 #include "PolicyTest.h"

--- a/PolicyServicePkg/Test/UnitTest/PolicyTest/PolicyLibTestCommon.c
+++ b/PolicyServicePkg/Test/UnitTest/PolicyTest/PolicyLibTestCommon.c
@@ -145,7 +145,7 @@ BasicPolicyTest (
 
 {
   EFI_STATUS      Status;
-  UINT8           TestData[16] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+  UINT8           TestData[16] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
   UINT8           ReadData[16] = { 0 };
   UINT16          PolicySize;
   CONST EFI_GUID  PolicyGuid = {

--- a/PolicyServicePkg/Tools/GenCfgData.py
+++ b/PolicyServicePkg/Tools/GenCfgData.py
@@ -1740,7 +1740,7 @@ class CGenCfgData:
         lines.append ("#ifndef __%s__\n"   % file_name_def)
         lines.append ("#define __%s__\n\n" % file_name_def)
         if type == 'h':
-            lines.append ("#include <Library/VerifiedPolicy.h>\n\n")
+            lines.append ("#include <Library/PolicyLib.h>\n\n")
             lines.append ("#pragma pack(1)\n\n")
         lines.extend (txt_body)
         if type == 'h':


### PR DESCRIPTION
## Description

Adds basic wrappers for the policy service PPI/Protocols to the PolicyLib as well as a basic test to invoke them. 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested using the included test on QEMU.

## Integration Instructions

VerifiedPolicy.h has been renamed to PolicyLib.h for clarify. Update any code using VerifiedPolicy.h