### PR TITLE
BaseTools: scan Edk2ToolsBuild.py make output

### DIFF
--- a/BaseTools/Edk2ToolsBuild.py
+++ b/BaseTools/Edk2ToolsBuild.py
@@ -189,8 +189,13 @@ class Edk2ToolsBuild(BaseAbstractInvocable):
                 shell_env.insert_path(shell_env.get_shell_var("EDK_TOOLS_BIN"))
 
             # Actually build the tools.
+            output_stream = edk2_logging.create_output_stream()
             ret = RunCmd('nmake.exe', None,
                          workingdir=shell_env.get_shell_var("EDK_TOOLS_PATH"))
+            edk2_logging.remove_output_stream(output_stream)
+            problems = edk2_logging.scan_compiler_output(output_stream)
+            for level, problem in problems:
+                logging.log(level, problem)
             if ret != 0:
                 raise Exception("Failed to build.")
 
@@ -284,7 +289,13 @@ class Edk2ToolsBuild(BaseAbstractInvocable):
             # MU_CHANGE ENDs
 
             cpu_count = self.GetCpuThreads()
+
+            output_stream = edk2_logging.create_output_stream()
             ret = RunCmd("make", f"-C .  -j {cpu_count}", workingdir=shell_env.get_shell_var("EDK_TOOLS_PATH"))
+            edk2_logging.remove_output_stream(output_stream)
+            problems = edk2_logging.scan_compiler_output(output_stream)
+            for level, problem in problems:
+                logging.log(level, problem)
             if ret != 0:
                 raise Exception("Failed to build.")
 


### PR DESCRIPTION
## Description

Adds edk2_logging.scan_compiler_output() to Edk2ToolsBuild.py to catch some compilation errors and log them as an error.

Not adding MU_CHANGE tags as this will be going to edk2 also.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Does not affect anything other than adding logging output.

## Integration Instructions

N/A
