### PR TITLE
Ensure Stack Guard Init is Performed Regardless of Platform NX Policy

### DIFF
--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -3359,11 +3359,11 @@ InitializePageAttributesForMemoryProtectionPolicy (
 
     // Add EFI_MEMORY_RP attribute for the first page of the stack if stack
     // guard is enabled.
-    if ((StackBase != 0) &&
+    if (gDxeMps.CpuStackGuard &&
+        (StackBase != 0) &&
         ((StackBase >= MemoryMapEntry->PhysicalStart) &&
          (StackBase <  MemoryMapEntry->PhysicalStart +
-          LShiftU64 (MemoryMapEntry->NumberOfPages, EFI_PAGE_SHIFT))) &&
-        gDxeMps.CpuStackGuard)
+          LShiftU64 (MemoryMapEntry->NumberOfPages, EFI_PAGE_SHIFT))))
     {
       SetUefiImageMemoryAttributes (
         StackBase,

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -3355,21 +3355,21 @@ InitializePageAttributesForMemoryProtectionPolicy (
         LShiftU64 (MemoryMapEntry->NumberOfPages, EFI_PAGE_SHIFT),
         MemoryMapEntry->Attribute
         );
+    }
 
-      // Add EFI_MEMORY_RP attribute for the first page of the stack if stack
-      // guard is enabled.
-      if ((StackBase != 0) &&
-          ((StackBase >= MemoryMapEntry->PhysicalStart) &&
-           (StackBase <  MemoryMapEntry->PhysicalStart +
-            LShiftU64 (MemoryMapEntry->NumberOfPages, EFI_PAGE_SHIFT))) &&
-          gDxeMps.CpuStackGuard)
-      {
-        SetUefiImageMemoryAttributes (
-          StackBase,
-          EFI_PAGES_TO_SIZE (1),
-          EFI_MEMORY_RP | MemoryMapEntry->Attribute
-          );
-      }
+    // Add EFI_MEMORY_RP attribute for the first page of the stack if stack
+    // guard is enabled.
+    if ((StackBase != 0) &&
+        ((StackBase >= MemoryMapEntry->PhysicalStart) &&
+         (StackBase <  MemoryMapEntry->PhysicalStart +
+          LShiftU64 (MemoryMapEntry->NumberOfPages, EFI_PAGE_SHIFT))) &&
+        gDxeMps.CpuStackGuard)
+    {
+      SetUefiImageMemoryAttributes (
+        StackBase,
+        EFI_PAGES_TO_SIZE (1),
+        EFI_MEMORY_RP | MemoryMapEntry->Attribute
+        );
     }
 
     MemoryMapEntry = NEXT_MEMORY_DESCRIPTOR (MemoryMapEntry, DescriptorSize);


### PR DESCRIPTION
## Description

If the region of memory which contains the stack doesn't have any attributes applied, the application of stack guard would be skipped. This PR moves the stack guard initialization logic after the general memory protection initialization routine to ensure it's run regardless of the NX protection policy.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on a Surface ARM platform and Q35

## Integration Instructions

N/A
