### PR TITLE
Reboot After Completing VariablePolicyFuncTestApp

### DIFF
--- a/MdeModulePkg/Test/ShellTest/VariablePolicyFuncTestApp/VariablePolicyFuncTestApp.c
+++ b/MdeModulePkg/Test/ShellTest/VariablePolicyFuncTestApp/VariablePolicyFuncTestApp.c
@@ -2454,6 +2454,9 @@ FinalCleanup (
                   NULL
                   );
   UT_LOG_INFO ("Delete ExistingLockOnVarStateVar status: %r\n", Status);
+
+  // Reset the system
+  SaveStateAndReboot ();
 }
 
 /**


### PR DESCRIPTION
## Description

When VariablePolicyFuncTestApp ends, the variable policy engine has been disabled. To accomodate automated testing, reboot the system at the end of the test suite to reset the variable policy state. The app already reboots several times during execution to reset the variable policy enablement/lock state.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on Q35

## Integration Instructions

N/A
