### PR TITLE
Don't Assert if InitializeSeparateExceptionStacks() Fails

### DIFF
--- a/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
+++ b/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
@@ -261,7 +261,7 @@ DxeMain (
   //
   // Setup Stack Guard
   //
-  // MU_CHANGE START: Check Memory Protection HOB, don't ASSERT if the exception stacks can't be created
+  // MU_CHANGE START: Check Memory Protection HOB, don't ASSERT if the exception stack init returns unsupported
   // if (PcdGetBool (PcdCpuStackGuard)) {
   GuidHob2 = GetFirstGuidHob (&gDxeMemoryProtectionSettingsGuid);
   if ((GuidHob2 != NULL) &&

--- a/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
+++ b/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
@@ -270,7 +270,9 @@ DxeMain (
   {
     Status = InitializeSeparateExceptionStacks (NULL, NULL);
     // ASSERT_EFI_ERROR (Status);
-    DEBUG ((DEBUG_ERROR, "%a: Failed to create exception stacks!\n", __FUNCTION__));
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to create exception stacks!\n", __FUNCTION__));
+    }
   }
 
   // }

--- a/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
+++ b/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
@@ -261,7 +261,7 @@ DxeMain (
   //
   // Setup Stack Guard
   //
-  // MU_CHANGE START: Check Memory Protection HOB
+  // MU_CHANGE START: Check Memory Protection HOB, don't ASSERT if the exception stacks can't be created
   // if (PcdGetBool (PcdCpuStackGuard)) {
   GuidHob2 = GetFirstGuidHob (&gDxeMemoryProtectionSettingsGuid);
   if ((GuidHob2 != NULL) &&
@@ -269,7 +269,8 @@ DxeMain (
       ((DXE_MEMORY_PROTECTION_SETTINGS *)GET_GUID_HOB_DATA (GuidHob2))->CpuStackGuard)
   {
     Status = InitializeSeparateExceptionStacks (NULL, NULL);
-    ASSERT_EFI_ERROR (Status);
+    // ASSERT_EFI_ERROR (Status);
+    DEBUG ((DEBUG_ERROR, "%a: Failed to create exception stacks!\n", __FUNCTION__));
   }
 
   // }

--- a/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
+++ b/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
@@ -269,7 +269,7 @@ DxeMain (
       ((DXE_MEMORY_PROTECTION_SETTINGS *)GET_GUID_HOB_DATA (GuidHob2))->CpuStackGuard)
   {
     Status = InitializeSeparateExceptionStacks (NULL, NULL);
-    // ASSERT_EFI_ERROR (Status);
+    ASSERT (Status == EFI_UNSUPPORTED || !EFI_ERROR (Status));
     if (EFI_ERROR (Status)) {
       DEBUG ((DEBUG_ERROR, "%a: Failed to create exception stacks!\n", __FUNCTION__));
     }


### PR DESCRIPTION
## Description

ARM platforms don't initialize separate exception stacks. The ARM CpuExceptionHandler libraries always return EFI_SUCCESS in InitializeSeparateExceptionStacks() to sidestep this exception. To accommodate the use of the NULL library instance which returns EFI_UNSUPPORTED, just print an error when the routine fails.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on a Surface ARM platform

## Integration Instructions

N/A
