### PR TITLE
Integrate PrEval Policy 5

### DIFF
--- a/CryptoPkg/CryptoPkg.ci.yaml
+++ b/CryptoPkg/CryptoPkg.ci.yaml
@@ -5,7 +5,11 @@
 # Copyright (c) 2020 - 2022, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
-{
+{   # MU_CHANGE begin
+    "PrEval": {
+        "DscPath": "CryptoPkg.dsc",
+    },
+    # MU_CHANGE end
     "LicenseCheck": {
         "IgnoreFiles": [
             # These directories contain auto-generated OpenSSL content

--- a/CryptoPkg/CryptoPkg.ci.yaml
+++ b/CryptoPkg/CryptoPkg.ci.yaml
@@ -5,7 +5,8 @@
 # Copyright (c) 2020 - 2022, Intel Corporation. All rights reserved.<BR>
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
-{   # MU_CHANGE begin
+{
+    # MU_CHANGE begin
     "PrEval": {
         "DscPath": "CryptoPkg.dsc",
     },

--- a/MdeModulePkg/MdeModulePkg.ci.yaml
+++ b/MdeModulePkg/MdeModulePkg.ci.yaml
@@ -7,6 +7,11 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 {
+    # MU_CHANGE begin
+    "PrEval": {
+        "DscPath": "MdeModulePkg.dsc",
+    },
+    # MU_CHANGE end
     ## options defined .pytool/Plugin/LicenseCheck
     "LicenseCheck": {
         "IgnoreFiles": [

--- a/MdePkg/MdePkg.ci.yaml
+++ b/MdePkg/MdePkg.ci.yaml
@@ -8,6 +8,11 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 {
+    # MU_CHANGE begin
+    "PrEval": {
+        "DscPath": "MdePkg.dsc",
+    },
+    # MU_CHANGE end
     ## options defined .pytool/Plugin/LicenseCheck
     "LicenseCheck": {
         "IgnoreFiles": []

--- a/NetworkPkg/NetworkPkg.ci.yaml
+++ b/NetworkPkg/NetworkPkg.ci.yaml
@@ -7,6 +7,11 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 {
+    # MU_CHANGE begin
+    "PrEval": {
+        "DscPath": "NetworkPkg.dsc",
+    },
+    # MU_CHANGE end
     "LicenseCheck": {
         "IgnoreFiles": []
     },

--- a/PcAtChipsetPkg/PcAtChipsetPkg.ci.yaml
+++ b/PcAtChipsetPkg/PcAtChipsetPkg.ci.yaml
@@ -6,6 +6,11 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 {
+    # MU_CHANGE begin
+    "PrEval": {
+        "DscPath": "PcAtChipsetPkg.dsc",
+    },
+    # MU_CHANGE end
     ## options defined .pytool/Plugin/LicenseCheck
     "LicenseCheck": {
         "IgnoreFiles": []

--- a/PolicyServicePkg/PolicyServicePkg.ci.yaml
+++ b/PolicyServicePkg/PolicyServicePkg.ci.yaml
@@ -6,6 +6,11 @@
 ##
 
 {
+    # MU_CHANGE begin
+    "PrEval": {
+        "DscPath": "PolicyServicePkg.dsc",
+    },
+    # MU_CHANGE begin
     "LicenseCheck": {
         "IgnoreFiles": []
     },

--- a/ShellPkg/ShellPkg.ci.yaml
+++ b/ShellPkg/ShellPkg.ci.yaml
@@ -6,6 +6,11 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 {
+    # MU_CHANGE begin
+    "PrEval": {
+        "DscPath": "ShellPkg.dsc",
+    },
+    # MU_CHANGE end
     "LicenseCheck": {
         "IgnoreFiles": []
     },

--- a/StandaloneMmPkg/StandaloneMmPkg.ci.yaml
+++ b/StandaloneMmPkg/StandaloneMmPkg.ci.yaml
@@ -5,6 +5,11 @@
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 {
+    # MU_CHANGE begin
+    "PrEval": {
+        "DscPath": "StandaloneMmPkg.dsc",
+    },
+    # MU_CHANGE end
     "EccCheck": {
         ## Exception sample looks like below:
         ## "ExceptionList": [

--- a/UefiCpuPkg/UefiCpuPkg.ci.yaml
+++ b/UefiCpuPkg/UefiCpuPkg.ci.yaml
@@ -6,6 +6,11 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 {
+    # MU_CHANGE begin
+    "PrEval": {
+        "DscPath": "UefiCpuPkg.dsc",
+    },
+    # MU_CHANGE end
     "LicenseCheck": {
         "IgnoreFiles": []
     },

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkg.ci.yaml
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkg.ci.yaml
@@ -5,6 +5,11 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 {
+    # MU_CHANGE begin
+    "PrEval": {
+        "DscPath": "UnitTestFrameworkPkg.dsc",
+    },
+    # MU_CHANGE end
     ## options defined .pytool/Plugin/LicenseCheck
     "LicenseCheck": {
         "IgnoreFiles": []

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -13,7 +13,7 @@
 ##
 
 edk2-pytool-library~=0.15.0 # MU_CHANGE
-edk2-pytool-extensions~=0.23.3 # MU_CHANGE
+edk2-pytool-extensions~=0.23.4 # MU_CHANGE
 edk2-basetools==0.1.48
 antlr4-python3-runtime==4.13.0
 regex


### PR DESCRIPTION
## Description

Integrates edk2-pytool-extension's PrEval's Policy 5 that runs whenever a INF has been changed. It will parse each package's dsc (as defined in `<pkg>.ci.yaml::PrEval.DscPath`) and mark it to be build if that package has a dependency on the changed INF.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

N/A

## Integration Instructions

N/A