### PR TITLE
CryptoPkg: Update shared crypto to 2023.2.8

### DIFF
--- a/CryptoPkg/Driver/Bin/BaseCryptoDriver_ext_dep.json
+++ b/CryptoPkg/Driver/Bin/BaseCryptoDriver_ext_dep.json
@@ -3,7 +3,7 @@
     "type": "nuget",
     "name": "edk2-basecrypto-driver-bin",
     "source": "https://pkgs.dev.azure.com/projectmu/mu/_packaging/Mu-Public/nuget/v3/index.json",
-    "version": "2023.2.6",
+    "version": "2023.2.8",
     "flags": ["set_build_var"],
     "var_name": "CRYPTO_BINARY_EXTDEP_PATH"
   }


### PR DESCRIPTION
## Description

Shared crypto binaries in this release include PEI and Standalone MM
AARCH64 builds.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- QemuQ35Pkg and QemuSbsaPkg CI, boot, and tests.
- Also test new AARCH64 binaries on a physical AARCH64 platform.

## Integration Instructions

Use the new PEI and Standalone MM AARCH64 binaries if needed for a platform.