### PR TITLE
[CHERRY-PICK] Add SHA384 and SHA512 to the STANDARD flavor of the crypto binary

### DIFF
--- a/CryptoPkg/Driver/Bin/Crypto.pcd.STANDARD.inc.dsc
+++ b/CryptoPkg/Driver/Bin/Crypto.pcd.STANDARD.inc.dsc
@@ -36,6 +36,20 @@
   gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceSha256Duplicate           | TRUE
   gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceSha256Update              | TRUE
   gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceSha256Final               | TRUE
+# SHA384 family
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceSha384GetContextSize      | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceSha384Init                | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceSha384Duplicate           | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceSha384Update              | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceSha384Final               | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceSha384HashAll             | TRUE
+# SHA512 family
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceSha512GetContextSize      | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceSha512Init                | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceSha512Duplicate           | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceSha512Update              | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceSha512Final               | TRUE
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceSha512HashAll             | TRUE
 # TLS family
   gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceTlsInitialize             | TRUE
   gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceTlsCtxFree                | TRUE

--- a/CryptoPkg/Driver/Packaging/generate_cryptodriver.py
+++ b/CryptoPkg/Driver/Packaging/generate_cryptodriver.py
@@ -143,7 +143,7 @@ def get_flavors():
             "guid": "d9a75606-caba-4aa0-80a6-591852335400"
         },
         "STANDARD": {
-            "families": ["HMACSHA256", "PKCS", "SHA1", "SHA256", "RANDOM", "TLS", "TLSGET", "TLSSET"],
+            "families": ["HMACSHA256", "PKCS", "SHA1", "SHA256", "SHA384", "SHA512", "RANDOM", "TLS", "TLSGET", "TLSSET"],
             "individuals": ["RsaPkcs1Verify", "RsaNew", "RsaFree", "RsaGetPublicKeyFromX509", "X509GetSubjectName", "X509GetCommonName", "X509GetOrganizationName", "X509GetTBSCert", "RsaPssSign", "RsaPssVerify"],
             "exclude": ["Sha1HashAll", "Sha256HashAll", "Pkcs7Sign", "Pkcs7GetCertificatesList", "ImageTimestampVerify"],
             "guid": "bdee011f-87f2-4a7f-bc5e-44b6b61fef00"


### PR DESCRIPTION
## Description

Authenticated variables were updated to allow the choice of SHA256, SHA384 or SHA512 for hashing. To accommodate this change, we need the algorithms available for use. This change updates the STANDARD flavor of shared crypto to include the SHA384 and SHA512 algorithms so that they can be used by consumers of the binary.

There is no size impact for the STANDARD flavor because all of the SHA implementations are built together in openssl. This simply enables their use.

- [x] Impacts functionality?
- **Functionality** - Does the change ultimately impact how firmware functions?
- Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
- **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter validation improvement, ...
- [ ] Breaking change?
- **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
- Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
- **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
- Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on locally generated binaries. SHA384 and SHA512 were available to use.

## Integration Instructions

N/A