### PR TITLE
Add BaseLib to StackCheckLib, Move Some Stack Check Functions to Assembly to Avoid Over Optimization

### DIFF
--- a/MdePkg/Library/StackCheckLib/IA32/CheckCookieMsvc.nasm
+++ b/MdePkg/Library/StackCheckLib/IA32/CheckCookieMsvc.nasm
@@ -10,6 +10,21 @@
 
 extern ASM_PFX(StackCheckFailure)
 extern ASM_PFX(__security_cookie)
+extern ASM_PFX(CpuDeadLoop)
+
+; Called when a buffer check fails. This functionality is dependent on MSVC
+; C runtime libraries and so is unsupported in UEFI.
+global ASM_PFX(__report_rangecheckfailure)
+ASM_PFX(__report_rangecheckfailure):
+    jmp ASM_PFX(CpuDeadLoop)
+    ret
+
+; The GS handler is for checking the stack cookie during SEH or
+; EH exceptions and is unsupported in UEFI.
+global ASM_PFX(__GSHandlerCheck)
+ASM_PFX(__GSHandlerCheck):
+    jmp ASM_PFX(CpuDeadLoop)
+    ret
 
 ;------------------------------------------------------------------------------
 ; Checks the stack cookie value against __security_cookie and calls the

--- a/MdePkg/Library/StackCheckLib/StackCheckLibCommon.c
+++ b/MdePkg/Library/StackCheckLib/StackCheckLibCommon.c
@@ -9,7 +9,6 @@
 #include <Base.h>
 
 #include <Library/BaseLib.h>
-#include <Library/DebugLib.h>
 #include <Library/StackCheckFailureHookLib.h>
 
 /**
@@ -35,22 +34,6 @@ __stack_chk_fail (
 
 #elif defined (_MSC_VER)
 VOID  *__security_cookie = (VOID *)(UINTN)STACK_COOKIE_VALUE;
-
-NORETURN VOID __cdecl
-__report_rangecheckfailure (
-  VOID
-  )
-{
-  CpuDeadLoop ();
-}
-
-NORETURN VOID __cdecl
-__GSHandlerCheck (
-  VOID
-  )
-{
-  CpuDeadLoop ();
-}
 
 VOID
 StackCheckFailure (

--- a/MdePkg/Library/StackCheckLib/StackCheckLibDynamicInit.inf
+++ b/MdePkg/Library/StackCheckLib/StackCheckLibDynamicInit.inf
@@ -40,6 +40,7 @@
 [LibraryClasses]
   RngLib
   StackCheckFailureHookLib
+  BaseLib
 
 [FixedPcd]
   gEfiMdePkgTokenSpaceGuid.PcdStackCookieExceptionVector

--- a/MdePkg/Library/StackCheckLib/StackCheckLibStaticInit.inf
+++ b/MdePkg/Library/StackCheckLib/StackCheckLibStaticInit.inf
@@ -36,6 +36,7 @@
 
 [LibraryClasses]
   StackCheckFailureHookLib
+  BaseLib
 
 [FixedPcd]
   gEfiMdePkgTokenSpaceGuid.PcdStackCookieExceptionVector

--- a/MdePkg/Library/StackCheckLib/X64/CheckCookieMsvc.nasm
+++ b/MdePkg/Library/StackCheckLib/X64/CheckCookieMsvc.nasm
@@ -10,6 +10,21 @@
 
 extern ASM_PFX(StackCheckFailure)
 extern ASM_PFX(__security_cookie)
+extern ASM_PFX(CpuDeadLoop)
+
+; Called when a buffer check fails. This functionality is dependent on MSVC
+; C runtime libraries and so is unsupported in UEFI.
+global ASM_PFX(__report_rangecheckfailure)
+ASM_PFX(__report_rangecheckfailure):
+    jmp ASM_PFX(CpuDeadLoop)
+    ret
+
+; The GS handler is for checking the stack cookie during SEH or
+; EH exceptions and is unsupported in UEFI.
+global ASM_PFX(__GSHandlerCheck)
+ASM_PFX(__GSHandlerCheck):
+    jmp ASM_PFX(CpuDeadLoop)
+    ret
 
 ;------------------------------------------------------------------------------
 ; Checks the stack cookie value against __security_cookie and calls the


### PR DESCRIPTION
## Description

1. StackCheckLib depends on BaseLib and it was not listed in the library INF files.
2. CpuDeadLoop() within __GSHandlerCheck and __report_rangecheckfailure were being optimized out on release builds due to the /OPT:REF linker option. This PR moves __GSHandlerCheck and __report_rangecheckfailure to assembly code so CpuDeadLoop() is not optimized out.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on Q35 MSVC build.

## Integration Instructions

N/A
