### PR TITLE
TCBZ 4492: Update SplitTable() Logic to Correctly Break Up Memory Map Descriptors

### DIFF
--- a/MdeModulePkg/Core/Dxe/Misc/MemoryAttributesTable.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryAttributesTable.c
@@ -911,7 +911,6 @@ SplitTable (
   AdditionalRecordCount = (2 * mImagePropertiesPrivateData.CodeSegmentCountMax + 1) * mImagePropertiesPrivateData.ImageRecordCount;
 
   TotalSkippedRecords = 0;
-
   //
   // Let old record point to end of valid MemoryMap buffer.
   //

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryAttributesTable.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryAttributesTable.c
@@ -916,7 +916,6 @@ SplitTable (
   // Let old record point to end of valid MemoryMap buffer.
   //
   IndexOld = ((*MemoryMapSize) / DescriptorSize) - 1;
-
   //
   // Let new record point to end of full MemoryMap buffer.
   //
@@ -945,21 +944,20 @@ SplitTable (
     IndexNew--;
   }
 
+  //
   // Move all records to the beginning.
+  //
   CopyMem (
     MemoryMap,
     (UINT8 *)MemoryMap + ((IndexNew + 1) * DescriptorSize),
     (IndexNewStarting - IndexNew) * DescriptorSize
     );
 
-  // Sort from low to high
-  SortMemoryMap (
-    MemoryMap,
-    (IndexNewStarting - IndexNew) * DescriptorSize,
-    DescriptorSize
-    );
+  //
+  // Sort from low to high (Just in case)
+  //
+  SortMemoryMap (MemoryMap, (IndexNewStarting - IndexNew) * DescriptorSize, DescriptorSize);
 
-  // Update the memory map size to be the actual number of used records
   *MemoryMapSize = (IndexNewStarting - IndexNew - TotalSkippedRecords) * DescriptorSize;
   // MU_CHANGE END
   //

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryAttributesTable.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryAttributesTable.c
@@ -899,6 +899,7 @@ SplitTable (
   IN UINTN                      DescriptorSize
   )
 {
+  // MU_CHANGE START: TCBZ 4492 - Fix SplitTable() Logic
   INTN   IndexOld;
   INTN   IndexNew;
   INTN   IndexNewStarting;
@@ -960,7 +961,7 @@ SplitTable (
 
   // Update the memory map size to be the actual number of used records
   *MemoryMapSize = (IndexNewStarting - IndexNew - TotalSkippedRecords) * DescriptorSize;
-
+  // MU_CHANGE END
   //
   // Set RuntimeData to XP
   //


### PR DESCRIPTION
## Description

Fixes https://github.com/microsoft/mu_basecore/issues/475

Fix the SplitTable() logic to correctly break up the memory map and fix errors in the Memory Attributes Table.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on Q35

## Integration Instructions

N/A
