### PR TITLE
CryptoPkg: Update shared crypto to 2023.2.6

### DIFF
--- a/CryptoPkg/Driver/Bin/BaseCryptoDriver_ext_dep.json
+++ b/CryptoPkg/Driver/Bin/BaseCryptoDriver_ext_dep.json
@@ -3,8 +3,7 @@
     "type": "nuget",
     "name": "edk2-basecrypto-driver-bin",
     "source": "https://pkgs.dev.azure.com/projectmu/mu/_packaging/Mu-Public/nuget/v3/index.json",
-    "version": "2023.02.2",
+    "version": "2023.2.6",
     "flags": ["set_build_var"],
     "var_name": "CRYPTO_BINARY_EXTDEP_PATH"
   }
-  


### PR DESCRIPTION
## Description

Crypto binaries in this release include Mu Basecore up to
`v2023020010.0.0` and Standalone MM binaries.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- Tested on the QEMU Q35 virtual platform (`QemuQ35Pkg`)

## Integration Instructions

- Review the [cyrpto binary release notes](https://github.com/microsoft/mu_crypto_release/releases/tag/v2023.2.6) for additional details