### PR TITLE
Fixing incorrect monotonic counter comment in INF file

### DIFF
--- a/MdeModulePkg/Universal/MonotonicCounterRuntimeDxe/MonotonicCounterRuntimeDxe.inf
+++ b/MdeModulePkg/Universal/MonotonicCounterRuntimeDxe/MonotonicCounterRuntimeDxe.inf
@@ -38,7 +38,7 @@
   UefiRuntimeLib
   UefiDriverEntryPoint
   BaseLib
-  VariablePolicyHelperLib              // MU_CHANGE
+  VariablePolicyHelperLib              # MU_CHANGE
 
 [Guids]
   ## PRODUCES ## Variable:L"MTC"


### PR DESCRIPTION
## Description

Incorrect comment identifier was used in module INF.

Found by running edk2-pytool-library INF parser over the mdemodulepkg dsc file

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Verified that CI continues to pass after fixing 

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
