### PR TITLE
Fix Python logging.warn() deprecation warnings

### DIFF
--- a/.pytool/Plugin/DebugMacroCheck/DebugMacroCheck.py
+++ b/.pytool/Plugin/DebugMacroCheck/DebugMacroCheck.py
@@ -68,7 +68,7 @@ class GitHelpers:
                         list will be returned.
         """
         if not shutil.which("git"):
-            logging.warn(
+            logging.warning(
                 "Git is not found on this system. Git submodule paths will "
                 "not be considered.")
             return []

--- a/.pytool/Plugin/ImageValidation/ImageValidation.py
+++ b/.pytool/Plugin/ImageValidation/ImageValidation.py
@@ -102,7 +102,7 @@ class ImageValidation(IUefiBuildPlugin):
                         efi_path = edk2.GetAbsolutePathOnThisSystemFromEdk2RelativePath(
                             efi_path)
                         if efi_path == None:
-                            logging.warn(
+                            logging.warning(
                                 "Unable to parse the path to the pre-compiled efi")
                             continue
                         if os.path.basename(efi_path) in self.ignore_list:
@@ -119,11 +119,11 @@ class ImageValidation(IUefiBuildPlugin):
         for arch in thebuilder.env.GetValue("TARGET_ARCH").split():
             efi_path_list = self._walk_directory_for_extension(
                 ['.efi'], f'{thebuilder.env.GetValue("BUILD_OUTPUT_BASE")}/{arch}')
-            
+
             for efi_path in efi_path_list:
                 if os.path.basename(efi_path) in self.ignore_list:
                     continue
-                
+
                 # Perform Image Verification on any output efi's
                 # Grab profile from makefile
                 if efi_path.__contains__("OUTPUT"):
@@ -131,27 +131,27 @@ class ImageValidation(IUefiBuildPlugin):
                         if tool_chain_tag.__contains__("VS"):
                             profile = self._get_profile_from_makefile(
                                 f'{Path(efi_path).parent.parent}/Makefile')
-                    
+
                         elif tool_chain_tag.__contains__("GCC"):
                             profile = self._get_profile_from_makefile(
                                 f'{Path(efi_path).parent.parent}/GNUmakefile')
-                        
+
                         elif tool_chain_tag.__contains__("CLANG"):
                             profile = self._get_profile_from_makefile(
                                 f'{Path(efi_path).parent.parent}/GNUmakefile')
                         else:
-                            logging.warn("Unexpected TOOL_CHAIN_TAG... Cannot parse makefile. Using DEFAULT profile.")
+                            logging.warning("Unexpected TOOL_CHAIN_TAG... Cannot parse makefile. Using DEFAULT profile.")
                             profile = "DEFAULT"
                     except:
-                        logging.warn(f'Failed to parse makefile at [{Path(efi_path).parent.parent}/GNUmakefile]')
-                        logging.warn(f'Using DEFAULT profile')
+                        logging.warning(f'Failed to parse makefile at [{Path(efi_path).parent.parent}/GNUmakefile]')
+                        logging.warning(f'Using DEFAULT profile')
                         profile = "DEFAULT"
 
                     logging.info(
                         f'Performing Image Verification ... {os.path.basename(efi_path)}')
                     if self._validate_image(efi_path, profile) == Result.FAIL:
                         result = Result.FAIL
-                    count += 1                
+                    count += 1
         # End Built Time Compiled Image Verification
 
         endtime = datetime.now()

--- a/.pytool/Plugin/LineEndingCheck/LineEndingCheck.py
+++ b/.pytool/Plugin/LineEndingCheck/LineEndingCheck.py
@@ -88,7 +88,7 @@ class LineEndingCheck(ICiBuildPlugin):
 
     # Note: This function access git via the command line
     #
-    #   function to check and warn if git config reports that 
+    #   function to check and warn if git config reports that
     #   autocrlf is configured to TRUE
     def _check_autocrlf(self):
         r = Repo(".")
@@ -121,7 +121,7 @@ class LineEndingCheck(ICiBuildPlugin):
             If git is not found, an empty list will be returned.
         """
         if not shutil.which("git"):
-            logging.warn(
+            logging.warning(
                 "Git is not found on this system. Git submodule paths will "
                 "not be considered.")
             return []
@@ -162,7 +162,7 @@ class LineEndingCheck(ICiBuildPlugin):
             If git is not found, an empty list will be returned.
         """
         if not shutil.which("git"):
-            logging.warn(
+            logging.warning(
                 "Git is not found on this system. Git submodule paths will "
                 "not be considered.")
             return []
@@ -271,7 +271,7 @@ class LineEndingCheck(ICiBuildPlugin):
         for file in Path(self._abs_pkg_path).rglob('*'):
             if file.is_dir():
                 continue
-            
+
             if any(file.is_relative_to(ignore_dir) for ignore_dir in ignore_dirs):
                 continue
 
@@ -280,7 +280,7 @@ class LineEndingCheck(ICiBuildPlugin):
 
             if file in ignore_files:
                 continue
-            
+
             with open(file.resolve(), 'rb') as fb:
                 if not fb.readable() or _is_binary_string(fb.read(1024)):
                     continue

--- a/.pytool/Plugin/UncrustifyCheck/UncrustifyCheck.py
+++ b/.pytool/Plugin/UncrustifyCheck/UncrustifyCheck.py
@@ -310,7 +310,7 @@ class UncrustifyCheck(ICiBuildPlugin):
         If git is not found, an empty list will be returned.
         """
         if not shutil.which("git"):
-            logging.warn(
+            logging.warning(
                 "Git is not found on this system. Git submodule paths will not be considered.")
             return []
 
@@ -336,7 +336,7 @@ class UncrustifyCheck(ICiBuildPlugin):
         If git is not found, an empty list will be returned.
         """
         if not shutil.which("git"):
-            logging.warn(
+            logging.warning(
                 "Git is not found on this system. Git submodule paths will not be considered.")
             return []
 
@@ -383,9 +383,9 @@ class UncrustifyCheck(ICiBuildPlugin):
                 file_template_path = pathlib.Path(os.path.join(self._plugin_path, file_template_name))
                 self._file_template_contents = file_template_path.read_text()
         except KeyError:
-            logging.warn("A file header template is not specified in the config file.")
+            logging.warning("A file header template is not specified in the config file.")
         except FileNotFoundError:
-            logging.warn("The specified file header template file was not found.")
+            logging.warning("The specified file header template file was not found.")
         try:
             func_template_name = parser["dummy_section"]["cmt_insert_func_header"]
 
@@ -395,9 +395,9 @@ class UncrustifyCheck(ICiBuildPlugin):
                 func_template_path = pathlib.Path(os.path.join(self._plugin_path, func_template_name))
                 self._func_template_contents = func_template_path.read_text()
         except KeyError:
-            logging.warn("A function header template is not specified in the config file.")
+            logging.warning("A function header template is not specified in the config file.")
         except FileNotFoundError:
-            logging.warn("The specified function header template file was not found.")
+            logging.warning("The specified function header template file was not found.")
 
     def _initialize_app_info(self) -> None:
         """
@@ -579,7 +579,6 @@ class UncrustifyCheck(ICiBuildPlugin):
                 "how to find the detailed formatting errors in Azure "
                 "DevOps CI: "
                 "https://github.com/tianocore/tianocore.github.io/wiki/EDK-II-Code-Formatting#how-to-find-uncrustify-formatting-errors-in-continuous-integration-ci")
-            
 
             if self._output_file_diffs:
                 logging.info("Calculating file diffs. This might take a while...")

--- a/PolicyServicePkg/Plugins/UpdatePolicyHdr/UpdatePolicyHdr.py
+++ b/PolicyServicePkg/Plugins/UpdatePolicyHdr/UpdatePolicyHdr.py
@@ -85,7 +85,7 @@ class UpdatePolicyHdr(IUefiBuildPlugin):
     def do_pre_build(self, thebuilder):
         need_check = thebuilder.env.GetValue("UPDATE_SETTINGS")
         if need_check is not None and need_check.upper() == "FALSE":
-            logging.warn ("Platform indicated as not checking YAML file changes, will not be updated!")
+            logging.warning("Platform indicated as not checking YAML file changes, will not be updated!")
             return 0
 
         yaml_list = []
@@ -159,7 +159,7 @@ class UpdatePolicyHdr(IUefiBuildPlugin):
 
             conf_file = setting
             if conf_file is None:
-                logging.warn ("YAML file not specified, system might not work as expected!!!")
+                logging.warning("YAML file not specified, system might not work as expected!!!")
                 return 0
             if not os.path.isfile(conf_file):
                 logging.error ("YAML file specified is not found!!!")


### PR DESCRIPTION
## Description

Updates `logging.warn()` to `logging.warning()` to prevent
deprecation warnings like this:

  .pytool\Plugin\UncrustifyCheck\UncrustifyCheck.py:386:
    DeprecationWarning: The 'warn' function is deprecated, use
    'warning' instead

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- Review Python code for `log.warn()` usage
- Check logs that reported issue earlier after changee

## Integration Instructions

N/A