### PR TITLE
[CHERRY-PICK] [202202] SpellCheck: force no color codes

### DIFF
--- a/.pytool/Plugin/SpellCheck/SpellCheck.py
+++ b/.pytool/Plugin/SpellCheck/SpellCheck.py
@@ -212,7 +212,7 @@ class SpellCheck(ICiBuildPlugin):
     def _check_spelling(self, abs_file_to_check: str, abs_config_file_to_use: str) -> []:
         output = StringIO()
         ret = RunCmd(
-            "cspell", f"--config {abs_config_file_to_use} {abs_file_to_check}", outstream=output)
+            "cspell", f"--config {abs_config_file_to_use} --no-color {abs_file_to_check}", outstream=output)
         if ret == 0:
             return []
         else:

--- a/MdePkg/Library/BaseMemoryLib/MemLibGeneric.c
+++ b/MdePkg/Library/BaseMemoryLib/MemLibGeneric.c
@@ -32,7 +32,9 @@ InternalMemSetMem16 (
   )
 {
   for ( ; Length != 0; Length--) {
-    ((UINT16 *)Buffer)[Length - 1] = Value;
+    // MU_CHANGE use a pointer to volatile data to prevent Visual Studio 17.5 (VS2022)
+    // from replacing the assignment with a `memset()` intrinsic
+    ((volatile UINT16 *)Buffer)[Length - 1] = Value;
   }
 
   return Buffer;
@@ -57,7 +59,9 @@ InternalMemSetMem32 (
   )
 {
   for ( ; Length != 0; Length--) {
-    ((UINT32 *)Buffer)[Length - 1] = Value;
+    // MU_CHANGE use a pointer to volatile data to prevent Visual Studio 17.5 (VS2022)
+    // from replacing the assignment with a `memset()` intrinsic
+    ((volatile UINT32 *)Buffer)[Length - 1] = Value;
   }
 
   return Buffer;
@@ -82,7 +86,9 @@ InternalMemSetMem64 (
   )
 {
   for ( ; Length != 0; Length--) {
-    ((UINT64 *)Buffer)[Length - 1] = Value;
+    // MU_CHANGE use a pointer to volatile data to prevent Visual Studio 17.5 (VS2022)
+    // from replacing the assignment with a `memset()` intrinsic
+    ((volatile UINT64 *)Buffer)[Length - 1] = Value;
   }
 
   return Buffer;

--- a/PolicyServicePkg/README.md
+++ b/PolicyServicePkg/README.md
@@ -189,7 +189,7 @@ Such YAML definition will be used to generate header files and the field accesso
 
 In addition to aforementioned YAML specification from slim bootloader, a few extra rules was added to the existing
 specification to facilitate the adaptation of policy specific usage. These rules will be enforced by a Pre-Build
-plugin, more details in its [implementation section](#Pre-Build-Plugin).
+plugin, more details in its [implementation section](#pre-build-plugin).
 
 1. Each policy definition group must include a `POLICY_HEADER_TMPL` section, as provided in this template [here](CommonPolicy/Template_PolicyHeader.yaml).
 This section should include a 64-bit signature, an expected major version, an maximally expected minor version and
@@ -222,7 +222,7 @@ This function could be invoked for a platform to initialize the newly created po
 
 ### Pre-Build Plugin
 
-A pre-build plugin is created to enforce rules indicated in the previous [section](#Field-Accessors).
+A pre-build plugin is created to enforce rules indicated in the previous [section](#field-accessors).
 
 This plugin requires 3 build environment variable to execute properly:
 


### PR DESCRIPTION
## Description

The SpellCheck plugin runs cspell, which uses ANSI color codes when displaying results. When ANSI color codes are used in a terminal that does not support ANSI, the color codes are displayed as text, which causes the rest of SpellCheck plugin to fail as the expected path is not a real path as it starts and ends with color codes:

i.e. `\[90m.\Path\To\File.txt[39m` instead of `.\Path\To\File.txt`

This change forces cspell to not colorize the output.

- [ ] Impacts functionality?
- **Functionality** - Does the change ultimately impact how firmware functions?
- Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
- **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter validation improvement, ...
- [ ] Breaking change?
- **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
- Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
- **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
- Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

CI

## Integration Instructions

N/A
