### PR TITLE
Check for Clang and GCC Support When Defining NO_STACK_COOKIE

### DIFF
--- a/MdePkg/Include/Base.h
+++ b/MdePkg/Include/Base.h
@@ -209,8 +209,14 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 // MU_CHANGE [START]: Stack Cookie Support.
 // Omit Function from Stack Overflow Protection.
 #ifndef NO_STACK_COOKIE
-  #if defined (__GNUC__) || defined (__clang__)
+  #if defined (__GNUC__)
 #define NO_STACK_COOKIE  __attribute__ ((no_stack_protector))
+  #elif defined (__clang__)
+    #if __has_attribute (no_stack_protector)
+#define NO_STACK_COOKIE  __attribute__ ((no_stack_protector))
+    #else
+#define NO_STACK_COOKIE
+    #endif
   #elif defined (_MSC_VER)
 #define NO_STACK_COOKIE  __declspec(safebuffers)
   #else

--- a/MdePkg/Include/Base.h
+++ b/MdePkg/Include/Base.h
@@ -210,12 +210,14 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 // Omit Function from Stack Overflow Protection.
 #ifndef NO_STACK_COOKIE
   #if defined (__GNUC__)
+    #if defined (__clang__)
+      #if __has_attribute (no_stack_protector)
 #define NO_STACK_COOKIE  __attribute__ ((no_stack_protector))
-  #elif defined (__clang__)
-    #if __has_attribute (no_stack_protector)
-#define NO_STACK_COOKIE  __attribute__ ((no_stack_protector))
-    #else
+      #else
 #define NO_STACK_COOKIE
+      #endif
+    #else
+#define NO_STACK_COOKIE  __attribute__ ((no_stack_protector))
     #endif
   #elif defined (_MSC_VER)
 #define NO_STACK_COOKIE  __declspec(safebuffers)

--- a/MdePkg/Include/Base.h
+++ b/MdePkg/Include/Base.h
@@ -209,15 +209,17 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 // MU_CHANGE [START]: Stack Cookie Support.
 // Omit Function from Stack Overflow Protection.
 #ifndef NO_STACK_COOKIE
-  #if defined (__GNUC__)
-    #if defined (__clang__)
-      #if __has_attribute (no_stack_protector)
+  #if defined (__clang__)
+    #if __has_attribute (no_stack_protector)
 #define NO_STACK_COOKIE  __attribute__ ((no_stack_protector))
-      #else
-#define NO_STACK_COOKIE
-      #endif
     #else
+#define NO_STACK_COOKIE
+    #endif
+  #elif defined (__GNUC__)
+    #if (__GNUC__ > 10)
 #define NO_STACK_COOKIE  __attribute__ ((no_stack_protector))
+    #else
+#define NO_STACK_COOKIE
     #endif
   #elif defined (_MSC_VER)
 #define NO_STACK_COOKIE  __declspec(safebuffers)


### PR DESCRIPTION
## Description

Older versions of Clang and GCC don't support the no_stack_protector attribute. To determine if the attribute is supported for the active Clang toolchain, the __has_attribute() language extension can be used. To determine support for GCC, the major version can be checked. According to the docs, the earliest version which supported the attribute was v11: https://gcc.gnu.org/onlinedocs/gcc-11.4.0/gcc/Common-Function-Attributes.html

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested via using the Clang and GCC toolchains, and building GCC Q35 + SBSA

## Integration Instructions

N/A