### PR TITLE
Remove static initialization of gMmst for MM Core Lib

### DIFF
--- a/StandaloneMmPkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLibCore.c
+++ b/StandaloneMmPkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLibCore.c
@@ -11,6 +11,4 @@
 #include <Library/MmServicesTableLib.h>
 #include <Library/DebugLib.h>
 
-extern EFI_MM_SYSTEM_TABLE  gMmCoreMmst;
-
-EFI_MM_SYSTEM_TABLE  *gMmst = &gMmCoreMmst;
+EFI_MM_SYSTEM_TABLE  *gMmst = NULL;


### PR DESCRIPTION
## Description

Removes static initialization for gMmst in the MM Core implementation of MmServicesTableLib. Static initialization of this structure is problematic as callers will use the initialized value as a indication services are ready for use. This results in premature calls to memory allocations causing early faults in the core.

- [X] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested boot with change.

## Integration Instructions

N/A
