### PR TITLE
[CHERRY-PICK] .pytool/Plugin: UncrustifyCheck: use stat instead of os.stat

### DIFF
--- a/.pytool/Plugin/UncrustifyCheck/UncrustifyCheck.py
+++ b/.pytool/Plugin/UncrustifyCheck/UncrustifyCheck.py
@@ -12,6 +12,7 @@ import logging
 import os
 import pathlib
 import shutil
+import stat
 import timeit
 from edk2toolext.environment import version_aggregator
 from edk2toolext.environment.plugin_manager import PluginManager
@@ -636,7 +637,7 @@ class UncrustifyCheck(ICiBuildPlugin):
             """
             Private function to attempt to change permissions on file/folder being deleted.
             """
-            os.chmod(path, os.stat.S_IWRITE)
+            os.chmod(path, stat.S_IWRITE)
             func(path)
 
         for _ in range(3):  # retry up to 3 times


### PR DESCRIPTION
## Description

The UncrustifyCheck plugin passes os.stat.S_IWRITE to os.chmod, when attempting to change file permissions. os.stat.S_IWRITE does not exist as os.stat is a function. The correct value is stat.S_IWRITE.


Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Sean Brogan <sean.brogan@microsoft.com>
Reviewed-by: Michael D Kinney <michael.d.kinney@intel.com>

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Verified that when failing, the failure is no longer overshadowed by the exception thrown for S_IWRITE not existing.

## Integration Instructions

N/A