### PR TITLE
BaseTools/RustEnvironmentCheck: Allow no tools in toolchain file

### DIFF
--- a/BaseTools/Plugin/RustEnvironmentCheck/RustEnvironmentCheck.py
+++ b/BaseTools/Plugin/RustEnvironmentCheck/RustEnvironmentCheck.py
@@ -61,10 +61,10 @@ class RustEnvironmentCheck(IUefiBuildPlugin):
                 params = tool.presence_cmd[1]
             ret = RunCmd(name, params, outstream=cmd_output,
                          logging_level=logging.DEBUG)
-            
+
             if ret != 0:
                 return 1
-            
+
             # If a specific version is required, check the version, returning
             # false if there is a version mismatch
             if tool.required_version:
@@ -110,9 +110,10 @@ class RustEnvironmentCheck(IUefiBuildPlugin):
                 with open(WORKSPACE_TOOLCHAIN_FILE, 'r') as toml_file:
                     content = toml_file.read()
                     match = re.search(r'\[tool\]\n((?:.+\s*=\s*.+\n)*)', content)
-                    for line in match.group(1).splitlines():
-                        (tool, version) = line.split('=',maxsplit=1)
-                        tool_versions[tool.strip()] = version.strip(" \"'")
+                    if match:
+                        for line in match.group(1).splitlines():
+                            (tool, version) = line.split('=',maxsplit=1)
+                            tool_versions[tool.strip()] = version.strip(" \"'")
                 return tool_versions
             except FileNotFoundError:
                 # If a file is not found. Do not check any further.
@@ -208,7 +209,7 @@ class RustEnvironmentCheck(IUefiBuildPlugin):
         generic_rust_install_instructions = \
             "Visit https://rustup.rs/ to install Rust and cargo."
         tool_versions = get_required_tool_versions()
-        
+
         tools = {
             "rustup": RustToolInfo(
                 presence_cmd=("rustup",),


### PR DESCRIPTION
## Description

The get_required_tool_versions() function currently assumes that a
tool match will be present in the workspace toolchain file. This
change prevents a `NoneType` `AttributeError` if no results are found
by first checking that match is not `None`.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- Run against `rust-toolchain.toml` file with a matching tool pattern
- Run against `rust-toolchain.toml` file without a matching tool pattern

## Integration Instructions

N/A