### PR TITLE
Skip Time-Based Auth Variable Deletion Test if User is Present

### DIFF
--- a/MdeModulePkg/Test/ShellTest/VariablePolicyFuncTestApp/VariablePolicyFuncTestApp.c
+++ b/MdeModulePkg/Test/ShellTest/VariablePolicyFuncTestApp/VariablePolicyFuncTestApp.c
@@ -17,6 +17,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/UefiRuntimeServicesTableLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/MemoryAllocationLib.h>
+#include <Library/PlatformSecureLib.h>
 
 #include "VariablePolicyFuncTestInternal.h"
 
@@ -2278,6 +2279,15 @@ TestAuthVarPart1 (
   UINTN       DataSize;
   UINT8       *DeleteData;
 
+  if (UserPhysicalPresent ()) {
+    UT_LOG_INFO (
+      "User is present. Testing the deletion of time-based authenticated variables \
+is not possible because deletion is allowed when the user is physically present. \
+See PlatformSecureLib for more info.\n"
+      );
+    return UNIT_TEST_SKIPPED;
+  }
+
   // First, we need to create our dummy Authenticated Variable.
   Status = gRT->SetVariable (
                   TEST_AUTH_VAR_NAME,
@@ -2335,6 +2345,15 @@ TestAuthVarPart2 (
   UINT32      Data;
   UINTN       DataSize;
   UINT8       *DeleteData;
+
+  if (UserPhysicalPresent ()) {
+    UT_LOG_INFO (
+      "User is present. Testing the deletion of time-based authenticated variables \
+is not possible because deletion is allowed when the user is physically present. \
+See PlatformSecureLib for more info.\n"
+      );
+    return UNIT_TEST_SKIPPED;
+  }
 
   // Prove that it exists.
   DataSize = sizeof (Data);

--- a/MdeModulePkg/Test/ShellTest/VariablePolicyFuncTestApp/VariablePolicyFuncTestApp.inf
+++ b/MdeModulePkg/Test/ShellTest/VariablePolicyFuncTestApp/VariablePolicyFuncTestApp.inf
@@ -28,6 +28,7 @@
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec
   UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  SecurityPkg/SecurityPkg.dec
 
 [LibraryClasses]
   UefiApplicationEntryPoint
@@ -40,6 +41,7 @@
   UefiRuntimeServicesTableLib
   MemoryAllocationLib
   VariablePolicyHelperLib
+  PlatformSecureLib
 
 [Guids]
   gEfiCertPkcs7Guid


### PR DESCRIPTION
## Description

One of the unit tests in VariablePolicyFuncTestApp will create a time-based authenticated variable and then attempt to delete it. If the user is present, the deletion will succeed which will cause the test to fail. This patch will skip the test if the user is present and provide a warning message.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [x] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on Q35

## Integration Instructions

N/A
