### PR TITLE
CryptoPkg/RuntimeDxeCryptLib: Make globals static

### DIFF
--- a/CryptoPkg/Library/BaseCryptLibOnProtocolPpi/RuntimeDxeCryptLib.c
+++ b/CryptoPkg/Library/BaseCryptLibOnProtocolPpi/RuntimeDxeCryptLib.c
@@ -14,8 +14,8 @@
 #include <Library/UefiRuntimeLib.h>
 #include <Protocol/Crypto.h>
 
-EDKII_CRYPTO_PROTOCOL  *mCryptoProtocol           = NULL;
-EFI_EVENT              mVirtualAddressChangeEvent = NULL;
+STATIC  EDKII_CRYPTO_PROTOCOL  *mCryptoProtocol           = NULL;
+STATIC  EFI_EVENT              mVirtualAddressChangeEvent = NULL;
 
 /**
   Internal worker function that returns the pointer to an EDK II Crypto


### PR DESCRIPTION
## Description

The GNU linker (ld) raises an error due to duplicate symbols for the
`mVirtualAddressChangeEvent` global. This change updates both globals
in the file to be static to prevent future symbol collisions.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- Built `VariableRuntimeDxe` using GCC on Ubuntu with the `RuntimeDxeCryptLib`
  library instance linked.

## Integration Instructions

N/A