### PR TITLE
Stop USB enumeration in case a malformed descriptor is found

### DIFF
--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.c
@@ -396,7 +396,7 @@ UsbParseConfigDesc (
 
     if (Setting == NULL) {
       DEBUG ((DEBUG_ERROR, "UsbParseConfigDesc: warning: failed to get interface setting, stop parsing now.\n"));
-      break;
+      goto ON_ERROR;  // MU_CHANGE
     } else if (Setting->Desc.InterfaceNumber >= NumIf) {
       DEBUG ((DEBUG_ERROR, "UsbParseConfigDesc: malformatted interface descriptor\n"));
 


### PR DESCRIPTION
## Description

When parsing interface descriptors for an attached USB device, the USB
bus driver correctly handles cases where a device has a malformed
interface . `UsbParseInterfaceDesc` returns `NULL` in such cases.

`UsbParseConfigDesc` which parses interface descriptors, stops parsing
in case `UsbParseInterfaceDesc` returns NULL but still returns
`EFI_SUCCESS` along with a partially filled `USB_CONFIG_DESC` structure.

This causes access exceptions when attempts are made subsequently to
communicate with the downstream device (for e.g. during endpoint
configuration) as the driver does not have valid interface descriptor
structures associated with the device.

To fix this, `UsbParseConfigDesc` should take the error path in cases
where `UsbParseInterfaceDesc` returns NULL and abandon enumerating the
device. This will allow a platform to boot instead of crashing when a
buggy USB device is attached to it.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?


## How This Was Tested

Tested on a platform with a USB keyboard that returns a malformed USB
interface descriptor. The platform fails to boot with an access
violation exception without this fix.

## Integration Instructions

Updating to the latest MU_BASECORE will automatically include this fix
if the UsbBus DXE driver is included in the fdf/dscs.
