### PR TITLE
Add deprecation warning support to OverrideValidation plugin

### DIFF
--- a/BaseTools/Plugin/OverrideValidation/OverrideValidation.py
+++ b/BaseTools/Plugin/OverrideValidation/OverrideValidation.py
@@ -400,7 +400,7 @@ try:
             normalized_file_path = filepath.replace("\\", "/")
 
             # Check if the module is part of the skip list
-            skip_list = thebuilder.env.GetValue("DEPRECATED_MODULES_SKIPLIST").split(";")
+            skip_list = thebuilder.env.GetValue("DEPRECATED_MODULES_SKIPLIST")
             for module in skip_list:
                 if module.strip() == "":
                     continue
@@ -705,12 +705,12 @@ def path_parse():
 
     if Paths.DeprecatedPath is not None:
         if not os.path.isfile(Paths.DeprecatedPath):
-            raise RuntimeError("Deprecation path module is invalid")
+            raise RuntimeError(f"Deprecation path {Paths.DeprecatedPath} module is invalid")
         # Needs to strip os.sep is to take care of the root path case
         # For a folder, this will do nothing on a formatted abspath
         # For a drive root, this will rip off the os.sep
         if not os.path.normcase(Paths.DeprecatedPath).startswith(os.path.normcase(Paths.WorkSpace.rstrip(os.sep)) + os.sep):
-            raise RuntimeError("Module is not within specified Workspace.")
+            raise RuntimeError(f"Module {Paths.DeprecatedPath} is not within the specified Workspace {Paths.WorkSpace.rstrip(os.sep)}.")
 
     return Paths
 

--- a/BaseTools/Plugin/OverrideValidation/OverrideValidation.py
+++ b/BaseTools/Plugin/OverrideValidation/OverrideValidation.py
@@ -3,6 +3,8 @@
 # This tool depends on EDK2 and will parse dsc files, inf files and other standard
 # EDK2 assets
 #
+# This tool also generates deprecation warnings if a given file is deprecated
+#
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
@@ -32,20 +34,21 @@ try:
     from edk2toollib.utility_functions import RunCmd
 
     #Tuple for (version, entrycount)
-    FORMAT_VERSION_1 = (1, 4)   #Version 1: #OVERRIDE : VERSION | PATH_TO_MODULE | HASH | YYYY-MM-DDThh-mm-ss
-    FORMAT_VERSION_2 = (2, 5)   #Version 2: #OVERRIDE : VERSION | PATH_TO_MODULE | HASH | YYYY-MM-DDThh-mm-ss | GIT_COMMIT
-    FORMAT_VERSIONS = [FORMAT_VERSION_1, FORMAT_VERSION_2]
-
+    OVERRIDE_FORMAT_VERSION_1 = (1, 4)   #Version 1: #OVERRIDE : VERSION | PATH_TO_MODULE | HASH | YYYY-MM-DDThh-mm-ss
+    OVERRIDE_FORMAT_VERSION_2 = (2, 5)   #Version 2: #OVERRIDE : VERSION | PATH_TO_MODULE | HASH | YYYY-MM-DDThh-mm-ss | GIT_COMMIT
+    DEPRECATION_FORMAT_VERSION_1 = (1, 3)   # Version 1: # DEPRECATED : VERSION | PATH_TO_NEW_MODULE_TO_USE | YYYY-MM-DDThh-mm-ss
+    FORMAT_VERSIONS = [OVERRIDE_FORMAT_VERSION_1, OVERRIDE_FORMAT_VERSION_2, DEPRECATION_FORMAT_VERSION_1]
 
     class OverrideValidation(IUefiBuildPlugin):
 
         class OverrideResult(object):
-            OR_ALL_GOOD             = 0
-            OR_FILE_CHANGE          = 1
-            OR_VER_UNRECOG          = 2
-            OR_INVALID_FORMAT       = 3
-            OR_DSC_INF_NOT_FOUND    = 4
-            OR_TARGET_INF_NOT_FOUND = 5
+            OR_ALL_GOOD               = 0
+            OR_FILE_CHANGE            = 1
+            OR_VER_UNRECOG            = 2
+            OR_INVALID_FORMAT         = 3
+            OR_DSC_INF_NOT_FOUND      = 4
+            OR_TARGET_INF_NOT_FOUND   = 5
+            OR_DEPRECATED_MODULE_USED = 6
 
             @classmethod
             def GetErrStr (cls, errcode):
@@ -62,6 +65,8 @@ try:
                     str = 'FILE_NOT_FOUND'
                 elif (errcode == cls.OR_TARGET_INF_NOT_FOUND):
                     str = 'INF_FILE_NOT_FOUND'
+                elif (errcode == cls.OR_DEPRECATED_MODULE_USED):
+                    str = 'DEPRECATED_MODULE_USED'
                 else:
                     str = 'UNKNOWN'
                 return str
@@ -176,20 +181,21 @@ try:
                     CommentLine = Line.strip('#').split(':')
                     if (len(CommentLine) != 2) or\
                        ((CommentLine[0].strip().lower() != 'override') and\
-                        (CommentLine[0].strip().lower() != 'track')):
+                        (CommentLine[0].strip().lower() != 'track') and
+                        (CommentLine[0].strip().lower() != 'deprecated')):
                         continue
 
                     # Process the override content, 1. Bail on bad data; 2. Print on formatted data (matched or not)
                     tagtype = CommentLine[0].strip().lower()
                     m_result = self.override_process_line(thebuilder, CommentLine[1], filepath, filelist, modulenode, status, tagtype)
 
-                    if CommentLine[0].strip().lower() == 'override':
+                    if tagtype == 'override':
                         # For override tags, the hash has to match
                         if m_result != self.OverrideResult.OR_ALL_GOOD:
                             result = m_result
                             logging.error("At Line %d: %s" %(lineno, Line))
 
-                    elif CommentLine[0].strip().lower() == 'track':
+                    elif tagtype == 'track':
                         # For track tags, ignore the tags of which inf modules are not found
                         trackno = trackno + 1
                         if m_result == self.OverrideResult.OR_TARGET_INF_NOT_FOUND:
@@ -203,6 +209,10 @@ try:
                             logging.error("At Line %d: %s" %(lineno, Line))
                         else:
                             track_ag.append(modulenode.reflist[-1].path)
+
+                    elif tagtype == 'deprecated':
+                        if m_result == self.OverrideResult.OR_DEPRECATED_MODULE_USED:
+                            logging.warning("At Line %d: %s" %(lineno, Line))
 
             if trackno != 0 and len(track_nf) == trackno:
                 # All track tags in this file are not found, this will enforce a failure, if not already failed
@@ -275,7 +285,9 @@ try:
                 m_node.status = result
                 return result
 
-            if version_match[0] == 1:
+            if version_match[0] == 1 and tagtype == 'deprecated':
+                return self.deprecation_process_line_with_version1(thebuilder, filepath, OverrideEntry)
+            elif version_match[0] == 1:
                 return self.override_process_line_with_version1(thebuilder, filelist, OverrideEntry, m_node, status, tagtype)
             elif version_match[0] == 2:
                 return self.override_process_line_with_version2(thebuilder, filelist, OverrideEntry, m_node, status, tagtype)
@@ -366,6 +378,12 @@ try:
             return result
         # END: override_process_line_version2(self, thebuilder, filelist, OverrideEntry, m_node, status)
 
+        def deprecation_process_line_with_version1(self, thebuilder, filepath, DeprecationEntry):
+            if thebuilder.env.GetValue("ALLOW_DEPRECATED_MODULES") == "TRUE":
+                logging.info("Deprecated modules check is disabled")
+                return self.OverrideResult.OR_ALL_GOOD
+            logging.warning("Use of Deprecated module: %s, Please switch to: %s.", filepath, thebuilder.edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath(DeprecationEntry[1].strip()))
+
         # Check override record against parsed entries
         # version: Override record's version number, normally parsed from the override record line
         # hash: Override record's hash field, normally parsed from the override record line, calculated by the standalone ModuleHash tool
@@ -375,7 +393,7 @@ try:
             hash_val = ''
 
             # Error out the unknown version
-            if (version == FORMAT_VERSION_1[0]):
+            if (version == OVERRIDE_FORMAT_VERSION_1[0]):
                 hash_val = ModuleHashCal(fullpath)
                 if (hash_val != hash):
                     result = self.OverrideResult.OR_FILE_CHANGE
@@ -582,6 +600,14 @@ def path_parse():
         '-r', '--regenpath', dest = 'RegenPath', type=str,
         help = '''Specify the absolute path to an inf with existing overrides to regen by passing r Path/To/Target or --regenpath Path/To/Target.'''
         )
+    group.add_argument (
+        '-d', '--deprecatepath', dest = 'DeprecatedPath', type=str,
+        help = '''Specify the absolute path to the file to be deprecated by passing -d DEPRECATED_MODULE_PATH or --deprecatepath DEPRECATED_MODULE_PATH.'''
+        )
+    parser.add_argument (
+        '-dr', '--deprecationreplacementpath', dest = 'DeprecationReplacementPath', type=str,
+        help = '''Specify the relative path from the package to the replacement module by passing -dr Path/To/ReplacementPath or --deprecationreplacementpath Path/To/Target.'''
+        )
     parser.add_argument (
         '-p', '--packagepath', dest = 'RegenPackagePath', nargs="*", default=[],
         help = '''Specify the packages path to be used to resolve relative paths when using --regenpath. ignored otherwise. Workspace is always included.'''
@@ -608,7 +634,7 @@ def path_parse():
         if not os.path.isfile(Paths.TargetPath):
             raise RuntimeError("Module path is invalid.")
 
-    if Paths.Version < 1 or Paths.Version > len(FORMAT_VERSIONS):
+    if Paths.Version not in [version_format[0] for version_format in FORMAT_VERSIONS]:
         raise RuntimeError("Version is invalid")
 
     if not os.path.isdir(Paths.WorkSpace):
@@ -629,6 +655,15 @@ def path_parse():
         # For a folder, this will do nothing on a formatted abspath
         # For a drive root, this will rip off the os.sep
         if not os.path.normcase(Paths.RegenPath).startswith(os.path.normcase(Paths.WorkSpace.rstrip(os.sep)) + os.sep):
+            raise RuntimeError("Module is not within specified Workspace.")
+
+    if Paths.DeprecatedPath is not None:
+        if not os.path.isfile(Paths.DeprecatedPath):
+            raise RuntimeError("Deprecation path module is invalid")
+        # Needs to strip os.sep is to take care of the root path case
+        # For a folder, this will do nothing on a formatted abspath
+        # For a drive root, this will rip off the os.sep
+        if not os.path.normcase(Paths.DeprecatedPath).startswith(os.path.normcase(Paths.WorkSpace.rstrip(os.sep)) + os.sep):
             raise RuntimeError("Module is not within specified Workspace.")
 
     return Paths
@@ -671,10 +706,10 @@ if __name__ == '__main__':
                         VERSION_INDEX = Paths.Version - 1
 
                         if VERSION_INDEX == 0:
-                            line = '#%s : %08d | %s | %s | %s\n' % (match.group(1), FORMAT_VERSION_1[0], rel_path, mod_hash, datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S"))
+                            line = '#%s : %08d | %s | %s | %s\n' % (match.group(1), OVERRIDE_FORMAT_VERSION_1[0], rel_path, mod_hash, datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S"))
                         elif VERSION_INDEX == 1:
                             git_hash = ModuleGitHash(abs_path)
-                            line = '#%s : %08d | %s | %s | %s | %s\n' % (match.group(1), FORMAT_VERSION_2[0], rel_path, mod_hash, datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S"), git_hash)
+                            line = '#%s : %08d | %s | %s | %s | %s\n' % (match.group(1), OVERRIDE_FORMAT_VERSION_2[0], rel_path, mod_hash, datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S"), git_hash)
                         print("Updating:\n" + line)
                 else:
                     print(f"Warning: Could not resolve relative path {rel_path}. Override line not updated.\n")
@@ -687,28 +722,50 @@ if __name__ == '__main__':
     else:
         dummy_list = []
         pathtool = Edk2Path(Paths.WorkSpace, dummy_list)
+        if Paths.DeprecatedPath is not None:
+            # Generate deprecation warning line
+            #    DEPRECATION_FORMAT_VERSION_1 = (1, 4)   # Version 1: # DEPRECATED : VERSION | PATH_TO_NEW_MODULE_TO_USE | YYYY-MM-DDThh-mm-ss
 
-        # Generate and print the override for pasting into the file.
-        # Use absolute module path to find package path
-        pkg_path = pathtool.GetContainingPackage(Paths.TargetPath)
-        if pkg_path is not None:
-            rel_path = Paths.TargetPath[Paths.TargetPath.find(pkg_path):]
+            if Paths.DeprecationReplacementPath is not None:
+                pkg_path = pathtool.GetContainingPackage(Paths.DeprecationReplacementPath)
+                if pkg_path is not None:
+                    rel_path = Paths.DeprecationReplacementPath[Paths.DeprecationReplacementPath.find(pkg_path):]
+                else:
+                    rel_path = pathtool.GetEdk2RelativePathFromAbsolutePath(Paths.DeprecationReplacementPath)
+                    if not rel_path:
+                        print(f"{Paths.DeprecationReplacementPath} is invalid for this workspace.")
+                        sys.exit(1)
+                rel_path = rel_path.replace('\\', '/')
+            else:
+                rel_path = "REMOVED_COMPLETELY"
+
+            print("Copy and paste the following line(s) to your deprecated inf file(s):\n")
+            print('#%s : %08d | %s | %s \n' % ('Deprecated', DEPRECATION_FORMAT_VERSION_1[0], rel_path, datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S")))
+
         else:
-            rel_path = pathtool.GetEdk2RelativePathFromAbsolutePath(Paths.TargetPath)
-            if not rel_path:
-                print(f"{Paths.TargetPath} is invalid for this workspace.")
-                sys.exit(1)
+            # Generate override hash
 
-        rel_path = rel_path.replace('\\', '/')
-        mod_hash = ModuleHashCal(Paths.TargetPath)
+            # Generate and print the override for pasting into the file.
+            # Use absolute module path to find package path
+            pkg_path = pathtool.GetContainingPackage(Paths.TargetPath)
+            if pkg_path is not None:
+                rel_path = Paths.TargetPath[Paths.TargetPath.find(pkg_path):]
+            else:
+                rel_path = pathtool.GetEdk2RelativePathFromAbsolutePath(Paths.TargetPath)
+                if not rel_path:
+                    print(f"{Paths.TargetPath} is invalid for this workspace.")
+                    sys.exit(1)
 
-        VERSION_INDEX = Paths.Version - 1
+            rel_path = rel_path.replace('\\', '/')
+            mod_hash = ModuleHashCal(Paths.TargetPath)
 
-        if VERSION_INDEX == 0:
-            print("Copy and paste the following line(s) to your overrider inf file(s):\n")
-            print('#%s : %08d | %s | %s | %s' % ("Override" if not Paths.Track else "Track", FORMAT_VERSION_1[0], rel_path, mod_hash, datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S")))
+            VERSION_INDEX = Paths.Version - 1
 
-        elif VERSION_INDEX == 1:
-            git_hash = ModuleGitHash(Paths.TargetPath)
-            print("Copy and paste the following line(s) to your overrider inf file(s):\n")
-            print('#%s : %08d | %s | %s | %s | %s' % ("Override" if not Paths.Track else "Track", FORMAT_VERSION_2[0], rel_path, mod_hash, datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S"), git_hash))
+            if VERSION_INDEX == 0:
+                print("Copy and paste the following line(s) to your overrider inf file(s):\n")
+                print('#%s : %08d | %s | %s | %s' % ("Override" if not Paths.Track else "Track", OVERRIDE_FORMAT_VERSION_1[0], rel_path, mod_hash, datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S")))
+
+            elif VERSION_INDEX == 1:
+                git_hash = ModuleGitHash(Paths.TargetPath)
+                print("Copy and paste the following line(s) to your overrider inf file(s):\n")
+                print('#%s : %08d | %s | %s | %s | %s' % ("Override" if not Paths.Track else "Track", OVERRIDE_FORMAT_VERSION_2[0], rel_path, mod_hash, datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S"), git_hash))

--- a/BaseTools/Plugin/OverrideValidation/OverrideValidation_plug_in.json
+++ b/BaseTools/Plugin/OverrideValidation/OverrideValidation_plug_in.json
@@ -1,5 +1,5 @@
 {
   "scope": "global",
-  "name": "Override Validation Pre Build Plugin",
+  "name": "Override Validation and Deprecation Warning Pre Build Plugin",
   "module": "OverrideValidation"
 }

--- a/BaseTools/Plugin/OverrideValidation/ReadMe.md
+++ b/BaseTools/Plugin/OverrideValidation/ReadMe.md
@@ -102,6 +102,29 @@ Override record to be included in overriding module's inf:
 #Override : 00000002 | MdeModulePkg/Library/BaseSerialPortLib16550 | 140759cf30a73b02f48cc1f226b015d8 | 2021-12-07T05-30-10 | fa99a33fdb7e8bf6063513fddb807105ec2fad81
 ```
 
+Command to generate a deprecation record:
+
+``` cmd
+OverrideValidation.py -w C:\Repo -d C:\Repo\MU_BASECORE\MdeModulePkg\BaseMemoryLib\BaseMemoryLib.inf -dr C:\Repo\MU_BASECORE\MdeModulePkg\BaseMemoryLibV2\BaseMemoryLib.inf
+```
+
+Deprecation record to be included in the deprecated module's inf:
+
+``` cmd
+#Deprecated : 00000001 | MdeModulePkg/BaseMemoryLibV2/BaseMemoryLib.inf | 2024-02-16T04-00-28
+```
+
+Deprecation warning example:
+
+``` cmd
+WARNING - Use of Deprecated module: C:\Repo\MU_BASECORE\MdeModulePkg\BaseMemoryLib\BaseMemoryLib.inf, Please switch to:  C:\Repo\MU_BASECORE\MdeModulePkg\BaseMemoryLibV2\BaseMemoryLib.inf.
+```
+
+To disable Deprecation warnings, Set the following value in the build scripts.
+
+``` cmd
+self.env.SetValue("ALLOW_DEPRECATED_MODULES", "TRUE", "Allow the usage of deprecated modules")
+```
 Override log generated during pre-build process:
 
 ``` cmd
@@ -151,15 +174,15 @@ index 2d4ca47299..90da207a39 100644
 
 ## Versions
 
-There are two versions of the override format.
+There are two versions of the override format and one version of the deprecation format
 
-### Version 1
+### Override Version 1
 
 ``` cmd
 #Override : 00000001 | MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf | cc255d9de141fccbdfca9ad02e0daa47 | 2018-05-09T17-54-17
 ```
 
-### Version 2
+### Override Version 2
 
 ``` cmd
 #Override : 00000002 | MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf | cc255d9de141fccbdfca9ad02e0daa47 | 2018-05-09T17-54-17 | 575096df6a
@@ -169,6 +192,12 @@ Version 2 includes a second hash at the end, which is the git commit that the
 upstream was last updated. This allows to tools to do a `git diff` between what
 you currently have and what is in the tree. It currently only diffs the
 overridden file (the INF or DSC) and the overriding file.
+
+### Deprecation Version 1
+
+``` cmd
+#Deprecated : 00000001 | MdeModulePkg/BaseMemoryLibV2/BaseMemoryLib.inf | 2024-02-16T04-00-28
+```
 
 ## Copyright & License
 

--- a/BaseTools/Plugin/OverrideValidation/ReadMe.md
+++ b/BaseTools/Plugin/OverrideValidation/ReadMe.md
@@ -105,13 +105,13 @@ Override record to be included in overriding module's inf:
 Command to generate a deprecation record:
 
 ``` cmd
-OverrideValidation.py -w C:\Repo -d C:\Repo\MU_BASECORE\MdeModulePkg\BaseMemoryLib\BaseMemoryLib.inf -dr C:\Repo\MU_BASECORE\MdeModulePkg\BaseMemoryLibV2\BaseMemoryLib.inf
+OverrideValidation.py -w C:\Repo -d C:\Repo\MU_BASECORE\MdeModulePkg\BaseMemoryLib\BaseMemoryLib.inf -dr C:\Repo\MU_BASECORE\MdeModulePkg\BaseMemoryLibV2\BaseMemoryLib.inf -dt 120
 ```
 
 Deprecation record to be included in the deprecated module's inf:
 
 ``` cmd
-#Deprecated : 00000001 | MdeModulePkg/BaseMemoryLibV2/BaseMemoryLib.inf | 2024-02-16T04-00-28
+#Deprecated : 00000001 | MdeModulePkg/BaseMemoryLibV2/BaseMemoryLib.inf | 2024-02-16T04-00-28 | 120
 ```
 
 Deprecation warning example:
@@ -120,10 +120,10 @@ Deprecation warning example:
 WARNING - Use of Deprecated module: C:\Repo\MU_BASECORE\MdeModulePkg\BaseMemoryLib\BaseMemoryLib.inf, Please switch to:  C:\Repo\MU_BASECORE\MdeModulePkg\BaseMemoryLibV2\BaseMemoryLib.inf.
 ```
 
-To disable Deprecation warnings, Set the following value in the build scripts.
+To disable Deprecation warnings for a given module, add it to the deprecation modules skip list.
 
 ``` cmd
-self.env.SetValue("ALLOW_DEPRECATED_MODULES", "TRUE", "Allow the usage of deprecated modules")
+self.env.SetValue("DEPRECATED_MODULES_SKIPLIST", ["MdeModulePkg\BaseMemoryLib\BaseMemoryLib.inf"], "Skip list for platforms")
 ```
 Override log generated during pre-build process:
 

--- a/BaseTools/Plugin/OverrideValidation/ReadMe.md
+++ b/BaseTools/Plugin/OverrideValidation/ReadMe.md
@@ -125,6 +125,7 @@ To disable Deprecation warnings for a given module, add it to the deprecation mo
 ``` cmd
 self.env.SetValue("DEPRECATED_MODULES_SKIPLIST", "MdeModulePkg\BaseMemoryLib\BaseMemoryLib.inf; MdeModulePkg\MemoryAllocationLib\MemoryAllocationLib.inf", "Skip list for platforms")
 ```
+
 Override log generated during pre-build process:
 
 ``` cmd

--- a/BaseTools/Plugin/OverrideValidation/ReadMe.md
+++ b/BaseTools/Plugin/OverrideValidation/ReadMe.md
@@ -123,7 +123,7 @@ WARNING - Use of Deprecated module: C:\Repo\MU_BASECORE\MdeModulePkg\BaseMemoryL
 To disable Deprecation warnings for a given module, add it to the deprecation modules skip list.
 
 ``` cmd
-self.env.SetValue("DEPRECATED_MODULES_SKIPLIST", ["MdeModulePkg\BaseMemoryLib\BaseMemoryLib.inf"], "Skip list for platforms")
+self.env.SetValue("DEPRECATED_MODULES_SKIPLIST", "MdeModulePkg\BaseMemoryLib\BaseMemoryLib.inf; MdeModulePkg\MemoryAllocationLib\MemoryAllocationLib.inf", "Skip list for platforms")
 ```
 Override log generated during pre-build process:
 
@@ -196,7 +196,7 @@ overridden file (the INF or DSC) and the overriding file.
 ### Deprecation Version 1
 
 ``` cmd
-#Deprecated : 00000001 | MdeModulePkg/BaseMemoryLibV2/BaseMemoryLib.inf | 2024-02-16T04-00-28
+#Deprecated : 00000001 | MdeModulePkg/BaseMemoryLibV2/BaseMemoryLib.inf | 2024-02-16T04-00-28 | 90
 ```
 
 ## Copyright & License

--- a/BaseTools/Plugin/OverrideValidation/ReadMe.md
+++ b/BaseTools/Plugin/OverrideValidation/ReadMe.md
@@ -179,12 +179,16 @@ There are two versions of the override format and one version of the deprecation
 ### Override Version 1
 
 ``` cmd
+OVERRIDE_FORMAT_VERSION_1 = (1, 4) # Version 1
+#Override : VERSION | PATH_TO_MODULE | HASH | YYYY-MM-DDThh-mm-ss
 #Override : 00000001 | MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf | cc255d9de141fccbdfca9ad02e0daa47 | 2018-05-09T17-54-17
 ```
 
 ### Override Version 2
 
 ``` cmd
+OVERRIDE_FORMAT_VERSION_2 = (2, 5) # Version 2
+#Override : VERSION | PATH_TO_MODULE | HASH | YYYY-MM-DDThh-mm-ss | GIT_COMMIT
 #Override : 00000002 | MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf | cc255d9de141fccbdfca9ad02e0daa47 | 2018-05-09T17-54-17 | 575096df6a
 ```
 
@@ -196,6 +200,10 @@ overridden file (the INF or DSC) and the overriding file.
 ### Deprecation Version 1
 
 ``` cmd
+# DEPRECATION_FORMAT_VERSION_1 = (1, 4) # Version 1
+#Deprecated : VERSION | PATH_TO_NEW_MODULE_TO_USE | YYYY-MM-DDThh-mm-ss | DEPRECATION_TIMELINE
+
+example:
 #Deprecated : 00000001 | MdeModulePkg/BaseMemoryLibV2/BaseMemoryLib.inf | 2024-02-16T04-00-28 | 90
 ```
 


### PR DESCRIPTION
## Description

Added deprecation warning support to the existing Override validation plugin/tool.

- [ ] Impacts functionality?
  - **Functionality** - All libraries/drivers that are no longer used should add a Deprecation warning
- [ ] Impacts security?
  - **Security** - N/A
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior? No
- [ ] Includes tests? No
- [ ] Includes documentation? Added documentation for how to use the Deprecation warnings module

## How This Was Tested

Added the Deprecation warnings to the INFs and a warning was thrown when a deprecated module was part of the DSC

## Integration Instructions

N/A