### PR TITLE
CodeQlFilters.yml: Glob file patterns in nested directories

### DIFF
--- a/CodeQlFilters.yml
+++ b/CodeQlFilters.yml
@@ -1,8 +1,13 @@
 ## @file
 # CodeQL Result Filters for Packages in Mu Basecore
 #
-# Note: Packages that use Mu Basecore can reuse this file to quickly pick up the
-#       same filters applied to results in the Mu Basecore repo.
+# Note:
+#   1. Packages that use Mu Basecore can reuse this file to quickly pick up the
+#      same filters applied to results in the Mu Basecore repo.
+#   2. It is recommended paths begin with `**/` in filter files residing in repos that
+#      are used as dependencies by other repos (e.g. MU_BASECORE). That way the filter
+#      will apply both in MU_BASECORE directly and regardless of where MU_BASECORE is
+#      located within a downstream repos directory hierarchy.
 #
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -10,39 +15,36 @@
 
 {
   "Filters": [
-    "-CryptoPkg/Library/BaseCryptLib/**/*.c:SM02690",
-    "-CryptoPkg/Library/BaseCryptLib/Pk/CryptDh.c:SM02311",
-    "-CryptoPkg/Library/BaseCryptLib/Pk/CryptRsaBasic.c:SM02311",
-    "-CryptoPkg/Library/BaseCryptLib/SysCall/TimerWrapper.c:SM02320",
-    "-CryptoPkg/Library/OpensslLib/**/*.c:*",
-    "-MdeModulePkg/Bus/Pci/PciBusDxe/PciResourceSupport.c:SM02311",
-    "-MdeModulePkg/Core/Pei/Ppi/Ppi.c:cpp/overflow-buffer",
-    "-MdeModulePkg/Library/UefiBootManagerLib/BmConsole.c:SM02311",
-    "-MdeModulePkg/Library/UefiBootManagerLib/BmMisc.c:SM02311",
-    "-MdeModulePkg/Universal/Acpi/S3SaveStateDxe/AcpiS3ContextSave.c:SM02311",
-    "-MdeModulePkg/Universal/BdsDxe/BdsEntry.c:SM02311",
-    "-MdeModulePkg/Universal/Console/ConPlatformDxe/ConPlatform.c:SM02311",
-    "-MdeModulePkg/Universal/Disk/UdfDxe/FileName.c:cpp/uselesstest",
-    "-MdeModulePkg/Universal/Disk/UdfDxe/FileName.c:cpp/uselesstest",
-    "-MdeModulePkg/Universal/Disk/UdfDxe/FileName.c:cpp/uselesstest",
-    "-MdeModulePkg/Universal/Disk/UdfDxe/FileSystemOperations.c:cpp/uselesstest",
-    "-MdeModulePkg/Universal/DriverSampleDxe/**:*",
-    "-MdeModulePkg/Universal/EbcDxe/EbcDebugger/EdbSupportString.c:cpp/uselesstest",
-    "-MdeModulePkg/Universal/EbcDxe/EbcDebugger/EdbSupportString.c:cpp/uselesstest",
-    "-MdeModulePkg/Universal/RegularExpressionDxe/oniguruma/src/**/*.c:*",
-    "-MdePkg/Library/UefiDevicePathLib/DevicePathFromText.c:SM02311",
-    "-MdePkg/Library/UefiDevicePathLib/DevicePathUtilities.c:SM02311",
-    "-MdePkg/Library/UefiDevicePathLibDevicePathProtocol/UefiDevicePathLib.c:SM02311",
+    "-**/CryptoPkg/Library/BaseCryptLib/**/*.c:SM02690",
+    "-**/CryptoPkg/Library/BaseCryptLib/Pk/CryptDh.c:SM02311",
+    "-**/CryptoPkg/Library/BaseCryptLib/Pk/CryptRsaBasic.c:SM02311",
+    "-**/CryptoPkg/Library/BaseCryptLib/SysCall/TimerWrapper.c:SM02320",
+    "-**/CryptoPkg/Library/OpensslLib/**/*.c:*",
+    "-**/MdeModulePkg/Bus/Pci/PciBusDxe/PciResourceSupport.c:SM02311",
+    "-**/MdeModulePkg/Core/Pei/Ppi/Ppi.c:cpp/overflow-buffer",
+    "-**/MdeModulePkg/Library/UefiBootManagerLib/BmConsole.c:SM02311",
+    "-**/MdeModulePkg/Library/UefiBootManagerLib/BmMisc.c:SM02311",
+    "-**/MdeModulePkg/Universal/Acpi/S3SaveStateDxe/AcpiS3ContextSave.c:SM02311",
+    "-**/MdeModulePkg/Universal/BdsDxe/BdsEntry.c:SM02311",
+    "-**/MdeModulePkg/Universal/Console/ConPlatformDxe/ConPlatform.c:SM02311",
+    "-**/MdeModulePkg/Universal/Disk/UdfDxe/FileName.c:cpp/uselesstest",
+    "-**/MdeModulePkg/Universal/Disk/UdfDxe/FileSystemOperations.c:cpp/uselesstest",
+    "-**/MdeModulePkg/Universal/DriverSampleDxe/**:*",
+    "-**/MdeModulePkg/Universal/EbcDxe/EbcDebugger/EdbSupportString.c:cpp/uselesstest",
+    "-**/MdeModulePkg/Universal/RegularExpressionDxe/oniguruma/src/**/*.c:*",
+    "-**/MdePkg/Library/UefiDevicePathLib/DevicePathFromText.c:SM02311",
+    "-**/MdePkg/Library/UefiDevicePathLib/DevicePathUtilities.c:SM02311",
+    "-**/MdePkg/Library/UefiDevicePathLibDevicePathProtocol/UefiDevicePathLib.c:SM02311",
     # Todo: Exclude for now, needs more review and testing
-    "-NetworkPkg/Ip6Dxe/Ip6Output.c:SM02313",
+    "-**/NetworkPkg/Ip6Dxe/Ip6Output.c:SM02313",
     # Todo: Exclude for now, needs more review and testing
-    "-NetworkPkg/Ip6Dxe/Ip6Output.c:cpp/likely-bugs/memory-management/v2/conditionally-uninitialized-variable",
-    "-ShellPkg/Application/Shell/ShellManParser.c:cpp/redundant-null-check-param",
-    "-ShellPkg/Application/Shell/ShellProtocol.c:SM02311",
-    "-ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Aest/AestParser.c:cpp/overflow-buffer",
-    "-ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Iort/IortParser.c:cpp/overflow-buffer",
-    "-ShellPkg/Library/UefiShellDebug1CommandsLib/DmpStore.c:SM02311",
-    "-ShellPkg/Library/UefiShellLevel2CommandsLib/Map.c:SM02311",
-    "-ShellPkg/Library/UefiShellLevel3CommandsLib/Alias.c:SM02311",
+    "-**/NetworkPkg/Ip6Dxe/Ip6Output.c:cpp/likely-bugs/memory-management/v2/conditionally-uninitialized-variable",
+    "-**/ShellPkg/Application/Shell/ShellManParser.c:cpp/redundant-null-check-param",
+    "-**/ShellPkg/Application/Shell/ShellProtocol.c:SM02311",
+    "-**/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Aest/AestParser.c:cpp/overflow-buffer",
+    "-**/ShellPkg/Library/UefiShellAcpiViewCommandLib/Parsers/Iort/IortParser.c:cpp/overflow-buffer",
+    "-**/ShellPkg/Library/UefiShellDebug1CommandsLib/DmpStore.c:SM02311",
+    "-**/ShellPkg/Library/UefiShellLevel2CommandsLib/Map.c:SM02311",
+    "-**/ShellPkg/Library/UefiShellLevel3CommandsLib/Alias.c:SM02311",
   ]
 }


### PR DESCRIPTION
## Description

This filter file is picked up both directly in `mu_basecore` but also
downstream repos. Therefore, the file patterns should allow matches
regardless of where a `mu_basecore` submodule or external dependency
may reside in the overall repo structure.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- Verified local `mu_basecore` CodeQL build
- Verified downstream (`mu_tiano_platforms`) CodeQL build that leverages
  the `CodeQlFilters.yml` file from `mu_basecore`.

## Integration Instructions

No change in filtering behavior within `mu_basecore`. Downstream repos that use
`mu_basecore` will see more results auto filtered matching the expectations of
upstream repos.