### PR TITLE
[REBASE && FF] Compatibility Mode Updates

### DIFF
--- a/MdeModulePkg/Core/Dxe/DxeMain.h
+++ b/MdeModulePkg/Core/Dxe/DxeMain.h
@@ -274,7 +274,7 @@ extern EFI_SECURITY_ARCH_PROTOCOL        *gSecurity;
 extern EFI_SECURITY2_ARCH_PROTOCOL       *gSecurity2;
 extern EFI_BDS_ARCH_PROTOCOL             *gBds;
 extern EFI_SMM_BASE2_PROTOCOL            *gSmmBase2;
-extern EFI_MEMORY_ATTRIBUTE_PROTOCOL     *MemoryAttributeProtocol;      // MU_CHANGE
+extern EFI_MEMORY_ATTRIBUTE_PROTOCOL     *mMemoryAttributeProtocol;      // MU_CHANGE
 
 extern volatile EFI_TPL  gEfiCurrentTpl;                                // MS_CHANGE
 

--- a/MdeModulePkg/Core/Dxe/Image/Image.c
+++ b/MdeModulePkg/Core/Dxe/Image/Image.c
@@ -665,7 +665,7 @@ CoreLoadPeImage (
       return EFI_SECURITY_VIOLATION;
     }
 
-    TurnOffNxCompatibility ();
+    ActivateCompatibilityMode ();
   }
 
   // MU_CHANGE END

--- a/MdeModulePkg/Core/Dxe/Mem/Page.c
+++ b/MdeModulePkg/Core/Dxe/Mem/Page.c
@@ -1572,8 +1572,8 @@ CoreInternalFreePages (
   // MU_CHANGE Start: Unprotect page(s) before free if the memory will be cleared on free
   UINT64  Attributes;
 
-  if (DebugClearMemoryEnabled () && (MemoryAttributeProtocol != NULL)) {
-    Status = MemoryAttributeProtocol->GetMemoryAttributes (MemoryAttributeProtocol, Memory, EFI_PAGES_TO_SIZE (NumberOfPages), &Attributes);
+  if (DebugClearMemoryEnabled () && (mMemoryAttributeProtocol != NULL)) {
+    Status = mMemoryAttributeProtocol->GetMemoryAttributes (mMemoryAttributeProtocol, Memory, EFI_PAGES_TO_SIZE (NumberOfPages), &Attributes);
 
     if ((Attributes & EFI_MEMORY_RO) || (Attributes & EFI_MEMORY_RP) || (Status == EFI_NO_MAPPING)) {
       Status = ClearAccessAttributesFromMemoryRange (Memory, EFI_PAGES_TO_SIZE (NumberOfPages));

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
@@ -1580,8 +1580,8 @@ ApplyMemoryProtectionPolicy (
   // To catch the edge case where the attributes are not consistent across the range, get the
   // attributes from the page table to see if they are consistent. If they are not consistent,
   // GetMemoryAttributes() will return an error.
-  if (MemoryAttributeProtocol != NULL) {
-    if (!EFI_ERROR (MemoryAttributeProtocol->GetMemoryAttributes (MemoryAttributeProtocol, Memory, Length, &OldAttributes)) &&
+  if (mMemoryAttributeProtocol != NULL) {
+    if (!EFI_ERROR (mMemoryAttributeProtocol->GetMemoryAttributes (mMemoryAttributeProtocol, Memory, Length, &OldAttributes)) &&
         (OldAttributes == NewAttributes))
     {
       return EFI_SUCCESS;

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
@@ -215,6 +215,13 @@ GetUefiImageProtectionPolicy (
     return FALSE;
   }
 
+  // MU_CHANGE [START]: Update for compatibility mode
+  if (!IsEnhancedMemoryProtectionActive ()) {
+    return DO_NOT_PROTECT;
+  }
+
+  // MU_CHANGE [END]
+
   //
   // Check DevicePath
   //
@@ -723,7 +730,7 @@ GetPermissionAttributeForMemoryType (
 
   // Handle code allocations according to the NX_COMPAT DLL flag. If the flag is
   // set, the image should update the attributes of code type allocates when it's ready to execute them.
-  if (IsCodeType (MemoryType) && !IsSystemNxCompatible ()) {
+  if (!IsEnhancedMemoryProtectionActive ()) {
     return 0;
   } else if (GetDxeMemoryTypeSettingFromBitfield (MemoryType, gDxeMps.NxProtectionPolicy)) {
     return EFI_MEMORY_XP;
@@ -1179,20 +1186,15 @@ MemoryProtectionExitBootServicesCallback (
   }
 }
 
-/**
-  Disable NULL pointer detection after EndOfDxe. This is a workaround resort in
-  order to skip unfixable NULL pointer access issues detected in OptionROM or
-  boot loaders.
+// MU_CHANGE [START]: Move disable NULL detection to separate routine so it can be called
+//                    outside of the event context.
 
-  @param[in]  Event     The Event this notify function registered to.
-  @param[in]  Context   Pointer to the context data registered to the Event.
+/**
+  Disable NULL pointer detection.
 **/
-// MU_CHANGE START Update naming due to addition of ability to disable at readytoboot
 VOID
-EFIAPI
 DisableNullDetection (
-  EFI_EVENT  Event,
-  VOID       *Context
+  VOID
   )
 {
   EFI_STATUS                       Status;
@@ -1221,18 +1223,32 @@ DisableNullDetection (
              );
   ASSERT_EFI_ERROR (Status);
 
-  //
-  // Page 0 might have be allocated to avoid misuses. Free it here anyway.
-  //
-  CoreFreePages (0, 1);
-
-  CoreCloseEvent (Event);
   DEBUG ((DEBUG_INFO, "%a - end\r\n", __FUNCTION__));
 
   return;
 }
 
-// MU_CHANGE END
+/**
+  Disable NULL pointer detection after EndOfDxe. This is a workaround resort in
+  order to skip unfixable NULL pointer access issues detected in OptionROM or
+  boot loaders.
+
+  @param[in]  Event     The Event this notify function registered to.
+  @param[in]  Context   Pointer to the context data registered to the Event.
+**/
+VOID
+EFIAPI
+DisableNullDetectionEventFunction (
+  EFI_EVENT  Event,
+  VOID       *Context
+  )
+{
+  DisableNullDetection ();
+  CoreCloseEvent (Event);
+  return;
+}
+
+// MU_CHANGE [END]
 
 // MU_CHANGE START: Add function to enable null detection as it is now done in DXE instead of PEI
 
@@ -1397,7 +1413,7 @@ CoreInitializeMemoryProtection (
         Status = CoreCreateEventEx (
                    EVT_NOTIFY_SIGNAL,
                    TPL_NOTIFY,
-                   DisableNullDetection,
+                   DisableNullDetectionEventFunction,
                    NULL,
                    &gEfiEndOfDxeEventGroupGuid,
                    &DisableNullDetectionEvent
@@ -1406,7 +1422,7 @@ CoreInitializeMemoryProtection (
         Status = CoreCreateEventEx (
                    EVT_NOTIFY_SIGNAL,
                    TPL_NOTIFY,
-                   DisableNullDetection,
+                   DisableNullDetectionEventFunction,
                    NULL,
                    &gEfiEventReadyToBootGuid,
                    &DisableNullDetectionEvent

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -25,10 +25,10 @@ MEMORY_PROTECTION_SPECIAL_REGION_PRIVATE_LIST_HEAD  mSpecialMemoryRegionsPrivate
   INITIALIZE_LIST_HEAD_VARIABLE (mSpecialMemoryRegionsPrivate.SpecialRegionList)
 };
 
-BOOLEAN                        mIsSystemNxCompatible       = TRUE;
-EFI_MEMORY_ATTRIBUTE_PROTOCOL  *MemoryAttributeProtocol    = NULL;
-UINT8                          *mBitmapGlobal              = NULL;
-LIST_ENTRY                     **mArrayOfListEntryPointers = NULL;
+BOOLEAN                        mEnhancedMemoryProtectionActive = TRUE;
+EFI_MEMORY_ATTRIBUTE_PROTOCOL  *MemoryAttributeProtocol        = NULL;
+UINT8                          *mBitmapGlobal                  = NULL;
+LIST_ENTRY                     **mArrayOfListEntryPointers     = NULL;
 
 #define IS_BITMAP_INDEX_SET(Bitmap, Index)  ((((UINT8*)Bitmap)[Index / 8] & (1 << (Index % 8))) != 0 ? TRUE : FALSE)
 #define SET_BITMAP_INDEX(Bitmap, Index)     (((UINT8*)Bitmap)[Index / 8] |= (1 << (Index % 8)))
@@ -274,6 +274,15 @@ SetUefiImageMemoryAttributes (
   IN UINT64  BaseAddress,
   IN UINT64  Length,
   IN UINT64  Attributes
+  );
+
+/**
+  Disable NULL pointer detection.
+**/
+VOID
+EFIAPI
+DisableNullDetection (
+  VOID
   );
 
 extern LIST_ENTRY  mGcdMemorySpaceMap;
@@ -3507,30 +3516,80 @@ GetDxeMemoryProtectionSettings (
 }
 
 /**
-  Sets the NX compatibility global to FALSE so future checks to
-  IsSystemNxCompatible() will return FALSE.
+  Uninstalls the Memory Attribute Protocol from all handles.
 **/
 VOID
 EFIAPI
-TurnOffNxCompatibility (
+UninstallMemoryAttributeProtocol (
   VOID
   )
 {
-  if (mIsSystemNxCompatible) {
-    DEBUG ((DEBUG_INFO, "%a - Setting Nx on Code types to FALSE\n", __FUNCTION__));
+  EFI_STATUS  Status;
+  UINTN       HandleCount;
+  UINTN       Index;
+  EFI_HANDLE  *HandleBuffer;
+
+  if (MemoryAttributeProtocol == NULL) {
+    Status = gBS->LocateProtocol (&gEfiMemoryAttributeProtocolGuid, NULL, (VOID **)&MemoryAttributeProtocol);
+    if (EFI_ERROR (Status)) {
+      return;
+    }
   }
 
-  mIsSystemNxCompatible = FALSE;
+  Status = gBS->LocateHandleBuffer (
+                  ByProtocol,
+                  &gEfiMemoryAttributeProtocolGuid,
+                  NULL,
+                  &HandleCount,
+                  &HandleBuffer
+                  );
+
+  if (!EFI_ERROR (Status)) {
+    for (Index = 0; Index < HandleCount; Index++) {
+      Status = gBS->UninstallProtocolInterface (
+                      HandleBuffer[Index],
+                      &gEfiMemoryAttributeProtocolGuid,
+                      MemoryAttributeProtocol
+                      );
+      ASSERT_EFI_ERROR (Status);
+    }
+  }
+
+  if (HandleBuffer != NULL) {
+    FreePool (HandleBuffer);
+  }
 }
 
 /**
-  Returns TRUE if TurnOffNxCompatibility() has never been called.
+  Sets the NX compatibility global to FALSE so future checks to
+  IsEnhancedMemoryProtectionActive() will return FALSE.
 **/
-BOOLEAN
+VOID
 EFIAPI
-IsSystemNxCompatible (
+ActivateCompatibilityMode (
   VOID
   )
 {
-  return mIsSystemNxCompatible;
+  if (!mEnhancedMemoryProtectionActive) {
+    return;
+  }
+
+  DEBUG ((DEBUG_ERROR, "%a - Activating Memory Protection Compatibility Mode!\n", __FUNCTION__));
+
+  mEnhancedMemoryProtectionActive = FALSE;
+
+  DisableNullDetection ();
+  UninstallMemoryAttributeProtocol ();
+}
+
+/**
+  Returns TRUE if ActivateCompatibilityMode() has never been called.
+**/
+BOOLEAN
+EFIAPI
+IsEnhancedMemoryProtectionActive (
+  VOID
+  )
+{
+  return mEnhancedMemoryProtectionActive;
 }

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -26,7 +26,7 @@ MEMORY_PROTECTION_SPECIAL_REGION_PRIVATE_LIST_HEAD  mSpecialMemoryRegionsPrivate
 };
 
 BOOLEAN                        mEnhancedMemoryProtectionActive = TRUE;
-EFI_MEMORY_ATTRIBUTE_PROTOCOL  *MemoryAttributeProtocol        = NULL;
+EFI_MEMORY_ATTRIBUTE_PROTOCOL  *mMemoryAttributeProtocol       = NULL;
 UINT8                          *mBitmapGlobal                  = NULL;
 LIST_ENTRY                     **mArrayOfListEntryPointers     = NULL;
 
@@ -3434,7 +3434,7 @@ MemoryAttributeProtocolNotify (
 {
   EFI_STATUS  Status;
 
-  Status = gBS->LocateProtocol (&gEfiMemoryAttributeProtocolGuid, NULL, (VOID **)&MemoryAttributeProtocol);
+  Status = gBS->LocateProtocol (&gEfiMemoryAttributeProtocolGuid, NULL, (VOID **)&mMemoryAttributeProtocol);
 
   if (EFI_ERROR (Status)) {
     DEBUG ((
@@ -3529,8 +3529,8 @@ UninstallMemoryAttributeProtocol (
   UINTN       Index;
   EFI_HANDLE  *HandleBuffer;
 
-  if (MemoryAttributeProtocol == NULL) {
-    Status = gBS->LocateProtocol (&gEfiMemoryAttributeProtocolGuid, NULL, (VOID **)&MemoryAttributeProtocol);
+  if (mMemoryAttributeProtocol == NULL) {
+    Status = gBS->LocateProtocol (&gEfiMemoryAttributeProtocolGuid, NULL, (VOID **)&mMemoryAttributeProtocol);
     if (EFI_ERROR (Status)) {
       return;
     }
@@ -3549,7 +3549,7 @@ UninstallMemoryAttributeProtocol (
       Status = gBS->UninstallProtocolInterface (
                       HandleBuffer[Index],
                       &gEfiMemoryAttributeProtocolGuid,
-                      MemoryAttributeProtocol
+                      mMemoryAttributeProtocol
                       );
       ASSERT_EFI_ERROR (Status);
     }

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.h
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.h
@@ -145,20 +145,20 @@ MemoryAttributeProtocolNotify (
 
 /**
   Sets the NX compatibility global to FALSE so future checks to
-  IsSystemNxCompatible() will return FALSE.
+  IsEnhancedMemoryProtectionActive() will return FALSE.
 **/
 VOID
 EFIAPI
-TurnOffNxCompatibility (
+ActivateCompatibilityMode (
   VOID
   );
 
 /**
-  Returns TRUE if TurnOffNxCompatibility() has never been called.
+  Returns TRUE if ActivateCompatibilityMode() has never been called.
 **/
 BOOLEAN
 EFIAPI
-IsSystemNxCompatible (
+IsEnhancedMemoryProtectionActive (
   VOID
   );
 

--- a/MdeModulePkg/Include/Guid/DxeMemoryProtectionSettings.h
+++ b/MdeModulePkg/Include/Guid/DxeMemoryProtectionSettings.h
@@ -65,7 +65,7 @@ typedef union {
 
 typedef UINT8 DXE_MEMORY_PROTECTION_SETTINGS_VERSION;
 
-#define DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION  5 // Current iteration of DXE_MEMORY_PROTECTION_SETTINGS
+#define DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION  6 // Current iteration of DXE_MEMORY_PROTECTION_SETTINGS
 
 //
 // Memory Protection Settings struct
@@ -160,9 +160,13 @@ typedef struct {
   // Indicates if stack cookie protection will be enabled
   //
   // A stack cookie check failure will trigger an interrupt. If this boolean is set to FALSE,
-
   // the interrupt should be ignored.
   BOOLEAN                        StackCookies;
+
+  // Indicates if the Memory Attribute Protocol (UEFI Specification 2.10) should be installed
+  //
+  // If TRUE, the protocol will be installed in CpuDxe. If FALSE, it will not be installed.
+  BOOLEAN                        InstallMemoryAttributeProtocol;
 } DXE_MEMORY_PROTECTION_SETTINGS;
 
 #define HOB_DXE_MEMORY_PROTECTION_SETTINGS_GUID \
@@ -263,6 +267,7 @@ extern GUID  gDxeMemoryProtectionSettingsGuid;
               .Fields.OEMReserved                     = 1,      \
               .Fields.OSReserved                      = 1       \
             },                                                  \
+            TRUE,                                               \
             TRUE                                                \
           }
 
@@ -352,6 +357,7 @@ extern GUID  gDxeMemoryProtectionSettingsGuid;
               .Fields.OEMReserved                     = 0,      \
               .Fields.OSReserved                      = 0       \
             },                                                  \
+            TRUE,                                               \
             TRUE                                                \
           }
 
@@ -440,6 +446,7 @@ extern GUID  gDxeMemoryProtectionSettingsGuid;
               .Fields.OEMReserved                     = 0,      \
               .Fields.OSReserved                      = 0       \
             },                                                  \
+            TRUE,                                               \
             TRUE                                                \
           }
 
@@ -527,6 +534,7 @@ extern GUID  gDxeMemoryProtectionSettingsGuid;
               .Fields.OEMReserved                     = 0,      \
               .Fields.OSReserved                      = 0       \
             },                                                  \
+            FALSE,                                              \
             FALSE                                               \
           }
 

--- a/UefiCpuPkg/CpuDxe/CpuDxe.c
+++ b/UefiCpuPkg/CpuDxe/CpuDxe.c
@@ -1256,7 +1256,9 @@ InitializeCpu (
   ASSERT_EFI_ERROR (Status);
 
   // TCBZ3519 MU_CHANGE START
-  InstallEfiMemoryAttributeProtocol ();
+  if (gDxeMps.InstallMemoryAttributeProtocol) {
+    InstallEfiMemoryAttributeProtocol ();
+  }
 
   // MU_CHANGE END
 

--- a/UefiCpuPkg/Library/MpInitLib/DxeMpInitLib.inf
+++ b/UefiCpuPkg/Library/MpInitLib/DxeMpInitLib.inf
@@ -60,7 +60,7 @@
 
 [Protocols]
   gEfiTimerArchProtocolGuid                     ## SOMETIMES_CONSUMES
-  gEfiMemoryAttributeProtocolGuid               ## CONSUMES ## MU_CHANGE
+  gEfiCpuArchProtocolGuid                       ## CONSUMES ## MU_CHANGE
   gCpuMpDebugProtocolGuid                       ## PRODUCES ## MU_CHANGE
 
 [Guids]

--- a/UefiCpuPkg/Library/MpInitLib/DxeMpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/DxeMpLib.c
@@ -22,7 +22,7 @@
 
 // MU_CHANGE START: Update to enable removal of NX attribute from buffer
 #include <Uefi.h>
-#include <Protocol/MemoryAttribute.h>
+#include <Protocol/Cpu.h>
 // MU_CHANGE END
 
 // MU_CHANGE: Add protocol for reporting multi-processor debug info
@@ -72,98 +72,30 @@ BufferRemoveNoExecuteSetReadOnly (
   IN UINTN                 Size
   )
 {
-  EFI_STATUS                     Status;
-  EFI_MEMORY_ATTRIBUTE_PROTOCOL  *MemoryAttribute;
+  EFI_CPU_ARCH_PROTOCOL  *CpuProtocol = NULL;
+  EFI_STATUS             Status;
 
   if ((Buffer == 0) || (Buffer % EFI_PAGE_SIZE != 0) || (Size % EFI_PAGE_SIZE != 0)) {
     return EFI_INVALID_PARAMETER;
   }
 
-  Status = gBS->LocateProtocol (
-                  &gEfiMemoryAttributeProtocolGuid,
-                  NULL,
-                  (VOID **)&MemoryAttribute
-                  );
+  Status = gBS->LocateProtocol (&gEfiCpuArchProtocolGuid, NULL, (VOID **)&CpuProtocol);
 
-  if EFI_ERROR (Status) {
-    DEBUG ((DEBUG_INFO, "%a - Unable to locate Memory Attribute Protocol\n", __FUNCTION__));
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - Unable to locate gEfiCpuArchProtocolGuid\n", __FUNCTION__));
     ASSERT_EFI_ERROR (Status);
     return Status;
   }
 
-  Status = MemoryAttribute->SetMemoryAttributes (
-                              MemoryAttribute,
-                              Buffer,
-                              Size,
-                              EFI_MEMORY_RO
-                              );
+  Status = CpuProtocol->SetMemoryAttributes (
+                          CpuProtocol,
+                          Buffer,
+                          Size,
+                          EFI_MEMORY_RO
+                          );
 
   if EFI_ERROR (Status) {
-    DEBUG ((DEBUG_INFO, "%a - Unable to apply RO attribute to buffer\n", __FUNCTION__));
-    ASSERT_EFI_ERROR (Status);
-  }
-
-  Status = MemoryAttribute->ClearMemoryAttributes (
-                              MemoryAttribute,
-                              Buffer,
-                              Size,
-                              EFI_MEMORY_XP
-                              );
-
-  if EFI_ERROR (Status) {
-    DEBUG ((DEBUG_INFO, "%a - Unable to clear NX attribute from buffer\n", __FUNCTION__));
-    ASSERT_EFI_ERROR (Status);
-  }
-
-  return Status;
-}
-
-/**
-  Remove NX attribute from Buffer
-
-  @param[in]  Buffer      Buffer whose attributes will be altered
-  @param[in]  Size        Size of the buffer
-
-  @retval EFI_SUCCESS             NX attribute removed
-  @retval EFI_INVALID_PARAMETER   Buffer is not page-aligned or Buffer is 0 or Size of buffer
-                                  is not page-aligned
-  @retval Other                   Return value of LocateProtocol or ClearMemoryAttributes
-**/
-EFI_STATUS
-BufferRemoveNoExecute (
-  IN EFI_PHYSICAL_ADDRESS  Buffer,
-  IN UINTN                 Size
-  )
-{
-  EFI_STATUS                     Status;
-  EFI_MEMORY_ATTRIBUTE_PROTOCOL  *MemoryAttribute;
-
-  if ((Buffer == 0) || (Buffer % EFI_PAGE_SIZE != 0) || (Size % EFI_PAGE_SIZE != 0)) {
-    DEBUG ((DEBUG_INFO, "%a - Invalid Parameter!\n", __FUNCTION__));
-    return EFI_INVALID_PARAMETER;
-  }
-
-  Status = gBS->LocateProtocol (
-                  &gEfiMemoryAttributeProtocolGuid,
-                  NULL,
-                  (VOID **)&MemoryAttribute
-                  );
-
-  if EFI_ERROR (Status) {
-    DEBUG ((DEBUG_INFO, "%a - Unable to locate Memory Attribute Protocol\n", __FUNCTION__));
-    ASSERT_EFI_ERROR (Status);
-    return Status;
-  }
-
-  Status = MemoryAttribute->ClearMemoryAttributes (
-                              MemoryAttribute,
-                              Buffer,
-                              Size,
-                              EFI_MEMORY_XP
-                              );
-
-  if EFI_ERROR (Status) {
-    DEBUG ((DEBUG_INFO, "%a - Unable to clear NX attribute from buffer\n", __FUNCTION__));
+    DEBUG ((DEBUG_INFO, "%a - Unable to update buffer attributes!\n", __FUNCTION__));
     ASSERT_EFI_ERROR (Status);
   }
 
@@ -670,7 +602,7 @@ MpInitChangeApLoopCallback (
   CpuMpData->ApLoopMode      = PcdGet8 (PcdCpuApLoopMode);
   mNumberToFinish            = CpuMpData->CpuCount - 1;
   // MU_CHANGE START: Remove NX from AP Loop Buffer
-  BufferRemoveNoExecute (
+  BufferRemoveNoExecuteSetReadOnly (
     (EFI_PHYSICAL_ADDRESS)(UINTN)mReservedApLoopFunc,
     EFI_PAGES_TO_SIZE (EFI_SIZE_TO_PAGES (CpuMpData->AddressMap.RelocateApLoopFuncSize))
     );


### PR DESCRIPTION
## Description

Patches:

1. Linux shim currently incorrectly uses the UEFI memory attribute protocol causing a page fault. The broken shim does not have the NXCOMPAT flag, so compatibility mode can be used to uninstall the protocol when it is loaded. For flexibility, this patch adds a policy configuration option to allow platforms to choose not to install the protocol.

2. Because the memory attribute protocol may not be present on the platform, this update uses the cpu arch protocol to update the attributes of the AP buffer to avoid a fault when executing the wakeup function.

3. As described in the enhanced memory protection document, entering compatibility mode maps page zero, no longer applies attributes to loaded images, allocates memory as RWX, and uninstalls the memory attribute protocol. This patch implements compatibility mode in the DXE Core as it is currently defined. Compatiblity mode is triggered when a non-NXCOMPAT image is loaded.

4. Renames the MemoryAttributeProtocol global to mMemoryAttributeProtocol.

These changes were tested on Q35 by booting to Windows and on SBSA by booting to Ubuntu with a shim which misuses the memory attribute protocol and is not NX compatible.
