### PR TITLE
ImageValidation: Pass build vars to fdf parser

### DIFF
--- a/.pytool/Plugin/ImageValidation/ImageValidation.py
+++ b/.pytool/Plugin/ImageValidation/ImageValidation.py
@@ -80,12 +80,13 @@ class ImageValidation(IUefiBuildPlugin):
             return 0
 
         # parse the DSC and the FDF
+        env_vars = thebuilder.env.GetAllBuildKeyValues()
         dsc_parser.SetEdk2Path(edk2)
-        dsc_parser.SetInputVars(thebuilder.env.GetAllBuildKeyValues()).ParseFile(
-            ActiveDsc)  # parse the DSC for build vars
+        dsc_parser.SetInputVars(env_vars).ParseFile(ActiveDsc)
+        
+        env_vars.update(dsc_parser.LocalVars)
         fdf_parser.SetEdk2Path(edk2)
-        fdf_parser.SetInputVars(dsc_parser.LocalVars).ParseFile(
-            ActiveFdf)  # give FDF parser the vars from DSC
+        fdf_parser.SetInputVars(env_vars).ParseFile(ActiveFdf)
 
         # Test all pre-compiled efis described in the fdf
         result = Result.PASS


### PR DESCRIPTION
## Description

Updates the ImageValidation plugin to pass the locally (to the DSC) defined variables and the build variables to the fdf parser. The previous implementation only passed the variables defined in the DSC, which is a bug.

This bug currently impacts any platform that actively uses the ImageValidation plugin, and consumes the new crypto binaries in the FDF. In this scenario, `SHARED_CRYPTO_PATH` is passed to the dsc parser, but not passed to the fdf parser, which results in the fdf parser failing due to paths not existing (as they contain `$(SHARED_CRYPTO_PATH)`) 

error example: `FileNotFoundError: $(SHARED_CRYPTO_PATH)/Driver/Bin/CryptoDriver.DXE.inc.fdf`

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Verified that build variables (such as BLD_*_<variable>) that are ultimetely passed to `build.py` are correctly passed to both the dsc parser and the fdf parser, rather than just the dsc parser, for the ImageValidatio plugin.

## Integration Instructions

N/A