### PR TITLE
Fixing page table handling for non-present pages.

### DIFF
--- a/UefiCpuPkg/Library/CpuPageTableLib/CpuPageTableMap.c
+++ b/UefiCpuPkg/Library/CpuPageTableLib/CpuPageTableMap.c
@@ -380,7 +380,9 @@ PageTableLibMapInLevel (
         return Status;
       }
 
-      OneOfPagingEntry.Uint64 = 0;
+      OneOfPagingEntry.Pnle.Uint64 = 0;
+      // MU_CHANGE: Populate base address bits for non present pages
+      // TODO: Author unit test to verify the splitted pages meet expected attribute bits.
       if (Level != 1 && Level != 2 && Level != 3) {
         PageTableLibSetPnle (&OneOfPagingEntry.Pnle, &PleBAttribute, &AllOneMask);
       } else {

--- a/UefiCpuPkg/Library/CpuPageTableLib/CpuPageTableMap.c
+++ b/UefiCpuPkg/Library/CpuPageTableLib/CpuPageTableMap.c
@@ -323,23 +323,11 @@ PageTableLibMapInLevel (
   IA32_PAGING_ENTRY   OriginalParentPagingEntry;
   IA32_PAGING_ENTRY   OriginalCurrentPagingEntry;
 
-  // MU_CHANGE: Configure propagate bit mask.
-  IA32_MAP_ATTRIBUTE  PropagateMask;
-
   ASSERT (Level != 0);
   ASSERT ((Attribute != NULL) && (Mask != NULL));
 
   CreateNew         = FALSE;
   AllOneMask.Uint64 = ~0ull;
-
-  // MU_CHANGE: Configure propagate bit mask.
-  PropagateMask.Uint64              = IA32_MAP_ATTRIBUTE_PAGE_TABLE_BASE_ADDRESS_MASK;
-  PropagateMask.Bits.Present        = 1;
-  PropagateMask.Bits.ReadWrite      = 1;
-  PropagateMask.Bits.UserSupervisor = 1;
-  PropagateMask.Bits.Dirty          = 1;
-  PropagateMask.Bits.Accessed       = 1;
-  PropagateMask.Bits.Nx             = 1;
 
   NopAttribute.Uint64              = 0;
   NopAttribute.Bits.Present        = 1;

--- a/UefiCpuPkg/Library/CpuPageTableLib/CpuPageTableMap.c
+++ b/UefiCpuPkg/Library/CpuPageTableLib/CpuPageTableMap.c
@@ -383,7 +383,7 @@ PageTableLibMapInLevel (
       OneOfPagingEntry.Pnle.Uint64 = 0;
       // MU_CHANGE: Populate base address bits for non present pages
       // TODO: Author unit test to verify the splitted pages meet expected attribute bits.
-      if (Level != 1 && Level != 2 && Level != 3) {
+      if ((Level != 1) && (Level != 2) && (Level != 3)) {
         PageTableLibSetPnle (&OneOfPagingEntry.Pnle, &PleBAttribute, &AllOneMask);
       } else {
         PageTableLibSetPle (Level, &OneOfPagingEntry, 0, &PleBAttribute, &AllOneMask);

--- a/UefiCpuPkg/Library/CpuPageTableLib/CpuPageTableMap.c
+++ b/UefiCpuPkg/Library/CpuPageTableLib/CpuPageTableMap.c
@@ -380,14 +380,7 @@ PageTableLibMapInLevel (
         return Status;
       }
 
-      // MU_CHANGE: Apply propagate bits for non-root entries.
-      //            Otherwise, start with PleBAttribute sans present bit.
-      // OneOfPagingEntry.Pnle.Uint64 = 0;
-      if ((Level != 1) && (Level != 2) && (Level != 3)) {
-        OneOfPagingEntry.Pnle.Uint64 = (PleBAttribute.Uint64 & PropagateMask.Uint64) & (~BIT0);
-      } else {
-        PageTableLibSetPle (Level, &OneOfPagingEntry, 0, &PleBAttribute, &PropagateMask);
-      }
+      OneOfPagingEntry.Pnle.Uint64 = 0;
     } else {
       PageTableLibSetPle (Level, &OneOfPagingEntry, 0, &PleBAttribute, &AllOneMask);
     }

--- a/UefiCpuPkg/Library/CpuPageTableLib/CpuPageTableMap.c
+++ b/UefiCpuPkg/Library/CpuPageTableLib/CpuPageTableMap.c
@@ -385,7 +385,7 @@ PageTableLibMapInLevel (
       // MU_CHANGE: Apply propagate bits for non-root entries.
       //            Otherwise, start with PleBAttribute sans present bit.
       // OneOfPagingEntry.Pnle.Uint64 = 0;
-      if (Level != 1 && Level != 2 && Level != 3) {
+      if ((Level != 1) && (Level != 2) && (Level != 3)) {
         OneOfPagingEntry.Pnle.Uint64 = (PleBAttribute.Uint64 & PropagateMask.Uint64) & (~BIT0);
       } else {
         PageTableLibSetPle (Level, &OneOfPagingEntry, 0, &PleBAttribute, &PropagateMask);

--- a/UefiCpuPkg/Library/CpuPageTableLib/CpuPageTableMap.c
+++ b/UefiCpuPkg/Library/CpuPageTableLib/CpuPageTableMap.c
@@ -380,7 +380,12 @@ PageTableLibMapInLevel (
         return Status;
       }
 
-      OneOfPagingEntry.Pnle.Uint64 = 0;
+      OneOfPagingEntry.Uint64 = 0;
+      if (Level != 1 && Level != 2 && Level != 3) {
+        PageTableLibSetPnle (&OneOfPagingEntry.Pnle, &PleBAttribute, &AllOneMask);
+      } else {
+        PageTableLibSetPle (Level, &OneOfPagingEntry, 0, &PleBAttribute, &AllOneMask);
+      }
     } else {
       PageTableLibSetPle (Level, &OneOfPagingEntry, 0, &PleBAttribute, &AllOneMask);
     }

--- a/UefiCpuPkg/Library/CpuPageTableLib/CpuPageTableMap.c
+++ b/UefiCpuPkg/Library/CpuPageTableLib/CpuPageTableMap.c
@@ -551,12 +551,6 @@ PageTableLibMapInLevel (
       //
       // Create one entry mapping the entire region (1G, 2M or 4K).
       //
-      if ((CurrentPagingEntry->Pce.Present == 0) && (Attribute->Bits.Present == 0)) {
-        Offset      += SubLength;
-        RegionStart += RegionLength;
-        Index++;
-        continue;
-      }
       if (Modify) {
         //
         // When the inheritable attributes in parent entry could override the child attributes,

--- a/UefiCpuPkg/Library/CpuPageTableLib/CpuPageTableMap.c
+++ b/UefiCpuPkg/Library/CpuPageTableLib/CpuPageTableMap.c
@@ -27,8 +27,7 @@ PageTableLibSetPte4K (
   )
 {
   if (Mask->Bits.PageTableBaseAddressLow || Mask->Bits.PageTableBaseAddressHigh) {
-    // MU_CHANGE: Should not apply all the bits to child entry...
-    Pte4K->Uint64 = (IA32_MAP_ATTRIBUTE_PAGE_TABLE_BASE_ADDRESS (Attribute) + Offset);
+    Pte4K->Uint64 = (IA32_MAP_ATTRIBUTE_PAGE_TABLE_BASE_ADDRESS (Attribute) + Offset) | (Pte4K->Uint64 & ~IA32_PE_BASE_ADDRESS_MASK_40);
   }
 
   if (Mask->Bits.Present) {
@@ -95,8 +94,7 @@ PageTableLibSetPleB (
   )
 {
   if (Mask->Bits.PageTableBaseAddressLow || Mask->Bits.PageTableBaseAddressHigh) {
-    // MU_CHANGE: Should not apply all the bits to child entry...
-    PleB->Uint64 = (IA32_MAP_ATTRIBUTE_PAGE_TABLE_BASE_ADDRESS (Attribute) + Offset);
+    PleB->Uint64 = (IA32_MAP_ATTRIBUTE_PAGE_TABLE_BASE_ADDRESS (Attribute) + Offset) | (PleB->Uint64 & ~IA32_PE_BASE_ADDRESS_MASK_39);
   }
 
   PleB->Bits.MustBeOne = 1;

--- a/UefiCpuPkg/Library/CpuPageTableLib/CpuPageTableMap.c
+++ b/UefiCpuPkg/Library/CpuPageTableLib/CpuPageTableMap.c
@@ -546,6 +546,12 @@ PageTableLibMapInLevel (
       //
       // Create one entry mapping the entire region (1G, 2M or 4K).
       //
+      if ((CurrentPagingEntry->Pce.Present == 0) && (Attribute->Bits.Present == 0)) {
+        Offset      += SubLength;
+        RegionStart += RegionLength;
+        Index++;
+        continue;
+      }
       if (Modify) {
         //
         // When the inheritable attributes in parent entry could override the child attributes,


### PR DESCRIPTION
## Description

This change will add logic to populate the address and propagate bits for the non-present pages.

Without this change, the issue can be seen as when a smaller page is marked present from a big non-present page, the remainder of the non-present pages will return `EFI_UNSUPPORTED` when using get attributes function though protocols like CPU arch.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This was tested on QEMU Q35 platform and booted to OS.

## Integration Instructions

N/A
