### PR TITLE
BaseTools: Detect invalid library override

### DIFF
--- a/BaseTools/Source/Python/Workspace/WorkspaceCommon.py
+++ b/BaseTools/Source/Python/Workspace/WorkspaceCommon.py
@@ -126,7 +126,7 @@ def GetModuleLibInstances(Module, Platform, BuildDatabase, Arch, Target, Toolcha
             
             if not match:
                 EdkLogger.error("build", BUILD_ERROR,
-                              "Library override [%s] library class does not match specified library class: [%s]" % (path, LibraryClass),
+                              "LIBRARY_CLASS for override: [%s] does not match the library class being overridden: [%s]" % (path, LibraryClass),
                               File=FileName)
         # MU_CHANGE end
 

--- a/BaseTools/Source/Python/Workspace/WorkspaceCommon.py
+++ b/BaseTools/Source/Python/Workspace/WorkspaceCommon.py
@@ -110,6 +110,26 @@ def GetModuleLibInstances(Module, Platform, BuildDatabase, Arch, Target, Toolcha
         if LibraryClass.startswith("NULL"):
             Module.LibraryClasses[LibraryClass] = Platform.Modules[str(Module)].LibraryClasses[LibraryClass]
 
+        # MU_CHANGE begin
+
+        # Compares the Library class being over written (var: LibraryClass) to the actual library class that is
+        # is doing the overridding.
+        # 
+        # i.e. ExampleLib|Path/To/ExampleLibBase.inf:
+        #     ensuring ExampleLib == LIBRARY_CLASS in the define section of ExampleLibBase.inf
+        else:
+            path = Platform.Modules[str(Module)].LibraryClasses[LibraryClass]
+            match = False
+            for LibraryClassObj in BuildDatabase[path, Arch, Target, Toolchain].LibraryClass:
+                if LibraryClass == LibraryClassObj.LibraryClass:
+                    match = True
+            
+            if not match:
+                EdkLogger.error("build", BUILD_ERROR,
+                              "Library override [%s] library class does not match specified library class: [%s]" % (path, LibraryClass),
+                              File=FileName)
+        # MU_CHANGE end
+
     # EdkII module
     LibraryConsumerList = [Module]
     Constructor = []


### PR DESCRIPTION
## Description

Ensures LIBRARY_CLASS as specified in the library override INF defines section is the same value as the library class specified in the override line.

## Example of mismatch
``` cmd
ERROR - EDK2 #002 from c:\src\mu_tiano_platforms\Platforms\QemuQ35Pkg\QemuQ35Pkg.dsc(...): LIBRARY_CLASS for override: [c:\src\mu_tiano_platforms\MU_BASECORE\MdePkg\Library\BasePcdLibNull\BasePcdLibNull.inf] does not match the library class being overridden: [DevicePathLib]
```

closes #314

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Ensured mismatched library override was caught, and INF's with multiple LIBRARY_CLASS definitions will not raise an error if one of the definitions matches.

## Integration Instructions

N/A
