### PR TITLE
CodeQL Fix: Add NULL Check to Generated Filename in UnitTestPersistLibSfs

### DIFF
--- a/UnitTestFrameworkPkg/Library/UnitTestPersistenceLibSimpleFileSystem/UnitTestPersistenceLibSimpleFileSystem.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestPersistenceLibSimpleFileSystem/UnitTestPersistenceLibSimpleFileSystem.c
@@ -391,13 +391,19 @@ LoadUnitTestCache (
   //
   // Now that we know the path to the file... let's open it for writing.
   //
-  // MU_CHANGE: Use file name and path instead of device path
+  // MU_CHANGE START: Use file name and path instead of device path
+  if (FileName == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a - Failed to generate file name and path to cache file!\n", __FUNCTION__));
+    goto Exit;
+  }
+
   Status = ShellOpenFileByName (
              FileName,
              &FileHandle,
              EFI_FILE_MODE_READ,
              0
              );
+  // MU_CHANGE END
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a - Opening file for writing failed! %r\n", __FUNCTION__, Status));
     goto Exit;


### PR DESCRIPTION
## Description

GetCacheFileName() may return NULL. Add a check before passing the return value to ShellOpenFileByName().

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Booting to shell on Q35

## Integration Instructions

N/A
