### PR TITLE
SpellCheck: force no color codes

### DIFF
--- a/.pytool/Plugin/SpellCheck/SpellCheck.py
+++ b/.pytool/Plugin/SpellCheck/SpellCheck.py
@@ -212,7 +212,7 @@ class SpellCheck(ICiBuildPlugin):
     def _check_spelling(self, abs_file_to_check: str, abs_config_file_to_use: str) -> []:
         output = StringIO()
         ret = RunCmd(
-            "cspell", f"--config {abs_config_file_to_use} {abs_file_to_check}", outstream=output)
+            "cspell", f"--config {abs_config_file_to_use} --no-color {abs_file_to_check}", outstream=output)
         if ret == 0:
             return []
         else:


### PR DESCRIPTION
## Description

The SpellCheck plugin runs cspell, which uses ANSI color codes when displaying results. When ANSI color codes are used in a terminal that does not support ANSI, the color codes are displayed as text, which causes the rest of SpellCheck plugin to fail as the expected path is not a real path as it starts and ends with color codes:

i.e. `\[90m.\Path\To\File.txt[39m` instead of `.\Path\To\File.txt`

This change forces cspell to not colorize the output.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

CI

## Integration Instructions

N/A
