### PR TITLE
release-basetools.yml: Update for compatibility with v4 GitHub actions

### DIFF
--- a/.github/workflows/release-basetools.yml
+++ b/.github/workflows/release-basetools.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload Build Logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: logs-${{ matrix.tool_chain }}-${{ matrix.target }}
           path: |
@@ -91,7 +91,7 @@ jobs:
             BaseTools/BaseToolsBuild/BASETOOLS_BUILD.txt
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: basetools-${{ matrix.tool_chain }}-${{ matrix.target }}
           path: ${{ matrix.output_dir }}


### PR DESCRIPTION
## Description

Commit edd2738 updated the actions/download-artifact GitHub action
in this workflow to v4. Both actions/download-artifact and
actions/upload-artifact recently released a v4 version with
significant breaking changes.

Relevant to this workflow and this change, is that a v4 download
action must be paired with a v4 upload action. See:
https://github.com/actions/download-artifact?tab=readme-ov-file#v4---whats-new

> ## Breaking Changes
> 1. On self hosted runners, additional firewall rules may be required.
> 2. Downloading artifacts that were created from
>    action/upload-artifact@v3 and below are not supported.

This results in the release-basetools.yml workflow currently
failing when attempting to download the artifacts in the publish
step (which only runs on a GitHub publish event - not tested in PRs).

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Ran workflow skipping conditional on publish step on my mu_basecore fork.

## Integration Instructions

N/A