### PR TITLE
Remove passing print from Char Encoding Check Plugin

### DIFF
--- a/.pytool/Plugin/CharEncodingCheck/CharEncodingCheck.py
+++ b/.pytool/Plugin/CharEncodingCheck/CharEncodingCheck.py
@@ -93,9 +93,7 @@ class CharEncodingCheck(ICiBuildPlugin):
             files = [Edk2pathObj.GetAbsolutePathOnThisSystemFromEdk2RelativePath(x) for x in files] # MU_CHANGE
             for a in files:
                 files_tested += 1
-                if(self.TestEncodingOk(a, enc)):
-                    logging.debug("File {0} Passed Encoding Check {1}".format(a, enc))
-                else:
+                if not self.TestEncodingOk(a, enc): # MU_CHANGE
                     tc.LogStdError("Encoding Failure in {0}.  Not {1}".format(a, enc))
                     overall_status += 1
 


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

This removes a noisy print from Char Encoding Check Plugin that prints every passing file (which scales with the size of a package). Closes #434 .

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested running the CI build.

## Integration Instructions

N/A.
