### PR TITLE
LineEndingsCheck: improve performance

### DIFF
--- a/.pytool/Plugin/LineEndingCheck/LineEndingCheck.py
+++ b/.pytool/Plugin/LineEndingCheck/LineEndingCheck.py
@@ -207,8 +207,10 @@ class LineEndingCheck(ICiBuildPlugin):
             Callable[[None], None]: A test case function.
         """
         ignored_files = []
+        if pkg_config.get("IgnoreFilesWithNoExtension", False):
+            ignored_files.extend(['*', '!*.*', '!*/'])
         if "IgnoreFiles" in pkg_config:
-            ignored_files = pkg_config["IgnoreFiles"]
+            ignored_files.extend(pkg_config["IgnoreFiles"])
 
         # Pass "Package configuration file" as the source file path since
         # the actual configuration file name is unknown to this plugin and
@@ -260,7 +262,6 @@ class LineEndingCheck(ICiBuildPlugin):
             tc.LogStdError(f"Package folder not found {self._abs_pkg_path}")
             return 0
 
-        # MU_CHANGE begin: Perf Improvements
         ignore_files = set(self._get_git_ignored_paths())
         ignore_dirs = set(self._get_git_submodule_paths())
         ignore_filter = self._get_files_ignored_in_config(package_config, self._abs_pkg_path)
@@ -280,7 +281,6 @@ class LineEndingCheck(ICiBuildPlugin):
             if file in ignore_files:
                 continue
             
-        # MU_CHANGE end: Perf Improvements
             with open(file.resolve(), 'rb') as fb:
                 if not fb.readable() or _is_binary_string(fb.read(1024)):
                     continue

--- a/.pytool/Plugin/LineEndingCheck/LineEndingCheck.py
+++ b/.pytool/Plugin/LineEndingCheck/LineEndingCheck.py
@@ -262,7 +262,6 @@ class LineEndingCheck(ICiBuildPlugin):
             tc.LogStdError(f"Package folder not found {self._abs_pkg_path}")
             return 0
 
-        # MU_CHANGE begin: Perf Improvements
         ignore_files = set(self._get_git_ignored_paths())
         ignore_dirs = set(self._get_git_submodule_paths())
         ignore_filter = self._get_files_ignored_in_config(package_config, self._abs_pkg_path)
@@ -282,7 +281,6 @@ class LineEndingCheck(ICiBuildPlugin):
             if file in ignore_files:
                 continue
             
-        # MU_CHANGE end: Perf Improvements
             with open(file.resolve(), 'rb') as fb:
                 if not fb.readable() or _is_binary_string(fb.read(1024)):
                     continue

--- a/.pytool/Plugin/LineEndingCheck/LineEndingCheck.py
+++ b/.pytool/Plugin/LineEndingCheck/LineEndingCheck.py
@@ -262,6 +262,7 @@ class LineEndingCheck(ICiBuildPlugin):
             tc.LogStdError(f"Package folder not found {self._abs_pkg_path}")
             return 0
 
+        # MU_CHANGE begin: Perf Improvements
         ignore_files = set(self._get_git_ignored_paths())
         ignore_dirs = set(self._get_git_submodule_paths())
         ignore_filter = self._get_files_ignored_in_config(package_config, self._abs_pkg_path)
@@ -281,6 +282,7 @@ class LineEndingCheck(ICiBuildPlugin):
             if file in ignore_files:
                 continue
             
+        # MU_CHANGE end: Perf Improvements
             with open(file.resolve(), 'rb') as fb:
                 if not fb.readable() or _is_binary_string(fb.read(1024)):
                     continue

--- a/.pytool/Plugin/LineEndingCheck/Readme.md
+++ b/.pytool/Plugin/LineEndingCheck/Readme.md
@@ -19,9 +19,15 @@ The plugin can be configured to ignore certain files.
 ``` yaml
 "LineEndingCheck": {
     "IgnoreFiles": []
+    "IgnoreFilesWithNoExtension": False
 }
 ```
 
 ### IgnoreFiles
 
 An **optional** list of git ignore patterns relative to the package root used to exclude files from being checked.
+
+### IgnoreFilesWithNoExtension
+
+An **optional** value that, if True, will insert the gitignore rules necessary to have this check ignore files
+that do not contain a file extension. Neccessary for binary files and/or POSIX like executables.

--- a/.pytool/Plugin/LineEndingCheck/Readme.md
+++ b/.pytool/Plugin/LineEndingCheck/Readme.md
@@ -30,4 +30,4 @@ An **optional** list of git ignore patterns relative to the package root used to
 ### IgnoreFilesWithNoExtension
 
 An **optional** value that, if True, will insert the gitignore rules necessary to have this check ignore files
-that do not contain a file extension. Neccessary for binary files and/or POSIX like executables.
+that do not contain a file extension. Necessary for binary files and/or POSIX like executables.

--- a/BaseTools/BaseTools.ci.yaml
+++ b/BaseTools/BaseTools.ci.yaml
@@ -44,7 +44,7 @@
         "AuditOnly": True,
     },
     "LineEndingCheck": {
-        "IgnoreFiles": ['*.*']
+        "IgnoreFiles": ["*"],
     }
     # MU_CHANGE [END]
 }


### PR DESCRIPTION
## Description

LineEndingsCheck generally takes anywhere from 4 to 6 seconds to run, depending on the size of the package. This change reduces the time to run by ~53% as tested on packages in MU_BASECORE due to the following changes:

1. Reorganized filters to reduce the amount of list comprehensions performed to filter out files that do not need to be checked

2. Organized the order of checks in regards to filters most likely to catch a file, and the expensiveness of the filter itself.

| Pkg                  | Before (s) | After (s) | Improvement |
|----------------------|------------|-----------|-------------|
| MdeModulePkg         | 5.50       | 3.00      | 45%         |
| MdePkg               | 5.72       | 2.88      | 50%         |
| NetworkPkg           | 4.30       | 2.09      | 51%         |
| PcAtChipsetPkg       | 3.98       | 1.79      | 55%         |
| PolicyServicePkg     | 4.12       | 1.87      | 55%         |
| ShellPkg             | 4.40       | 1.85      | 58%         |
| StandaloneMmPkg      | 4.17       | 1.72      | 59%         |
| UefiCpuPkg           | 4.13       | 2.12      | 49%         |
| UnitTestFrameworkPkg | 3.94       | 1.79      | 55%         |

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [x] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Ensured the same number of files had the line endings check performed after filtering for all packages in MU_BASECORE

## Integration Instructions

Previously, only files with extensions were checked for valid line endings. Now, all files are checked for valid line endings.

If your package begins to fail because a file with no extension has invalid line endings and you do **not** want to update the line endings, you will need to do the following integration steps:

1. Ensure edk2-pytool-library is >= v0.16.2
2. Set IgnoreFilesWithNoExtension: True in the package config file:

```json
"LineEndingCheck": {
    "IgnoreFilesWithNoExtension": "True"
}
```