### PR TITLE
[CHERRY-PICK] Update pytool dependency (#688)

### DIFF
--- a/BaseTools/Plugin/HostBasedUnitTestRunner/HostBasedUnitTestRunner.py
+++ b/BaseTools/Plugin/HostBasedUnitTestRunner/HostBasedUnitTestRunner.py
@@ -17,7 +17,7 @@ from edk2toolext.environment import shell_environment
 from edk2toollib.utility_functions import RunCmd
 from edk2toollib.utility_functions import GetHostInfo
 from edk2toollib.database import Edk2DB  # MU_CHANGE - reformat coverage data
-from edk2toollib.database.tables import SourceTable, PackageTable, InfTable  # MU_CHANGE - reformat coverage data
+from edk2toollib.database.tables import EnvironmentTable, SourceTable, PackageTable, InfTable  # MU_CHANGE - reformat coverage data
 from textwrap import dedent
 
 
@@ -280,10 +280,10 @@ class HostBasedUnitTestRunner(IUefiBuildPlugin):
     def parse_workspace(self, thebuilder) -> str:
         """Parses the workspace with Edk2DB with the tables necessarty to run stuart_report."""
         db_path = os.path.join(thebuilder.env.GetValue("BUILD_OUTPUT_BASE"), "DATABASE.db")
-        with Edk2DB(db_path, thebuilder.edk2path) as db:
-            db.register(SourceTable(), PackageTable(), InfTable())
-            env_dict = thebuilder.env.GetAllBuildKeyValues() | thebuilder.env.GetAllNonBuildKeyValues()
-            db.parse(env_dict)
+        db = Edk2DB(db_path, thebuilder.edk2path)
+        db.register(EnvironmentTable(), SourceTable(), PackageTable(), InfTable())
+        env_dict = thebuilder.env.GetAllBuildKeyValues() | thebuilder.env.GetAllNonBuildKeyValues()
+        db.parse(env_dict)
         
         return db_path
     # MU_CHANGE end - reformat coverage data

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -12,8 +12,8 @@
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 ##
 
-edk2-pytool-library~=0.19.9 # MU_CHANGE
-edk2-pytool-extensions~=0.26.4 # MU_CHANGE
+edk2-pytool-library~=0.20.0 # MU_CHANGE
+edk2-pytool-extensions~=0.27.0 # MU_CHANGE
 edk2-basetools==0.1.49
 antlr4-python3-runtime==4.13.1
 regex


### PR DESCRIPTION
## Description

Integrates edk2-pytool-extensions 0.27.0 and edk2-pytool-library 0.20.0, which overhauls the database functionality to use an ORM for managing the database schema and access to the database.

Updates the only plugin in MU_BASECORE that uses the database functionality, HostBasedUnitTestRunner.

- [ ] Impacts functionality?
- **Functionality** - Does the change ultimately impact how firmware functions?
- Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
- **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter validation improvement, ...
- [x] Breaking change?
- **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
- Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
- **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
- Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Verified HostBaseUnitTestRunner works as expected with `CC_REORGANIZE=TRUE`, which results in the Edk2DB functionality being used.

## Integration Instructions

HostBasedUnitTestRunner will continue to work in the default configuration, but setting `CC_REORGANIZE=TRUE` on the command line will not work unless the consuming repository also updates the below:
 
- Update edk2-pytool-extensions >= v0.27.0
- Update edk2-pytool-library to >= v0.20.0

(cherry picked from commit c9bc490ab6e26a3f4e4e7aa39f3bec77958db33b)
