### PR TITLE
[Rebase & FF] Fixes for standalone MM and AARCH64 builds

### DIFF
--- a/MdePkg/Library/BaseLib/AArch64/SetJumpLongJump.asm
+++ b/MdePkg/Library/BaseLib/AArch64/SetJumpLongJump.asm
@@ -7,6 +7,7 @@
 
   EXPORT SetJump
   EXPORT InternalLongJump
+  IMPORT InternalAssertJumpBuffer  ; MU_CHANGE: to resolve the symbol
 ; MS_CHANGE: change area name to |.text| and add an ALIGN directive
   AREA |.text|, ALIGN=3, CODE, READONLY
 

--- a/MdePkg/Library/BaseLib/Arm/SetJumpLongJump.asm
+++ b/MdePkg/Library/BaseLib/Arm/SetJumpLongJump.asm
@@ -8,6 +8,7 @@
 
   EXPORT  SetJump
   EXPORT  InternalLongJump
+  IMPORT InternalAssertJumpBuffer ; MU_CHANGE: to resolve the symbol
 
   AREA  BaseLib, CODE, READONLY
 

--- a/StandaloneMmPkg/Library/StandaloneMmCoreMemoryAllocationLib/StandaloneMmCoreMemoryAllocationLib.c
+++ b/StandaloneMmPkg/Library/StandaloneMmCoreMemoryAllocationLib/StandaloneMmCoreMemoryAllocationLib.c
@@ -15,9 +15,10 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
 #include <Library/HobLib.h>
+#include <Library/MmServicesTableLib.h> // MU_CHANGE: Added for gMmst
 #include "StandaloneMmCoreMemoryAllocationServices.h"
 
-EFI_MM_SYSTEM_TABLE  *gMmst = NULL;
+// EFI_MM_SYSTEM_TABLE  *gMmst = NULL; // MU_CHANGE: Removed for gMmst
 
 /**
   Allocates one or more 4KB pages of a certain memory type.

--- a/StandaloneMmPkg/Library/StandaloneMmCoreMemoryAllocationLib/StandaloneMmCoreMemoryAllocationLib.inf
+++ b/StandaloneMmPkg/Library/StandaloneMmCoreMemoryAllocationLib/StandaloneMmCoreMemoryAllocationLib.inf
@@ -39,6 +39,8 @@
   BaseMemoryLib
   DebugLib
   HobLib
+  # MU_CHANGE: Added for gMmst
+  MmServicesTableLib
 
 [Guids]
   gEfiMmPeiMmramMemoryReserveGuid

--- a/StandaloneMmPkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLibCore.c
+++ b/StandaloneMmPkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLibCore.c
@@ -1,0 +1,16 @@
+/** @file
+  MM Services Table Library.
+
+  Copyright (c) 2009 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2018, Linaro, Ltd. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiMm.h>
+#include <Library/MmServicesTableLib.h>
+#include <Library/DebugLib.h>
+
+extern EFI_MM_SYSTEM_TABLE  gMmCoreMmst;
+
+EFI_MM_SYSTEM_TABLE  *gMmst = &gMmCoreMmst;

--- a/StandaloneMmPkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLibCore.inf
+++ b/StandaloneMmPkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLibCore.inf
@@ -1,0 +1,28 @@
+## @file
+# Standalone MM Services Table Library.
+#
+# Copyright (c) Microsoft Corporation.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001B
+  BASE_NAME                      = StandaloneMmServicesTableLibCore
+  FILE_GUID                      = A9E61A64-FDD4-4162-9321-C6769FB96E3B
+  MODULE_TYPE                    = MM_CORE_STANDALONE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = MmServicesTableLib|MM_CORE_STANDALONE
+  PI_SPECIFICATION_VERSION       = 0x00010032
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64 ARM AARCH64
+#
+
+[Sources]
+  StandaloneMmServicesTableLibCore.c
+
+[Packages]
+  MdePkg/MdePkg.dec

--- a/StandaloneMmPkg/StandaloneMmPkg.dsc
+++ b/StandaloneMmPkg/StandaloneMmPkg.dsc
@@ -90,6 +90,8 @@
 
 [LibraryClasses.common.MM_CORE_STANDALONE]
   HobLib|StandaloneMmPkg/Library/StandaloneMmCoreHobLib/StandaloneMmCoreHobLib.inf
+  # MU_CHANGE: Added core instance of MmServicesTableLib
+  MmServicesTableLib|StandaloneMmPkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLibCore.inf
 
 [LibraryClasses.common.MM_STANDALONE]
   MemoryAllocationLib|StandaloneMmPkg/Library/StandaloneMmMemoryAllocationLib/StandaloneMmMemoryAllocationLib.inf
@@ -145,6 +147,7 @@
 
 # MU_CHANGE [BEGIN]
   StandaloneMmPkg/Library/StandaloneMmCoreEntryPointNull/StandaloneMmCoreEntryPointNull.inf
+  StandaloneMmPkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLibCore.inf
 
 [Components.X64]
   StandaloneMmPkg/Library/StandaloneMmCoreEntryPoint/StandaloneMmCoreEntryPoint.inf

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/SmmCpuExceptionHandlerLib.inf
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/SmmCpuExceptionHandlerLib.inf
@@ -63,3 +63,5 @@
 
 [BuildOptions]
   XCODE:*_*_X64_NASM_FLAGS = -D NO_ABSOLUTE_RELOCS_IN_TEXT
+  # MU_CHANGE: Disable absolute relocations in text for GCC as well
+  GCC:*_*_X64_NASM_FLAGS = -D NO_ABSOLUTE_RELOCS_IN_TEXT


### PR DESCRIPTION
## Description

Standalone MM core has a build break when it is done with GCC. The reasons are:

1. The exception handler change in 202311 is causing the assembler to relocate the code, which in cause the GCC linker to complain.
2. The current population of gMmst is done in the MemoryAllocationLib. If this is needed through other libraries in the inf, the build will break.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [x] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This was tested on QEMU Q35 and SBSA platforms and booted to UEFI shell.

## Integration Instructions

Platforms using Standalone MM module will need to include:
```
[LibraryClasses.common.MM_CORE_STANDALONE]
  MmServicesTableLib|StandaloneMmPkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLibCore.inf
```