### PR TITLE
.pytool/Plugin/RustHostUnitTestPlugin: Handle no coverage results

### DIFF
--- a/.pytool/Plugin/RustHostUnitTestPlugin/RustHostUnitTestPlugin.py
+++ b/.pytool/Plugin/RustHostUnitTestPlugin/RustHostUnitTestPlugin.py
@@ -85,18 +85,19 @@ class RustHostUnitTestPlugin(ICiBuildPlugin):
 
         # Move coverage.xml to Build Directory
         xml = Path(rust_ws.path) / "target" / "cobertura.xml"
-        out = Path(rust_ws.path) / "Build"
+        if xml.exists():
+            out = Path(rust_ws.path) / "Build"
 
-        if (out / "coverage.xml").exists():
-            (out / "coverage.xml").unlink()
-        xml = xml.rename(out / "coverage.xml")
+            if (out / "coverage.xml").exists():
+                (out / "coverage.xml").unlink()
+            xml = xml.rename(out / "coverage.xml")
 
-        with open(xml, 'r') as f:
-            contents = f.read()
-            contents = re.sub(r'<source>(.*?)</source>', r'<source>.</source>', contents)
+            with open(xml, 'r') as f:
+                contents = f.read()
+                contents = re.sub(r'<source>(.*?)</source>', r'<source>.</source>', contents)
 
-        with open (xml, "w") as f:
-            f.write(contents)
+            with open (xml, "w") as f:
+                f.write(contents)
 
         # Return
         if failed > 0:


### PR DESCRIPTION
## Description

In the case that all possible crates are ignored, do not fail if
a `cobertura.xml` file is not present.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- Ran builds with and without Rust unit test results
- Checked locally and in CI

## Integration Instructions

N/A