### PR TITLE
Resolve mws deprecations

### DIFF
--- a/.pytool/Plugin/CodeQL/CodeQlAnalyzePlugin.py
+++ b/.pytool/Plugin/CodeQL/CodeQlAnalyzePlugin.py
@@ -35,18 +35,18 @@ class CodeQlAnalyzePlugin(IUefiBuildPlugin):
             int: The number of CodeQL errors found. Zero indicates that
             AuditOnly mode is enabled or no failures were found.
         """
-
-        pp = builder.pp.split(os.pathsep)
-        edk2_path = Edk2Path(builder.ws, pp)
-
         self.builder = builder
-        self.package = edk2_path.GetContainingPackage(
-                            builder.mws.join(builder.ws,
-                                             builder.env.GetValue(
-                                                "ACTIVE_PLATFORM")))
+        self.package = builder.edk2path.GetContainingPackage(
+            builder.edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath(
+                builder.env.GetValue("ACTIVE_PLATFORM")
+            )
+        )
+
         self.package_path = Path(
-            edk2_path.GetAbsolutePathOnThisSystemFromEdk2RelativePath(
-                self.package))
+            builder.edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath(
+                self.package
+            )
+        )
         self.target = builder.env.GetValue("TARGET")
 
         self.codeql_db_path = codeql_plugin.get_codeql_db_path(

--- a/.pytool/Plugin/CodeQL/CodeQlBuildPlugin.py
+++ b/.pytool/Plugin/CodeQL/CodeQlBuildPlugin.py
@@ -36,14 +36,13 @@ class CodeQlBuildPlugin(IUefiBuildPlugin):
         """
 
         if not builder.SkipBuild:
-            pp = builder.pp.split(os.pathsep)
-            edk2_path = Edk2Path(builder.ws, pp)
-
             self.builder = builder
-            self.package = edk2_path.GetContainingPackage(
-                                builder.mws.join(builder.ws,
-                                                builder.env.GetValue(
-                                                    "ACTIVE_PLATFORM")))
+            self.package = builder.GetContainingPackage(
+                builder.edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath(
+                    builder.env.GetValue("ACTIVE_PLATFORM")
+                )
+            )
+
             self.target = builder.env.GetValue("TARGET")
 
             self.build_output_dir = builder.env.GetValue("BUILD_OUTPUT_BASE")
@@ -89,9 +88,11 @@ class CodeQlBuildPlugin(IUefiBuildPlugin):
             # Since it's unclear how quotes are handled and may change in the
             # future, this code is going to use the workaround to place the
             # command in an executable file that is instead passed to CodeQL.
-            self.codeql_cmd_path = Path(builder.mws.join(
-                                        builder.ws, self.build_output_dir,
-                                        "codeql_build_command"))
+            self.codeql_cmd_path = Path(
+                builder.edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath(
+                    self.build_output_dir, "codeql_build_command"
+                )
+            )
 
             build_params = self._get_build_params()
 

--- a/.pytool/Plugin/CodeQL/CodeQlBuildPlugin.py
+++ b/.pytool/Plugin/CodeQL/CodeQlBuildPlugin.py
@@ -88,11 +88,7 @@ class CodeQlBuildPlugin(IUefiBuildPlugin):
             # Since it's unclear how quotes are handled and may change in the
             # future, this code is going to use the workaround to place the
             # command in an executable file that is instead passed to CodeQL.
-            self.codeql_cmd_path = Path(
-                builder.edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath(
-                    self.build_output_dir, "codeql_build_command"
-                )
-            )
+            self.codeql_cmd_path = Path(self.build_output_dir, "codeql_build_command")
 
             build_params = self._get_build_params()
 

--- a/.pytool/Plugin/CodeQL/CodeQlBuildPlugin.py
+++ b/.pytool/Plugin/CodeQL/CodeQlBuildPlugin.py
@@ -37,7 +37,7 @@ class CodeQlBuildPlugin(IUefiBuildPlugin):
 
         if not builder.SkipBuild:
             self.builder = builder
-            self.package = builder.GetContainingPackage(
+            self.package = builder.edk2path.GetContainingPackage(
                 builder.edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath(
                     builder.env.GetValue("ACTIVE_PLATFORM")
                 )

--- a/.pytool/Plugin/DebugMacroCheck/BuildPlugin/DebugMacroCheckBuildPlugin.py
+++ b/.pytool/Plugin/DebugMacroCheck/BuildPlugin/DebugMacroCheckBuildPlugin.py
@@ -58,12 +58,12 @@ class DebugMacroCheckBuildPlugin(IUefiBuildPlugin):
         if "no-target" in build_target:
             return 0
 
-        pp = builder.pp.split(os.pathsep)
-        edk2 = Edk2Path(builder.ws, pp)
+        edk2 = builder.edk2path
         package = edk2.GetContainingPackage(
-                            builder.mws.join(builder.ws,
-                                             builder.env.GetValue(
-                                                "ACTIVE_PLATFORM")))
+            builder.edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath(
+                builder.env.GetValue("ACTIVE_PLATFORM")
+            )
+        )
         package_path = Path(
                           edk2.GetAbsolutePathOnThisSystemFromEdk2RelativePath(
                                 package))

--- a/.pytool/Plugin/ImageValidation/ImageValidation.py
+++ b/.pytool/Plugin/ImageValidation/ImageValidation.py
@@ -68,9 +68,7 @@ class ImageValidation(IUefiBuildPlugin):
         fdf_parser = FdfParser()
         dsc_parser = DscParser()
 
-        ws = thebuilder.ws
-        pp = thebuilder.pp.split(os.pathsep)
-        edk2 = Edk2Path(ws, pp)
+        edk2 = thebuilder.edk2path
 
         ActiveDsc = edk2.GetAbsolutePathOnThisSystemFromEdk2RelativePath(
             thebuilder.env.GetValue("ACTIVE_PLATFORM"))

--- a/BaseTools/Plugin/BmpCheck/BmpCheckPlugin.py
+++ b/BaseTools/Plugin/BmpCheck/BmpCheckPlugin.py
@@ -121,9 +121,7 @@ class BmpCheckPlugin(IUefiBuildPlugin):
             fp = FdfParser()
             dp = DscParser()
 
-            ws = thebuilder.ws
-            pp = thebuilder.pp.split(";")
-            edk2 = Edk2Path(ws, pp)
+            edk2 = thebuilder.edk2path
 
             ActiveDsc = edk2.GetAbsolutePathOnThisSystemFromEdk2RelativePath(
                 thebuilder.env.GetValue("ACTIVE_PLATFORM"))

--- a/BaseTools/Plugin/FdSizeReport/FdSizeReportGenerator.py
+++ b/BaseTools/Plugin/FdSizeReport/FdSizeReportGenerator.py
@@ -53,7 +53,7 @@ try:
             #1 - Get the output path for report file
             OutF = thebuilder.env.GetValue("FDSIZEREPORT_FILE")
             #2 - Get the FDF path
-            FdfF = thebuilder.mws.join(thebuilder.ws, thebuilder.env.GetValue("FLASH_DEFINITION"))
+            FdfF = thebuilder.edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath(thebuilder.env.GetValue("FLASH_DEFINITION"))
             #3 - Get the product name
             Product = thebuilder.env.GetValue("PRODUCT_NAME")
             if Product is None:

--- a/PolicyServicePkg/Plugins/UpdatePolicyHdr/UpdatePolicyHdr.py
+++ b/PolicyServicePkg/Plugins/UpdatePolicyHdr/UpdatePolicyHdr.py
@@ -90,17 +90,15 @@ class UpdatePolicyHdr(IUefiBuildPlugin):
 
         yaml_list = []
         exception_list = []
-        ws = thebuilder.ws
-        pp = thebuilder.pp.split(os.pathsep)
-        edk2 = Edk2Path(ws, pp)
+        edk2 = thebuilder.edk2path
 
         # Form the exception list of formatted absolute paths. And always ignore our own samples.
-        exception_list.append (thebuilder.mws.join (thebuilder.ws, "PolicyServicePkg", "Samples"))
+        exception_list.append (edk2.GetAbsolutePathOnThisSystemFromEdk2RelativePath("PolicyServicePkg", "Samples"))
         platform_exception = thebuilder.env.GetValue("POLICY_IGNORE_PATHS")
         if platform_exception is not None:
           plat_list = platform_exception.split(';')
           for each in plat_list:
-            exception_list.append(os.path.normpath (thebuilder.mws.join (thebuilder.ws, each)))
+            exception_list.append(os.path.normpath (edk2.GetAbsolutePathOnThisSystemFromEdk2RelativePath(each)))
 
         # Look for *_policy_def.yaml files in all package paths.
         for pkg_path in pp:
@@ -151,11 +149,11 @@ class UpdatePolicyHdr(IUefiBuildPlugin):
               os.mkdir (final_dir)
 
             # Set up a playground first
-            op_dir = thebuilder.mws.join(thebuilder.ws, thebuilder.env.GetValue("BUILD_OUTPUT_BASE"), "ConfPolicy")
+            op_dir = thebuilder.edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath(thebuilder.env.GetValue("BUILD_OUTPUT_BASE"), "ConfPolicy")
             if not os.path.isdir(op_dir):
                 os.makedirs(op_dir)
 
-            cmd = thebuilder.mws.join(thebuilder.ws, "PolicyServicePkg", "Tools", "GenCfgData.py")
+            cmd = thebuilder.edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath("PolicyServicePkg", "Tools", "GenCfgData.py")
 
             conf_file = setting
             if conf_file is None:


### PR DESCRIPTION
## Description

thebuilder.mws was deprecated in favor of thebuilder.edk2path. this commit removes any usage of thebuilder.mws and replaces it with thebuilder.edk2path. Now that edk2path is available, it also removes the manual instantiation of an Edk2Path object in favor of the existing edk2path that is now associated with thebuilder.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [x] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

verified `stuart_ci_build` success for MU_BASECORE
verified `stuart_build` success for mu_tiano_platforms

## Integration Instructions

Ensure edk2-pytool-extensions is v0.24.0 or greater.