### PR TITLE
[CHERRY-PICK] Take changes from 202208 into 202302 [Rebase & FF]

### DIFF
--- a/.github/workflows/release-basetools.yml
+++ b/.github/workflows/release-basetools.yml
@@ -1,0 +1,120 @@
+# This workflow automatically publishes the basetools binaries for a given
+# release.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+name: Publish BaseTools
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    name: Build Base Tools
+    strategy:
+      matrix:
+        include:
+          - os: windows-2022
+            tool_chain: VS2022
+            output_dir: "BaseTools\\Bin\\Win32"
+            target: IA32
+
+          - os: windows-2022
+            tool_chain: VS2022
+            output_dir: "BaseTools\\Bin\\Win32"
+            target: ARM
+
+          - os: windows-2022
+            tool_chain: VS2022
+            output_dir: "BaseTools\\Bin\\Win64"
+            target: AARCH64
+
+          - os: ubuntu-22.04
+            tool_chain: GCC5
+            output_dir: "BaseTools/Source/C/bin"
+            target: X64
+
+          - os: ubuntu-22.04
+            tool_chain: GCC5
+            output_dir: "BaseTools/Source/C/bin"
+            target: AARCH64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install Linux Tools
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get install -y gcc-aarch64-linux-gnu gcc-arm-linux-gnueabi g++-aarch64-linux-gnu g++-arm-linux-gnueabi
+          echo "GCC5_AARCH64_PREFIX=/usr/bin/aarch64-linux-gnu-" >> "$GITHUB_ENV"
+          echo "GCC5_ARM_PREFIX=/usr/bin/arm-linux-gnueabi-" >> "$GITHUB_ENV"
+
+      - name: Install Pip Modules
+        run: pip install -r pip-requirements.txt --upgrade
+
+      - name: Stuart Setup
+        run: stuart_setup -c .pytool/CISettings.py
+
+      - name: Stuart Update
+        run: stuart_update -c .pytool/CISettings.py TOOL_CHAIN_TAG=${{ matrix.tool_chain}} -a ${{ matrix.target }}
+
+      - name: Build Base Tools
+        run: python BaseTools/Edk2ToolsBuild.py -t ${{ matrix.tool_chain}} -a ${{ matrix.target }} --skip_path_env
+
+      - name: Upload Build Logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: logs-${{ matrix.tool_chain }}-${{ matrix.target }}
+          path: |
+            Build/SETUPLOG.txt
+            Build/UPDATE_LOG.txt
+            BaseTools/BaseToolsBuild/BASETOOLS_BUILD.txt
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: basetools-${{ matrix.tool_chain }}-${{ matrix.target }}
+          path: ${{ matrix.output_dir }}
+
+  publish:
+    name: Publish Base Tools
+    needs: build
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: ${{ runner.temp }}/artifacts
+
+      - name: Stage Files
+        run: mkdir ${{ runner.temp }}/basetools ;
+          mv ${{ runner.temp }}/artifacts/basetools-GCC5-X64       ${{ runner.temp }}/basetools/Linux-x86 ;
+          mv ${{ runner.temp }}/artifacts/basetools-GCC5-AARCH64   ${{ runner.temp }}/basetools/Linux-ARM-64 ;
+          mv ${{ runner.temp }}/artifacts/basetools-VS2022-IA32    ${{ runner.temp }}/basetools/Windows-x86 ;
+          mv ${{ runner.temp }}/artifacts/basetools-VS2022-ARM     ${{ runner.temp }}/basetools/Windows-ARM ;
+          mv ${{ runner.temp }}/artifacts/basetools-VS2022-AARCH64 ${{ runner.temp }}/basetools/Windows-ARM-64 ;
+
+      - name: Zip Files
+        run: cd ${{ runner.temp }} ; zip -r basetools-${{ github.event.release.tag_name }}.zip basetools/*
+
+      - name: Upload Release Asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload ${{ github.event.release.tag_name }} ${{ runner.temp }}/basetools-*.zip

--- a/BaseTools/Edk2ToolsBuild.py
+++ b/BaseTools/Edk2ToolsBuild.py
@@ -210,20 +210,26 @@ class Edk2ToolsBuild(BaseAbstractInvocable):
                 shell_env.set_shell_var('HOST_ARCH', self.target_arch)
 
                 if "AARCH64" in self.target_arch:
-                    # now check for install dir.  If set then set the Prefix
-                    install_path = shell_environment.GetEnvironment().get_shell_var("GCC5_AARCH64_INSTALL")
+                    prefix = shell_env.get_shell_var("GCC5_AARCH64_PREFIX")
+                    if prefix == None:
+                        # now check for install dir.  If set then set the Prefix
+                        install_path = shell_environment.GetEnvironment().get_shell_var("GCC5_AARCH64_INSTALL")
 
-                    # make GCC5_AARCH64_PREFIX to align with tools_def.txt
-                    prefix = os.path.join(install_path, "bin", "aarch64-none-linux-gnu-")
+                        # make GCC5_AARCH64_PREFIX to align with tools_def.txt
+                        prefix = os.path.join(install_path, "bin", "aarch64-none-linux-gnu-")
+
                     shell_environment.GetEnvironment().set_shell_var("GCC_PREFIX", prefix)
                     TargetInfoArch = "ARM"
 
                 elif "ARM" in self.target_arch:
-                    # now check for install dir.  If set then set the Prefix
-                    install_path = shell_environment.GetEnvironment().get_shell_var("GCC5_ARM_INSTALL")
+                    prefix = shell_env.get_shell_var("GCC5_ARM_PREFIX")
+                    if prefix == None:
+                        # now check for install dir.  If set then set the Prefix
+                        install_path = shell_environment.GetEnvironment().get_shell_var("GCC5_ARM_INSTALL")
 
-                    # make GCC5_ARM_PREFIX to align with tools_def.txt
-                    prefix = os.path.join(install_path, "bin", "arm-none-linux-gnueabihf-")
+                        # make GCC5_ARM_PREFIX to align with tools_def.txt
+                        prefix = os.path.join(install_path, "bin", "arm-none-linux-gnueabihf-")
+
                     shell_environment.GetEnvironment().set_shell_var("GCC_PREFIX", prefix)
                     TargetInfoArch = "ARM"
 

--- a/CodeQlFilters.yml
+++ b/CodeQlFilters.yml
@@ -38,6 +38,7 @@
     # Todo: Exclude for now, needs more review and testing
     "-NetworkPkg/Ip6Dxe/Ip6Output.c:cpp/likely-bugs/memory-management/v2/conditionally-uninitialized-variable",
     "-ShellPkg/Application/Shell/ShellManParser.c:cpp/redundant-null-check-param",
+    "-ShellPkg/Application/Shell/ShellProtocol.c:SM02311",
     "-ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Aest/AestParser.c:cpp/overflow-buffer",
     "-ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Iort/IortParser.c:cpp/overflow-buffer",
     "-ShellPkg/Library/UefiShellDebug1CommandsLib/DmpStore.c:SM02311",

--- a/NetworkPkg/Ip6Dxe/Ip6Mld.c
+++ b/NetworkPkg/Ip6Dxe/Ip6Mld.c
@@ -299,7 +299,15 @@ Ip6SendMldDone (
   // Fill a IPv6 Router Alert option in a Hop-by-Hop Options Header
   //
   Options = NetbufAllocSpace (Packet, (UINT32)OptionLen, FALSE);
-  ASSERT (Options != NULL);
+  // MU_CHANGE [BEGIN] - CodeQL change
+  if (Options == NULL) {
+    ASSERT (Options != NULL);
+    NetbufFree (Packet);
+    Packet = NULL;
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  // MU_CHANGE [END] - CodeQL change
   Status = Ip6FillHopByHop (Options, &OptionLen, IP6_ICMP);
   if (EFI_ERROR (Status)) {
     NetbufFree (Packet);

--- a/NetworkPkg/Ip6Dxe/Ip6Nd.c
+++ b/NetworkPkg/Ip6Dxe/Ip6Nd.c
@@ -1791,8 +1791,15 @@ Ip6ProcessNeighborAdvertise (
   } else {
     OptionLen = (UINT16)(Head->PayloadLength - IP6_ND_LENGTH);
     if (OptionLen != 0) {
+      // MU_CHANGE [BEGIN] - CodeQL change
       Option = NetbufGetByte (Packet, IP6_ND_LENGTH, NULL);
-      ASSERT (Option != NULL);
+      if (Option == NULL) {
+        ASSERT (Option != NULL);
+        Status = EFI_OUT_OF_RESOURCES;
+        goto Exit;
+      }
+
+      // MU_CHANGE [END] - CodeQL change
 
       //
       // All included options should have a length that is greater than zero.
@@ -2517,8 +2524,15 @@ Ip6ProcessRedirect (
   //
   OptionLen = (UINT16)(Head->PayloadLength - IP6_REDITECT_LENGTH);
   if (OptionLen != 0) {
+    // MU_CHANGE [BEGIN] - CodeQL change
     Option = NetbufGetByte (Packet, IP6_REDITECT_LENGTH, NULL);
-    ASSERT (Option != NULL);
+    if (Option == NULL) {
+      ASSERT (Option != NULL);
+      Status = EFI_OUT_OF_RESOURCES;
+      goto Exit;
+    }
+
+    // MU_CHANGE [END] - CodeQL change
 
     if (!Ip6IsNDOptionValid (Option, OptionLen)) {
       goto Exit;

--- a/ShellPkg/Application/Shell/ShellParametersProtocol.c
+++ b/ShellPkg/Application/Shell/ShellParametersProtocol.c
@@ -744,6 +744,7 @@ UpdateStdInStdOutStdErr (
   OutAppend        = FALSE;
   CommandLineCopy  = NULL;
   FirstLocation    = NULL;
+  TempHandle       = NULL; // MU_CHANGE - CodeQL change
 
   if ((ShellParameters == NULL) || (SystemTableInfo == NULL) || (OldStdIn == NULL) || (OldStdOut == NULL) || (OldStdErr == NULL)) {
     return (EFI_INVALID_PARAMETER);
@@ -1182,7 +1183,13 @@ UpdateStdInStdOutStdErr (
 
         if (!ErrUnicode && !EFI_ERROR (Status)) {
           TempHandle = CreateFileInterfaceFile (TempHandle, FALSE);
-          ASSERT (TempHandle != NULL);
+          // MU_CHANGE [BEGIN] - CodeQL change
+          if (TempHandle == NULL) {
+            ASSERT (TempHandle != NULL);
+            Status = EFI_OUT_OF_RESOURCES;
+          }
+
+          // MU_CHANGE [END] - CodeQL change
         }
 
         if (!EFI_ERROR (Status)) {
@@ -1229,7 +1236,13 @@ UpdateStdInStdOutStdErr (
 
           if (!OutUnicode && !EFI_ERROR (Status)) {
             TempHandle = CreateFileInterfaceFile (TempHandle, FALSE);
-            ASSERT (TempHandle != NULL);
+            // MU_CHANGE [BEGIN] - CodeQL change
+            if (TempHandle == NULL) {
+              ASSERT (TempHandle != NULL);
+              Status = EFI_OUT_OF_RESOURCES;
+            }
+
+            // MU_CHANGE [END] - CodeQL change
           }
 
           if (!EFI_ERROR (Status)) {
@@ -1251,9 +1264,16 @@ UpdateStdInStdOutStdErr (
         }
 
         TempHandle = CreateFileInterfaceEnv (StdOutVarName);
-        ASSERT (TempHandle != NULL);
-        ShellParameters->StdOut = TempHandle;
-        gST->ConOut             = CreateSimpleTextOutOnFile (TempHandle, &gST->ConsoleOutHandle, gST->ConOut);
+        // MU_CHANGE [BEGIN] - CodeQL change
+        if (TempHandle == NULL) {
+          ASSERT (TempHandle != NULL);
+          Status = EFI_OUT_OF_RESOURCES;
+        } else {
+          ShellParameters->StdOut = TempHandle;
+          gST->ConOut             = CreateSimpleTextOutOnFile (TempHandle, &gST->ConsoleOutHandle, gST->ConOut);
+        }
+
+        // MU_CHANGE [BEGIN] - CodeQL change
       }
 
       //
@@ -1268,9 +1288,16 @@ UpdateStdInStdOutStdErr (
         }
 
         TempHandle = CreateFileInterfaceEnv (StdErrVarName);
-        ASSERT (TempHandle != NULL);
-        ShellParameters->StdErr = TempHandle;
-        gST->StdErr             = CreateSimpleTextOutOnFile (TempHandle, &gST->StandardErrorHandle, gST->StdErr);
+        // MU_CHANGE [BEGIN] - CodeQL change
+        if (TempHandle == NULL) {
+          ASSERT (TempHandle != NULL);
+          Status = EFI_OUT_OF_RESOURCES;
+        } else {
+          ShellParameters->StdErr = TempHandle;
+          gST->StdErr             = CreateSimpleTextOutOnFile (TempHandle, &gST->StandardErrorHandle, gST->StdErr);
+        }
+
+        // MU_CHANGE [END] - CodeQL change
       }
 
       //

--- a/ShellPkg/Library/UefiShellDriver1CommandsLib/OpenInfo.c
+++ b/ShellPkg/Library/UefiShellDriver1CommandsLib/OpenInfo.c
@@ -113,7 +113,7 @@ TraverseHandleDatabase (
 
           Name            = GetStringNameFromHandle (OpenInfo[OpenInfoIndex].AgentHandle, NULL);
           ControllerIndex = ConvertHandleToHandleIndex (OpenInfo[OpenInfoIndex].ControllerHandle);
-          if (ControllerIndex != 0) {
+          if ((ControllerIndex != 0) && (Name != NULL)) {
             ShellPrintHiiEx (
               -1,
               -1,

--- a/UnitTestFrameworkPkg/Library/UnitTestPersistenceLibSimpleFileSystem/UnitTestPersistenceLibSimpleFileSystem.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestPersistenceLibSimpleFileSystem/UnitTestPersistenceLibSimpleFileSystem.c
@@ -270,6 +270,14 @@ SaveUnitTestCache (
   // MU_CHANGE: Use file name and path instead of device path
   FileName = GetCacheFileName (FrameworkHandle);
 
+  // MU_CHANGE [BEGIN] - CodeQL change
+  if (FileName == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a - Failed to get cache file name.\n", __FUNCTION__));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  // MU_CHANGE [END] - CodeQL change
+
   //
   // First lets open the file if it exists so we can delete it...This is the work around for truncation
   //

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -13,7 +13,7 @@
 ##
 
 edk2-pytool-library~=0.15.0 # MU_CHANGE
-edk2-pytool-extensions~=0.23.2 # MU_CHANGE
+edk2-pytool-extensions~=0.23.3 # MU_CHANGE
 edk2-basetools==0.1.48
 antlr4-python3-runtime==4.13.0
 regex

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -14,7 +14,7 @@
 
 edk2-pytool-library~=0.14.1 # MU_CHANGE
 edk2-pytool-extensions~=0.23.2 # MU_CHANGE
-edk2-basetools==0.1.45
+edk2-basetools==0.1.48
 antlr4-python3-runtime==4.12.0
 regex
 lcov-cobertura==2.0.2

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -12,7 +12,7 @@
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 ##
 
-edk2-pytool-library~=0.14.1 # MU_CHANGE
+edk2-pytool-library~=0.15.0 # MU_CHANGE
 edk2-pytool-extensions~=0.23.2 # MU_CHANGE
 edk2-basetools==0.1.48
 antlr4-python3-runtime==4.12.0

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -13,7 +13,7 @@
 ##
 
 edk2-pytool-library~=0.14.1 # MU_CHANGE
-edk2-pytool-extensions~=0.23.0 # MU_CHANGE
+edk2-pytool-extensions~=0.23.2 # MU_CHANGE
 edk2-basetools==0.1.45
 antlr4-python3-runtime==4.12.0
 regex

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -15,6 +15,6 @@
 edk2-pytool-library~=0.15.0 # MU_CHANGE
 edk2-pytool-extensions~=0.23.2 # MU_CHANGE
 edk2-basetools==0.1.48
-antlr4-python3-runtime==4.12.0
+antlr4-python3-runtime==4.13.0
 regex
 lcov-cobertura==2.0.2


### PR DESCRIPTION
## Description

Cherry-picked the commits that have gone into 202208 that haven't made it into 202302.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Build on a physical platform.

## Integration Instructions

N/A
