### PR TITLE
MdeModulePkg: PciHostBridgeDxe: ignore TypeIo

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
@@ -685,7 +685,8 @@ ResourceConflict (
 
   for (Link = GetFirstNode (&HostBridge->RootBridges), Descriptor = Resources; !IsNull (&HostBridge->RootBridges, Link); Link = GetNextNode (&HostBridge->RootBridges, Link)) {
     RootBridge = ROOT_BRIDGE_FROM_LINK (Link);
-    for (Index = PCI_RESOURCE_TYPE_ENUM_START; Index < TypeMax; Index++) {  // MU_CHANGE
+    // MU_CHANGE - PCI_RESOURCE_TYPE_ENUM_START
+    for (Index = PCI_RESOURCE_TYPE_ENUM_START; Index < TypeMax; Index++) {
       ResAllocNode = &RootBridge->ResAllocNode[Index];
 
       Descriptor->Desc         = ACPI_ADDRESS_SPACE_DESCRIPTOR;
@@ -928,7 +929,8 @@ NotifyPhase (
         RootBridge = ROOT_BRIDGE_FROM_LINK (Link);
         DEBUG ((DEBUG_INFO, " RootBridge: %s\n", RootBridge->DevicePathStr));
 
-        for (Index1 = PCI_RESOURCE_TYPE_ENUM_START; Index1 < TypeBus; Index1++) {  // MU_CHANGE
+        // MU_CHANGE - PCI_RESOURCE_TYPE_ENUM_START
+        for (Index1 = PCI_RESOURCE_TYPE_ENUM_START; Index1 < TypeBus; Index1++) {
           if (RootBridge->ResAllocNode[Index1].Status == ResNone) {
             ResNodeHandled[Index1] = TRUE;
           } else {
@@ -937,7 +939,8 @@ NotifyPhase (
             //
             MaxAlignment = 0;
             Index        = TypeMax;
-            for (Index2 = PCI_RESOURCE_TYPE_ENUM_START; Index2 < TypeBus; Index2++) {  // MU_CHANGE
+            // MU_CHANGE - PCI_RESOURCE_TYPE_ENUM_START
+            for (Index2 = PCI_RESOURCE_TYPE_ENUM_START; Index2 < TypeBus; Index2++) {
               if (ResNodeHandled[Index2]) {
                 continue;
               }
@@ -1142,7 +1145,8 @@ NotifyPhase (
            )
       {
         RootBridge = ROOT_BRIDGE_FROM_LINK (Link);
-        for (Index = PCI_RESOURCE_TYPE_ENUM_START; Index < TypeBus; Index++) {  // MU_CHANGE
+        // MU_CHANGE - PCI_RESOURCE_TYPE_ENUM_START
+        for (Index = PCI_RESOURCE_TYPE_ENUM_START; Index < TypeBus; Index++) {
           if (RootBridge->ResAllocNode[Index].Status == ResAllocated) {
             switch (Index) {
               case TypeIo:
@@ -1642,7 +1646,8 @@ GetProposedResources (
       }
 
       Descriptor = (EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR *)Buffer;
-      for (Index = PCI_RESOURCE_TYPE_ENUM_START; Index < TypeBus; Index++) { // MU_CHANGE
+      // MU_CHANGE - PCI_RESOURCE_TYPE_ENUM_START
+      for (Index = PCI_RESOURCE_TYPE_ENUM_START; Index < TypeBus; Index++) {
         ResStatus = RootBridge->ResAllocNode[Index].Status;
         if (ResStatus != ResNone) {
           Descriptor->Desc    = ACPI_ADDRESS_SPACE_DESCRIPTOR;

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
@@ -685,7 +685,7 @@ ResourceConflict (
 
   for (Link = GetFirstNode (&HostBridge->RootBridges), Descriptor = Resources; !IsNull (&HostBridge->RootBridges, Link); Link = GetNextNode (&HostBridge->RootBridges, Link)) {
     RootBridge = ROOT_BRIDGE_FROM_LINK (Link);
-    for (Index = TypeIo; Index < TypeMax; Index++) {
+    for (Index = PCI_RESOURCE_TYPE_ENUM_START; Index < TypeMax; Index++) {  // MU_CHANGE
       ResAllocNode = &RootBridge->ResAllocNode[Index];
 
       Descriptor->Desc         = ACPI_ADDRESS_SPACE_DESCRIPTOR;
@@ -928,7 +928,7 @@ NotifyPhase (
         RootBridge = ROOT_BRIDGE_FROM_LINK (Link);
         DEBUG ((DEBUG_INFO, " RootBridge: %s\n", RootBridge->DevicePathStr));
 
-        for (Index1 = TypeIo; Index1 < TypeBus; Index1++) {
+        for (Index1 = PCI_RESOURCE_TYPE_ENUM_START; Index1 < TypeBus; Index1++) {  // MU_CHANGE
           if (RootBridge->ResAllocNode[Index1].Status == ResNone) {
             ResNodeHandled[Index1] = TRUE;
           } else {
@@ -937,7 +937,7 @@ NotifyPhase (
             //
             MaxAlignment = 0;
             Index        = TypeMax;
-            for (Index2 = TypeIo; Index2 < TypeBus; Index2++) {
+            for (Index2 = PCI_RESOURCE_TYPE_ENUM_START; Index2 < TypeBus; Index2++) {  // MU_CHANGE
               if (ResNodeHandled[Index2]) {
                 continue;
               }
@@ -1142,7 +1142,7 @@ NotifyPhase (
            )
       {
         RootBridge = ROOT_BRIDGE_FROM_LINK (Link);
-        for (Index = TypeIo; Index < TypeBus; Index++) {
+        for (Index = PCI_RESOURCE_TYPE_ENUM_START; Index < TypeBus; Index++) {  // MU_CHANGE
           if (RootBridge->ResAllocNode[Index].Status == ResAllocated) {
             switch (Index) {
               case TypeIo:
@@ -1642,7 +1642,7 @@ GetProposedResources (
       }
 
       Descriptor = (EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR *)Buffer;
-      for (Index = 0; Index < TypeBus; Index++) {
+      for (Index = PCI_RESOURCE_TYPE_ENUM_START; Index < TypeBus; Index++) { // MU_CHANGE
         ResStatus = RootBridge->ResAllocNode[Index].Status;
         if (ResStatus != ResNone) {
           Descriptor->Desc    = ACPI_ADDRESS_SPACE_DESCRIPTOR;

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostResource.h
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostResource.h
@@ -15,7 +15,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define PCI_RESOURCE_LESS  0xFFFFFFFFFFFFFFFEULL
 
 typedef enum {
-  TypeIo = 0,
+  TypeIo,  // MU_CHANGE
   TypeMem32,
   TypePMem32,
   TypeMem64,
@@ -23,6 +23,15 @@ typedef enum {
   TypeBus,
   TypeMax
 } PCI_RESOURCE_TYPE;
+
+// MU_CHANGE begin
+// Only x86_64 has IO resource
+#if defined(__x86_64__)
+#define PCI_RESOURCE_TYPE_ENUM_START TypeIo
+#else
+#define PCI_RESOURCE_TYPE_ENUM_START TypeMem32
+#endif
+// MU_CHANGE end
 
 typedef enum {
   ResNone,

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostResource.h
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostResource.h
@@ -26,7 +26,7 @@ typedef enum {
 
 // MU_CHANGE begin
 // Only processor type X64 has IO resource
-#if defined(MDE_CPU_X64)
+#if defined (MDE_CPU_X64)
 #define PCI_RESOURCE_TYPE_ENUM_START  TypeIo
 #else
 #define PCI_RESOURCE_TYPE_ENUM_START  TypeMem32

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostResource.h
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostResource.h
@@ -27,9 +27,9 @@ typedef enum {
 // MU_CHANGE begin
 // Only processor type X64 has IO resource
 #if defined(MDE_CPU_X64)
-#define PCI_RESOURCE_TYPE_ENUM_START TypeIo
+#define PCI_RESOURCE_TYPE_ENUM_START  TypeIo
 #else
-#define PCI_RESOURCE_TYPE_ENUM_START TypeMem32
+#define PCI_RESOURCE_TYPE_ENUM_START  TypeMem32
 #endif
 // MU_CHANGE end
 

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostResource.h
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostResource.h
@@ -25,8 +25,8 @@ typedef enum {
 } PCI_RESOURCE_TYPE;
 
 // MU_CHANGE begin
-// Only x86_64 has IO resource
-#if defined(__x86_64__)
+// Only processor type X64 has IO resource
+#if defined(MDE_CPU_X64)
 #define PCI_RESOURCE_TYPE_ENUM_START TypeIo
 #else
 #define PCI_RESOURCE_TYPE_ENUM_START TypeMem32

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostResource.h
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostResource.h
@@ -15,7 +15,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define PCI_RESOURCE_LESS  0xFFFFFFFFFFFFFFFEULL
 
 typedef enum {
-  TypeIo,  // MU_CHANGE
+  TypeIo = 0,
   TypeMem32,
   TypePMem32,
   TypeMem64,

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostResource.h
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostResource.h
@@ -26,7 +26,8 @@ typedef enum {
 
 // MU_CHANGE begin
 // Only processor type X64 has IO resource
-#if defined (MDE_CPU_X64)
+#if defined (MDE_CPU_IA32) || defined (MDE_CPU_X64)
+
 #define PCI_RESOURCE_TYPE_ENUM_START  TypeIo
 #else
 #define PCI_RESOURCE_TYPE_ENUM_START  TypeMem32

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
@@ -226,7 +226,7 @@ CreateRootBridge (
   CopyMem (&RootBridge->PMem, &Bridge->PMem, sizeof (PCI_ROOT_BRIDGE_APERTURE));
   CopyMem (&RootBridge->PMemAbove4G, &Bridge->PMemAbove4G, sizeof (PCI_ROOT_BRIDGE_APERTURE));
 
-  for (Index = TypeIo; Index < TypeMax; Index++) {
+  for (Index = PCI_RESOURCE_TYPE_ENUM_START; Index < TypeMax; Index++) {  // MU_CHANGE
     switch (Index) {
       case TypeBus:
         Aperture = &RootBridge->Bus;
@@ -1940,7 +1940,7 @@ RootBridgeIoConfiguration (
     TypeMax * sizeof (EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR) + sizeof (EFI_ACPI_END_TAG_DESCRIPTOR)
     );
   Descriptor = RootBridge->ConfigBuffer;
-  for (Index = TypeIo; Index < TypeMax; Index++) {
+  for (Index = PCI_RESOURCE_TYPE_ENUM_START; Index < TypeMax; Index++) {  // MU_CHANGE
     ResAllocNode = &RootBridge->ResAllocNode[Index];
 
     if (ResAllocNode->Status != ResAllocated) {

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
@@ -226,7 +226,8 @@ CreateRootBridge (
   CopyMem (&RootBridge->PMem, &Bridge->PMem, sizeof (PCI_ROOT_BRIDGE_APERTURE));
   CopyMem (&RootBridge->PMemAbove4G, &Bridge->PMemAbove4G, sizeof (PCI_ROOT_BRIDGE_APERTURE));
 
-  for (Index = PCI_RESOURCE_TYPE_ENUM_START; Index < TypeMax; Index++) {  // MU_CHANGE
+  // MU_CHANGE - PCI_RESOURCE_TYPE_ENUM_START
+  for (Index = PCI_RESOURCE_TYPE_ENUM_START; Index < TypeMax; Index++) {
     switch (Index) {
       case TypeBus:
         Aperture = &RootBridge->Bus;
@@ -1940,7 +1941,8 @@ RootBridgeIoConfiguration (
     TypeMax * sizeof (EFI_ACPI_ADDRESS_SPACE_DESCRIPTOR) + sizeof (EFI_ACPI_END_TAG_DESCRIPTOR)
     );
   Descriptor = RootBridge->ConfigBuffer;
-  for (Index = PCI_RESOURCE_TYPE_ENUM_START; Index < TypeMax; Index++) {  // MU_CHANGE
+  // MU_CHANGE - PCI_RESOURCE_TYPE_ENUM_START
+  for (Index = PCI_RESOURCE_TYPE_ENUM_START; Index < TypeMax; Index++) {
     ResAllocNode = &RootBridge->ResAllocNode[Index];
 
     if (ResAllocNode->Status != ResAllocated) {


### PR DESCRIPTION
## Description

Throughout PciHostBridgeDxe, functions iterate through all entries in the PCI_RESOURCE_TYPE enum.  However TypeIo only applies for x86_64 platforms. This changes the starting point of the PCI_RESOURCE_TYPE enum loops from 0 to PCI_RESOURCE_TYPE_ENUM_START and conditionally sets that value to TypeIo or TypeMem32 based on if the platform is x86_64 or not.

closes #444

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Will be platform tested

## Integration Instructions

N/A