### PR TITLE
DXE and SMM core performance lib codeql changes.

### DIFF
--- a/MdeModulePkg/Library/DxeCorePerformanceLib/DxeCorePerformanceLib.c
+++ b/MdeModulePkg/Library/DxeCorePerformanceLib/DxeCorePerformanceLib.c
@@ -1191,7 +1191,11 @@ InsertFpdtRecord (
     case PERF_INMODULE_END_ID:
     case PERF_CROSSMODULE_START_ID:
     case PERF_CROSSMODULE_END_ID:
-      GetModuleInfoFromHandle ((EFI_HANDLE)CallerIdentifier, ModuleName, sizeof (ModuleName), &ModuleGuid);
+      Status = GetModuleInfoFromHandle ((EFI_HANDLE)CallerIdentifier, ModuleName, sizeof (ModuleName), &ModuleGuid);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "Failed to get Module Info from Handle! Status = %r\n", Status));
+      }
+
       if (String != NULL) {
         StringPtr = String;
       } else {
@@ -1216,7 +1220,11 @@ InsertFpdtRecord (
 
     default:
       if (Attribute != PerfEntry) {
-        GetModuleInfoFromHandle ((EFI_HANDLE)CallerIdentifier, ModuleName, sizeof (ModuleName), &ModuleGuid);
+        Status = GetModuleInfoFromHandle ((EFI_HANDLE)CallerIdentifier, ModuleName, sizeof (ModuleName), &ModuleGuid);
+        if (EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_ERROR, "Failed to get Module Info from Handle! Status = %r\n", Status));
+        }
+
         if (String != NULL) {
           StringPtr = String;
         } else {

--- a/MdeModulePkg/Library/DxeCorePerformanceLib/DxeCorePerformanceLib.c
+++ b/MdeModulePkg/Library/DxeCorePerformanceLib/DxeCorePerformanceLib.c
@@ -1197,17 +1197,19 @@ InsertFpdtRecord (
         DEBUG ((DEBUG_ERROR, "Failed to get Module Info from Handle! Status = %r\n", Status));
       }
 
-      // MU_CHANGE [END] - CodeQL change
+      StringPtr = NULL;
 
       if (String != NULL) {
         StringPtr = String;
-      } else {
+      } else if (ModuleName != NULL) {
         StringPtr = ModuleName;
       }
 
-      if (AsciiStrLen (StringPtr) == 0) {
+      if ((StringPtr == NULL) || (AsciiStrLen (StringPtr) == 0)) {
         StringPtr = "unknown name";
       }
+
+      // MU_CHANGE [END] - CodeQL change
 
       if (!PcdGetBool (PcdEdkiiFpdtStringRecordEnableOnly)) {
         FpdtRecordPtr.DynamicStringEvent->Header.Type     = FPDT_DYNAMIC_STRING_EVENT_TYPE;
@@ -1229,17 +1231,19 @@ InsertFpdtRecord (
           DEBUG ((DEBUG_ERROR, "Failed to get Module Info from Handle! Status = %r\n", Status));
         }
 
-        // MU_CHANGE [END] - CodeQL change
+        StringPtr = NULL;
 
         if (String != NULL) {
           StringPtr = String;
-        } else {
+        } else if (ModuleName != NULL) {
           StringPtr = ModuleName;
         }
 
-        if (AsciiStrLen (StringPtr) == 0) {
+        if ((StringPtr == NULL) || (AsciiStrLen (StringPtr) == 0)) {
           StringPtr = "unknown name";
         }
+
+        // MU_CHANGE [END] - CodeQL change
 
         if (!PcdGetBool (PcdEdkiiFpdtStringRecordEnableOnly)) {
           FpdtRecordPtr.DynamicStringEvent->Header.Type     = FPDT_DYNAMIC_STRING_EVENT_TYPE;

--- a/MdeModulePkg/Library/DxeCorePerformanceLib/DxeCorePerformanceLib.c
+++ b/MdeModulePkg/Library/DxeCorePerformanceLib/DxeCorePerformanceLib.c
@@ -1191,10 +1191,13 @@ InsertFpdtRecord (
     case PERF_INMODULE_END_ID:
     case PERF_CROSSMODULE_START_ID:
     case PERF_CROSSMODULE_END_ID:
+      // MU_CHANGE [BEGIN] - CodeQL change
       Status = GetModuleInfoFromHandle ((EFI_HANDLE)CallerIdentifier, ModuleName, sizeof (ModuleName), &ModuleGuid);
       if (EFI_ERROR (Status)) {
         DEBUG ((DEBUG_ERROR, "Failed to get Module Info from Handle! Status = %r\n", Status));
       }
+
+      // MU_CHANGE [END] - CodeQL change
 
       if (String != NULL) {
         StringPtr = String;
@@ -1220,10 +1223,13 @@ InsertFpdtRecord (
 
     default:
       if (Attribute != PerfEntry) {
+        // MU_CHANGE [BEGIN] - CodeQL change
         Status = GetModuleInfoFromHandle ((EFI_HANDLE)CallerIdentifier, ModuleName, sizeof (ModuleName), &ModuleGuid);
         if (EFI_ERROR (Status)) {
           DEBUG ((DEBUG_ERROR, "Failed to get Module Info from Handle! Status = %r\n", Status));
         }
+
+        // MU_CHANGE [END] - CodeQL change
 
         if (String != NULL) {
           StringPtr = String;

--- a/MdeModulePkg/Library/SmmCorePerformanceLib/SmmCorePerformanceLib.c
+++ b/MdeModulePkg/Library/SmmCorePerformanceLib/SmmCorePerformanceLib.c
@@ -693,10 +693,13 @@ InsertFpdtRecord (
     case PERF_INMODULE_END_ID:
     case PERF_CROSSMODULE_START_ID:
     case PERF_CROSSMODULE_END_ID:
+      // MU_CHANGE [BEGIN] - CodeQL change
       Status = GetModuleInfoFromHandle ((EFI_HANDLE)CallerIdentifier, ModuleName, sizeof (ModuleName), &ModuleGuid);
       if (EFI_ERROR (Status)) {
         DEBUG ((DEBUG_ERROR, "Failed to get Module Info from Handle! Status = %r\n", Status));
       }
+
+      // MU_CHANGE [END] - CodeQL change
 
       if (String != NULL) {
         StringPtr = String;
@@ -722,10 +725,13 @@ InsertFpdtRecord (
 
     default:
       if (Attribute != PerfEntry) {
+        // MU_CHANGE [BEGIN] - CodeQL change
         Status = GetModuleInfoFromHandle ((EFI_HANDLE)CallerIdentifier, ModuleName, sizeof (ModuleName), &ModuleGuid);
         if (EFI_ERROR (Status)) {
           DEBUG ((DEBUG_ERROR, "Failed to get Module Info from Handle! Status = %r\n", Status));
         }
+
+        // MU_CHANGE [END] - CodeQL change
 
         if (String != NULL) {
           StringPtr = String;

--- a/MdeModulePkg/Library/SmmCorePerformanceLib/SmmCorePerformanceLib.c
+++ b/MdeModulePkg/Library/SmmCorePerformanceLib/SmmCorePerformanceLib.c
@@ -693,7 +693,11 @@ InsertFpdtRecord (
     case PERF_INMODULE_END_ID:
     case PERF_CROSSMODULE_START_ID:
     case PERF_CROSSMODULE_END_ID:
-      GetModuleInfoFromHandle ((EFI_HANDLE)CallerIdentifier, ModuleName, sizeof (ModuleName), &ModuleGuid);
+      Status = GetModuleInfoFromHandle ((EFI_HANDLE)CallerIdentifier, ModuleName, sizeof (ModuleName), &ModuleGuid);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "Failed to get Module Info from Handle! Status = %r\n", Status));
+      }
+
       if (String != NULL) {
         StringPtr = String;
       } else {
@@ -718,7 +722,11 @@ InsertFpdtRecord (
 
     default:
       if (Attribute != PerfEntry) {
-        GetModuleInfoFromHandle ((EFI_HANDLE)CallerIdentifier, ModuleName, sizeof (ModuleName), &ModuleGuid);
+        Status = GetModuleInfoFromHandle ((EFI_HANDLE)CallerIdentifier, ModuleName, sizeof (ModuleName), &ModuleGuid);
+        if (EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_ERROR, "Failed to get Module Info from Handle! Status = %r\n", Status));
+        }
+
         if (String != NULL) {
           StringPtr = String;
         } else {

--- a/MdeModulePkg/Library/SmmCorePerformanceLib/SmmCorePerformanceLib.c
+++ b/MdeModulePkg/Library/SmmCorePerformanceLib/SmmCorePerformanceLib.c
@@ -699,17 +699,19 @@ InsertFpdtRecord (
         DEBUG ((DEBUG_ERROR, "Failed to get Module Info from Handle! Status = %r\n", Status));
       }
 
-      // MU_CHANGE [END] - CodeQL change
+      StringPtr = NULL;
 
       if (String != NULL) {
         StringPtr = String;
-      } else {
+      } else if (ModuleName != NULL) {
         StringPtr = ModuleName;
       }
 
-      if (AsciiStrLen (StringPtr) == 0) {
+      if ((StringPtr == NULL) || (AsciiStrLen (StringPtr) == 0)) {
         StringPtr = "unknown name";
       }
+
+      // MU_CHANGE [END] - CodeQL change
 
       if (!PcdGetBool (PcdEdkiiFpdtStringRecordEnableOnly)) {
         FpdtRecordPtr.DynamicStringEvent->Header.Type     = FPDT_DYNAMIC_STRING_EVENT_TYPE;
@@ -731,17 +733,19 @@ InsertFpdtRecord (
           DEBUG ((DEBUG_ERROR, "Failed to get Module Info from Handle! Status = %r\n", Status));
         }
 
-        // MU_CHANGE [END] - CodeQL change
+        StringPtr = NULL;
 
         if (String != NULL) {
           StringPtr = String;
-        } else {
+        } else if (ModuleName != NULL) {
           StringPtr = ModuleName;
         }
 
-        if (AsciiStrLen (StringPtr) == 0) {
+        if ((StringPtr == NULL) || (AsciiStrLen (StringPtr) == 0)) {
           StringPtr = "unknown name";
         }
+
+        // MU_CHANGE [END] - CodeQL change
 
         if (!PcdGetBool (PcdEdkiiFpdtStringRecordEnableOnly)) {
           FpdtRecordPtr.DynamicStringEvent->Header.Type     = FPDT_DYNAMIC_STRING_EVENT_TYPE;


### PR DESCRIPTION
## Description

Added a few more codeql fixes for the DXE and SMM core performance libs.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on intel physical platforms.  No issues building and booting.

## Integration Instructions

N/A
