### PR TITLE
BinToPcd.py: Update regex strings to use raw strings

### DIFF
--- a/BaseTools/Scripts/BinToPcd.py
+++ b/BaseTools/Scripts/BinToPcd.py
@@ -10,12 +10,12 @@ BinToPcd
 '''
 from __future__ import print_function
 
-import sys
 import argparse
-import re
 import io
-import struct
 import math
+import re
+import struct
+import sys
 
 #
 # Globals for help information
@@ -37,17 +37,17 @@ if __name__ == '__main__':
         return Value
 
     def ValidatePcdName (Argument):
-        if re.split ('[a-zA-Z\_][a-zA-Z0-9\_]*\.[a-zA-Z\_][a-zA-Z0-9\_]*', Argument) != ['', '']:
+        if re.split (r'[a-zA-Z\_][a-zA-Z0-9\_]*\.[a-zA-Z\_][a-zA-Z0-9\_]*', Argument) != ['', '']:
             Message = '{Argument} is not in the form <PcdTokenSpaceGuidCName>.<PcdCName>'.format (Argument = Argument)
             raise argparse.ArgumentTypeError (Message)
         return Argument
 
     def ValidateGuidName (Argument):
-        if re.split ('[a-zA-Z\_][a-zA-Z0-9\_]*', Argument) != ['', '']:
+        if re.split (r'[a-zA-Z\_][a-zA-Z0-9\_]*', Argument) != ['', '']:
             Message = '{Argument} is not a valid GUID C name'.format (Argument = Argument)
             raise argparse.ArgumentTypeError (Message)
         return Argument
-    
+
     def XdrPackBuffer (buffer):
         packed_bytes = io.BytesIO()
         for unpacked_bytes in buffer:

--- a/BaseTools/Scripts/BinToPcd.py
+++ b/BaseTools/Scripts/BinToPcd.py
@@ -10,12 +10,14 @@ BinToPcd
 '''
 from __future__ import print_function
 
+# MU_CHANGE BEGIN: isort imports
 import argparse
 import io
 import math
 import re
 import struct
 import sys
+# MU_CHANGE END
 
 #
 # Globals for help information
@@ -37,12 +39,14 @@ if __name__ == '__main__':
         return Value
 
     def ValidatePcdName (Argument):
+        # MU_CHANGE: make regex string a raw string
         if re.split (r'[a-zA-Z\_][a-zA-Z0-9\_]*\.[a-zA-Z\_][a-zA-Z0-9\_]*', Argument) != ['', '']:
             Message = '{Argument} is not in the form <PcdTokenSpaceGuidCName>.<PcdCName>'.format (Argument = Argument)
             raise argparse.ArgumentTypeError (Message)
         return Argument
 
     def ValidateGuidName (Argument):
+        # MU_CHANGE: make regex string a raw string
         if re.split (r'[a-zA-Z\_][a-zA-Z0-9\_]*', Argument) != ['', '']:
             Message = '{Argument} is not a valid GUID C name'.format (Argument = Argument)
             raise argparse.ArgumentTypeError (Message)


### PR DESCRIPTION
## Description

With Python 3.12 invalid escape sequences now generate warning messages. This change fixes the problem exposed by the warning message.
```
INFO - mu_basecore\BaseTools\Scripts\BinToPcd.py:40: SyntaxWarning: invalid escape sequence '\_'
INFO -   if re.split ('[a-zA-Z\_][a-zA-Z0-9\_]*\.[a-zA-Z\_][a-zA-Z0-9\_]*', Argument) != ['', '']:
INFO - mu_basecore\BaseTools\Scripts\BinToPcd.py:46: SyntaxWarning: invalid escape sequence '\_'
INFO -   if re.split ('[a-zA-Z\_][a-zA-Z0-9\_]*', Argument) != ['', '']:
```

Additional updates:
* run isort
* removed trailing whitespace

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

I verified that the Python 3.12 character invalid escape sequence print is no longer output, and that the regex expression is still functioning as expected.

## Integration Instructions

N/A
