### PR TITLE
Fixing the string matching for Windows ARM64 system

### DIFF
--- a/.pytool/Plugin/RustHostUnitTestPlugin/RustHostUnitTestPlugin.py
+++ b/.pytool/Plugin/RustHostUnitTestPlugin/RustHostUnitTestPlugin.py
@@ -26,7 +26,7 @@ class RustHostUnitTestPlugin(ICiBuildPlugin):
         
         with_coverage = pkgconfig.get("CalculateCoverage", True)
 
-        if platform.system() == "Windows" and platform.machine() == 'aarch64':
+        if platform.system() == "Windows" and platform.machine() == 'ARM64':
             logging.debug("Coverage skipped by plugin, not supported on Windows ARM")
             with_coverage = False
 


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

Python platform inquiry will return `Windows` and `ARM64` for OS name and architecture, respectively.

This change will update the value to match that, and thus properly skip rust coverage step from this plugin.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This was tested on Windows ARM64 system.

## Integration Instructions

N/A
