### PR TITLE
Bugfix: Fix Tools Def Version Number Incrementation

### DIFF
--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -26,7 +26,7 @@
 # 2.44 - Add Rust build support
 # 2.45 - Enable stack cookies to GCC X64 builds via -fstack-protector flag
 #
-#!VERSION=2.44
+#!VERSION=2.45
 
 IDENTIFIER = Default TOOL_CHAIN_CONF
 


### PR DESCRIPTION
## Description

The previous PR added the version and description but did not update the !VERSION value. This PR correctly increments the version number so consumers are warned to update their Conf directories.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested by kicking off the Q35 build with an old Conf folder

## Integration Instructions

Consumers who build with this update will experience a 30-second timeout
during build on pre-existing clones. To resolve this, simply delete the
Conf folder so the tools_def is refreshed.