### PR TITLE
.pytool/CISettings.py: Re-enable Code Coverage

### DIFF
--- a/.azurepipelines/Ubuntu-GCC5.yml
+++ b/.azurepipelines/Ubuntu-GCC5.yml
@@ -26,6 +26,7 @@ extends:
     do_non_ci_build: false
     do_non_ci_setup: true
     do_pr_eval: true
+    calculate_code_coverage: true
     container_build: true
     os_type: Linux
     build_matrix:

--- a/.azurepipelines/Windows-VS.yml
+++ b/.azurepipelines/Windows-VS.yml
@@ -26,6 +26,7 @@ extends:
     do_non_ci_build: false
     do_non_ci_setup: true
     do_pr_eval: true
+    calculate_code_coverage: true
     os_type: Windows_NT
     build_matrix:
       TARGET_MDE_CPU:

--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -10,9 +10,11 @@ import logging
 import sys
 from edk2toolext.environment import shell_environment
 from edk2toolext.invocables.edk2_ci_build import CiBuildSettingsManager
+from edk2toolext.invocables.edk2_parse import ParseSettingsManager
+from edk2toolext.invocables.edk2_pr_eval import PrEvalSettingsManager
 from edk2toolext.invocables.edk2_setup import SetupSettingsManager, RequiredSubmodule
 from edk2toolext.invocables.edk2_update import UpdateSettingsManager
-from edk2toolext.invocables.edk2_pr_eval import PrEvalSettingsManager
+
 from edk2toollib.utility_functions import GetHostInfo
 from pathlib import Path
 
@@ -25,7 +27,7 @@ except ImportError:
     pass
 
 
-class Settings(CiBuildSettingsManager, UpdateSettingsManager, SetupSettingsManager, PrEvalSettingsManager):
+class Settings(CiBuildSettingsManager, UpdateSettingsManager, SetupSettingsManager, PrEvalSettingsManager, ParseSettingsManager):
 
     def __init__(self):
         self.ActualPackages = []

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -12,8 +12,8 @@
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 ##
 
-edk2-pytool-library~=0.19.3 # MU_CHANGE
-edk2-pytool-extensions~=0.25.1 # MU_CHANGE
+edk2-pytool-library~=0.19.4 # MU_CHANGE
+edk2-pytool-extensions~=0.26.0 # MU_CHANGE
 edk2-basetools==0.1.49
 antlr4-python3-runtime==4.13.1
 regex


### PR DESCRIPTION
## Description

#612 added an additional `MuDevOpsWrapper.yml` parameter configuration to opt in or out of code coverage, with the default being `false`, disabling code coverage. This was due to the fact that uploading code coverage data required a minimum `edk2-pytool-extensions` and `edk2-pytool-library` version and associated `ParseSettingsManager` to be implemented.

This commit upgrades Edk2-pytools to the required version, implements `ParseSettingsManager`, and re-enables code coverage. This change only restores previous functionality, with the caveat that code coverage data is now organized by INF rather than by test executable. 

This change results in no impact to consumers of MU_BASECORE, however maintainers and contributors may view code coverage results by selecting the pipeline in github and navigating to the pipeline run located at `dev.azure.com`

![image](https://github.com/microsoft/mu_basecore/assets/24388509/fe97a067-2b97-45c9-af12-68d906c3b9b4)


- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

N/A

## Integration Instructions

No impact to consumers of MU_BASECORE, however maintainers and contributors may view code coverage results by selecting the pipeline in github and navigating to the pipeline run located at `dev.azure.com`
