### PR TITLE
FlattenPdbs.py: Support python 3.9

### DIFF
--- a/BaseTools/Plugin/FlattenPdbs/FlattenPdbs.py
+++ b/BaseTools/Plugin/FlattenPdbs/FlattenPdbs.py
@@ -61,5 +61,5 @@ class FlattenPdbs(IUefiBuildPlugin):
             # Hard link it, which is slightly faster, but mainly allows us to tell
             # if the file has changed (st_ino is different)
             pdb_out.unlink(missing_ok=True)
-            pdb_out.hardlink_to(file)
+            file.link_to(pdb_out) # Replace with pdb_out.hardlink_to(file) when support for python 3.9 is dropped
         return 0


### PR DESCRIPTION
## Description

Recent improvements to FlattenPdbs.py broke support for python 3.9 due to using pathlib's `hardlink_to` method, which was added in python 3.10.

This commit replaces that function with `link_to`, which is the same functionality, but with the direction of the linking reversed.

`link_to` is deprecated, so once Project Mu drops support for python 3.9, this commit can be reverted.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

N/A

## Integration Instructions

N/A
