### PR TITLE
[REBASE & FF] Several Fixes for 64k Runtime Page Allocation Granularity

### DIFF
--- a/MdeModulePkg/Core/Dxe/Mem/Page.c
+++ b/MdeModulePkg/Core/Dxe/Mem/Page.c
@@ -1608,9 +1608,17 @@ CoreInternalFreePages (
     goto Done;
   }
 
+  // MU_CHANGE: 64k exposed CodeQL issue
+  if (Entry == NULL) {
+    ASSERT (Entry != NULL);
+    Status = EFI_NOT_FOUND;
+    goto Done;
+  }
+
+  // MU_CHANGE END
+
   Alignment = DEFAULT_PAGE_ALLOCATION_GRANULARITY;
 
-  ASSERT (Entry != NULL);
   if ((Entry->Type == EfiACPIReclaimMemory) ||
       (Entry->Type == EfiACPIMemoryNVS) ||
       (Entry->Type == EfiRuntimeServicesCode) ||

--- a/MdeModulePkg/Core/Dxe/Mem/Page.c
+++ b/MdeModulePkg/Core/Dxe/Mem/Page.c
@@ -1344,6 +1344,20 @@ CoreInternalAllocatePages (
     Alignment = RUNTIME_PAGE_ALLOCATION_GRANULARITY;
   }
 
+  // MU_CHANGE: 64k don't guard too large pages
+  //
+  // The heap guard system does not support non-EFI_PAGE_SIZE alignments.
+  // Architectures that require larger RUNTIME_PAGE_ALLOCATION_GRANULARITY
+  // will have the runtime memory regions unguarded. OSes do not
+  // map guard pages anyway, so this is a minimal loss. Not guarding prevents
+  // alignment mismatches
+  //
+  if (Alignment != EFI_PAGE_SIZE) {
+    NeedGuard = FALSE;
+  }
+
+  // MU_CHANGE END
+
   if (Type == AllocateAddress) {
     if ((*Memory & (Alignment - 1)) != 0) {
       return EFI_NOT_FOUND;

--- a/MdeModulePkg/Core/Dxe/Mem/Page.c
+++ b/MdeModulePkg/Core/Dxe/Mem/Page.c
@@ -1336,7 +1336,7 @@ CoreInternalAllocatePages (
 
   Alignment = DEFAULT_PAGE_ALLOCATION_GRANULARITY;
 
-  if ((MemoryType == EfiACPIReclaimMemory) ||
+  if ((MemoryType == EfiReservedMemoryType) || // MU_CHANGE: 64k fix spec defined types
       (MemoryType == EfiACPIMemoryNVS) ||
       (MemoryType == EfiRuntimeServicesCode) ||
       (MemoryType == EfiRuntimeServicesData))
@@ -1619,7 +1619,7 @@ CoreInternalFreePages (
 
   Alignment = DEFAULT_PAGE_ALLOCATION_GRANULARITY;
 
-  if ((Entry->Type == EfiACPIReclaimMemory) ||
+  if ((Entry->Type == EfiReservedMemoryType) || // MU_CHANGE: 64k fix spec defined types
       (Entry->Type == EfiACPIMemoryNVS) ||
       (Entry->Type == EfiRuntimeServicesCode) ||
       (Entry->Type == EfiRuntimeServicesData))

--- a/MdeModulePkg/Core/Dxe/Mem/Pool.c
+++ b/MdeModulePkg/Core/Dxe/Mem/Pool.c
@@ -380,6 +380,20 @@ CoreAllocatePoolI (
     Granularity = DEFAULT_PAGE_ALLOCATION_GRANULARITY;
   }
 
+  // MU_CHANGE: 64k don't guard too large pages
+  //
+  // The heap guard system does not support non-EFI_PAGE_SIZE alignments.
+  // Architectures that require larger RUNTIME_PAGE_ALLOCATION_GRANULARITY
+  // will have the runtime memory regions unguarded. OSes do not
+  // map guard pages anyway, so this is a minimal loss. Not guarding prevents
+  // alignment mismatches
+  //
+  if (Granularity != EFI_PAGE_SIZE) {
+    NeedGuard = FALSE;
+  }
+
+  // MU_CHANGE END
+
   //
   // Adjust the size by the pool header & tail overhead
   //

--- a/MdeModulePkg/Core/Dxe/Mem/Pool.c
+++ b/MdeModulePkg/Core/Dxe/Mem/Pool.c
@@ -370,7 +370,7 @@ CoreAllocatePoolI (
 
   ASSERT_LOCKED (&mPoolMemoryLock);
 
-  if ((PoolType == EfiACPIReclaimMemory) ||
+  if ((PoolType == EfiReservedMemoryType) || // MU_CHANGE: 64k fix spec defined types
       (PoolType == EfiACPIMemoryNVS) ||
       (PoolType == EfiRuntimeServicesCode) ||
       (PoolType == EfiRuntimeServicesData))
@@ -764,7 +764,7 @@ CoreFreePoolI (
   Pool->Used -= Size;
   DEBUG ((DEBUG_POOL, "FreePool: %p (len %lx) %,ld\n", Head->Data, (UINT64)(Head->Size - POOL_OVERHEAD), (UINT64)Pool->Used));
 
-  if ((Head->Type == EfiACPIReclaimMemory) ||
+  if ((Head->Type == EfiReservedMemoryType) || // MU_CHANGE: 64k fix spec defined types
       (Head->Type == EfiACPIMemoryNVS) ||
       (Head->Type == EfiRuntimeServicesCode) ||
       (Head->Type == EfiRuntimeServicesData))

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryAttributesTable.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryAttributesTable.c
@@ -1431,7 +1431,7 @@ InsertImageRecord (
       ImageRecordCodeSection->Signature = IMAGE_PROPERTIES_RECORD_CODE_SECTION_SIGNATURE;
 
       ImageRecordCodeSection->CodeSegmentBase = (UINTN)ImageAddress + Section[Index].VirtualAddress;
-      ImageRecordCodeSection->CodeSegmentSize = Section[Index].SizeOfRawData;
+      ImageRecordCodeSection->CodeSegmentSize = ALIGN_VALUE (Section[Index].SizeOfRawData, SectionAlignment); // MU_CHANGE: 64k report correct code size
 
       DEBUG ((DEBUG_VERBOSE, "ImageCode: 0x%016lx - 0x%016lx\n", ImageRecordCodeSection->CodeSegmentBase, ImageRecordCodeSection->CodeSegmentSize));
 

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
@@ -379,26 +379,29 @@ IsMemoryProtectionSectionAligned (
 {
   UINT32  PageAlignment;
 
+  // MU_CHANGE: 64k fix spec defined types
   switch (MemoryType) {
     case EfiRuntimeServicesCode:
     case EfiACPIMemoryNVS:
+    case EfiReservedMemoryType:
       PageAlignment = RUNTIME_PAGE_ALLOCATION_GRANULARITY;
       break;
     case EfiRuntimeServicesData:
-    case EfiACPIReclaimMemory:
       ASSERT (FALSE);
       PageAlignment = RUNTIME_PAGE_ALLOCATION_GRANULARITY;
       break;
     case EfiBootServicesCode:
     case EfiLoaderCode:
-    case EfiReservedMemoryType:
       PageAlignment = EFI_PAGE_SIZE;
       break;
+    case EfiACPIReclaimMemory:
     default:
       ASSERT (FALSE);
       PageAlignment = EFI_PAGE_SIZE;
       break;
   }
+
+  // MU_CHANGE END
 
   if ((SectionAlignment & (PageAlignment - 1)) != 0) {
     return FALSE;

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -1824,7 +1824,7 @@ CreateImagePropertiesRecord (
       ImageRecordCodeSection->Signature = IMAGE_PROPERTIES_RECORD_CODE_SECTION_SIGNATURE;
 
       ImageRecordCodeSection->CodeSegmentBase = (UINTN)ImageAddress + Section[Index].VirtualAddress;
-      ImageRecordCodeSection->CodeSegmentSize = EfiPagesToSize (EfiSizeToPages (Section[Index].SizeOfRawData));
+      ImageRecordCodeSection->CodeSegmentSize = ALIGN_VALUE (Section[Index].SizeOfRawData, SectionAlignment);
 
       OrderedInsertUint64Comparison (
         &ImageRecord->CodeSegmentList,

--- a/MdeModulePkg/Core/Pei/Memory/MemoryServices.c
+++ b/MdeModulePkg/Core/Pei/Memory/MemoryServices.c
@@ -624,7 +624,7 @@ PeiAllocatePages (
   }
 
   if ((RUNTIME_PAGE_ALLOCATION_GRANULARITY > DEFAULT_PAGE_ALLOCATION_GRANULARITY) &&
-      ((MemoryType == EfiACPIReclaimMemory) ||
+      ((MemoryType == EfiReservedMemoryType) || // MU_CHANGE: 64k fix spec defined types
        (MemoryType == EfiACPIMemoryNVS) ||
        (MemoryType == EfiRuntimeServicesCode) ||
        (MemoryType == EfiRuntimeServicesData)))

--- a/MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.c
+++ b/MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.c
@@ -171,6 +171,99 @@ inactive but RaiseErrorIfProtectionFails is active. RaiseErrorIfProtectionFails 
       ));
     gDxeMps.ImageProtectionPolicy.Fields.RaiseErrorIfProtectionFails = 0;
   }
+
+  //
+  // the heap guard system does not support non-EFI_PAGE_SIZE alignments
+  // architectures that require larger RUNTIME_PAGE_ALLOCATION_GRANULARITY
+  // cannot have EfiRuntimeServicesCode, EfiRuntimeServicesData, EfiReservedMemoryType,
+  // and EfiACPIMemoryNVS guarded. OSes do not map guard pages anyway, so this is a
+  // minimal loss. Not guarding prevents alignment mismatches
+  //
+  if (RUNTIME_PAGE_ALLOCATION_GRANULARITY != EFI_PAGE_SIZE) {
+    if (gDxeMps.HeapGuardPolicy.Fields.UefiPageGuard) {
+      if (gDxeMps.HeapGuardPageType.Fields.EfiACPIMemoryNVS != 0) {
+        DEBUG ((
+          DEBUG_WARN,
+          "%a: - RUNTIME_PAGE_ALLOCATION_GRANULARITY != EFI_PAGE_SIZE but Page Guard set on \
+          EfiACPIMemoryNVS. This is not supported by Heap Guard system, disabling.\n",
+          __func__
+          ));
+        gDxeMps.HeapGuardPageType.Fields.EfiACPIMemoryNVS = 0;
+      }
+
+      if (gDxeMps.HeapGuardPageType.Fields.EfiReservedMemoryType != 0) {
+        DEBUG ((
+          DEBUG_WARN,
+          "%a: - RUNTIME_PAGE_ALLOCATION_GRANULARITY != EFI_PAGE_SIZE but Page Guard set on \
+          EfiReservedMemoryType. This is not supported by Heap Guard system, disabling.\n",
+          __func__
+          ));
+        gDxeMps.HeapGuardPageType.Fields.EfiReservedMemoryType = 0;
+      }
+
+      if (gDxeMps.HeapGuardPageType.Fields.EfiRuntimeServicesCode != 0) {
+        DEBUG ((
+          DEBUG_WARN,
+          "%a: - RUNTIME_PAGE_ALLOCATION_GRANULARITY != EFI_PAGE_SIZE but Page Guard set on \
+          EfiRuntimeServicesCode. This is not supported by Heap Guard system, disabling.\n",
+          __func__
+          ));
+        gDxeMps.HeapGuardPageType.Fields.EfiRuntimeServicesCode = 0;
+      }
+
+      if (gDxeMps.HeapGuardPageType.Fields.EfiRuntimeServicesData != 0) {
+        DEBUG ((
+          DEBUG_WARN,
+          "%a: - RUNTIME_PAGE_ALLOCATION_GRANULARITY != EFI_PAGE_SIZE but Page Guard set on \
+          EfiRuntimeServicesData. This is not supported by Heap Guard system, disabling.\n",
+          __func__
+          ));
+        gDxeMps.HeapGuardPageType.Fields.EfiRuntimeServicesData = 0;
+      }
+    }
+
+    if (gDxeMps.HeapGuardPolicy.Fields.UefiPoolGuard) {
+      if (gDxeMps.HeapGuardPoolType.Fields.EfiACPIMemoryNVS != 0) {
+        DEBUG ((
+          DEBUG_WARN,
+          "%a: - RUNTIME_PAGE_ALLOCATION_GRANULARITY != EFI_PAGE_SIZE but Pool Guard set on \
+          EfiACPIMemoryNVS. This is not supported by Heap Guard system, disabling.\n",
+          __func__
+          ));
+        gDxeMps.HeapGuardPoolType.Fields.EfiACPIMemoryNVS = 0;
+      }
+
+      if (gDxeMps.HeapGuardPoolType.Fields.EfiReservedMemoryType != 0) {
+        DEBUG ((
+          DEBUG_WARN,
+          "%a: - RUNTIME_PAGE_ALLOCATION_GRANULARITY != EFI_PAGE_SIZE but Pool Guard set on \
+          EfiReservedMemoryType. This is not supported by Heap Guard system, disabling.\n",
+          __func__
+          ));
+        gDxeMps.HeapGuardPoolType.Fields.EfiReservedMemoryType = 0;
+      }
+
+      if (gDxeMps.HeapGuardPoolType.Fields.EfiRuntimeServicesCode != 0) {
+        DEBUG ((
+          DEBUG_WARN,
+          "%a: - RUNTIME_PAGE_ALLOCATION_GRANULARITY != EFI_PAGE_SIZE but Pool Guard set on \
+          EfiRuntimeServicesCode. This is not supported by Heap Guard system, disabling.\n",
+          __func__
+          ));
+        gDxeMps.HeapGuardPoolType.Fields.EfiRuntimeServicesCode = 0;
+      }
+
+      if (gDxeMps.HeapGuardPoolType.Fields.EfiRuntimeServicesData != 0) {
+        DEBUG ((
+          DEBUG_WARN,
+          "%a: - RUNTIME_PAGE_ALLOCATION_GRANULARITY != EFI_PAGE_SIZE but Pool Guard set on \
+          EfiRuntimeServicesData. This is not supported by Heap Guard system, disabling.\n",
+          __func__
+          ));
+        gDxeMps.HeapGuardPoolType.Fields.EfiRuntimeServicesData = 0;
+      }
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## Description

This PR is a collection of patches to edk2 (some in slightly different forms due to changes in Mu vs the upstream). They are intended to be pulled into Mu before the upstream accepts them, to fix active bugs before the upstream cadence allows for them to be accepted.

These commits fix a series of issues that have prevented Project Mu from using 64k runtime page allocation granularity for ARM64. The commit messages each have greater detail on the change in question, but in summary:

A CodeQL error is fixed that was uncovered by making a change to Page.c
A UEFI spec 2.10 violation is fixed by changing EfiACPIReclaimMemory to EfiReservedMemoryType for memory types that should have runtime page allocation granularity
Page and pool guards are not set for EfiACPIMemoryNVS, EfiReservedMemoryType, EfiRuntimeServicesCode, and EfiRuntimeServicesData for systems with a runtime page allocation granularity greater than EFI_PAGE_SIZE as the heap guard system does not support this
The HOB based memory protections are updated to ensure the above point is consistent in platform provided HOB
Image Records are fixed to correctly report the size of the images as aligned to the section alignment

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [x] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on multiple physical and virtual platforms, both x86 and ARM64.

## Integration Instructions

Page or Pool guards that are being set on EfiACPIMemoryNVS, EfiReservedMemoryType, EfiRuntimeServicesCode, or EfiRuntimeServicesData for systems that do not have a runtime page allocation granularity equal to the EFI_PAGE_SIZE (ARM64 is the main example, after the revert PR goes in) will need to be removed. A system will not break as a result, the FW will print a warning and remove these memory protections.