### PR TITLE
Bugfix rust module incremental build support

### DIFF
--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -293,8 +293,6 @@
         $(OUTPUT_DIR)(+)$(MODULE_NAME).efi
 
     <Command>
-        # Temporary_Rust_Todo - Remove .efi files to better support Rust incremental build for now.
-        $(RM) $(OUTPUT_DIR)(+)*.efi
         $(CARGO) make $(CARGOMAKE_FLAGS) -e RUSTFLAGS="-C link-arg=/MAP:$(DEBUG_DIR)(+)$(MODULE_NAME).map $(RUST_FLAGS)" build $(MODULE_NAME)
         "$(GENFW)" -e $(MODULE_TYPE) -o $(DEBUG_DIR)(+)$(MODULE_NAME).efi $(DEBUG_DIR)(+)$(TARGET_TRIPLE)(+)$(RUST_TARGET)(+)$(MODULE_NAME).efi $(GENFW_FLAGS)
         $(CP) $(DEBUG_DIR)(+)$(MODULE_NAME).map  $(OUTPUT_DIR)(+)$(MODULE_NAME).map

--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -119,8 +119,9 @@
 # 2.25 - Split OemData rule into intermediate binary and final binary rules.
 # 2.26 - Rename OemData to ProductData.
 # 2.27 - Add Rust build support.
+# 2.28 - Remove Rust Incremental Build Support Hack
 
-#!VERSION=2.27
+#!VERSION=2.28
 
 [C-Code-File]
     <InputFile>

--- a/BaseTools/Source/Python/Common/Misc.py
+++ b/BaseTools/Source/Python/Common/Misc.py
@@ -1931,30 +1931,3 @@ def CopyDict(ori_dict):
 #
 def RemoveCComments(ctext):
     return re.sub('//.*?\n|/\*.*?\*/', '\n', ctext, flags=re.S)
-
-
-# MU_CHANGE [BEGIN] - Add Rust build support
-
-#  Update all .toml file's mtime
-#   If toml related source file changed. update .toml file's mtime
-#   all toml file saved in file TomlFileListFileName
-#
-def UpdateTomlFileMTime(TomlFileListFileName):
-    try:
-        with open(TomlFileListFileName, 'r') as file:
-            lines = file.readlines()
-            for toml in lines:
-                TomlFile = toml[0:-1]
-                TomlSourceDir = os.path.join(PathClass(TomlFile).Dir, "src")
-                TomlSourceFiles = glob.glob(TomlSourceDir + "/*.rs")
-                LatestFile = max(TomlSourceFiles, key=os.path.getmtime)
-                LatestFileMTime = os.path.getmtime(LatestFile)
-                CurrentMTime = os.path.getmtime(str(TomlFile))
-                if CurrentMTime < LatestFileMTime:
-                    os.utime(str(TomlFile), (os.path.getatime(LatestFile), LatestFileMTime))
-    except FileNotFoundError:
-        pass
-    except:
-        pass
-
-# MU_CHANGE [END] - Add Rust build support


### PR DESCRIPTION
## Description

Previously, the incremental build support for rust modules was broken because the previous attempt of updating the last modified time using utime() was not permanent (for an unknown reason). This commit does two things:

1. Updates the logic to use pathlib.Path's `touch()` function, which has proven to reliably update the last modified time of the file.

2. Always touch the toml file instead of checking to see if any of the rust files has been touched since the last build. The previous logic was unnecessary complicated because the cargo build system will decide if a re-build is necessary, and make will only copy the file if the efi has changed.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

1. Verified changes to a rust module propagated into the final firmware.
2. Verified changes to a rust library propagated to a rust module that then also propagated into the final firmware.
3. Verified that making no changes to a rust module or library resulted in cargo build skipping the re-build and the final efi remained the same exact efi of the previous build (efi was not modified or re-copied)

This was verified on Windows and Ubuntu 22.04

## Integration Instructions

Clear your Conf folder
