### PR TITLE
RustHostUnitTestPlugin: Skip plugin when package has no rust crates

### DIFF
--- a/.pytool/Plugin/RustHostUnitTestPlugin/RustHostUnitTestPlugin.py
+++ b/.pytool/Plugin/RustHostUnitTestPlugin/RustHostUnitTestPlugin.py
@@ -34,6 +34,10 @@ class RustHostUnitTestPlugin(ICiBuildPlugin):
         pp = Path(Edk2pathObj.GetAbsolutePathOnThisSystemFromEdk2RelativePath(packagename))
         crate_name_list = [pkg.name for pkg in filter(lambda pkg: Path(pkg.path).is_relative_to(pp), rust_ws.members)]
         crate_path_list = [pkg.path for pkg in filter(lambda pkg: Path(pkg.path).is_relative_to(pp), rust_ws.members)]
+        if not crate_name_list: 
+            logging.debug("No Rust crates found in package, skipping...")
+            tc.SetSkipped()
+            return -1
         logging.debug(f"Rust Crates to test: {' '.join(crate_name_list)}")
 
         # Build a list of paths to ignore when computing results. This includes:


### PR DESCRIPTION
## Description

RustHostUnitTestPlugin is a plugin that is run when the scope "rust-ci" is set, however the scope is set for an entire repository (for `stuart_ci_build`) rather than on a per-package basis. This means that the plugin is run for all packages in the repository, not just the package containing a rust crate.

In the scenario where there are no rust crates in the package, the coverage provider, tarpaulin, will not collect any coverage data and return a failure, causing the plugin to fail. This commit skips the plugin if it is detected that no crust crates exist in the package.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

CI

## Integration Instructions

N/A
