### PR TITLE
MdeModulePkgHostTest: UefiSortLib -> SortLib for library overrides

### DIFF
--- a/MdeModulePkg/Library/UefiSortLib/GoogleTest/UefiSortLibGoogleTest.inf
+++ b/MdeModulePkg/Library/UefiSortLib/GoogleTest/UefiSortLibGoogleTest.inf
@@ -28,4 +28,4 @@
 
 [LibraryClasses]
   GoogleTestLib
-  UefiSortLib
+  SortLib

--- a/MdeModulePkg/Library/UefiSortLib/UnitTest/UefiSortLibUnitTest.inf
+++ b/MdeModulePkg/Library/UefiSortLib/UnitTest/UefiSortLibUnitTest.inf
@@ -29,4 +29,4 @@
 [LibraryClasses]
   UnitTestLib
   DebugLib
-  UefiSortLib
+  SortLib

--- a/MdeModulePkg/Test/MdeModulePkgHostTest.dsc
+++ b/MdeModulePkg/Test/MdeModulePkgHostTest.dsc
@@ -74,7 +74,7 @@
 
   MdeModulePkg/Library/UefiSortLib/UnitTest/UefiSortLibUnitTest.inf {
     <LibraryClasses>
-      UefiSortLib|MdeModulePkg/Library/UefiSortLib/UefiSortLib.inf
+      SortLib|MdeModulePkg/Library/UefiSortLib/UefiSortLib.inf
       DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLib.inf
       # MU_CHANGE
       # The UefiBootServicesTableLib cannot be used in a generic way, but is
@@ -128,6 +128,6 @@
 
   MdeModulePkg/Library/UefiSortLib/GoogleTest/UefiSortLibGoogleTest.inf {
     <LibraryClasses>
-      UefiSortLib|MdeModulePkg/Library/UefiSortLib/UefiSortLib.inf
+      SortLib|MdeModulePkg/Library/UefiSortLib/UefiSortLib.inf
       DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLib.inf
   }


### PR DESCRIPTION
## Description

In multiple locations, UefiSortLib was being used as the library type when the true base library is SortLib

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

CI

## Integration Instructions

N/A
