### PR TITLE
.pytool/Plugin/DscCompleteCheck: Allow git ignore syntax

### DIFF
--- a/.pytool/Plugin/DscCompleteCheck/DscCompleteCheck.py
+++ b/.pytool/Plugin/DscCompleteCheck/DscCompleteCheck.py
@@ -9,6 +9,7 @@ from edk2toolext.environment.plugintypes.ci_build_plugin import ICiBuildPlugin
 from edk2toollib.uefi.edk2.parsers.dsc_parser import DscParser
 from edk2toollib.uefi.edk2.parsers.inf_parser import InfParser
 from edk2toolext.environment.var_dict import VarDict
+from edk2toollib.gitignore_parser import parse_gitignore_lines  # MU_CHANGE - Add git ignore syntax
 from pathlib import Path
 from edk2toollib.uefi.edk2.path_utilities import Edk2Path
 
@@ -77,10 +78,17 @@ class DscCompleteCheck(ICiBuildPlugin):
             x) for x in INFFiles]  # make edk2relative path so can compare with DSC
 
         # remove ignores
-
+        # MU_CHANGE [BEGIN] - Add git ignore syntax
+        ignored_paths = []
         if "IgnoreInf" in pkgconfig:
-            for a in pkgconfig["IgnoreInf"]:
-                a = a.replace(os.sep, "/")
+            ignore_filter = parse_gitignore_lines(
+                pkgconfig["IgnoreInf"],
+                "DSC Complete Check Config",
+                os.path.dirname(abs_pkg_path))
+            ignored_paths = list(filter(ignore_filter, INFFiles))
+        # MU_CHANGE [END] - Add git ignore syntax
+
+            for a in ignored_paths:  # MU_CHANGE - Add git ignore syntax
                 try:
                     tc.LogStdOut("Ignoring INF {0}".format(a))
                     INFFiles.remove(a)

--- a/.pytool/Plugin/DscCompleteCheck/Readme.md
+++ b/.pytool/Plugin/DscCompleteCheck/Readme.md
@@ -29,4 +29,5 @@ Path to DSC to consider platform dsc
 
 ### IgnoreInf
 
-Ignore error if Inf file is not listed in DSC file
+A list of paths in git ignore syntax to ignore in the check. These can include directory and file paths. The path is
+relative to the directory that contains the pacakge.


### PR DESCRIPTION
## Description

Allows ignore lines in the CI YAML file to use git ignore syntax.

This is especially useful for ignore files recursively in directories
like those that may exist in an external dependency folder.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [x] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- DSC Complete against all packages in Mu Basecore
- DSC Complete against CryptoPkg ignoring shared crypto ext dep INFs
  with `CryptoPkg/Binaries/**`

## Integration Instructions

Use the new syntax if beneficial in a platform.