### PR TITLE
BaseTools: Fix raw strings containing valid escape characters

### DIFF
--- a/BaseTools/Source/Python/AutoGen/GenMake.py
+++ b/BaseTools/Source/Python/AutoGen/GenMake.py
@@ -29,7 +29,9 @@ from Common.DataType import TAB_COMPILER_MSFT
 gIncludePattern = re.compile(r"^[ \t]*[#%]?[ \t]*include(?:[ \t]*(?:\\(?:\r\n|\r|\n))*[ \t]*)*(?:\(?[\"<]?[ \t]*)([-\w.\\/() \t]+)(?:[ \t]*[\">]?\)?)", re.MULTILINE | re.UNICODE | re.IGNORECASE)
 
 ## Regular expression for matching macro used in header file inclusion
-gMacroPattern = re.compile(r"([_A-Z][_A-Z0-9]*)[ \t]*\((.+)\)", re.UNICODE)
+# MU_CHANGE begin
+gMacroPattern = re.compile("([_A-Z][_A-Z0-9]*)[ \t]*\\((.+)\\)", re.UNICODE)
+# MU_CHANGE end
 
 gIsFileMap = {}
 

--- a/BaseTools/Source/Python/Common/Misc.py
+++ b/BaseTools/Source/Python/Common/Misc.py
@@ -1930,4 +1930,6 @@ def CopyDict(ori_dict):
 # Remove the c/c++ comments: // and /* */
 #
 def RemoveCComments(ctext):
-    return re.sub(r'//.*?\n|/\*.*?\*/', '\n', ctext, flags=re.S)
+    # MU_CHANGE begin
+    return re.sub('//.*?\n|/\\*.*?\\*/', '\n', ctext, flags=re.S)
+    # MU_CHANGE end

--- a/BaseTools/Source/Python/Workspace/DscBuildData.py
+++ b/BaseTools/Source/Python/Workspace/DscBuildData.py
@@ -2944,7 +2944,9 @@ class DscBuildData(PlatformBuildClassObject):
         # start generating makefile
         MakeApp = PcdMakefileHeader
         if sys.platform == "win32":
-            MakeApp = MakeApp + r'APPFILE = %s\%s.exe\n' % (self.OutputPath, PcdValueInitName) + r'APPNAME = %s\n' % (PcdValueInitName) + r'OBJECTS = %s\%s.obj %s.obj\n' % (self.OutputPath, PcdValueInitName, os.path.join(self.OutputPath, PcdValueCommonName)) + 'INC = '
+            # MU_CHANGE begin
+            MakeApp = MakeApp + 'APPFILE = %s\\%s.exe\n' % (self.OutputPath, PcdValueInitName) + 'APPNAME = %s\n' % (PcdValueInitName) + 'OBJECTS = %s\\%s.obj %s.obj\n' % (self.OutputPath, PcdValueInitName, os.path.join(self.OutputPath, PcdValueCommonName)) + 'INC = '
+            # MU_CHANGE end
         else:
             MakeApp = MakeApp + PcdGccMakefile
             MakeApp = MakeApp + 'APPFILE = %s/%s\n' % (self.OutputPath, PcdValueInitName) + 'APPNAME = %s\n' % (PcdValueInitName) + 'OBJECTS = %s/%s.o %s.o\n' % (self.OutputPath, PcdValueInitName, os.path.join(self.OutputPath, PcdValueCommonName)) + \
@@ -3054,7 +3056,9 @@ class DscBuildData(PlatformBuildClassObject):
             MakeApp += "$(OBJECTS) : %s\n" % include_file
         if sys.platform == "win32":
             PcdValueCommonPath = os.path.normpath(mws.join(GlobalData.gGlobalDefines["EDK_TOOLS_PATH"], "Source\C\Common\PcdValueCommon.c"))
-            MakeApp = MakeApp + r'%s\PcdValueCommon.c : %s\n' % (self.OutputPath, PcdValueCommonPath)
+            # MU_CHANGE begin
+            MakeApp = MakeApp + '%s\\PcdValueCommon.c : %s\n' % (self.OutputPath, PcdValueCommonPath)
+            # MU_CHANGE end
             MakeApp = MakeApp + '\tcopy /y %s $@\n' % (PcdValueCommonPath)
         else:
             PcdValueCommonPath = os.path.normpath(mws.join(GlobalData.gGlobalDefines["EDK_TOOLS_PATH"], "Source/C/Common/PcdValueCommon.c"))


### PR DESCRIPTION
## Description

Fixes raw regex strings that contain valid (and purposeful) escape characters as they are being treated as individual characters rather than the single escaped character they represent (i.e. '\t' is being treated as a '\\' and a 't' rather than a single tab character).

**Note**: This is the same patch series being added via https://edk2.groups.io/g/devel/message/112986, but seeing as this is a breaking change being seen by partners, I figured we should get this into MU_BASECORE as quickly as possible.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Verified on multiple partner platforms

## Integration Instructions

N/A
