### PR TITLE
[CHERRY-PICK] CryptoPkg/generate_cryptodriver.py: Fix Crypto protocol include path

### DIFF
--- a/CryptoPkg/Driver/Packaging/generate_cryptodriver.py
+++ b/CryptoPkg/Driver/Packaging/generate_cryptodriver.py
@@ -45,7 +45,7 @@ def main():
         if options.copy:
             # TODO: define this somewhere globally
             h_file_path = os.path.join(options.out_dir, "temp_Crypto.h")
-            shutil.copyfile(h_file_path, os.path.join(ROOT_DIR, "CryptoPkg", "Private", "Protocol", "Crypto.h"))
+            shutil.copyfile(h_file_path, os.path.join(ROOT_DIR, "CryptoPkg", "Include", "Protocol", "Crypto.h"))
     if options.p_file:
         get_crypto_pcds(options, crypto_functions)
     if options.d_file:


### PR DESCRIPTION
## Description

The CryptoPkg/Private directory no longer exists. Replace with
the EDK II Crypto protocol definition in CryptoPkg/Include/Protocol which
is identical.

(cherry picked from commit 46a55e136cf887efd450e2e8f8ce08e1f6fb6cbc)

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- Run `generate_cryptodriver.py` to generate crypto binaries

## Integration Instructions

N/A - Only impacts the script