### PR TITLE
Add gmock implementation of PolicyLib

### DIFF
--- a/PolicyServicePkg/PolicyServicePkg.ci.yaml
+++ b/PolicyServicePkg/PolicyServicePkg.ci.yaml
@@ -23,6 +23,9 @@
     "CompilerPlugin": {
         "DscPath": "PolicyServicePkg.dsc"
     },
+    "HostUnitTestCompilerPlugin": {
+        "DscPath": "Test/PolicyServicePkgHostTest.dsc"
+    },
     "CharEncodingCheck": {
         "IgnoreFiles": []
     },
@@ -33,14 +36,22 @@
             "PolicyServicePkg/PolicyServicePkg.dec",
         ],
         # For host based unit tests
-        "AcceptableDependencies-HOST_APPLICATION":[],
+        "AcceptableDependencies-HOST_APPLICATION":[
+            "UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec"
+        ],
         # For UEFI shell based apps
-        "AcceptableDependencies-UEFI_APPLICATION":[],
+        "AcceptableDependencies-UEFI_APPLICATION":[
+            "UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec"
+        ],
         "IgnoreInf": []
     },
     "DscCompleteCheck": {
         "DscPath": "PolicyServicePkg.dsc",
         "IgnoreInf": []
+    },
+    "HostUnitTestDscCompleteCheck": {
+        "IgnoreInf": [""],
+        "DscPath": "Test/PolicyServicePkgHostTest.dsc"
     },
     "GuidCheck": {
         "IgnoreGuidName": [],

--- a/PolicyServicePkg/Test/MdePkgHostTest.dsc
+++ b/PolicyServicePkg/Test/MdePkgHostTest.dsc
@@ -1,0 +1,46 @@
+## @file
+# PolicyServicePkg DSC file used to build host-based unit tests.
+#
+# Copyright (C) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  PLATFORM_NAME           = PolicyServicePkgHostTest
+  PLATFORM_GUID           = 77C72A3D-89BE-4521-BC99-33E25DC59F6D
+  PLATFORM_VERSION        = 0.1
+  DSC_SPECIFICATION       = 0x00010005
+  OUTPUT_DIRECTORY        = Build/PolicyServicePkg/HostTest
+  SUPPORTED_ARCHITECTURES = IA32|X64|AARCH64
+  BUILD_TARGETS           = NOOPT
+  SKUID_IDENTIFIER        = DEFAULT
+
+!include UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
+
+#[LibraryClasses]
+#  SafeIntLib|MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf
+
+[Components]
+  PolicyServicePkg/Test/Mock/Library/GoogleTest/MockPolicyLib/MockPolicyLib.inf
+# #
+# # Build HOST_APPLICATION that tests the SafeIntLib
+# #
+# MdePkg/Test/UnitTest/Library/BaseSafeIntLib/TestBaseSafeIntLibHost.inf
+# MdePkg/Test/UnitTest/Library/BaseLib/BaseLibUnitTestsHost.inf
+# MdePkg/Test/GoogleTest/Library/BaseSafeIntLib/GoogleTestBaseSafeIntLib.inf
+# # MU_CHANGE [BEGIN]
+# MdePkg/Test/Library/MockUefiBootServicesTableLib/MockUefiBootServicesTableLib.inf
+# MdePkg/Test/Library/MockUefiRuntimeServicesTableLib/MockUefiRuntimeServicesTableLib.inf
+# MdePkg/Test/Library/RngLibHostTestLfsr/RngLibHostTestLfsr.inf
+# MdePkg/Test/Library/StubHobLib/StubHobLib.inf
+# MdePkg/Test/Library/StubUefiLib/StubUefiLib.inf
+# MdePkg/Test/Library/SynchronizationLibHostUnitTest/SynchronizationLibHostUnitTest.inf
+# # MU_CHANGE [END]
+#
+# #
+# # Build HOST_APPLICATION Libraries
+# #
+# MdePkg/Library/BaseLib/UnitTestHostBaseLib.inf
+# MdePkg/Test/Mock/Library/GoogleTest/MockUefiLib/MockUefiLib.inf
+# MdePkg/Test/Mock/Library/GoogleTest/MockUefiRuntimeServicesTableLib/MockUefiRuntimeServicesTableLib.inf

--- a/PolicyServicePkg/Test/Mock/Include/GoogleTest/Library/MockPolicyLib.h
+++ b/PolicyServicePkg/Test/Mock/Include/GoogleTest/Library/MockPolicyLib.h
@@ -1,0 +1,95 @@
+/** @file
+  Mock definitions for PolicyLib for Google Test.
+
+  Copyright (c) Microsoft Corporation
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef MOCK_POLICY_LIB_H_
+#define MOCK_POLICY_LIB_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+extern "C" {
+#include <Uefi.h>
+#include <Library/PolicyLib.h>
+}
+
+struct MockPolicyLib {
+  MOCK_INTERFACE_DECLARATION (MockPolicyLib);
+
+  //
+  // Standard policy access routines.
+  //
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    SetPolicy,
+    (IN CONST EFI_GUID  *PolicyGuid,
+     IN UINT64          Attributes,
+     IN VOID            *Policy,
+     IN UINT16          PolicySize)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    GetPolicy,
+    (IN CONST EFI_GUID  *PolicyGuid,
+     OUT UINT64         *Attributes OPTIONAL,
+     OUT VOID           *Policy,
+     IN OUT UINT16      *PolicySize)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    RemovePolicy,
+    (IN CONST EFI_GUID  *PolicyGuid)
+    );
+
+  //
+  // Verified policy routines.
+  //
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    GetVerifiedPolicy,
+    (IN CONST EFI_GUID                    *PolicyGuid,
+     IN CONST VERIFIED_POLICY_DESCRIPTOR  *Descriptor,
+     OUT UINT64                           *Attributes OPTIONAL,
+     OUT EFI_HANDLE                       *DataHandle)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    CreateVerifiedPolicy,
+    (IN CONST VERIFIED_POLICY_DESCRIPTOR  *Descriptor,
+     OUT EFI_HANDLE                       *DataHandle)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    SetVerifiedPolicy,
+    (IN CONST EFI_GUID  *PolicyGuid,
+     IN UINT64          Attributes,
+     IN EFI_HANDLE      DataHandle)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    CloseVerifiedPolicy,
+    (IN EFI_HANDLE  DataHandle)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ReportVerifiedPolicyAccess,
+    (IN EFI_HANDLE      DataHandle,
+     IN CONST EFI_GUID  *CallerGuid,
+     IN UINT32          Offset,
+     IN UINT32          Size,
+     IN BOOLEAN         Write)
+    );
+};
+
+#endif

--- a/PolicyServicePkg/Test/Mock/Library/GoogleTest/MockPolicyLib/MockPolicyLib.cpp
+++ b/PolicyServicePkg/Test/Mock/Library/GoogleTest/MockPolicyLib/MockPolicyLib.cpp
@@ -1,0 +1,29 @@
+/** @file
+  Implementation of the Verified Policy library for gMock.
+
+  Copyright (c) Microsoft Corporation
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <GoogleTest/Library/MockPolicyLib.h>
+
+MOCK_INTERFACE_DEFINITION(MockPolicyLib);
+
+//
+// Standard policy access mock routines.
+//
+
+MOCK_FUNCTION_DEFINITION(MockPolicyLib, SetPolicy, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION(MockPolicyLib, GetPolicy, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION(MockPolicyLib, RemovePolicy, 1, EFIAPI);
+
+//
+// Verified policy access mock routines.
+//
+
+MOCK_FUNCTION_DEFINITION(MockPolicyLib, GetVerifiedPolicy, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION(MockPolicyLib, CreateVerifiedPolicy, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION(MockPolicyLib, SetVerifiedPolicy, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION(MockPolicyLib, CloseVerifiedPolicy, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION(MockPolicyLib, ReportVerifiedPolicyAccess, 5, EFIAPI);

--- a/PolicyServicePkg/Test/Mock/Library/GoogleTest/MockPolicyLib/MockPolicyLib.inf
+++ b/PolicyServicePkg/Test/Mock/Library/GoogleTest/MockPolicyLib/MockPolicyLib.inf
@@ -1,0 +1,31 @@
+## @file
+#  gMock instance of verified policy library.
+#
+#  Copyright (c) Microsoft Corporation.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 1.26
+  PI_SPECIFICATION_VERSION       = 0x00010032
+  BASE_NAME                      = MmPolicyLib
+  FILE_GUID                      = 569E5804-8D3D-43E6-B37E-8196A6D045FB
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = PolicyLib | HOST_APPLICATION
+
+[Sources]
+  MockPolicyLib.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  PolicyServicePkg/PolicyServicePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHsc


### PR DESCRIPTION
## Description

Adds a basic mock implementation of PolicyLib for google tests.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
