### PR TITLE
BaseTools: Add Cargo Feature support for build

### DIFF
--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -282,7 +282,7 @@
         $(OUTPUT_DIR)(+)$(MODULE_NAME)rust.lib
 
     <Command>
-        $(CARGO) make $(CARGOMAKE_FLAGS) -e RUSTFLAGS="-C link-arg=/MAP:$(DEBUG_DIR)(+)$(MODULE_NAME).map $(RUST_FLAGS)" build $(MODULE_NAME)
+        $(CARGO) make $(CARGOMAKE_FLAGS) -e FEATURES=$(CARGO_FEATURES) -e RUSTFLAGS="-C link-arg=/MAP:$(DEBUG_DIR)(+)$(MODULE_NAME).map $(RUST_FLAGS)" build $(MODULE_NAME)
         $(CP) $(DEBUG_DIR)(+)$(TARGET_TRIPLE)(+)$(RUST_TARGET)(+)*.a $(DEBUG_DIR)(+)$(MODULE_NAME)rust.lib
         $(CP) $(DEBUG_DIR)(+)$(TARGET_TRIPLE)(+)$(RUST_TARGET)(+)*.a $(OUTPUT_DIR)(+)$(MODULE_NAME)rust.lib
 
@@ -294,7 +294,7 @@
         $(OUTPUT_DIR)(+)$(MODULE_NAME).efi
 
     <Command>
-        $(CARGO) make $(CARGOMAKE_FLAGS) -e RUSTFLAGS="-C link-arg=/MAP:$(DEBUG_DIR)(+)$(MODULE_NAME).map $(RUST_FLAGS)" build $(MODULE_NAME)
+        $(CARGO) make $(CARGOMAKE_FLAGS) -e FEATURES=$(CARGO_FEATURES) -e RUSTFLAGS="-C link-arg=/MAP:$(DEBUG_DIR)(+)$(MODULE_NAME).map $(RUST_FLAGS)" build $(MODULE_NAME)
         "$(GENFW)" -e $(MODULE_TYPE) -o $(DEBUG_DIR)(+)$(MODULE_NAME).efi $(DEBUG_DIR)(+)$(TARGET_TRIPLE)(+)$(RUST_TARGET)(+)$(MODULE_NAME).efi $(GENFW_FLAGS)
         $(CP) $(DEBUG_DIR)(+)$(MODULE_NAME).map  $(OUTPUT_DIR)(+)$(MODULE_NAME).map
         $(CP) $(DEBUG_DIR)(+)$(MODULE_NAME).efi $(OUTPUT_DIR)(+)$(MODULE_NAME).efi

--- a/BaseTools/Source/Python/AutoGen/GenMake.py
+++ b/BaseTools/Source/Python/AutoGen/GenMake.py
@@ -314,6 +314,7 @@ DEST_DIR_DEBUG = $(DEBUG_DIR)
 
 # MU_CHANGE [BEGIN] - Add Rust build support
 CARGO_OUTPUT_DIR = ${cargo_module_output_directory}
+CARGO_FEATURES = ${cargo_module_enabled_features}
 # MU_CHANGE [END] - Add Rust build support
 
 #
@@ -729,6 +730,7 @@ cleanlib:
             "module_output_directory"   : MyAgo.OutputDir,
             # MU_CHANGE [BEGIN] - Add Rust build support
             "cargo_module_output_directory": MyAgo.OutputDir,
+            "cargo_module_enabled_features": self.GetModuleEnabledRustFeatures(),
             # MU_CHANGE [END] - Add Rust build support
             "module_debug_directory"    : MyAgo.DebugDir,
 
@@ -1196,6 +1198,19 @@ cleanlib:
             Dependency[F] = GetDependencyList(self._AutoGenObject, self.FileCache, F, ForceInculeList, SearchPathList)
         return Dependency
 
+    ## Returns a comma delimited string of enabled cargo features for this module
+    #
+    #   @retval     str            comma delimited string of cargo feature flags
+    #
+    def GetModuleEnabledRustFeatures(self):
+        if self._AutoGenObject.BuildType != "RUST_MODULE":
+            return ""
+        
+        features = ""
+        for pcd in self._AutoGenObject.ModulePcdList:
+            if pcd.Type == "FeatureFlag" and bool(pcd.DefaultValue):
+                features += f'{pcd.TokenCName},'
+        return features
 
 ## CustomMakefile class
 #

--- a/BaseTools/Source/Python/AutoGen/GenMake.py
+++ b/BaseTools/Source/Python/AutoGen/GenMake.py
@@ -1198,6 +1198,7 @@ cleanlib:
             Dependency[F] = GetDependencyList(self._AutoGenObject, self.FileCache, F, ForceInculeList, SearchPathList)
         return Dependency
 
+    # MU_CHANGE [BEGIN] - Add Rust build support
     ## Returns a comma delimited string of enabled cargo features for this module
     #
     #   @retval     str            comma delimited string of cargo feature flags
@@ -1208,6 +1209,7 @@ cleanlib:
             if pcd.Type == "FeatureFlag" and bool(pcd.DefaultValue):
                 features += f'{pcd.TokenCName},'
         return features
+    # MU_CHANGE [END] - Add Rust build support
 
 ## CustomMakefile class
 #

--- a/BaseTools/Source/Python/AutoGen/GenMake.py
+++ b/BaseTools/Source/Python/AutoGen/GenMake.py
@@ -1202,10 +1202,7 @@ cleanlib:
     #
     #   @retval     str            comma delimited string of cargo feature flags
     #
-    def GetModuleEnabledRustFeatures(self):
-        if self._AutoGenObject.BuildType != "RUST_MODULE":
-            return ""
-        
+    def GetModuleEnabledRustFeatures(self):        
         features = ""
         for pcd in self._AutoGenObject.ModulePcdList:
             if pcd.Type == "FeatureFlag" and bool(pcd.DefaultValue):

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -7,7 +7,6 @@ RUSTC_BOOTSTRAP = 1
 ARCH = "X64"
 TARGET_TRIPLE = { source = "${ARCH}", mapping = { "X64" = "x86_64-unknown-uefi", "IA32" = "i686-unknown-uefi", "AARCH64" = "aarch64-unknown-uefi", "LOCAL" = "${CARGO_MAKE_RUST_TARGET_TRIPLE}" }, condition = { env_not_set = [ "TARGET_TRIPLE" ] } }
 
-CARGO_FEATURES_FLAG = {value = "--features ${FEATURES}", condition = {env_set = ["FEATURES"], env_true = ["FEATURES"]}}
 BUILD_FLAGS = "--profile ${RUSTC_PROFILE} --target ${TARGET_TRIPLE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options --timings=html"
 TEST_FLAGS = { value = "", condition = { env_not_set = ["TEST_FLAGS"] } }
 COV_FLAGS = { value = "--out html --exclude-files **/tests/*", condition = { env_not_set = ["COV_FLAGS"] } }
@@ -56,7 +55,7 @@ Example:
 """
 clear = true
 command = "cargo"
-args = ["build", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "@@split(BUILD_FLAGS, )", "@@split(CARGO_FEATURES_FLAG, ,remove-empty)"]
+args = ["build", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "@@split(BUILD_FLAGS, )"]
 dependencies = ["individual-package-targets"]
 
 [tasks.check]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -7,6 +7,7 @@ RUSTC_BOOTSTRAP = 1
 ARCH = "X64"
 TARGET_TRIPLE = { source = "${ARCH}", mapping = { "X64" = "x86_64-unknown-uefi", "IA32" = "i686-unknown-uefi", "AARCH64" = "aarch64-unknown-uefi", "LOCAL" = "${CARGO_MAKE_RUST_TARGET_TRIPLE}" }, condition = { env_not_set = [ "TARGET_TRIPLE" ] } }
 
+CARGO_FEATURES_FLAG = {value = "--features ${FEATURES}", condition = {env_set = ["FEATURES"], env_true = ["FEATURES"]}}
 BUILD_FLAGS = "--profile ${RUSTC_PROFILE} --target ${TARGET_TRIPLE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options --timings=html"
 TEST_FLAGS = { value = "", condition = { env_not_set = ["TEST_FLAGS"] } }
 COV_FLAGS = { value = "--out html --exclude-files **/tests/*", condition = { env_not_set = ["COV_FLAGS"] } }
@@ -55,7 +56,7 @@ Example:
 """
 clear = true
 command = "cargo"
-args = ["build", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "@@split(BUILD_FLAGS, )"]
+args = ["build", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "@@split(BUILD_FLAGS, )", "@@split(CARGO_FEATURES_FLAG, ,remove-empty)"]
 dependencies = ["individual-package-targets"]
 
 [tasks.check]


### PR DESCRIPTION
## Description

Adds build support for setting cargo features via EDKII Feature Pcds.
Adds a new makefile variable, CARGO_FEATURES [a comma separated list]
that is generated per module based on any FeaturePcds in the INF that
are enabled. any build rule can consume this makefile variable.

Updates the build rules for building rust crates to consume this
variable.

Updates cargo make's config to pass the variable to the underlying
build command.

**WARNING: Makefile.toml will be updated via mu_devops (https://github.com/microsoft/mu_devops/pull/298)**

``` diff
diff --git a/.sync/rust_config/Makefile.toml b/.sync/rust_config/Makefile.toml
index 3019bc95..fdcf5643 100644
--- a/.sync/rust_config/Makefile.toml
+++ b/.sync/rust_config/Makefile.toml
@@ -7,6 +7,7 @@ RUSTC_BOOTSTRAP = 1
 ARCH = "X64"
 TARGET_TRIPLE = { source = "${ARCH}", mapping = { "X64" = "x86_64-unknown-uefi", "IA32" = "i686-unknown-uefi", "AARCH64" = "aarch64-unknown-uefi", "LOCAL" = "${CARGO_MAKE_RUST_TARGET_TRIPLE}" }, condition = { env_not_set = [ "TARGET_TRIPLE" ] } }
 
+CARGO_FEATURES_FLAG = {value = "--features ${FEATURES}", condition = {env_set = ["FEATURES"], env_true = ["FEATURES"]}}
 BUILD_FLAGS = "--profile ${RUSTC_PROFILE} --target ${TARGET_TRIPLE} -Zbuild-std=core,compiler_builtins,alloc -Zbuild-std-features=compiler-builtins-mem -Zunstable-options --timings=html"
 TEST_FLAGS = { value = "", condition = { env_not_set = ["TEST_FLAGS"] } }
 COV_FLAGS = { value = "--out html --exclude-files **/tests/*", condition = { env_not_set = ["COV_FLAGS"] } }
@@ -47,15 +48,17 @@ description = """Builds a single rust package.
 Customizations:
     -p [development|release]: Builds in debug or release. Default: development
     -e ARCH=[IA32|X64|AARCH64|LOCAL]: Builds with specifed arch. Default: X64
+    -e FEATURES=[feature,...]: Builds with the specified features. Default: none
 
 Example:
     `cargo make build RustModule`
     `cargo make -p release build RustModule`
     `cargo make -e ARCH=IA32 build RustLib`
+    `cargo make -e FEATURES=feature1,feature2 build RustLib`
 """
 clear = true
 command = "cargo"
-args = ["build", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "@@split(BUILD_FLAGS, )"]
+args = ["build", "@@split(INDIVIDUAL_PACKAGE_TARGETS, )", "@@split(BUILD_FLAGS, )", "@@split(CARGO_FEATURES_FLAG, ,remove-empty)"]
 dependencies = ["individual-package-targets"]
 
 [tasks.check]
```

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [x] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Created a featurePCD and ensured that the rust feature is passed to cargo. Ensured that when the featurepcd is set to true, the feature is enabled in cargo. Ensured that when the featurepcd is set to false, the feature is not enabled in cargo.

## Integration Instructions

Developers will need to complete the following:
1. Remove the temporary Conf file, so that it can be repopulated.
2. Update consuming repository's Makefile.toml from mu_devops.
