### PR TITLE
Explicitly make Linux binaries executable and create Basetools tar file.

### DIFF
--- a/.github/workflows/release-basetools.yml
+++ b/.github/workflows/release-basetools.yml
@@ -113,7 +113,9 @@ jobs:
       - name: Stage Files
         run: mkdir ${{ runner.temp }}/basetools ;
           mv ${{ runner.temp }}/artifacts/basetools-GCC5-X64       ${{ runner.temp }}/basetools/Linux-x86 ;
+          chmod a+x ${{ runner.temp }}/basetools/Linux-x86/* ;
           mv ${{ runner.temp }}/artifacts/basetools-GCC5-AARCH64   ${{ runner.temp }}/basetools/Linux-ARM-64 ;
+          chmod a+x ${{ runner.temp }}/basetools/Linux-ARM-64/* ;
           mv ${{ runner.temp }}/artifacts/basetools-VS2022-IA32    ${{ runner.temp }}/basetools/Windows-x86 ;
           mv ${{ runner.temp }}/artifacts/basetools-VS2022-ARM     ${{ runner.temp }}/basetools/Windows-ARM ;
           mv ${{ runner.temp }}/artifacts/basetools-VS2022-AARCH64 ${{ runner.temp }}/basetools/Windows-ARM-64 ;

--- a/.github/workflows/release-basetools.yml
+++ b/.github/workflows/release-basetools.yml
@@ -120,10 +120,15 @@ jobs:
           mv ${{ runner.temp }}/artifacts/basetools-VS2022-ARM     ${{ runner.temp }}/basetools/Windows-ARM ;
           mv ${{ runner.temp }}/artifacts/basetools-VS2022-AARCH64 ${{ runner.temp }}/basetools/Windows-ARM-64 ;
 
-      - name: Zip Files
-        run: cd ${{ runner.temp }} ; zip -r basetools-${{ github.event.release.tag_name }}.zip basetools/*
+      - name: Package Files
+        run: |
+          cd ${{ runner.temp }} ;
+          zip -r basetools-${{ github.event.release.tag_name }}.zip basetools/* ;
+          tar -czf basetools-${{ github.event.release.tag_name }}.tar.gz basetools/*
 
       - name: Upload Release Asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.event.release.tag_name }} ${{ runner.temp }}/basetools-*.zip
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} ${{ runner.temp }}/basetools-*.zip
+          gh release upload ${{ github.event.release.tag_name }} ${{ runner.temp }}/basetools-*.tar.gz


### PR DESCRIPTION
## Description

This change address two issues related to executable files in the basetools zip.

1. The artifacts published from the build stage of the basetools pipelines will lose their executable attributes when downloaded in the published phase. This change explicitly makes the binaries executable as part of the publishing job for linux binaries. This could also be done by zipping the binaries in the first stage of the pipeline, but the added steps add little value over the simple chmod fix.

2. The python implementation of zipfile does not set the executable filemode attributes when decrompressing a zip archive, so any zip extdep with executable files will not be executable when downloaded in extracted. Tar files do not have this same issue so this creates a tarfile version of the basetools package to allow a work-around to this issue. This is being tracked in pytools-extensions by https://github.com/tianocore/edk2-pytool-extensions/issues/579. 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on a forked release, and locally confirmed with an updated extdep.

## Integration Instructions

N/A
