### PR TITLE
OverrideValidation: bugfix handling file missing from workspace

### DIFF
--- a/BaseTools/Plugin/OverrideValidation/OverrideValidation.py
+++ b/BaseTools/Plugin/OverrideValidation/OverrideValidation.py
@@ -289,9 +289,9 @@ try:
             # Step 2: Process the path to overridden module
             # Normalize the path to support different slashes, then strip the initial '\\' to make sure os.path.join will work correctly
             overriddenpath = os.path.normpath(OverrideEntry[1].strip()).strip('\\')
-            fullpath = os.path.normpath(thebuilder.edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath(overriddenpath))
+            fullpath = thebuilder.edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath(overriddenpath, log_errors=False)
             # Search overridden module in workspace
-            if not os.path.isfile(fullpath) and not os.path.isdir(fullpath):
+            if fullpath is None:
                 logging.info("Inf Overridden File/Path Not Found in Workspace or Packages_Path: %s" %(overriddenpath))
                 result = self.OverrideResult.OR_TARGET_INF_NOT_FOUND
                 m_node.path = overriddenpath
@@ -352,8 +352,8 @@ try:
             # if we failed, do a diff of the overridden file (as long as exist) and show the output
             if result != self.OverrideResult.OR_ALL_GOOD and result != self.OverrideResult.OR_TARGET_INF_NOT_FOUND:
                 overriddenpath = os.path.normpath(OverrideEntry[1].strip()).strip('\\')
-                fullpath = os.path.normpath(thebuilder.edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath(overriddenpath))
-                if os.path.exists(fullpath):
+                fullpath = thebuilder.edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath(overriddenpath, log_errors=False)
+                if fullpath is not None:
                     patch = ModuleGitPatch(fullpath, GitHash)
                     # TODO: figure out how to get the log file
                 pnt_str = f"Override diff since last update at commit {GitHash}"


### PR DESCRIPTION
## Description

OverrideValidation supports multiple overrides from multiple sources. In a repository where each platform initializes a subset of submodules rather than all submodules, some of the files for the override may not exist.

When removing the deprecated mws.join() functionality, the ability to handle this scenario was lost.
GetAbsolutePathOnThisSystemFromEdk2RelativePath only returns a path if the file or directory exists, otherwise it returns None. Therefore the changes made check for None rather than checking if the file / path exists.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

CI and various platforms that have the scenario this fixes.

## Integration Instructions

N/A
