### PR TITLE
Revert "Stop USB enumeration in case a malformed descriptor is found (#410)"

### DIFF
--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.c
@@ -396,7 +396,7 @@ UsbParseConfigDesc (
 
     if (Setting == NULL) {
       DEBUG ((DEBUG_ERROR, "UsbParseConfigDesc: warning: failed to get interface setting, stop parsing now.\n"));
-      goto ON_ERROR;  // MU_CHANGE
+      break;
     } else if (Setting->Desc.InterfaceNumber >= NumIf) {
       DEBUG ((DEBUG_ERROR, "UsbParseConfigDesc: malformatted interface descriptor\n"));
 


### PR DESCRIPTION
## Description

This reverts commit 714d41b7278194ace70026b5eb8c8bcce68da963.

Some devices are dependent on this functionality and can be important
sources of input during boot. Until a more robust solution is devised
that can support these devices, this change is reverted.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Verified a USB mass storage device that failed to enumerate with
the change can be enumerated after reverting it.

## Integration Instructions

N/A