### PR TITLE
MdePkg/GoogleTest: Add GetTime() RT service mock interface

### DIFF
--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiRuntimeServicesTableLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiRuntimeServicesTableLib.h
@@ -37,6 +37,13 @@ struct MockUefiRuntimeServicesTableLib {
      IN UINTN     DataSize,
      IN VOID      *Data)
     );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gRT_GetTime,
+    (OUT  EFI_TIME                    *Time,
+     OUT  EFI_TIME_CAPABILITIES       *Capabilities OPTIONAL)
+    );
 };
 
 #endif

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiRuntimeServicesTableLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiRuntimeServicesTableLib.h
@@ -10,6 +10,7 @@
 
 #include <Library/GoogleTestLib.h>
 #include <Library/FunctionMockLib.h>
+
 extern "C" {
 #include <Uefi.h>
 #include <Library/UefiRuntimeServicesTableLib.h>

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockUefiRuntimeServicesTableLib/MockUefiRuntimeServicesTableLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockUefiRuntimeServicesTableLib/MockUefiRuntimeServicesTableLib.cpp
@@ -6,15 +6,15 @@
 **/
 #include <GoogleTest/Library/MockUefiRuntimeServicesTableLib.h>
 
-MOCK_INTERFACE_DEFINITION(MockUefiRuntimeServicesTableLib);
+MOCK_INTERFACE_DEFINITION (MockUefiRuntimeServicesTableLib);
 
-MOCK_FUNCTION_DEFINITION(MockUefiRuntimeServicesTableLib, gRT_GetVariable, 5, EFIAPI);
-MOCK_FUNCTION_DEFINITION(MockUefiRuntimeServicesTableLib, gRT_SetVariable, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeServicesTableLib, gRT_GetVariable, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeServicesTableLib, gRT_SetVariable, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeServicesTableLib, gRT_GetTime, 2, EFIAPI);
 
-static EFI_RUNTIME_SERVICES localRt = {
-  {0},              // EFI_TABLE_HEADER
-
-  NULL,             // EFI_GET_TIME
+static EFI_RUNTIME_SERVICES  localRt = {
+  { 0 },            // EFI_TABLE_HEADER
+  gRT_GetTime,      // EFI_GET_TIME
   NULL,             // EFI_SET_TIME
   NULL,             // EFI_GET_WAKEUP_TIME
   NULL,             // EFI_SET_WAKEUP_TIME
@@ -36,5 +36,5 @@ static EFI_RUNTIME_SERVICES localRt = {
 };
 
 extern "C" {
-  EFI_RUNTIME_SERVICES* gRT = &localRt;
+EFI_RUNTIME_SERVICES  *gRT = &localRt;
 }


### PR DESCRIPTION
## Description

This change is required to allow test's that depend on the google test mock function gRT_GetTime to function.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?

- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?


## How This Was Tested

This was tested on a test that is currently not public.

## Integration Instructions

N/A