### PR TITLE
LineEndingCheck: bugfix: Fails if not run from workspace root

### DIFF
--- a/.pytool/Plugin/LineEndingCheck/LineEndingCheck.py
+++ b/.pytool/Plugin/LineEndingCheck/LineEndingCheck.py
@@ -91,7 +91,7 @@ class LineEndingCheck(ICiBuildPlugin):
     #   function to check and warn if git config reports that
     #   autocrlf is configured to TRUE
     def _check_autocrlf(self):
-        r = Repo(".")
+        r = Repo(self._abs_workspace_path)
         try:
             result = r.config_reader().get_value("core", "autocrlf")
             if result:
@@ -250,9 +250,8 @@ class LineEndingCheck(ICiBuildPlugin):
           0  : Ran successfully
           -1 : Skipped due to a missing pre-requisite
         """
+        self._abs_workspace_path = edk2_path.WorkspacePath
         self._check_autocrlf()
-        self._abs_workspace_path = \
-            edk2_path.GetAbsolutePathOnThisSystemFromEdk2RelativePath('.')
         self._abs_pkg_path = \
             edk2_path.GetAbsolutePathOnThisSystemFromEdk2RelativePath(
                         package_rel_path)


### PR DESCRIPTION
## Description

LineEndingCheck would fail if `stuart_ci_build` was not run from the workspace root because of two separate locations that used "." for the workspace root rather than the true workspace root. This commit updates it to use the true workspace root rather than ".".

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

CI

## Integration Instructions

N/A
