### PR TITLE
Add MuCodeQlQueries.qls and update the CodeQlAnalyzePlugin to use it

### DIFF
--- a/BaseTools/Plugin/CodeQL/CodeQlAnalyzePlugin.py
+++ b/BaseTools/Plugin/CodeQL/CodeQlAnalyzePlugin.py
@@ -113,7 +113,7 @@ class CodeQlAnalyzePlugin(IUefiBuildPlugin):
         # Use this plugins query set file as the default fallback if it is
         # not overridden. It is possible the file is not present if modified
         # locally. In that case, skip the plugin.
-        plugin_query_set = Path(Path(__file__).parent, "CodeQlQueries.qls")
+        plugin_query_set = Path(Path(__file__).parent, "MuCodeQlQueries.qls")
 
         if not query_specifiers and plugin_query_set.is_file():
             query_specifiers = str(plugin_query_set.resolve())

--- a/BaseTools/Plugin/CodeQL/MuCodeQlQueries.qls
+++ b/BaseTools/Plugin/CodeQL/MuCodeQlQueries.qls
@@ -1,0 +1,135 @@
+---
+- description: Project Mu UEFI (C++) queries
+
+- queries: '.'
+  from: codeql/cpp-queries
+
+##########################################################################################
+# "Core" Queries - Part of Core SDL
+##########################################################################################
+
+## Errors
+- include:
+    id: cpp/badoverflowguard
+- include:
+    id: cpp/likely-bugs/memory-management/v2/conditionally-uninitialized-variable
+- include:
+    id: cpp/pointer-overflow-check
+- include:
+    id: cpp/unguardednullreturndereference
+
+## Warnings
+- include:
+    id: cpp/comparison-with-wider-type
+- include:
+    id: cpp/conditionallyuninitializedvariable
+- include:
+    id: cpp/paddingbyteinformationdisclosure
+- include:
+    id: cpp/uselesstest
+
+## Recommendations
+- include:
+    id: cpp/redundant-null-check-param
+
+##########################################################################################
+# Extra Queries - Outside Core SDL
+##########################################################################################
+
+## Enable When Time is Available to Fix Issues
+# Hundreds of issues. Most appear valid. Type: Recommendation.
+#- include:
+#    id: cpp/missing-null-test
+
+## Errors
+- include:
+    id: cpp/infiniteloop
+- include:
+    id: cpp/missing-return
+- include:
+    id: cpp/no-space-for-terminator
+- include:
+    id: cpp/pointer-overflow-check
+- include:
+    id: cpp/redundant-null-check-simple
+- include:
+    id: cpp/sizeof/const-int-argument
+- include:
+    id: cpp/sizeof/sizeof-or-operation-as-argument
+- include:
+    id: cpp/very-likely-overrunning-write
+
+## Warnings
+- include:
+    id: cpp/comparison-precedence
+- include:
+    id: cpp/implicit-bitfield-downcast
+- include:
+    id: cpp/infinite-loop-with-unsatisfiable-exit-condition
+- include:
+    id: cpp/offset-use-before-range-check
+- include:
+    id: cpp/overflow-buffer
+- include:
+    id: cpp/overflow-calculated
+- include:
+    id: cpp/overflow-destination
+- include:
+    id: cpp/return-stack-allocated-memory
+- include:
+    id: cpp/static-buffer-overflow
+- include:
+    id: cpp/unsigned-comparison-zero
+
+## Recommendations
+- include:
+    id: cpp/missing-header-guard
+- include:
+    id: cpp/unused-local-variable
+- include:
+    id: cpp/unused-static-function
+- include:
+    id: cpp/unused-static-variable
+
+# Note: Some queries above are not active by default with the below filter.
+#       Update the filter and run the queries again to get all results.
+- include:
+    tags:
+      - "security"
+      - "correctness"
+    severity:
+      - "error"
+      - "warning"
+      - "recommendation"
+
+# Specifically hide the results of these.
+#
+# The following rules have been evaluated and explicitly not included for the following reasons:
+#   - `cpp/allocation-too-small` - Appears to be hardcoded for C standard library functions `malloc`, `calloc`,
+#     `realloc`, so it consumes time without much value with custom allocation functions in the codebase.
+#   - `cpp/commented-out-code` - Triggers (way) too often on MU_CHANGE tags.
+#   - `cpp/duplicate-include-guard` - The <Phase>EntryPoint.h files includes a common include guard value
+#     `__MODULE_ENTRY_POINT_H__`. This was the only occurrence found. So not very useful.
+#   - `cpp/invalid-pointer-deref` - Very limited results with what appear to be false positives.
+#   - `cpp/use-of-goto` - Goto is valid and allowed in the codebase.
+#   - `cpp/useless-expression` - Triggers too often on cases where a NULL lib implementation is provided for a function.
+#     Because the implementation simply returns, the check considers it useless.
+#   - `cpp/weak-crypto/*` - Crypto algorithms are tracked outside CodeQL.
+- exclude:
+    id: cpp/allocation-too-small
+- exclude:
+    id: cpp/commented-out-code
+- exclude:
+    id: cpp/duplicate-include-guard
+- exclude:
+    id: cpp/invalid-pointer-deref
+- exclude:
+    id: cpp/use-of-goto
+- exclude:
+    id: cpp/useless-expression
+- exclude:
+    id: cpp/weak-crypto/banned-hash-algorithms
+- exclude:
+    id: cpp/weak-crypto/capi/banned-modes
+- exclude:
+    id: cpp/weak-crypto/openssl/banned-hash-algorithms

--- a/BaseTools/Plugin/CodeQL/Readme.md
+++ b/BaseTools/Plugin/CodeQL/Readme.md
@@ -332,7 +332,7 @@ operation behind the plugin and can be skipped by anyone not interested in those
 6. Determine the CodeQL query specifiers to use for the given package and target
    - First choice, the package CI YAML file value
    - Second choice, the `STUART_CODEQL_QUERY_SPECIFIERS`
-   - Third choice, use `CodeQlQueries.qls` (in the plugin directory)
+   - Third choice, use `MuCodeQlQueries.qls` (in the plugin directory)
 7. Run CodeQL CLI to perform database analysis
 8. Parse the analysis SARIF file to determine the number of CodeQL failures
 9. Return the number of failures (or zero if `AuditOnly` is enabled)


### PR DESCRIPTION
## Description

Added the MuCodeQlQueries.qls file that existed in the .pytool plugin into the BaseTools plugin.  Additionally changed the CodeQlAnalyzePlugin to use MuCodeQlQueries instead of the edk2 CodeQlQueries file.  This runs the codeql queries that project mu cares about instead of the edk2 codeql queries that don't all apply here.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

N/A

## Integration Instructions

Update your MU_BASECORE pin to this commit or later.