### PR TITLE
Fix Redefined Callback

### DIFF
--- a/PolicyServicePkg/Library/DxePolicyLib/DxePolicy.c
+++ b/PolicyServicePkg/Library/DxePolicyLib/DxePolicy.c
@@ -68,9 +68,10 @@ GetPolicyInterface (
   @param[in]  Context The Event Context.
 
 **/
+STATIC
 VOID
 EFIAPI
-RuntimeLibExitBootServicesEvent (
+PolicyExitBootServicesEventCallback (
   IN EFI_EVENT  Event,
   IN VOID       *Context
   )
@@ -101,7 +102,7 @@ PolicyLibConstructor (
   Status = gBS->CreateEvent (
                   EVT_SIGNAL_EXIT_BOOT_SERVICES,
                   TPL_NOTIFY,
-                  RuntimeLibExitBootServicesEvent,
+                  PolicyExitBootServicesEventCallback,
                   NULL,
                   &mPolicyExitBootServicesEvent
                   );


### PR DESCRIPTION
## Description

RuntimeLibExitBootServicesEventCallback is defined and exported in two locations, RuntimeLib and PolicyLib. This causes a linker error if both libraries are linked to a module.

This patch both changes the name of the callback in PolicyLib (as this was not an accurate name) and marks it STATIC, as this function should not be called at all except for the function pointer that is registered for the event firing.

Closes #565.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Unit tests ran.

## Integration Instructions

N/A.
