### PR TITLE
Set AARCH64 RUNTIME_PAGE_ALLOCATION_GRANULARITY to 64k instead of 4k

### DIFF
--- a/MdePkg/Include/AArch64/ProcessorBind.h
+++ b/MdePkg/Include/AArch64/ProcessorBind.h
@@ -161,8 +161,7 @@ typedef INT64 INTN;
 /// Page allocation granularity for AARCH64
 ///
 #define DEFAULT_PAGE_ALLOCATION_GRANULARITY  (0x1000)
-// MS_CHANGE: Change from 64K to 4K.
-#define RUNTIME_PAGE_ALLOCATION_GRANULARITY  (0x1000)
+#define RUNTIME_PAGE_ALLOCATION_GRANULARITY  (0x10000)
 
 //
 // Modifier to ensure that all protocol member functions and EFI intrinsics


### PR DESCRIPTION
## Description

There were a lot of issues with 64k as a runtime page allocation granularity for ARM64 when this was removed from Project Mu. These issues have been fixed and 64k OSes have been confirmed to boot with proper Memory Attribute Tables.

See https://github.com/microsoft/mu_basecore/pull/764 for the last group of core changes required for 64k runtime page allocation granularity on ARM64.

This reverts commit https://github.com/microsoft/mu_basecore/commit/e640f2cc23bb9ef53181bc1054f1e3fcbf409ae9.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [x] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on multiple ARM64 physical and virtual platforms.

## Integration Instructions

ARM64 platforms should set the section alignment of RUNTIME_DXE_DRIVERs to 0x10000 to match the expectations of the UEFI spec 2.10.