### PR TITLE
MdeModulePkg/VariablePolicyLib: Use wildcard character constant

### DIFF
--- a/MdeModulePkg/Library/VariablePolicyLib/VariablePolicyLib.c
+++ b/MdeModulePkg/Library/VariablePolicyLib/VariablePolicyLib.c
@@ -180,7 +180,7 @@ IsValidVariablePolicyStructure (
     WildcardCount = 0;
     while (*CheckChar != CHAR_NULL) {
       // Make sure there aren't excessive wildcards.
-      if (*CheckChar == '#') {
+      if (*CheckChar == L'#') {
         WildcardCount++;
         if (WildcardCount > MATCH_PRIORITY_MIN) {
           return FALSE;
@@ -265,7 +265,7 @@ EvaluatePolicyMatch (
   // Keep going until the end of both strings.
   while (PolicyName[Index] != CHAR_NULL || VariableName[Index] != CHAR_NULL) {
     // If we don't have a match...
-    if ((PolicyName[Index] != VariableName[Index]) || (PolicyName[Index] == '#')) {
+    if ((PolicyName[Index] != VariableName[Index]) || (PolicyName[Index] == L'#')) {
       // If this is a numerical wildcard, we can consider
       // it a match if we alter the priority.
       if ((PolicyName[Index] == L'#') &&

--- a/MdeModulePkg/Library/VariablePolicyLib/VariablePolicyUnitTest/VariablePolicyUnitTest.c
+++ b/MdeModulePkg/Library/VariablePolicyLib/VariablePolicyUnitTest/VariablePolicyUnitTest.c
@@ -27,7 +27,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/VariablePolicyLib.h>
 
 #ifndef INTERNAL_UNIT_TEST
-  #error Make sure to build thie with INTERNAL_UNIT_TEST enabled! Otherwise, some important tests may be skipped!
+  #error Make sure to build this with INTERNAL_UNIT_TEST enabled! Otherwise, some important tests may be skipped!
 #endif
 
 #define UNIT_TEST_NAME     "UEFI Variable Policy UnitTest"
@@ -489,6 +489,37 @@ WildcardPoliciesShouldMatchDigitsAdvanced (
   UT_ASSERT_TRUE (EvaluatePolicyMatch (&MatchCheckPolicy.Header, CheckValidString, &mTestGuid1, &MatchPriority));
   UT_ASSERT_TRUE (EvaluatePolicyMatch (&MatchCheckPolicy.Header, CheckValidHexString, &mTestGuid1, &MatchPriority));
   UT_ASSERT_EQUAL (MatchPriority, MAX_UINT8);
+
+  return UNIT_TEST_PASSED;
+}
+
+/**
+  Test case to check that excessive wildcard characters are rejected.
+
+  @param        Context
+  **/
+UNIT_TEST_STATUS
+EFIAPI
+ExcessiveWilcardCharactersShouldBeRejected (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  SIMPLE_VARIABLE_POLICY_ENTRY  TestPolicy = {
+    {
+      VARIABLE_POLICY_ENTRY_REVISION,
+      sizeof (VARIABLE_POLICY_ENTRY) + sizeof (TEST_300_HASHES_STRING),
+      sizeof (VARIABLE_POLICY_ENTRY),
+      TEST_GUID_1,
+      TEST_POLICY_MIN_SIZE_NULL,
+      TEST_POLICY_MAX_SIZE_NULL,
+      TEST_POLICY_ATTRIBUTES_NULL,
+      TEST_POLICY_ATTRIBUTES_NULL,
+      VARIABLE_POLICY_TYPE_NO_LOCK
+    },
+    TEST_300_HASHES_STRING
+  };
+
+  UT_ASSERT_TRUE (EFI_ERROR (RegisterVariablePolicy (&TestPolicy.Header)));
 
   return UNIT_TEST_PASSED;
 }
@@ -3978,6 +4009,15 @@ UnitTestMain (
     "Digit wildcards should check edge cases",
     "VarPolicy.Internal.WildDigitsAdvanced",
     WildcardPoliciesShouldMatchDigitsAdvanced,
+    LibInitMocked,
+    LibCleanup,
+    NULL
+    );
+  AddTestCase (
+    InternalTests,
+    "Excessive wildcard characters in var name should be rejected",
+    "VarPolicy.Internal.ExcessiveWildcardChars",
+    ExcessiveWilcardCharactersShouldBeRejected,
     LibInitMocked,
     LibCleanup,
     NULL


### PR DESCRIPTION
## Description

Makes the `#` character used for comparison against wildcard
characters in `CHAR16` strings to be prefixed with `L` so the
character is treated as a wide character constant.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [x] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Verified using C/C++ debugger that the character comparison is tested
and the expected result is returned.

## Integration Instructions

N/A