### PR TITLE
Change assert to not fire when intentionally disabling PCI enumeration

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciDeviceSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciDeviceSupport.c
@@ -888,7 +888,8 @@ StartPciDevices (
 
   RootBridge = GetRootBridgeByHandle (Controller);
   if (RootBridge == NULL) {
-    ASSERT (RootBridge != NULL);
+    // ASSERT (RootBridge != NULL);                    // MU_CHANGE
+    ASSERT (PcdGetBool (PcdPciDisableBusEnumeration)); // MU_CHANGE
     return EFI_NOT_READY;
   }
 


### PR DESCRIPTION
## Description

When setting PcdPciDisableBusEnumeration to TRUE, an assert is hit in StartPciDevices due to the RootBridge not existing. This is expected when skipping enumeration so change the assert to only fail if enumeration was not disabled. 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on QEMU Q35 platform

## Integration Instructions

N/A
