### PR TITLE
Use gMuEventPreExitBootServicesGuid for SnpDxe to issue PxeShutdown

### DIFF
--- a/NetworkPkg/SnpDxe/Snp.c
+++ b/NetworkPkg/SnpDxe/Snp.c
@@ -655,7 +655,7 @@ SimpleNetworkDriverStart (
                     TPL_CALLBACK,
                     SnpNotifyExitBootServices,
                     Snp,
-                    &gEfiEventExitBootServicesGuid,
+                    &gMuEventPreExitBootServicesGuid,
                     &Snp->ExitBootServicesEvent
                     );
     if (EFI_ERROR (Status)) {

--- a/NetworkPkg/SnpDxe/Snp.c
+++ b/NetworkPkg/SnpDxe/Snp.c
@@ -655,7 +655,7 @@ SimpleNetworkDriverStart (
                     TPL_CALLBACK,
                     SnpNotifyExitBootServices,
                     Snp,
-                    &gMuEventPreExitBootServicesGuid,
+                    &gMuEventPreExitBootServicesGuid,   // MU_CHANGE
                     &Snp->ExitBootServicesEvent
                     );
     if (EFI_ERROR (Status)) {

--- a/NetworkPkg/SnpDxe/SnpDxe.inf
+++ b/NetworkPkg/SnpDxe/SnpDxe.inf
@@ -65,7 +65,7 @@
   NetLib
 
 [Guids]
-  gEfiEventExitBootServicesGuid                 ## SOMETIMES_CONSUMES ## Event
+  gMuEventPreExitBootServicesGuid               ## SOMETIMES_CONSUMES ## Event
   # MU_CHANGE - Signal gSnpNetworkInitializedEventGuid when Snp->Initialized() called.
   gSnpNetworkInitializedEventGuid               ## SOMETIMES_PRODUCES
 

--- a/NetworkPkg/SnpDxe/SnpDxe.inf
+++ b/NetworkPkg/SnpDxe/SnpDxe.inf
@@ -65,6 +65,7 @@
   NetLib
 
 [Guids]
+  # MU_CHANGE - Use gMuEventPreExitBootServicesGuid for SnpDxe to issue PxeShutdown
   gMuEventPreExitBootServicesGuid               ## SOMETIMES_CONSUMES ## Event
   # MU_CHANGE - Signal gSnpNetworkInitializedEventGuid when Snp->Initialized() called.
   gSnpNetworkInitializedEventGuid               ## SOMETIMES_PRODUCES


### PR DESCRIPTION
## Description
Fixes https://github.com/microsoft/mu_basecore/issues/520

SnpDxe registers for an ExitBootServices callback and runs the PXE_OPCODE_SHUTDOWN and PXE_OPCODE_STOP commands for any network controllers that the driver is attached to. If the Bus Master Enable bit is cleared by PciBusDxe before this point, then completions returned by the network cards will be unreadable to their drivers during the shutdown sequence.

Register the SnpDxe callback for gMuEventPreExitBootServicesGuid instead of gEfiEventExitBootServicesGuid to ensure the correct ordering:

1. ExitBootServices event
2. Network card shutdown sequence is completed
3. BME is disabled on PCI bridges (if configured)

- [X] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

verified on ARM platform with two network cards

## Integration Instructions

N/A
