### PR TITLE
Fix undefined symbol for MSVC AARCH64 build

### DIFF
--- a/MdePkg/Library/BaseLib/AArch64/SetJumpLongJump.asm
+++ b/MdePkg/Library/BaseLib/AArch64/SetJumpLongJump.asm
@@ -10,7 +10,7 @@
 ; MS_CHANGE: change area name to |.text| and add an ALIGN directive
   AREA |.text|, ALIGN=3, CODE, READONLY
 
-
+  EXTERN InternalAssertJumpBuffer
 ;/**
 ;  Saves the current CPU context that can be restored with a call to LongJump() and returns 0.#
 ;


### PR DESCRIPTION
## Description

When attempting to build BaseLib using MSVC AARCH64 compiler, the build breaks with error message `undefined symbol: InternalAssertJumpBuffer` (when MDEPKG_NDEBUG is not defined in the dsc file)

Added extern statement for the InternalAssertJumpBuffer to the MS version of the assembly file. 

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

After adding extern statement, compiler was able to build successfully.

## Integration Instructions

N/A
