### PR TITLE
[CHERRY-PICK] MdePkg: Add ProcessorUpgradeSocket definitions from SMBIOS 3.7.0

### DIFF
--- a/MdePkg/Include/IndustryStandard/SmBios.h
+++ b/MdePkg/Include/IndustryStandard/SmBios.h
@@ -1,7 +1,7 @@
 /** @file
-  Industry Standard Definitions of SMBIOS Table Specification v3.6.0.
+  Industry Standard Definitions of SMBIOS Table Specification v3.7.0.
 
-Copyright (c) 2006 - 2021, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2006 - 2023, Intel Corporation. All rights reserved.<BR>
 (C) Copyright 2015-2017 Hewlett Packard Enterprise Development LP<BR>
 (C) Copyright 2015 - 2019 Hewlett Packard Enterprise Development LP<BR>
 Copyright (c) 2022, AMD Incorporated. All rights reserved.<BR>
@@ -845,7 +845,15 @@ typedef enum {
   ProcessorUpgradeSocketLGA1211   = 0x45,
   ProcessorUpgradeSocketLGA2422   = 0x46,
   ProcessorUpgradeSocketLGA5773   = 0x47,
-  ProcessorUpgradeSocketBGA5773   = 0x48
+  ProcessorUpgradeSocketBGA5773   = 0x48,
+  ProcessorUpgradeSocketAM5       = 0x49,
+  ProcessorUpgradeSocketSP5       = 0x4A,
+  ProcessorUpgradeSocketSP6       = 0x4B,
+  ProcessorUpgradeSocketBGA883    = 0x4C,
+  ProcessorUpgradeSocketBGA1190   = 0x4D,
+  ProcessorUpgradeSocketBGA4129   = 0x4E,
+  ProcessorUpgradeSocketLGA4710   = 0x4F,
+  ProcessorUpgradeSocketLGA7529   = 0x50
 } PROCESSOR_UPGRADE;
 
 ///


### PR DESCRIPTION
## Description

Add newer Smbios 3.7 enums to PROCESSOR_UPGRADE in MdePkg/Include/IndustryStandard/Smbios.h

This patch adds below definitions from SMBIOS 3.7.0 into Smbios.h
- ProcessorUpgradeSocketAM5
- ProcessorUpgradeSocketSP5
- ProcessorUpgradeSocketSP6
- ProcessorUpgradeSocketBGA883
- ProcessorUpgradeSocketBGA1190
- ProcessorUpgradeSocketBGA4129
- ProcessorUpgradeSocketLGA4710
- ProcessorUpgradeSocketLGA7529

Reviewed-by: Star Zeng <star.zeng@intel.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested
Verified build with just cherry pick of updated enum.

## Integration Instructions
n/a