### PR TITLE
Add late initialization for Debug Agent

### DIFF
--- a/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
+++ b/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
@@ -471,6 +471,13 @@ DxeMain (
   Status = CoreInitializeEventServices ();
   ASSERT_EFI_ERROR (Status);
 
+  // MU_CHANGE: START
+  // Give the debug agent a chance to initialize with events.
+
+  InitializeDebugAgent (DEBUG_AGENT_INIT_DXE_CORE_LATE, HobStart, NULL);
+
+  // MU_CHANGE: END
+
   MemoryProfileInstallProtocol ();
 
   CoreInitializeMemoryAttributesTable ();

--- a/MdeModulePkg/Include/Library/DebugAgentLib.h
+++ b/MdeModulePkg/Include/Library/DebugAgentLib.h
@@ -22,6 +22,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define DEBUG_AGENT_INIT_DXE_UNLOAD           11
 #define DEBUG_AGENT_INIT_THUNK_PEI_IA32TOX64  12
 #define DEBUG_AGENT_INIT_REINITIALIZE         13      // MS_CHANGE
+#define DEBUG_AGENT_INIT_DXE_CORE_LATE        14      // MU_CHANGE
 
 //
 // Context for DEBUG_AGENT_INIT_POSTMEM_SEC


### PR DESCRIPTION
## Description

Adds a late initialize in DxeMain for the debug agent. This is required for the debug agent to be able to setup events to handle image loads, exit boot services, and other important callbacks. 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on QEMU

## Integration Instructions

N/A
