### PR TITLE
[CHERRY-PICK] Stop USB enumeration in case a malformed descriptor is found (#410)

### DIFF
--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.c
@@ -396,7 +396,7 @@ UsbParseConfigDesc (
 
     if (Setting == NULL) {
       DEBUG ((DEBUG_ERROR, "UsbParseConfigDesc: warning: failed to get interface setting, stop parsing now.\n"));
-      break;
+      goto ON_ERROR;  // MU_CHANGE
     } else if (Setting->Desc.InterfaceNumber >= NumIf) {
       DEBUG ((DEBUG_ERROR, "UsbParseConfigDesc: malformatted interface descriptor\n"));
 


### PR DESCRIPTION
## Description

This is a cherry-pick of commit 714d41b7278194ace70026b5eb8c8bcce68da963 to release/202208.

When parsing interface descriptors for an attached USB device, the USB bus driver correctly handles cases where a device has a malformed interface . `UsbParseInterfaceDesc` returns `NULL` in such cases.

`UsbParseConfigDesc` which parses interface descriptors, stops parsing in case `UsbParseInterfaceDesc` returns NULL but still returns `EFI_SUCCESS` along with a partially filled `USB_CONFIG_DESC` structure.

This causes access exceptions when attempts are made subsequently to communicate with the downstream device (for e.g. during endpoint configuration) as the driver does not have valid interface descriptor structures associated with the device.

To fix this, `UsbParseConfigDesc` should take the error path in cases where `UsbParseInterfaceDesc` returns NULL and abandon enumerating the device. This will allow a platform to boot instead of crashing when a buggy USB device is attached to it.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?


## How This Was Tested

Tested on a platform with a USB keyboard that returns a malformed USB interface descriptor. The platform fails to boot with an access violation exception without this fix.

## Integration Instructions

Updating to the latest MU_BASECORE will automatically include this fix if the UsbBus DXE driver is included in the fdf/dscs.

# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

<_Please include a description of the change and why this change was made._>

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

<_Please describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
