### PR TITLE
MdeModule: resolve invalid library override

### DIFF
--- a/MdeModulePkg/Test/MdeModulePkgHostTest.dsc
+++ b/MdeModulePkg/Test/MdeModulePkgHostTest.dsc
@@ -83,7 +83,7 @@
       UefiBootServicesTableLib|MdePkg/Library/UefiBootServicesTableLib/UefiBootServicesTableLib.inf
   }
 
-  MdeModulePkg/Bus/Pci/NvmExpressDxe/UnitTest/MediaSanitizeUnitTestHost.inf  # MU_CHANGE - Invalid Library override
+  MdeModulePkg/Bus/Pci/NvmExpressDxe/UnitTest/MediaSanitizeUnitTestHost.inf  # MU_CHANGE - Add Additional Testing
 
   # MU_CHANGE [BEGIN]
   MdeModulePkg/Library/VariablePolicyLib/VariablePolicyUnitTest/VariablePolicyUnitTest.inf {

--- a/MdeModulePkg/Test/MdeModulePkgHostTest.dsc
+++ b/MdeModulePkg/Test/MdeModulePkgHostTest.dsc
@@ -83,10 +83,7 @@
       UefiBootServicesTableLib|MdePkg/Library/UefiBootServicesTableLib/UefiBootServicesTableLib.inf
   }
 
-  MdeModulePkg/Bus/Pci/NvmExpressDxe/UnitTest/MediaSanitizeUnitTestHost.inf {
-    <LibraryClasses>
-      NvmExpressDxe|MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressDxe.inf
-  }
+  MdeModulePkg/Bus/Pci/NvmExpressDxe/UnitTest/MediaSanitizeUnitTestHost.inf  # MU_CHANGE - Invalid Library override
 
   # MU_CHANGE [BEGIN]
   MdeModulePkg/Library/VariablePolicyLib/VariablePolicyUnitTest/VariablePolicyUnitTest.inf {


### PR DESCRIPTION
## Description

MediaSanitizeUnitTestHost used an invalid library override, attempting to override a non-existent library with a component that does not have an associated library.  Comparing generated output of the inf files with and without a library override showed no changes.  Therefore, this commit removes the invalid library override.

Additionally, the two files provided byt NvmExpressDxe.inf (  NvmExpressMediaSanitize.c
  NvmExpressMediaSanitize.h) are already included in MediaSanitizeUnitTestHost.inf.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Diff'd the build artifacts of the component with and without the library class override and saw no changes in the following:

- deps.txt
- Makefile
- static_library_files.lst
- NvmExpressMdeiaSanitize.c.deps
- MediaSanitizeUnitTestHost.inf
- MediaSanitizeUnitTest.c.deps

## Integration Instructions

N/A
