### PR TITLE
Moving stall to end so status is checked without an unnecessary delay

### DIFF
--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
@@ -351,7 +351,7 @@ NvmeDisableController (
   }
 
   for (Index = (Timeout * 500); Index != 0; --Index) {
-    gBS->Stall (1000);
+    // gBS->Stall (1000);  // MU_CHANGE
 
     //
     // Check if the controller is initialized
@@ -365,6 +365,8 @@ NvmeDisableController (
     if (Csts.Rdy == 0) {
       break;
     }
+
+    gBS->Stall (1000);  // MU_CHANGE
   }
 
   if (Index == 0) {
@@ -430,7 +432,7 @@ NvmeEnableController (
   }
 
   for (Index = (Timeout * 500); Index != 0; --Index) {
-    gBS->Stall (1000);
+    // gBS->Stall (1000);  // MU_CHANGE
 
     //
     // Check if the controller is initialized
@@ -446,6 +448,8 @@ NvmeEnableController (
     if (Csts.Rdy) {
       break;
     }
+
+    gBS->Stall (1000);  // MU_CHANGE
   }
 
   if (Index == 0) {


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

Moving stall to the end (after status is checked) so system can complete the for loop without needing to stall 1 ms delay. 

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This was tested on a platform that had multiple Nvm Storage Controllers. The Nvme controller status was already ready in the first loop regardless of if the status was at the beginning or the end of the for loop, and moving the stall to the end improves the performance.

## Integration Instructions

N/A
