### PR TITLE
pip-requirements.txt: Add edk2-pytool py3.12 support

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -12,8 +12,8 @@
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 ##
 
-edk2-pytool-library~=0.18.2 # MU_CHANGE
-edk2-pytool-extensions~=0.24.1 # MU_CHANGE
+edk2-pytool-library~=0.19.0 # MU_CHANGE
+edk2-pytool-extensions~=0.25.0 # MU_CHANGE
 edk2-basetools==0.1.49
 antlr4-python3-runtime==4.13.1
 regex


### PR DESCRIPTION
## Description

Upgrades edk2-pytools to the latest versions, which add python v3.12 support. This commit also drops python v3.9 support.

- edk2-pytool-extensions 0.25.0
- edk2-pytool-library 0.19.0

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [x] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

CI

## Integration Instructions

Any repository consuming MU_BASECORE must be on python 3.10 or greater.
