### PR TITLE
BaseTools: Rust support enhancements

### DIFF
--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -280,8 +280,9 @@
         $(OUTPUT_DIR)(+)$(MODULE_NAME)rust.lib
 
     <Command>
-        $(CARGO) $(CARGOMAKE_BUILD) $(MODULE_NAME)
-        $(CP) $(CARGO_BINDIR)(+)*.a $(OUTPUT_DIR)(+)$(MODULE_NAME)rust.lib
+        $(CARGO) make $(CARGOMAKE_FLAGS) -e RUSTFLAGS="-C link-arg=/MAP:$(DEBUG_DIR)(+)$(MODULE_NAME).map $(RUST_FLAGS)" build $(MODULE_NAME)
+        $(CP) $(DEBUG_DIR)(+)$(TARGET_TRIPLE)(+)$(RUST_TARGET)(+)*.a $(DEBUG_DIR)(+)$(MODULE_NAME)rust.lib
+        $(CP) $(DEBUG_DIR)(+)$(TARGET_TRIPLE)(+)$(RUST_TARGET)(+)*.a $(OUTPUT_DIR)(+)$(MODULE_NAME)rust.lib
 
 [Toml-File.RUST_MODULE]
     <InputFile>
@@ -293,11 +294,12 @@
     <Command>
         # Temporary_Rust_Todo - Remove .efi files to better support Rust incremental build for now.
         $(RM) $(OUTPUT_DIR)(+)*.efi
-        $(CARGO) $(CARGOMAKE_BUILD) $(MODULE_NAME)
-        "$(GENFW)" -e $(MODULE_TYPE) -o $(CARGO_BINDIR)(+)$(MODULE_NAME).efi $(CARGO_BINDIR)(+)$(MODULE_NAME).efi $(GENFW_FLAGS)
-        $(CP) $(CARGO_BINDIR)(+)$(MODULE_NAME).map $(OUTPUT_DIR)(+)$(MODULE_NAME).map
-        $(CP) $(CARGO_BINDIR)(+)$(MODULE_NAME).efi $(OUTPUT_DIR)(+)$(MODULE_NAME).efi
-        $(CP) $(CARGO_BINDIR)(+)$(MODULE_NAME).efi $(BIN_DIR)(+)$(MODULE_NAME).efi
+        $(CARGO) make $(CARGOMAKE_FLAGS) -e RUSTFLAGS="-C link-arg=/MAP:$(DEBUG_DIR)(+)$(MODULE_NAME).map $(RUST_FLAGS)" build $(MODULE_NAME)
+        "$(GENFW)" -e $(MODULE_TYPE) -o $(DEBUG_DIR)(+)$(MODULE_NAME).efi $(DEBUG_DIR)(+)$(TARGET_TRIPLE)(+)$(RUST_TARGET)(+)$(MODULE_NAME).efi $(GENFW_FLAGS)
+        $(CP) $(DEBUG_DIR)(+)$(MODULE_NAME).map  $(OUTPUT_DIR)(+)$(MODULE_NAME).map
+        $(CP) $(DEBUG_DIR)(+)$(MODULE_NAME).efi $(OUTPUT_DIR)(+)$(MODULE_NAME).efi
+        $(CP) $(OUTPUT_DIR)(+)$(MODULE_NAME).efi $(BIN_DIR)(+)$(MODULE_NAME).efi
+
 [Static-Library-File.RUST_MODULE]
     <InputFile>
         *.lib

--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -294,9 +294,17 @@
         # Temporary_Rust_Todo - Remove .efi files to better support Rust incremental build for now.
         $(RM) $(OUTPUT_DIR)(+)*.efi
         $(CARGO) $(CARGOMAKE_BUILD) $(MODULE_NAME)
+        "$(GENFW)" -e $(MODULE_TYPE) -o $(CARGO_BINDIR)(+)$(MODULE_NAME).efi $(CARGO_BINDIR)(+)$(MODULE_NAME).efi $(GENFW_FLAGS)
         $(CP) $(CARGO_BINDIR)(+)$(MODULE_NAME).map $(OUTPUT_DIR)(+)$(MODULE_NAME).map
         $(CP) $(CARGO_BINDIR)(+)$(MODULE_NAME).efi $(OUTPUT_DIR)(+)$(MODULE_NAME).efi
         $(CP) $(CARGO_BINDIR)(+)$(MODULE_NAME).efi $(BIN_DIR)(+)$(MODULE_NAME).efi
+[Static-Library-File.RUST_MODULE]
+    <InputFile>
+        *.lib
+    <ExtraDependency>
+        $(MAKE_FILE)
+    <OutputFile>
+    <Command>
 
 # MU_CHANGE [END] - Add Rust build support
 

--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -3342,19 +3342,16 @@ RELEASE_XCODE5_X64_CC_FLAGS   = -target x86_64-pc-win32-macho -c    -Os       -W
 ##################
 *_*_X64_TARGET_TRIPLE = x86_64-unknown-uefi
 *_*_IA32_TARGET_TRIPLE = i686-unknown-uefi
+*_*_AARCH64_TARGET_TRIPLE = aarch64-unknown-uefi
 
-*_*_*_RUSTC_PATH            = rustc
-DEBUG_*_X64_RUSTC_FLAGS     = --edition=2018 --target $(TARGET_TRIPLE) -C debuginfo=2 --crate-type staticlib
-RELEASE_*_X64_RUSTC_FLAGS   = --edition=2018 --target $(TARGET_TRIPLE) -C debuginfo=3 --crate-type staticlib
-DEBUG_*_IA32_RUSTC_FLAGS    = --edition=2018 --target $(TARGET_TRIPLE) -C debuginfo=2 --crate-type staticlib
-RELEASE_*_IA32_RUSTC_FLAGS  = --edition=2018 --target $(TARGET_TRIPLE) -C debuginfo=2 --crate-type staticlib
+*_*_*_RUSTC_PATH              = rustc
+DEBUG_*_*_RUSTC_FLAGS       = --edition=2018 --target $(TARGET_TRIPLE) -C debuginfo=2 --crate-type staticlib
+RELEASE_*_*_RUSTC_FLAGS     = --edition=2018 --target $(TARGET_TRIPLE) -C debuginfo=3 --crate-type staticlib
 
 ##########################
 # CARGO MAKE definitions #
 ##########################
-*_VS2019_*_CARGOMAKE_RUSTFLAGS  = "-C link-arg=/MAP:$(CARGO_BINDIR)\$(MODULE_NAME).map"
-*_VS2022_*_CARGOMAKE_RUSTFLAGS  = "-C link-arg=/MAP:$(CARGO_BINDIR)\$(MODULE_NAME).map"
-*_GCC5_*_CARGOMAKE_RUSTFLAGS  = "-C link-arg=/MAP:$(CARGO_BINDIR)/$(MODULE_NAME).map"
+*_*_*_CARGOMAKE_RUSTFLAGS  = "-C link-arg=/MAP:$(CARGO_BINDIR)\$(MODULE_NAME).map"
 
 DEBUG_*_*_CARGOMAKE_BUILD    = make --cwd ENV(WORKSPACE) -p development -e TARGET_TRIPLE=$(TARGET_TRIPLE) -e RUSTFLAGS=$(CARGOMAKE_RUSTFLAGS) build
 RELEASE_*_*_CARGOMAKE_BUILD  = make --cwd ENV(WORKSPACE) -p release -e TARGET_TRIPLE=$(TARGET_TRIPLE) -e RUSTFLAGS=$(CARGOMAKE_RUSTFLAGS) build
@@ -3363,14 +3360,10 @@ RELEASE_*_*_CARGOMAKE_BUILD  = make --cwd ENV(WORKSPACE) -p release -e TARGET_TR
 # CARGO definitions
 ##################
 # The path to where cargo generated binaries are placed (.efi, .a, .d,)
-DEBUG_VS2019_*_CARGO_BINDIR  = ENV(WORKSPACE)\target\$(TARGET_TRIPLE)\debug
-RELEASE_VS2019_*_CARGO_BINDIR  = ENV(WORKSPACE)\target\$(TARGET_TRIPLE)\release
+DEBUG_*_*_CARGO_BINDIR  = ENV(WORKSPACE)\target\$(TARGET_TRIPLE)\debug
+RELEASE_*_*_CARGO_BINDIR  = ENV(WORKSPACE)\target\$(TARGET_TRIPLE)\release
 
-DEBUG_VS2022_*_CARGO_BINDIR  = ENV(WORKSPACE)\target\$(TARGET_TRIPLE)\debug
-RELEASE_VS2022_*_CARGO_BINDIR  = ENV(WORKSPACE)\target\$(TARGET_TRIPLE)\release
 
-DEBUG_GCC5_*_CARGO_BINDIR    = ENV(WORKSPACE)/target/$(TARGET_TRIPLE)/debug
-RELEASE_GCC5_*_CARGO_BINDIR    = ENV(WORKSPACE)/target/$(TARGET_TRIPLE)/release
 
 *_*_*_CARGO_PATH         = cargo
 

--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -3338,34 +3338,29 @@ RELEASE_XCODE5_X64_CC_FLAGS   = -target x86_64-pc-win32-macho -c    -Os       -W
 # MU_CHANGE [BEGIN] - Add Rust build support
 
 ##################
-# RUSTC definitions
+# RUST definitions
 ##################
-*_*_X64_TARGET_TRIPLE = x86_64-unknown-uefi
-*_*_IA32_TARGET_TRIPLE = i686-unknown-uefi
-*_*_AARCH64_TARGET_TRIPLE = aarch64-unknown-uefi
+*_*_X64_TARGET_TRIPLE      = x86_64-unknown-uefi
+*_*_IA32_TARGET_TRIPLE     = i686-unknown-uefi
+*_*_AARCH64_TARGET_TRIPLE  = aarch64-unknown-uefi
 
-*_*_*_RUSTC_PATH              = rustc
-DEBUG_*_*_RUSTC_FLAGS       = --edition=2018 --target $(TARGET_TRIPLE) -C debuginfo=2 --crate-type staticlib
-RELEASE_*_*_RUSTC_FLAGS     = --edition=2018 --target $(TARGET_TRIPLE) -C debuginfo=3 --crate-type staticlib
+DEBUG_*_*_RUST_TARGET      = debug
+RELEASE_*_*_RUST_TARGET    = release
+NOOPT_*_*_RUST_TARGET      = debug
+
+*_*_*_RUST_FLAGS           =    
+
+####################
+# CARGO defintions #
+####################
+*_*_*_CARGO_PATH  = cargo
 
 ##########################
 # CARGO MAKE definitions #
 ##########################
-*_*_*_CARGOMAKE_RUSTFLAGS  = "-C link-arg=/MAP:$(CARGO_BINDIR)\$(MODULE_NAME).map"
-
-DEBUG_*_*_CARGOMAKE_BUILD    = make --cwd ENV(WORKSPACE) -p development -e TARGET_TRIPLE=$(TARGET_TRIPLE) -e RUSTFLAGS=$(CARGOMAKE_RUSTFLAGS) build
-RELEASE_*_*_CARGOMAKE_BUILD  = make --cwd ENV(WORKSPACE) -p release -e TARGET_TRIPLE=$(TARGET_TRIPLE) -e RUSTFLAGS=$(CARGOMAKE_RUSTFLAGS) build
-
-##################
-# CARGO definitions
-##################
-# The path to where cargo generated binaries are placed (.efi, .a, .d,)
-DEBUG_*_*_CARGO_BINDIR  = ENV(WORKSPACE)\target\$(TARGET_TRIPLE)\debug
-RELEASE_*_*_CARGO_BINDIR  = ENV(WORKSPACE)\target\$(TARGET_TRIPLE)\release
-
-
-
-*_*_*_CARGO_PATH         = cargo
+DEBUG_*_*_CARGOMAKE_FLAGS    = --cwd ENV(WORKSPACE) -e CARGO_TARGET_DIR=$(DEBUG_DIR) -p development -e TARGET_TRIPLE=$(TARGET_TRIPLE)
+RELEASE_*_*_CARGOMAKE_FLAGS  = --cwd ENV(WORKSPACE) -e CARGO_TARGET_DIR=$(DEBUG_DIR) -p release -e TARGET_TRIPLE=$(TARGET_TRIPLE)
+NOOPT_*_*_CARGOMAKE_FLAGS    = --cwd ENV(WORKSPACE) -e CARGO_TARGET_DIR=$(DEBUG_DIR) -p development -e TARGET_TRIPLE=$(TARGET_TRIPLE)
 
 # MU_CHANGE [END] - Add Rust build support
 

--- a/Docs/rust_build.md
+++ b/Docs/rust_build.md
@@ -76,7 +76,7 @@ be produced.
 The following command line options are available:
 
 1. `-p PROFILE [development|release]`. `DEFAULT` = `development (debug)`
-2. `-e ARCH=[IA32|X64|LOCAL]`. `DEFAULT` = `X64`
+2. `-e ARCH=[IA32|X64|AARCH64|LOCAL]`. `DEFAULT` = `X64`
 3. `-e TARGET_TRIPLE=[triple]`.
 
 - `ARCH=LOCAL` is used to build any locally executable tools associated with a Rust library package (e.g., a

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -5,7 +5,7 @@ default_to_workspace = false
 CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
 RUSTC_BOOTSTRAP = 1
 ARCH = "X64"
-TARGET_TRIPLE = { source = "${ARCH}", mapping = { "X64" = "x86_64-unknown-uefi", "IA32" = "i686-unknown-uefi", "LOCAL" = "${CARGO_MAKE_RUST_TARGET_TRIPLE}" }, condition = { env_not_set = [ "TARGET_TRIPLE" ] } }
+TARGET_TRIPLE = { source = "${ARCH}", mapping = { "X64" = "x86_64-unknown-uefi", "IA32" = "i686-unknown-uefi", "AARCH64" = "aarch64-unknown-uefi", "LOCAL" = "${CARGO_MAKE_RUST_TARGET_TRIPLE}" }, condition = { env_not_set = [ "TARGET_TRIPLE" ] } }
 PACKAGE_TARGET = {value = "-p ${CARGO_MAKE_TASK_ARGS}",condition = { env_true = [ "CARGO_MAKE_TASK_ARGS", ] } }
 
 BUILD_FLAGS = "--profile ${RUSTC_PROFILE} --target ${TARGET_TRIPLE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options --timings=html"
@@ -25,7 +25,7 @@ description = """Builds a single rust package.
 
 Customizations:
     -p [development|release]: Builds in debug or release. Default: development
-    -e ARCH=[IA32|X64|LOCAL]: Builds with specifed arch. Default: X64
+    -e ARCH=[IA32|X64|AARCH64|LOCAL]: Builds with specifed arch. Default: X64
 
 Example:
     `cargo make build RustModule`


### PR DESCRIPTION
## Description

Updates the build tools for Rust support with the following enhancements:

1. Add AARCH64 build support
2. Add NOOPT build support
3. Moves build artifacts from `$(WORKSPACE)/target to $(DEBUG_DIR)` where `$(DEBUG_DIR)` is the debug dir for the particular rust module being built.
4. Removes RUSTC definitions as all builds are done through cargo make.

Additionally cleans up much of the defines in tools_def.template, which was overly complicated due to the path separator ("/", "\") differences between linux and windows by moving those directly to the build_rule.template file.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Confirmed successful builds on Windows and Linux

## Integration Instructions

N/A
