### PR TITLE
Don't Create Variable Policy for PlatformRecovery#### if SetVariable Failed

### DIFF
--- a/MdeModulePkg/Include/Library/UefiBootManagerLib.h
+++ b/MdeModulePkg/Include/Library/UefiBootManagerLib.h
@@ -155,7 +155,14 @@ EfiBootManagerVariableToLoadOption (
   );
 
 /**
-  Create the Boot#### or Driver#### variable from the load option.
+  // MU_CHANGE START
+  Create the Boot####, Driver####, SysPrep####, PlatformRecovery#### variable
+  from the load option.
+
+  If the OptionNumber is LoadOptionTypePlatformRecovery and the call to
+  SetVariable was successful, a lock now variable policy will be registered
+  for the PlatformRecovery#### variable.
+  // MU_CHANGE END
 
   @param  LoadOption      Pointer to the load option.
 

--- a/MdeModulePkg/Library/UefiBootManagerLib/BmLoadOption.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmLoadOption.c
@@ -166,6 +166,12 @@ BmGetFreeOptionNumber (
   Create the Boot####, Driver####, SysPrep####, PlatformRecovery#### variable
   from the load option.
 
+  // MU_CHANGE START
+  If the OptionNumber is LoadOptionTypePlatformRecovery and the call to
+  SetVariable was successful, a variable policy will be registered for
+  the PlatformRecovery#### variable.
+  // MU_CHANGE END
+
   @param  LoadOption      Pointer to the load option.
 
   @retval EFI_SUCCESS     The variable was created.
@@ -261,6 +267,13 @@ structure.
                   Variable
                   );
   FreePool (Variable);
+
+  // MU_CHANGE START: Don't register a variable policy if the SetVariable call failed
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  // MU_CHANGE END
 
   // MU_CHANGE - Move RegisterBasicVariablePolicy after SetVariable for OptionName
   if (Option->OptionType == LoadOptionTypePlatformRecovery) {

--- a/MdeModulePkg/Library/UefiBootManagerLib/BmLoadOption.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmLoadOption.c
@@ -168,8 +168,8 @@ BmGetFreeOptionNumber (
 
   // MU_CHANGE START
   If the OptionNumber is LoadOptionTypePlatformRecovery and the call to
-  SetVariable was successful, a variable policy will be registered for
-  the PlatformRecovery#### variable.
+  SetVariable was successful, a lock now variable policy will be registered
+  for the PlatformRecovery#### variable.
   // MU_CHANGE END
 
   @param  LoadOption      Pointer to the load option.


### PR DESCRIPTION
## Description

A variable policy is automatically applied when EfiBootManagerLoadOptionToVariable() is used to set the PlatformRecovery#### variable. If the attempt to set the PlatformRecovery#### fails, we should not register a variable policy.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested using the BootAuditTestApp on Q35

## Integration Instructions

N/A
