### PR TITLE
Edk2ToolsBuild: override basetoolsbin_ext_dep

### DIFF
--- a/BaseTools/Bin/basetoolsbin_ext_dep.yaml
+++ b/BaseTools/Bin/basetoolsbin_ext_dep.yaml
@@ -9,6 +9,7 @@
 ##
 {
   "scope": "global",
+  "id": "edk-tools-bin",
   "type": "web",
   "name": "Mu-Basetools",
   "source": "https://github.com/microsoft/mu_basecore/releases/download/v2023020002.0.3/basetools-v2023020002.0.3.tar.gz",

--- a/BaseTools/Edk2ToolsBuild.py
+++ b/BaseTools/Edk2ToolsBuild.py
@@ -104,6 +104,7 @@ class Edk2ToolsBuild(BaseAbstractInvocable):
 ##
 {
   "id": "You-Built-BaseTools",
+  "id_override": "edk-tools-bin", # MU_CHANGE
   "scope": "edk2-build",
   "flags": ["set_shell_var", "set_path"],
   "var_name": "EDK_TOOLS_BIN"


### PR DESCRIPTION
## Description

Building a local copy of Edk2ToolsBuild does not automatically override the pre-compiled copy of the basetools provided by basetoolsbin_ext_dep.

This commit adds an id to the external dependency, that can then be overridden with override_id in the path_env file that is generated when you build the basetools locally with Edk2ToolsBuild.


- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Verified EDK_TOOLS_BIN now points at the locally-built basetools once they have been built.

## Integration Instructions

N/A
