### PR TITLE
BaseTools/GenFds: Resolve absolute workspace INF paths

### DIFF
--- a/BaseTools/Source/Python/GenFds/FfsInfStatement.py
+++ b/BaseTools/Source/Python/GenFds/FfsInfStatement.py
@@ -19,6 +19,7 @@ from .GenFdsGlobalVariable import GenFdsGlobalVariable
 from .Ffs import SectionSuffix,FdfFvFileTypeToFileType
 import subprocess
 import sys
+from pathlib import Path        # MU_CHANGE - Consolidate absolute INF paths
 from . import Section
 from . import RuleSimpleFile
 from . import RuleComplexFile
@@ -156,7 +157,14 @@ class FfsInfStatement(FfsInfStatementClassObject):
         if len(self.InfFileName) > 1 and self.InfFileName[0] == '\\' and self.InfFileName[1] == '\\':
             pass
         elif self.InfFileName[0] == '\\' or self.InfFileName[0] == '/' :
-            self.InfFileName = self.InfFileName[1:]
+            # MU_CHANGE [BEGIN] - Consolidate absolute INF paths
+            ws_path = Path(GenFdsGlobalVariable.WorkSpaceDir)
+            inf_path = Path(self.InfFileName)
+            if ws_path in inf_path.parents:
+                self.InfFileName = str(inf_path.relative_to(ws_path))
+            else:
+                self.InfFileName = self.InfFileName[1:]
+            # MU_CHANGE [END] - Consolidate absolute INF paths
 
         if self.InfFileName.find('$') == -1:
             InfPath = NormPath(self.InfFileName)


### PR DESCRIPTION
## Description

Currently, if an INF path is an absolute path on Linux (begins with
"/"), the "/" character will be removed. If the path is an absolute
system path, this creates an invalid path.

This creates an issue, for example, if an INF is in an ext dep where
the ext dep has the `set_build_var` flag set and DSC files refer to
files by its build variable (e.g. `$(SHARED_CRYPTO_PATH)/Module.inf`).

`$(SHARED_CRYPTO_PATH)` will be an absolute path to the ext dep
directory and `FfsInfStatement.__InfParse__` will remove the leading
"/" character so the path is invalid.

This change first checks if the absolute path will resolve into the
current workspace. If it does (as will happen in the shared crypto
ext dep example above), it modifies the path to be relative to the
workspace so later logic dependent on relative paths can operate on
it. If the absolute path is not within the current workspace, it
follows previous behavior for backward compatibility to that
scenario.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- Build with the change against Mu Basecore CI and Mu Tiano Platforms platform builds.
- Build on Ubuntu with an ext dep that sets an absolute path in a build variable that
  is used to build an INF file. Verify failure before and success after the change.

## Integration Instructions

N/A