### PR TITLE
Support building BaseLib for AARCH64 with VC on 202311

### DIFF
--- a/MdePkg/Library/BaseLib/AArch64/SetJumpLongJump.asm
+++ b/MdePkg/Library/BaseLib/AArch64/SetJumpLongJump.asm
@@ -7,6 +7,7 @@
 
   EXPORT SetJump
   EXPORT InternalLongJump
+  IMPORT InternalAssertJumpBuffer  ; MU_CHANGE: to resolve the symbol
 ; MS_CHANGE: change area name to |.text| and add an ALIGN directive
   AREA |.text|, ALIGN=3, CODE, READONLY
 

--- a/MdePkg/Library/BaseLib/Arm/SetJumpLongJump.asm
+++ b/MdePkg/Library/BaseLib/Arm/SetJumpLongJump.asm
@@ -8,6 +8,7 @@
 
   EXPORT  SetJump
   EXPORT  InternalLongJump
+  IMPORT InternalAssertJumpBuffer ; MU_CHANGE: to resolve the symbol
 
   AREA  BaseLib, CODE, READONLY
 


### PR DESCRIPTION
# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

The existing assembly file for AARCH64 has a direct reference to InternalAssertJumpBuffer, which is an external symbol, thus causing VC to fail compilation for this file.

The change added the explicit import to resolve the symbol.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This change is verified against QemuPkg CI build pipeline.

## Integration Instructions

N/A
