### PR TITLE
RustEnvironmentCheck: Bugfix embedded quotes

### DIFF
--- a/BaseTools/Plugin/RustEnvironmentCheck/RustEnvironmentCheck.py
+++ b/BaseTools/Plugin/RustEnvironmentCheck/RustEnvironmentCheck.py
@@ -256,18 +256,18 @@ class RustEnvironmentCheck(IUefiBuildPlugin):
             "cargo make": RustToolInfo(
                 presence_cmd=("cargo", "make --version"),
                 install_help= \
-                f"  cargo binstall cargo-make {('--version ' + tool_versions.get("cargo-make", "")) if "cargo-make" in tool_versions else ""}"
+                f"  cargo binstall cargo-make {('--version ' + tool_versions.get('cargo-make', '')) if 'cargo-make' in tool_versions else ''}"
                 "\nOR\n"
-                f"  cargo install cargo-make {('--version ' + tool_versions.get("cargo-make", "")) if "cargo-make" in tool_versions else ""}\n",
+                f"  cargo install cargo-make {('--version ' + tool_versions.get('cargo-make', '')) if 'cargo-make' in tool_versions else ''}\n",
                 required_version=tool_versions.get("cargo-make"),
                 regex = r'\d+\.\d+\.\d+'
                 ),
             "cargo tarpaulin": RustToolInfo(
                 presence_cmd=("cargo", "tarpaulin --version"),
                 install_help= \
-                f"  cargo binstall cargo-tarpaulin {('--version ' + tool_versions.get("cargo-tarpaulin", "")) if "cargo-tarpaulin" in tool_versions else ""}"
+                f"  cargo binstall cargo-tarpaulin {('--version ' + tool_versions.get('cargo-tarpaulin', '')) if 'cargo-tarpaulin' in tool_versions else ''}"
                 "\nOR\n"
-                f"  cargo install cargo-tarpaulin {('--version ' + tool_versions.get("cargo-tarpaulin", "")) if "cargo-tarpaulin" in tool_versions else ""}\n",
+                f"  cargo install cargo-tarpaulin {('--version ' + tool_versions.get('cargo-tarpaulin', '')) if 'cargo-tarpaulin' in tool_versions else ''}\n",
                 required_version=tool_versions.get("cargo-tarpaulin"),
                 regex = r'\d+\.\d+\.\d+'
                 ),


### PR DESCRIPTION
## Description

Replaces embedded double quotes with single quotes in the RustEnvironmentCheck plugin as embedded double quotes support when working with f-strings was only added in python 3.12, and this project should support python 3.10, 3.11, and 3.12.

``` cmd
File "C:\src\mu_plus\MU_BASECORE\BaseTools\Plugin\RustEnvironmentCheck\RustEnvironmentCheck.py", line 259
    f"  cargo binstall cargo-make {('--version ' + tool_versions.get("cargo-make", "")) if "cargo-make" in tool_versions else ""}"

SyntaxError: f-string: unmatched '('
```

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Verified the plugin works on 3.10, 3.11, and 3.12

## Integration Instructions

N/A
