### PR TITLE
CryptoPkg: Update to Shared Crypto 2023.2.11

### DIFF
--- a/CryptoPkg/Binaries/BaseCryptoDriver_ext_dep.json
+++ b/CryptoPkg/Binaries/BaseCryptoDriver_ext_dep.json
@@ -3,7 +3,7 @@
   "type": "nuget",
   "name": "edk2-basecrypto-driver-bin",
   "source": "https://pkgs.dev.azure.com/projectmu/mu/_packaging/Mu-Public/nuget/v3/index.json",
-  "version": "2023.2.10",
+  "version": "2023.2.11",
   "flags": ["set_build_var"],
   "var_name": "BLD_*_SHARED_CRYPTO_PATH"
 }


### PR DESCRIPTION
## Description

See the following release notes for updates [v2023.2.11](https://github.com/microsoft/mu_crypto_release/releases/tag/v2023.2.11).

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- The crypto release was tested per the test description in the release.

## Integration Instructions

Platforms no longer have to explicitly specify that
a crypto service is `"NONE"`. If a crypto service, is not used,
the arch no longer needs to be explicitly set to `"NONE"` either.

For example, a platform that only uses Standalone MM can now entirely
omit the following lines from the platform DSC file:

- `SMM_CRYPTO_SERVICES = NONE`
- `SMM_CRYPTO_ARCH = NONE`