### PR TITLE
.pytool/Plugin: Better Rust Support

### DIFF
--- a/.pytool/Plugin/RustHostUnitTestPlugin/Readme.md
+++ b/.pytool/Plugin/RustHostUnitTestPlugin/Readme.md
@@ -1,21 +1,25 @@
 # Rust Host Unit Test Plugin
 
-This CI plugin runs all unit tests with coverage enabled, calculating coverage results on a per package basis. It filters results to only calculate coverage on files within the package.
-
-This CI plugin will also calculate coverage for the entire workspace.
+This CI plugin runs all unit tests and requires that they pass. If code coverage is turned on with
+`"CalculateCoverage": true`, then coverage percentages will be calculated on a per rust crate basis.
 
 ## Plugin Customizations
 
-As a default, this plugin requires 75% coverage, though this can be configured within a packages ci.yaml file by adding the entry `RustCoverageCheck`. The required coverage percent can also be customized on a per (rust) package bases.
+- `CalculateCoverage`: true / false - Whether or not to calculate coverage results 
+- `Coverage`: int (0, 1) - The percentage of coverage required to pass the CI check, if `CalculateCoverage` is enabled
+- `CoverageOverrides` int (0, 1) - Crate specific override of percentage needed to pass
+
+As a default, Calculating Coverage is enabled and at least 75% (.75) code coverage is required to pass.
 
 ### Example ci settings
 
 ``` yaml
 "RustHostUnitTestPlugin": {
+    "CalculateCoverage": true,
     "Coverage": 1,
     "CoverageOverrides": {
-        "DxeRust": 0.0,
-        "UefiEventLib": 0.0,
+        "DxeRust": 0.4,
+        "UefiEventLib": 0.67,
     }
 }
 ```

--- a/.pytool/Plugin/RustHostUnitTestPlugin/RustHostUnitTestPlugin.py
+++ b/.pytool/Plugin/RustHostUnitTestPlugin/RustHostUnitTestPlugin.py
@@ -25,8 +25,8 @@ class RustHostUnitTestPlugin(ICiBuildPlugin):
         rust_ws = PLMHelper.RustWorkspace(ws)  # .pytool/Plugin/RustPackageHelper
         
         with_coverage = pkgconfig.get("CalculateCoverage", True)
-        
-        if platform.system() == "Windows" and platform.machine() in ["i386", "i686"]:
+
+        if platform.system() == "Windows" and platform.machine() == 'aarch64':
             logging.debug("Coverage skipped by plugin, not supported on Windows ARM")
             with_coverage = False
 

--- a/.pytool/Plugin/RustPackageHelper/RustPackageHelper.py
+++ b/.pytool/Plugin/RustPackageHelper/RustPackageHelper.py
@@ -55,7 +55,7 @@ class RustWorkspace:
         
         self.members = list(members)
 
-    def coverage(self, pkg_list = None, ignore_list = None, report_type: str = "html" ):
+    def test(self, pkg_list = None, ignore_list = None, report_type: str = "html", coverage = True):
         """Runs coverage at the workspace level.
         
         Generates a single report that provides coverage information for all
@@ -67,11 +67,15 @@ class RustWorkspace:
         # Set up the command
         command = "cargo"
         params = "make"
-        if ignore_list:
-            params += f' -e COV_FLAGS="--out {report_type} --exclude-files {" --exclude-files ".join(ignore_list)}"'
+
+        if coverage:
+            if ignore_list:
+                params += f' -e COV_FLAGS="--out {report_type} --exclude-files {" --exclude-files ".join(ignore_list)}"'
+            else:
+                params += f' -e COV_FLAGS="--out {report_type}"'
+            params += f" coverage {','.join(pkg_list)}"
         else:
-            params += f' -e COV_FLAGS="--out {report_type}"'
-        params += f" coverage {','.join(pkg_list)}"
+            params += f" test {','.join(pkg_list)}"
 
         # Run the command
         output = io.StringIO()
@@ -96,9 +100,10 @@ class RustWorkspace:
                 line = line.replace("test ", "")
                 if line.endswith("... ok"):
                     result["pass"].append(line.replace(" ... ok", ""))
+                elif line.endswith("... ignored"):
+                    continue
                 else:
                     result["fail"].append(line.replace(" ... FAILED", "")) 
-                continue
 
         # Command failed, but we didn't parse any failed tests
         if return_value != 0 and len(result["fail"]) == 0:
@@ -107,6 +112,9 @@ class RustWorkspace:
         if len(result["fail"]) > 0:
             return result
         
+        if not coverage:
+            return result
+
         # Determine coverage if all tests passed
         for line in lines:
             line = line.strip().strip("\n")

--- a/.pytool/Plugin/RustPackageHelper/RustPackageHelper.py
+++ b/.pytool/Plugin/RustPackageHelper/RustPackageHelper.py
@@ -55,11 +55,10 @@ class RustWorkspace:
         
         self.members = list(members)
 
-    def test(self, pkg_list = None, ignore_list = None, report_type: str = "html", coverage = True):
-        """Runs coverage at the workspace level.
+    def test(self, pkg_list: list[str] = None, ignore_list: list[str] = None, report_type: str = "html", coverage: bool = True):
+        """Runs tests on a list of rust packages / crates.
         
-        Generates a single report that provides coverage information for all
-        packages in the workspace.
+        Will additionally calculate code coverage if coverage is set to True.
         """ 
         if pkg_list is None:
             pkg_list = [pkg.name for pkg in self.members]


### PR DESCRIPTION
## Description

Updates the RustHostUnitTestPlugin to allow the developer to enable or disable the code coverage portion of the plugin.

Additionally fixes a bug in which doctests marked as ignored were still causing the CI plugin to fail.

Additionally turns off code coverage if it detects its running on a Windows ARM device as tarpaulin does not support that type of device.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

CI

## Integration Instructions

CI
