### PR TITLE
Memory Protection: Add Missing Special Region Pattern Application in SeparateSpecialRegionsInMemoryMap()

### DIFF
--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -2218,6 +2218,7 @@ SeparateSpecialRegionsInMemoryMap (
             MemoryMapEntry->Type
             );
           MapEntryInsert->Attribute = SpecialRegionEntry->SpecialRegion.EfiAttributes;
+          MapEntryInsert->VirtualStart = SPECIAL_REGION_PATTERN;
 
           // Trim the current memory map entry
           MemoryMapEntry->NumberOfPages -= MapEntryInsert->NumberOfPages;

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -2217,7 +2217,7 @@ SeparateSpecialRegionsInMemoryMap (
             EFI_SIZE_TO_PAGES (SpecialRegionEnd - SpecialRegionStart),
             MemoryMapEntry->Type
             );
-          MapEntryInsert->Attribute = SpecialRegionEntry->SpecialRegion.EfiAttributes;
+          MapEntryInsert->Attribute    = SpecialRegionEntry->SpecialRegion.EfiAttributes;
           MapEntryInsert->VirtualStart = SPECIAL_REGION_PATTERN;
 
           // Trim the current memory map entry


### PR DESCRIPTION
## Description

SPECIAL_REGION_PATTERN is used to identify special regions in the memory map constructed by GetMemoryMapWithPopulatedAccessAttributes(). One of the cases encountered when splitting special regions
within the memory map did not apply the SPECIAL_REGION_PATTERN which can cause incorrect attribute application for platforms using this functionality.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on a Qualcomm Surface platform by creating a special region and checking the output memory map.

## Integration Instructions

N/A
