### PR TITLE
[PolicyServicePkg] Adding MemoryAllocationLib to library classes that rely on it

### DIFF
--- a/PolicyServicePkg/Library/DxePolicyLib/DxePolicyLib.inf
+++ b/PolicyServicePkg/Library/DxePolicyLib/DxePolicyLib.inf
@@ -31,6 +31,7 @@
   BaseLib
   DebugLib
   UefiBootServicesTableLib
+  MemoryAllocationLib
 
 [Protocols]
   gPolicyProtocolGuid                 ## CONSUMES

--- a/PolicyServicePkg/Library/DxePolicyLib/DxePolicyLib.inf
+++ b/PolicyServicePkg/Library/DxePolicyLib/DxePolicyLib.inf
@@ -30,8 +30,8 @@
 [LibraryClasses]
   BaseLib
   DebugLib
-  UefiBootServicesTableLib
   MemoryAllocationLib
+  UefiBootServicesTableLib
 
 [Protocols]
   gPolicyProtocolGuid                 ## CONSUMES

--- a/PolicyServicePkg/Library/MmPolicyLib/MmPolicyLib.inf
+++ b/PolicyServicePkg/Library/MmPolicyLib/MmPolicyLib.inf
@@ -29,6 +29,7 @@
   BaseLib
   DebugLib
   MmServicesTableLib
+  MemoryAllocationLib
 
 [Protocols]
   gMmPolicyProtocolGuid                 ## CONSUMES

--- a/PolicyServicePkg/Library/PeiPolicyLib/PeiPolicyLib.inf
+++ b/PolicyServicePkg/Library/PeiPolicyLib/PeiPolicyLib.inf
@@ -28,6 +28,7 @@
 [LibraryClasses]
   BaseLib
   DebugLib
+  MemoryAllocationLib
 
 [Ppis]
   gPeiPolicyPpiGuid                ## CONSUMES


### PR DESCRIPTION
## Description

PolicyServicePkg's PolicyLib rely on PolicyLibCommon, which includes MemoryAllocationLib, header.
The Policy Libs do not enumerate MemoryAllocationLib in the LibraryClasses section of their INF files.

If one of the enumerated library classes do not include MemoryAllocationLib, a build error will occur.

Fixes #596 

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested
A platform threw a build error because of unresolved externals coming from the MemoryAllocationLib usage.
Adding MemoryAllocationLib to the INFs resolved the build error. 

## Integration Instructions
N/A