### PR TITLE
Don't Lock Variable Policy if Device is in Unit Test Mode

### DIFF
--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -116,6 +116,7 @@
   AdvLoggerAccessLib|MdeModulePkg/Library/AdvLoggerAccessLibNull/AdvLoggerAccessLib.inf                               ## MS_CHANGE
   MemoryTypeInfoSecVarCheckLib|MdeModulePkg/Library/MemoryTypeInfoSecVarCheckLib/MemoryTypeInfoSecVarCheckLib.inf     # MU_CHANGE TCBZ1086
   ExceptionPersistenceLib|MdeModulePkg/Library/BaseExceptionPersistenceLibNull/BaseExceptionPersistenceLibNull.inf # MU_CHANGE
+  DeviceStateLib|MdeModulePkg/Library/DeviceStateLib/DeviceStateLib.inf                                            # MU_CHANGE
 
   MmuLib|MdePkg/Library/BaseMmuLibNull/BaseMmuLibNull.inf       ## MU_CHANGE
 

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariablePolicyLockingCommon.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariablePolicyLockingCommon.c
@@ -62,7 +62,7 @@ LockPolicyInterfaceAtReadyToBoot (
 {
   EFI_STATUS  Status;
 
-  if ((GetDeviceState() & DEVICE_STATE_UNIT_TEST_MODE) != 0) {
+  if ((GetDeviceState () & DEVICE_STATE_UNIT_TEST_MODE) != 0) {
     DEBUG ((DEBUG_INFO, "[%a] Unit test mode is enabled. Skipping lock.\n", __FUNCTION__));
     return;
   }

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariablePolicyLockingCommon.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariablePolicyLockingCommon.c
@@ -62,10 +62,13 @@ LockPolicyInterfaceAtReadyToBoot (
 {
   EFI_STATUS  Status;
 
+  DEBUG_CODE_BEGIN ();
   if ((GetDeviceState () & DEVICE_STATE_UNIT_TEST_MODE) != 0) {
-    DEBUG ((DEBUG_INFO, "[%a] Unit test mode is enabled. Skipping lock.\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "[%a] Unit test mode is enabled -- skipping variable policy lock.\n", __FUNCTION__));
     return;
   }
+
+  DEBUG_CODE_END ();
 
   if (mCallbackInterface != NULL) {
     DEBUG ((DEBUG_INFO, "[%a] Invoking pre-lock callback.\n", __FUNCTION__));

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariablePolicyLockingCommon.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariablePolicyLockingCommon.c
@@ -10,6 +10,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Uefi.h>
 #include <Library/UefiLib.h>
 #include <Library/DebugLib.h>
+#include <Library/DeviceStateLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 
 #include <Protocol/VariablePolicy.h>
@@ -60,6 +61,11 @@ LockPolicyInterfaceAtReadyToBoot (
   )
 {
   EFI_STATUS  Status;
+
+  if ((GetDeviceState() & DEVICE_STATE_UNIT_TEST_MODE) != 0) {
+    DEBUG ((DEBUG_INFO, "[%a] Unit test mode is enabled. Skipping lock.\n", __FUNCTION__));
+    return;
+  }
 
   if (mCallbackInterface != NULL) {
     DEBUG ((DEBUG_INFO, "[%a] Invoking pre-lock callback.\n", __FUNCTION__));

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
@@ -78,6 +78,7 @@
   VariablePolicyHelperLib
   SafeIntLib
   MemoryTypeInfoSecVarCheckLib  # MU_CHANGE TCBZ1086 - Mitigate potential system brick due to UEFI MemoryTypeInformation var changes
+  DeviceStateLib  # MU_CHANGE - Check device state before locking variable policy
 
 [Protocols]
   gEfiFirmwareVolumeBlockProtocolGuid           ## CONSUMES

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf
@@ -63,6 +63,7 @@
   SafeIntLib
   PcdLib
   MmUnblockMemoryLib
+  DeviceStateLib # MU_CHANGE - Check device state before locking variable policy
 
 [Protocols]
   gEfiVariableWriteArchProtocolGuid             ## PRODUCES


### PR DESCRIPTION
## Description

To enable testing variable policy functionality in the shell, it needs to be unlocked when the test starts. This PR adds a check to the system device state and avoids locking if it is in unit test mode.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested by running the variable policy test app in Q35.

## Integration Instructions

N/A
