### PR TITLE
PolicyServicePkg/PolicyLib.h: Add missing include guard

### DIFF
--- a/PolicyServicePkg/Test/UnitTest/PolicyTest/PolicyTest.h
+++ b/PolicyServicePkg/Test/UnitTest/PolicyTest/PolicyTest.h
@@ -6,6 +6,9 @@
 
 **/
 
+#ifndef POLICY_TEST_H_
+#define POLICY_TEST_H_
+
 extern POLICY_INTERFACE  *mPolicyInterface;
 
 //
@@ -40,3 +43,5 @@ EFI_STATUS
 PolicyLibCommonCreateTests (
   UNIT_TEST_FRAMEWORK_HANDLE  Framework
   );
+
+#endif


### PR DESCRIPTION
## Description

Every header file should have a header guard.

See the following for more information:
https://codeql.github.com/codeql-query-help/cpp/cpp-missing-header-guard/

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- Package compilation
- Run CodeQL query `cpp/cpp-missing-header-guard` rule against the package

## Integration Instructions

N/A