### PR TITLE
Update Memory Protection Special Region Logic to Handle Edge Case

### DIFF
--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -2171,9 +2171,9 @@ SeparateSpecialRegionsInMemoryMap (
     {
       MapEntryStart = (UINTN)MemoryMapEntry->PhysicalStart;
       MapEntryEnd   = (UINTN)MemoryMapEntry->PhysicalStart + (UINTN)EFI_PAGES_TO_SIZE (MemoryMapEntry->NumberOfPages);
-      if ((MapEntryStart <= SpecialRegionStart) && (MapEntryEnd > SpecialRegionStart)) {
-        // Check if some portion of the map entry isn't covered by the special region
-        if (MapEntryStart != SpecialRegionStart) {
+      if (CHECK_OVERLAP (SpecialRegionStart, SpecialRegionEnd, MapEntryStart, MapEntryEnd)) {
+        // Check if some portion before the map entry isn't covered by the special region
+        if (MapEntryStart < SpecialRegionStart) {
           // Populate a new descriptor for the region before the special region. This entry can go to the end
           // of the memory map because the special region list is sorted
           POPULATE_MEMORY_DESCRIPTOR_ENTRY (


### PR DESCRIPTION
## Description

The special region functionality enables platforms to describe what the memory attributes should be for any number of memory regions when the memory protection initialization routine is complete. The logic which ensures that the special regions are accounted for has a case which is unhandled and described below:

Thef following is a special region which says that the address range should have EFI_MEMORY_RP:
0x4000-0x8000, EFI_MEMORY_RP

When generating the memory map used as a blueprint for applying attributes to the platform, there can be some gaps. Take the following example:
0x0000-0x6000,
0x7000-0x8000

The logic before would properly apply the attributes to the region 0x4000-0x6000 but would get confused when there is a gap between the last map entry and next map entry when the special region covers both. This change fixes this issue by checking if the special region start is within the map entry interval OR the map entry start is within the special region interval (a proper overlap check).

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on Q35 and a Surface ARM platform by publishing a special region which encounters the edge case.

## Integration Instructions

N/A