### PR TITLE
[Cherry-Pick] UefiCpuPkg: Add, Implement and Consume SmmCpuSyncLib library

### DIFF
--- a/UefiCpuPkg/Include/Library/SmmCpuSyncLib.h
+++ b/UefiCpuPkg/Include/Library/SmmCpuSyncLib.h
@@ -1,0 +1,290 @@
+/** @file
+  Library that provides SMM CPU Sync related operations.
+
+  The lib provides 3 sets of APIs:
+  1. ContextInit/ContextDeinit/ContextReset:
+
+    ContextInit() is called in driver's entrypoint to allocate and initialize the SMM CPU Sync context.
+    ContextDeinit() is called in driver's unload function to deinitialize the SMM CPU Sync context.
+    ContextReset() is called by one of CPUs after all CPUs are ready to exit SMI, which allows CPU to
+    check into the next SMI from this point.
+
+  2. GetArrivedCpuCount/CheckInCpu/CheckOutCpu/LockDoor:
+    When SMI happens, all processors including BSP enter to SMM mode by calling CheckInCpu().
+    CheckOutCpu() can be called in error handling flow for the CPU who calls CheckInCpu() earlier.
+    The elected BSP calls LockDoor() so that CheckInCpu() and CheckOutCpu() will return the error code after that.
+    GetArrivedCpuCount() returns the number of checked-in CPUs.
+
+  3. WaitForAPs/ReleaseOneAp/WaitForBsp/ReleaseBsp
+    WaitForAPs() & ReleaseOneAp() are called from BSP to wait the number of APs and release one specific AP.
+    WaitForBsp() & ReleaseBsp() are called from APs to wait and release BSP.
+    The 4 APIs are used to synchronize the running flow among BSP and APs.
+    BSP and AP Sync flow can be easy understand as below:
+    BSP: ReleaseOneAp  -->  AP: WaitForBsp
+    BSP: WaitForAPs    <--  AP: ReleaseBsp
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef SMM_CPU_SYNC_LIB_H_
+#define SMM_CPU_SYNC_LIB_H_
+
+#include <Uefi/UefiBaseType.h>
+
+//
+// Opaque structure for SMM CPU Sync context.
+//
+typedef struct SMM_CPU_SYNC_CONTEXT SMM_CPU_SYNC_CONTEXT;
+
+/**
+  Create and initialize the SMM CPU Sync context. It is to allocate and initialize the
+  SMM CPU Sync context.
+
+  If Context is NULL, then ASSERT().
+
+  @param[in]  NumberOfCpus          The number of Logical Processors in the system.
+  @param[out] Context               Pointer to the new created and initialized SMM CPU Sync context object.
+                                    NULL will be returned if any error happen during init.
+
+  @retval RETURN_SUCCESS            The SMM CPU Sync context was successful created and initialized.
+  @retval RETURN_OUT_OF_RESOURCES   There are not enough resources available to create and initialize SMM CPU Sync context.
+  @retval RETURN_BUFFER_TOO_SMALL   Overflow happen
+
+**/
+RETURN_STATUS
+EFIAPI
+SmmCpuSyncContextInit (
+  IN   UINTN                 NumberOfCpus,
+  OUT  SMM_CPU_SYNC_CONTEXT  **Context
+  );
+
+/**
+  Deinit an allocated SMM CPU Sync context. The resources allocated in SmmCpuSyncContextInit() will
+  be freed.
+
+  If Context is NULL, then ASSERT().
+
+  @param[in,out]  Context     Pointer to the SMM CPU Sync context object to be deinitialized.
+
+**/
+VOID
+EFIAPI
+SmmCpuSyncContextDeinit (
+  IN OUT SMM_CPU_SYNC_CONTEXT  *Context
+  );
+
+/**
+  Reset SMM CPU Sync context. SMM CPU Sync context will be reset to the initialized state.
+
+  This function is called by one of CPUs after all CPUs are ready to exit SMI, which allows CPU to
+  check into the next SMI from this point.
+
+  If Context is NULL, then ASSERT().
+
+  @param[in,out]  Context     Pointer to the SMM CPU Sync context object to be reset.
+
+**/
+VOID
+EFIAPI
+SmmCpuSyncContextReset (
+  IN OUT SMM_CPU_SYNC_CONTEXT  *Context
+  );
+
+/**
+  Get current number of arrived CPU in SMI.
+
+  BSP might need to know the current number of arrived CPU in SMI to make sure all APs
+  in SMI. This API can be for that purpose.
+
+  If Context is NULL, then ASSERT().
+
+  @param[in]      Context     Pointer to the SMM CPU Sync context object.
+
+  @retval    Current number of arrived CPU in SMI.
+
+**/
+UINTN
+EFIAPI
+SmmCpuSyncGetArrivedCpuCount (
+  IN  SMM_CPU_SYNC_CONTEXT  *Context
+  );
+
+/**
+  Performs an atomic operation to check in CPU.
+
+  When SMI happens, all processors including BSP enter to SMM mode by calling SmmCpuSyncCheckInCpu().
+
+  If Context is NULL, then ASSERT().
+  If CpuIndex exceeds the range of all CPUs in the system, then ASSERT().
+
+  @param[in,out]  Context           Pointer to the SMM CPU Sync context object.
+  @param[in]      CpuIndex          Check in CPU index.
+
+  @retval RETURN_SUCCESS            Check in CPU (CpuIndex) successfully.
+  @retval RETURN_ABORTED            Check in CPU failed due to SmmCpuSyncLockDoor() has been called by one elected CPU.
+
+**/
+RETURN_STATUS
+EFIAPI
+SmmCpuSyncCheckInCpu (
+  IN OUT SMM_CPU_SYNC_CONTEXT  *Context,
+  IN     UINTN                 CpuIndex
+  );
+
+/**
+  Performs an atomic operation to check out CPU.
+
+  This function can be called in error handling flow for the CPU who calls CheckInCpu() earlier.
+  The caller shall make sure the CPU specified by CpuIndex has already checked-in.
+
+  If Context is NULL, then ASSERT().
+  If CpuIndex exceeds the range of all CPUs in the system, then ASSERT().
+
+  @param[in,out]  Context           Pointer to the SMM CPU Sync context object.
+  @param[in]      CpuIndex          Check out CPU index.
+
+  @retval RETURN_SUCCESS            Check out CPU (CpuIndex) successfully.
+  @retval RETURN_ABORTED            Check out CPU failed due to SmmCpuSyncLockDoor() has been called by one elected CPU.
+
+**/
+RETURN_STATUS
+EFIAPI
+SmmCpuSyncCheckOutCpu (
+  IN OUT SMM_CPU_SYNC_CONTEXT  *Context,
+  IN     UINTN                 CpuIndex
+  );
+
+/**
+  Performs an atomic operation lock door for CPU checkin and checkout. After this function:
+  CPU can not check in via SmmCpuSyncCheckInCpu().
+  CPU can not check out via SmmCpuSyncCheckOutCpu().
+
+  The CPU specified by CpuIndex is elected to lock door. The caller shall make sure the CpuIndex
+  is the actual CPU calling this function to avoid the undefined behavior.
+
+  If Context is NULL, then ASSERT().
+  If CpuCount is NULL, then ASSERT().
+  If CpuIndex exceeds the range of all CPUs in the system, then ASSERT().
+
+  @param[in,out]  Context           Pointer to the SMM CPU Sync context object.
+  @param[in]      CpuIndex          Indicate which CPU to lock door.
+  @param[out]     CpuCount          Number of arrived CPU in SMI after look door.
+
+**/
+VOID
+EFIAPI
+SmmCpuSyncLockDoor (
+  IN OUT SMM_CPU_SYNC_CONTEXT  *Context,
+  IN     UINTN                 CpuIndex,
+  OUT UINTN                    *CpuCount
+  );
+
+/**
+  Used by the BSP to wait for APs.
+
+  The number of APs need to be waited is specified by NumberOfAPs. The BSP is specified by BspIndex.
+  The caller shall make sure the BspIndex is the actual CPU calling this function to avoid the undefined behavior.
+  The caller shall make sure the NumberOfAPs have already checked-in to avoid the undefined behavior.
+
+  If Context is NULL, then ASSERT().
+  If NumberOfAPs >= All CPUs in system, then ASSERT().
+  If BspIndex exceeds the range of all CPUs in the system, then ASSERT().
+
+  Note:
+  This function is blocking mode, and it will return only after the number of APs released by
+  calling SmmCpuSyncReleaseBsp():
+  BSP: WaitForAPs    <--  AP: ReleaseBsp
+
+  @param[in,out]  Context           Pointer to the SMM CPU Sync context object.
+  @param[in]      NumberOfAPs       Number of APs need to be waited by BSP.
+  @param[in]      BspIndex          The BSP Index to wait for APs.
+
+**/
+VOID
+EFIAPI
+SmmCpuSyncWaitForAPs (
+  IN OUT SMM_CPU_SYNC_CONTEXT  *Context,
+  IN     UINTN                 NumberOfAPs,
+  IN     UINTN                 BspIndex
+  );
+
+/**
+  Used by the BSP to release one AP.
+
+  The AP is specified by CpuIndex. The BSP is specified by BspIndex.
+  The caller shall make sure the BspIndex is the actual CPU calling this function to avoid the undefined behavior.
+  The caller shall make sure the CpuIndex has already checked-in to avoid the undefined behavior.
+
+  If Context is NULL, then ASSERT().
+  If CpuIndex == BspIndex, then ASSERT().
+  If BspIndex or CpuIndex exceed the range of all CPUs in the system, then ASSERT().
+
+  @param[in,out]  Context           Pointer to the SMM CPU Sync context object.
+  @param[in]      CpuIndex          Indicate which AP need to be released.
+  @param[in]      BspIndex          The BSP Index to release AP.
+
+**/
+VOID
+EFIAPI
+SmmCpuSyncReleaseOneAp   (
+  IN OUT SMM_CPU_SYNC_CONTEXT  *Context,
+  IN     UINTN                 CpuIndex,
+  IN     UINTN                 BspIndex
+  );
+
+/**
+  Used by the AP to wait BSP.
+
+  The AP is specified by CpuIndex.
+  The caller shall make sure the CpuIndex is the actual CPU calling this function to avoid the undefined behavior.
+  The BSP is specified by BspIndex.
+
+  If Context is NULL, then ASSERT().
+  If CpuIndex == BspIndex, then ASSERT().
+  If BspIndex or CpuIndex exceed the range of all CPUs in the system, then ASSERT().
+
+  Note:
+  This function is blocking mode, and it will return only after the AP released by
+  calling SmmCpuSyncReleaseOneAp():
+  BSP: ReleaseOneAp  -->  AP: WaitForBsp
+
+  @param[in,out]  Context          Pointer to the SMM CPU Sync context object.
+  @param[in]      CpuIndex         Indicate which AP wait BSP.
+  @param[in]      BspIndex         The BSP Index to be waited.
+
+**/
+VOID
+EFIAPI
+SmmCpuSyncWaitForBsp (
+  IN OUT SMM_CPU_SYNC_CONTEXT  *Context,
+  IN     UINTN                 CpuIndex,
+  IN     UINTN                 BspIndex
+  );
+
+/**
+  Used by the AP to release BSP.
+
+  The AP is specified by CpuIndex.
+  The caller shall make sure the CpuIndex is the actual CPU calling this function to avoid the undefined behavior.
+  The BSP is specified by BspIndex.
+
+  If Context is NULL, then ASSERT().
+  If CpuIndex == BspIndex, then ASSERT().
+  If BspIndex or CpuIndex exceed the range of all CPUs in the system, then ASSERT().
+
+  @param[in,out]  Context           Pointer to the SMM CPU Sync context object.
+  @param[in]      CpuIndex          Indicate which AP release BSP.
+  @param[in]      BspIndex          The BSP Index to be released.
+
+**/
+VOID
+EFIAPI
+SmmCpuSyncReleaseBsp (
+  IN OUT SMM_CPU_SYNC_CONTEXT  *Context,
+  IN     UINTN                 CpuIndex,
+  IN     UINTN                 BspIndex
+  );
+
+#endif

--- a/UefiCpuPkg/Library/SmmCpuSyncLib/SmmCpuSyncLib.c
+++ b/UefiCpuPkg/Library/SmmCpuSyncLib/SmmCpuSyncLib.c
@@ -1,0 +1,652 @@
+/** @file
+  SMM CPU Sync lib implementation.
+
+  The lib provides 3 sets of APIs:
+  1. ContextInit/ContextDeinit/ContextReset:
+
+    ContextInit() is called in driver's entrypoint to allocate and initialize the SMM CPU Sync context.
+    ContextDeinit() is called in driver's unload function to deinitialize the SMM CPU Sync context.
+    ContextReset() is called by one of CPUs after all CPUs are ready to exit SMI, which allows CPU to
+    check into the next SMI from this point.
+
+  2. GetArrivedCpuCount/CheckInCpu/CheckOutCpu/LockDoor:
+    When SMI happens, all processors including BSP enter to SMM mode by calling CheckInCpu().
+    CheckOutCpu() can be called in error handling flow for the CPU who calls CheckInCpu() earlier.
+    The elected BSP calls LockDoor() so that CheckInCpu() and CheckOutCpu() will return the error code after that.
+    GetArrivedCpuCount() returns the number of checked-in CPUs.
+
+  3. WaitForAPs/ReleaseOneAp/WaitForBsp/ReleaseBsp
+    WaitForAPs() & ReleaseOneAp() are called from BSP to wait the number of APs and release one specific AP.
+    WaitForBsp() & ReleaseBsp() are called from APs to wait and release BSP.
+    The 4 APIs are used to synchronize the running flow among BSP and APs.
+    BSP and AP Sync flow can be easy understand as below:
+    BSP: ReleaseOneAp  -->  AP: WaitForBsp
+    BSP: WaitForAPs    <--  AP: ReleaseBsp
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/SafeIntLib.h>
+#include <Library/SmmCpuSyncLib.h>
+#include <Library/SynchronizationLib.h>
+#include <Uefi.h>
+
+///
+/// The implementation shall place one semaphore on exclusive cache line for good performance.
+///
+typedef volatile UINT32 SMM_CPU_SYNC_SEMAPHORE;
+
+typedef struct {
+  ///
+  /// Used for control each CPU continue run or wait for signal
+  ///
+  SMM_CPU_SYNC_SEMAPHORE    *Run;
+} SMM_CPU_SYNC_SEMAPHORE_FOR_EACH_CPU;
+
+struct SMM_CPU_SYNC_CONTEXT  {
+  ///
+  /// Indicate all CPUs in the system.
+  ///
+  UINTN                                  NumberOfCpus;
+  ///
+  /// Address of semaphores.
+  ///
+  VOID                                   *SemBuffer;
+  ///
+  /// Size of semaphores.
+  ///
+  UINTN                                  SemBufferPages;
+  ///
+  /// Before the door is locked, CpuCount stores the arrived CPU count.
+  /// After the door is locked, CpuCount is set to -1 indicating the door is locked.
+  /// ArrivedCpuCountUponLock stores the arrived CPU count then.
+  ///
+  UINTN                                  ArrivedCpuCountUponLock;
+  ///
+  /// Indicate CPUs entered SMM before lock door.
+  ///
+  SMM_CPU_SYNC_SEMAPHORE                 *CpuCount;
+  ///
+  /// Define an array of structure for each CPU semaphore due to the size alignment
+  /// requirement. With the array of structure for each CPU semaphore, it's easy to
+  /// reach the specific CPU with CPU Index for its own semaphore access: CpuSem[CpuIndex].
+  ///
+  SMM_CPU_SYNC_SEMAPHORE_FOR_EACH_CPU    CpuSem[];
+};
+
+/**
+  Performs an atomic compare exchange operation to get semaphore.
+  The compare exchange operation must be performed using MP safe
+  mechanisms.
+
+  @param[in,out]  Sem    IN:  32-bit unsigned integer
+                         OUT: original integer - 1 if Sem is not locked.
+                         OUT: MAX_UINT32 if Sem is locked.
+
+  @retval     Original integer - 1 if Sem is not locked.
+              MAX_UINT32 if Sem is locked.
+
+**/
+STATIC
+UINT32
+InternalWaitForSemaphore (
+  IN OUT  volatile UINT32  *Sem
+  )
+{
+  UINT32  Value;
+
+  for ( ; ;) {
+    Value = *Sem;
+    if (Value == MAX_UINT32) {
+      return Value;
+    }
+
+    if ((Value != 0) &&
+        (InterlockedCompareExchange32 (
+           (UINT32 *)Sem,
+           Value,
+           Value - 1
+           ) == Value))
+    {
+      break;
+    }
+
+    CpuPause ();
+  }
+
+  return Value - 1;
+}
+
+/**
+  Performs an atomic compare exchange operation to release semaphore.
+  The compare exchange operation must be performed using MP safe
+  mechanisms.
+
+  @param[in,out]  Sem    IN:  32-bit unsigned integer
+                         OUT: original integer + 1 if Sem is not locked.
+                         OUT: MAX_UINT32 if Sem is locked.
+
+  @retval    Original integer + 1 if Sem is not locked.
+             MAX_UINT32 if Sem is locked.
+
+**/
+STATIC
+UINT32
+InternalReleaseSemaphore (
+  IN OUT  volatile UINT32  *Sem
+  )
+{
+  UINT32  Value;
+
+  do {
+    Value = *Sem;
+  } while (Value + 1 != 0 &&
+           InterlockedCompareExchange32 (
+             (UINT32 *)Sem,
+             Value,
+             Value + 1
+             ) != Value);
+
+  if (Value == MAX_UINT32) {
+    return Value;
+  }
+
+  return Value + 1;
+}
+
+/**
+  Performs an atomic compare exchange operation to lock semaphore.
+  The compare exchange operation must be performed using MP safe
+  mechanisms.
+
+  @param[in,out]  Sem    IN:  32-bit unsigned integer
+                         OUT: -1
+
+  @retval    Original integer
+
+**/
+STATIC
+UINT32
+InternalLockdownSemaphore (
+  IN OUT  volatile UINT32  *Sem
+  )
+{
+  UINT32  Value;
+
+  do {
+    Value = *Sem;
+  } while (InterlockedCompareExchange32 (
+             (UINT32 *)Sem,
+             Value,
+             (UINT32)-1
+             ) != Value);
+
+  return Value;
+}
+
+/**
+  Create and initialize the SMM CPU Sync context. It is to allocate and initialize the
+  SMM CPU Sync context.
+
+  If Context is NULL, then ASSERT().
+
+  @param[in]  NumberOfCpus          The number of Logical Processors in the system.
+  @param[out] Context               Pointer to the new created and initialized SMM CPU Sync context object.
+                                    NULL will be returned if any error happen during init.
+
+  @retval RETURN_SUCCESS            The SMM CPU Sync context was successful created and initialized.
+  @retval RETURN_OUT_OF_RESOURCES   There are not enough resources available to create and initialize SMM CPU Sync context.
+  @retval RETURN_BUFFER_TOO_SMALL   Overflow happen
+
+**/
+RETURN_STATUS
+EFIAPI
+SmmCpuSyncContextInit (
+  IN   UINTN                 NumberOfCpus,
+  OUT  SMM_CPU_SYNC_CONTEXT  **Context
+  )
+{
+  RETURN_STATUS                        Status;
+  UINTN                                ContextSize;
+  UINTN                                OneSemSize;
+  UINTN                                NumSem;
+  UINTN                                TotalSemSize;
+  UINTN                                SemAddr;
+  UINTN                                CpuIndex;
+  SMM_CPU_SYNC_SEMAPHORE_FOR_EACH_CPU  *CpuSem;
+
+  ASSERT (Context != NULL);
+
+  //
+  // Calculate ContextSize
+  //
+  Status = SafeUintnMult (NumberOfCpus, sizeof (SMM_CPU_SYNC_SEMAPHORE_FOR_EACH_CPU), &ContextSize);
+  if (RETURN_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = SafeUintnAdd (ContextSize, sizeof (SMM_CPU_SYNC_CONTEXT), &ContextSize);
+  if (RETURN_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Allocate Buffer for Context
+  //
+  *Context = AllocatePool (ContextSize);
+  if (*Context == NULL) {
+    return RETURN_OUT_OF_RESOURCES;
+  }
+
+  (*Context)->ArrivedCpuCountUponLock = 0;
+
+  //
+  // Save NumberOfCpus
+  //
+  (*Context)->NumberOfCpus = NumberOfCpus;
+
+  //
+  // Calculate total semaphore size
+  //
+  OneSemSize = GetSpinLockProperties ();
+  ASSERT (sizeof (SMM_CPU_SYNC_SEMAPHORE) <= OneSemSize);
+
+  Status = SafeUintnAdd (1, NumberOfCpus, &NumSem);
+  if (RETURN_ERROR (Status)) {
+    goto ON_ERROR;
+  }
+
+  Status = SafeUintnMult (NumSem, OneSemSize, &TotalSemSize);
+  if (RETURN_ERROR (Status)) {
+    goto ON_ERROR;
+  }
+
+  //
+  // Allocate for Semaphores in the *Context
+  //
+  (*Context)->SemBufferPages = EFI_SIZE_TO_PAGES (TotalSemSize);
+  (*Context)->SemBuffer      = AllocatePages ((*Context)->SemBufferPages);
+  if ((*Context)->SemBuffer == NULL) {
+    Status = RETURN_OUT_OF_RESOURCES;
+    goto ON_ERROR;
+  }
+
+  //
+  // Assign Global Semaphore pointer
+  //
+  SemAddr               = (UINTN)(*Context)->SemBuffer;
+  (*Context)->CpuCount  = (SMM_CPU_SYNC_SEMAPHORE *)SemAddr;
+  *(*Context)->CpuCount = 0;
+
+  SemAddr += OneSemSize;
+
+  //
+  // Assign CPU Semaphore pointer
+  //
+  CpuSem = (*Context)->CpuSem;
+  for (CpuIndex = 0; CpuIndex < NumberOfCpus; CpuIndex++) {
+    CpuSem->Run  = (SMM_CPU_SYNC_SEMAPHORE *)SemAddr;
+    *CpuSem->Run = 0;
+
+    CpuSem++;
+    SemAddr += OneSemSize;
+  }
+
+  return RETURN_SUCCESS;
+
+ON_ERROR:
+  FreePool (*Context);
+  return Status;
+}
+
+/**
+  Deinit an allocated SMM CPU Sync context. The resources allocated in SmmCpuSyncContextInit() will
+  be freed.
+
+  If Context is NULL, then ASSERT().
+
+  @param[in,out]  Context     Pointer to the SMM CPU Sync context object to be deinitialized.
+
+**/
+VOID
+EFIAPI
+SmmCpuSyncContextDeinit (
+  IN OUT SMM_CPU_SYNC_CONTEXT  *Context
+  )
+{
+  ASSERT (Context != NULL);
+
+  FreePages (Context->SemBuffer, Context->SemBufferPages);
+
+  FreePool (Context);
+}
+
+/**
+  Reset SMM CPU Sync context. SMM CPU Sync context will be reset to the initialized state.
+
+  This function is called by one of CPUs after all CPUs are ready to exit SMI, which allows CPU to
+  check into the next SMI from this point.
+
+  If Context is NULL, then ASSERT().
+
+  @param[in,out]  Context     Pointer to the SMM CPU Sync context object to be reset.
+
+**/
+VOID
+EFIAPI
+SmmCpuSyncContextReset (
+  IN OUT SMM_CPU_SYNC_CONTEXT  *Context
+  )
+{
+  ASSERT (Context != NULL);
+
+  Context->ArrivedCpuCountUponLock = 0;
+  *Context->CpuCount               = 0;
+}
+
+/**
+  Get current number of arrived CPU in SMI.
+
+  BSP might need to know the current number of arrived CPU in SMI to make sure all APs
+  in SMI. This API can be for that purpose.
+
+  If Context is NULL, then ASSERT().
+
+  @param[in]      Context     Pointer to the SMM CPU Sync context object.
+
+  @retval    Current number of arrived CPU in SMI.
+
+**/
+UINTN
+EFIAPI
+SmmCpuSyncGetArrivedCpuCount (
+  IN  SMM_CPU_SYNC_CONTEXT  *Context
+  )
+{
+  UINT32  Value;
+
+  ASSERT (Context != NULL);
+
+  Value = *Context->CpuCount;
+
+  if (Value == (UINT32)-1) {
+    return Context->ArrivedCpuCountUponLock;
+  }
+
+  return Value;
+}
+
+/**
+  Performs an atomic operation to check in CPU.
+
+  When SMI happens, all processors including BSP enter to SMM mode by calling SmmCpuSyncCheckInCpu().
+
+  If Context is NULL, then ASSERT().
+  If CpuIndex exceeds the range of all CPUs in the system, then ASSERT().
+
+  @param[in,out]  Context           Pointer to the SMM CPU Sync context object.
+  @param[in]      CpuIndex          Check in CPU index.
+
+  @retval RETURN_SUCCESS            Check in CPU (CpuIndex) successfully.
+  @retval RETURN_ABORTED            Check in CPU failed due to SmmCpuSyncLockDoor() has been called by one elected CPU.
+
+**/
+RETURN_STATUS
+EFIAPI
+SmmCpuSyncCheckInCpu (
+  IN OUT SMM_CPU_SYNC_CONTEXT  *Context,
+  IN     UINTN                 CpuIndex
+  )
+{
+  ASSERT (Context != NULL);
+
+  ASSERT (CpuIndex < Context->NumberOfCpus);
+
+  //
+  // Check to return if CpuCount has already been locked.
+  //
+  if (InternalReleaseSemaphore (Context->CpuCount) == MAX_UINT32) {
+    return RETURN_ABORTED;
+  }
+
+  return RETURN_SUCCESS;
+}
+
+/**
+  Performs an atomic operation to check out CPU.
+
+  This function can be called in error handling flow for the CPU who calls CheckInCpu() earlier.
+  The caller shall make sure the CPU specified by CpuIndex has already checked-in.
+
+  If Context is NULL, then ASSERT().
+  If CpuIndex exceeds the range of all CPUs in the system, then ASSERT().
+
+  @param[in,out]  Context           Pointer to the SMM CPU Sync context object.
+  @param[in]      CpuIndex          Check out CPU index.
+
+  @retval RETURN_SUCCESS            Check out CPU (CpuIndex) successfully.
+  @retval RETURN_ABORTED            Check out CPU failed due to SmmCpuSyncLockDoor() has been called by one elected CPU.
+
+**/
+RETURN_STATUS
+EFIAPI
+SmmCpuSyncCheckOutCpu (
+  IN OUT SMM_CPU_SYNC_CONTEXT  *Context,
+  IN     UINTN                 CpuIndex
+  )
+{
+  ASSERT (Context != NULL);
+
+  ASSERT (CpuIndex < Context->NumberOfCpus);
+
+  if (InternalWaitForSemaphore (Context->CpuCount) == MAX_UINT32) {
+    return RETURN_ABORTED;
+  }
+
+  return RETURN_SUCCESS;
+}
+
+/**
+  Performs an atomic operation lock door for CPU checkin and checkout. After this function:
+  CPU can not check in via SmmCpuSyncCheckInCpu().
+  CPU can not check out via SmmCpuSyncCheckOutCpu().
+
+  The CPU specified by CpuIndex is elected to lock door. The caller shall make sure the CpuIndex
+  is the actual CPU calling this function to avoid the undefined behavior.
+
+  If Context is NULL, then ASSERT().
+  If CpuCount is NULL, then ASSERT().
+  If CpuIndex exceeds the range of all CPUs in the system, then ASSERT().
+
+  @param[in,out]  Context           Pointer to the SMM CPU Sync context object.
+  @param[in]      CpuIndex          Indicate which CPU to lock door.
+  @param[out]     CpuCount          Number of arrived CPU in SMI after look door.
+
+**/
+VOID
+EFIAPI
+SmmCpuSyncLockDoor (
+  IN OUT SMM_CPU_SYNC_CONTEXT  *Context,
+  IN     UINTN                 CpuIndex,
+  OUT UINTN                    *CpuCount
+  )
+{
+  ASSERT (Context != NULL);
+
+  ASSERT (CpuCount != NULL);
+
+  ASSERT (CpuIndex < Context->NumberOfCpus);
+
+  //
+  // Temporarily record the CpuCount into the ArrivedCpuCountUponLock before lock door.
+  // Recording before lock door is to avoid the Context->CpuCount is locked but possible
+  // Context->ArrivedCpuCountUponLock is not updated.
+  //
+  Context->ArrivedCpuCountUponLock = *Context->CpuCount;
+
+  //
+  // Lock door operation
+  //
+  *CpuCount = InternalLockdownSemaphore (Context->CpuCount);
+
+  //
+  // Update the ArrivedCpuCountUponLock
+  //
+  Context->ArrivedCpuCountUponLock = *CpuCount;
+}
+
+/**
+  Used by the BSP to wait for APs.
+
+  The number of APs need to be waited is specified by NumberOfAPs. The BSP is specified by BspIndex.
+  The caller shall make sure the BspIndex is the actual CPU calling this function to avoid the undefined behavior.
+  The caller shall make sure the NumberOfAPs have already checked-in to avoid the undefined behavior.
+
+  If Context is NULL, then ASSERT().
+  If NumberOfAPs >= All CPUs in system, then ASSERT().
+  If BspIndex exceeds the range of all CPUs in the system, then ASSERT().
+
+  Note:
+  This function is blocking mode, and it will return only after the number of APs released by
+  calling SmmCpuSyncReleaseBsp():
+  BSP: WaitForAPs    <--  AP: ReleaseBsp
+
+  @param[in,out]  Context           Pointer to the SMM CPU Sync context object.
+  @param[in]      NumberOfAPs       Number of APs need to be waited by BSP.
+  @param[in]      BspIndex          The BSP Index to wait for APs.
+
+**/
+VOID
+EFIAPI
+SmmCpuSyncWaitForAPs (
+  IN OUT SMM_CPU_SYNC_CONTEXT  *Context,
+  IN     UINTN                 NumberOfAPs,
+  IN     UINTN                 BspIndex
+  )
+{
+  UINTN  Arrived;
+
+  ASSERT (Context != NULL);
+
+  ASSERT (NumberOfAPs < Context->NumberOfCpus);
+
+  ASSERT (BspIndex < Context->NumberOfCpus);
+
+  for (Arrived = 0; Arrived < NumberOfAPs; Arrived++) {
+    InternalWaitForSemaphore (Context->CpuSem[BspIndex].Run);
+  }
+}
+
+/**
+  Used by the BSP to release one AP.
+
+  The AP is specified by CpuIndex. The BSP is specified by BspIndex.
+  The caller shall make sure the BspIndex is the actual CPU calling this function to avoid the undefined behavior.
+  The caller shall make sure the CpuIndex has already checked-in to avoid the undefined behavior.
+
+  If Context is NULL, then ASSERT().
+  If CpuIndex == BspIndex, then ASSERT().
+  If BspIndex or CpuIndex exceed the range of all CPUs in the system, then ASSERT().
+
+  @param[in,out]  Context           Pointer to the SMM CPU Sync context object.
+  @param[in]      CpuIndex          Indicate which AP need to be released.
+  @param[in]      BspIndex          The BSP Index to release AP.
+
+**/
+VOID
+EFIAPI
+SmmCpuSyncReleaseOneAp   (
+  IN OUT SMM_CPU_SYNC_CONTEXT  *Context,
+  IN     UINTN                 CpuIndex,
+  IN     UINTN                 BspIndex
+  )
+{
+  ASSERT (Context != NULL);
+
+  ASSERT (BspIndex != CpuIndex);
+
+  ASSERT (CpuIndex < Context->NumberOfCpus);
+
+  ASSERT (BspIndex < Context->NumberOfCpus);
+
+  InternalReleaseSemaphore (Context->CpuSem[CpuIndex].Run);
+}
+
+/**
+  Used by the AP to wait BSP.
+
+  The AP is specified by CpuIndex.
+  The caller shall make sure the CpuIndex is the actual CPU calling this function to avoid the undefined behavior.
+  The BSP is specified by BspIndex.
+
+  If Context is NULL, then ASSERT().
+  If CpuIndex == BspIndex, then ASSERT().
+  If BspIndex or CpuIndex exceed the range of all CPUs in the system, then ASSERT().
+
+  Note:
+  This function is blocking mode, and it will return only after the AP released by
+  calling SmmCpuSyncReleaseOneAp():
+  BSP: ReleaseOneAp  -->  AP: WaitForBsp
+
+  @param[in,out]  Context          Pointer to the SMM CPU Sync context object.
+  @param[in]      CpuIndex         Indicate which AP wait BSP.
+  @param[in]      BspIndex         The BSP Index to be waited.
+
+**/
+VOID
+EFIAPI
+SmmCpuSyncWaitForBsp (
+  IN OUT SMM_CPU_SYNC_CONTEXT  *Context,
+  IN     UINTN                 CpuIndex,
+  IN     UINTN                 BspIndex
+  )
+{
+  ASSERT (Context != NULL);
+
+  ASSERT (BspIndex != CpuIndex);
+
+  ASSERT (CpuIndex < Context->NumberOfCpus);
+
+  ASSERT (BspIndex < Context->NumberOfCpus);
+
+  InternalWaitForSemaphore (Context->CpuSem[CpuIndex].Run);
+}
+
+/**
+  Used by the AP to release BSP.
+
+  The AP is specified by CpuIndex.
+  The caller shall make sure the CpuIndex is the actual CPU calling this function to avoid the undefined behavior.
+  The BSP is specified by BspIndex.
+
+  If Context is NULL, then ASSERT().
+  If CpuIndex == BspIndex, then ASSERT().
+  If BspIndex or CpuIndex exceed the range of all CPUs in the system, then ASSERT().
+
+  @param[in,out]  Context           Pointer to the SMM CPU Sync context object.
+  @param[in]      CpuIndex          Indicate which AP release BSP.
+  @param[in]      BspIndex          The BSP Index to be released.
+
+**/
+VOID
+EFIAPI
+SmmCpuSyncReleaseBsp (
+  IN OUT SMM_CPU_SYNC_CONTEXT  *Context,
+  IN     UINTN                 CpuIndex,
+  IN     UINTN                 BspIndex
+  )
+{
+  ASSERT (Context != NULL);
+
+  ASSERT (BspIndex != CpuIndex);
+
+  ASSERT (CpuIndex < Context->NumberOfCpus);
+
+  ASSERT (BspIndex < Context->NumberOfCpus);
+
+  InternalReleaseSemaphore (Context->CpuSem[BspIndex].Run);
+}

--- a/UefiCpuPkg/Library/SmmCpuSyncLib/SmmCpuSyncLib.inf
+++ b/UefiCpuPkg/Library/SmmCpuSyncLib/SmmCpuSyncLib.inf
@@ -1,0 +1,34 @@
+## @file
+# SMM CPU Synchronization lib.
+#
+# This is SMM CPU Synchronization lib used for SMM CPU sync operations.
+#
+# Copyright (c) 2023, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = SmmCpuSyncLib
+  FILE_GUID                      = 1ca1bc1a-16a4-46ef-956a-ca500fd3381f
+  MODULE_TYPE                    = DXE_SMM_DRIVER
+  LIBRARY_CLASS                  = SmmCpuSyncLib|DXE_SMM_DRIVER
+
+[Sources]
+  SmmCpuSyncLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UefiCpuPkg/UefiCpuPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  MemoryAllocationLib
+  SafeIntLib
+  SynchronizationLib
+
+[Pcd]
+
+[Protocols]

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/MpService.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/MpService.c
@@ -32,117 +32,7 @@ MM_COMPLETION                mSmmStartupThisApToken;
 UINT32  *mPackageFirstThreadIndex = NULL;
 
 /**
-  Performs an atomic compare exchange operation to get semaphore.
-  The compare exchange operation must be performed using
-  MP safe mechanisms.
-
-  @param      Sem        IN:  32-bit unsigned integer
-                         OUT: original integer - 1
-  @return     Original integer - 1
-
-**/
-UINT32
-WaitForSemaphore (
-  IN OUT  volatile UINT32  *Sem
-  )
-{
-  UINT32  Value;
-
-  for ( ; ;) {
-    Value = *Sem;
-    if ((Value != 0) &&
-        (InterlockedCompareExchange32 (
-           (UINT32 *)Sem,
-           Value,
-           Value - 1
-           ) == Value))
-    {
-      break;
-    }
-
-    CpuPause ();
-  }
-
-  return Value - 1;
-}
-
-/**
-  Performs an atomic compare exchange operation to release semaphore.
-  The compare exchange operation must be performed using
-  MP safe mechanisms.
-
-  @param      Sem        IN:  32-bit unsigned integer
-                         OUT: original integer + 1
-  @return     Original integer + 1
-
-**/
-UINT32
-ReleaseSemaphore (
-  IN OUT  volatile UINT32  *Sem
-  )
-{
-  UINT32  Value;
-
-  do {
-    Value = *Sem;
-  } while (Value + 1 != 0 &&
-           InterlockedCompareExchange32 (
-             (UINT32 *)Sem,
-             Value,
-             Value + 1
-             ) != Value);
-
-  return Value + 1;
-}
-
-/**
-  Performs an atomic compare exchange operation to lock semaphore.
-  The compare exchange operation must be performed using
-  MP safe mechanisms.
-
-  @param      Sem        IN:  32-bit unsigned integer
-                         OUT: -1
-  @return     Original integer
-
-**/
-UINT32
-LockdownSemaphore (
-  IN OUT  volatile UINT32  *Sem
-  )
-{
-  UINT32  Value;
-
-  do {
-    Value = *Sem;
-  } while (InterlockedCompareExchange32 (
-             (UINT32 *)Sem,
-             Value,
-             (UINT32)-1
-             ) != Value);
-
-  return Value;
-}
-
-/**
-  Wait all APs to performs an atomic compare exchange operation to release semaphore.
-
-  @param   NumberOfAPs      AP number
-
-**/
-VOID
-WaitForAllAPs (
-  IN      UINTN  NumberOfAPs
-  )
-{
-  UINTN  BspIndex;
-
-  BspIndex = mSmmMpSyncData->BspIndex;
-  while (NumberOfAPs-- > 0) {
-    WaitForSemaphore (mSmmMpSyncData->CpuData[BspIndex].Run);
-  }
-}
-
-/**
+  Used for BSP to release all APs.
   Performs an atomic compare exchange operation to release semaphore
   for each AP.
 
@@ -156,7 +46,7 @@ ReleaseAllAPs (
 
   for (Index = 0; Index < mMaxNumberOfCpus; Index++) {
     if (IsPresentAp (Index)) {
-      ReleaseSemaphore (mSmmMpSyncData->CpuData[Index].Run);
+      SmmCpuSyncReleaseOneAp (mSmmMpSyncData->SyncContext, Index, gSmmCpuPrivate->SmmCoreEntryContext.CurrentlyExecutingCpu);
     }
   }
 }
@@ -252,14 +142,14 @@ AllCpusInSmmExceptBlockedDisabled (
   DisabledCount = 0;
 
   //
-  // Check to make sure mSmmMpSyncData->Counter is valid and not locked.
+  // Check to make sure the CPU arrival count is valid and not locked.
   //
-  ASSERT (*mSmmMpSyncData->Counter <= mNumberOfCpus);
+  ASSERT (SmmCpuSyncGetArrivedCpuCount (mSmmMpSyncData->SyncContext) <= mNumberOfCpus);
 
   //
   // Check whether all CPUs in SMM.
   //
-  if (*mSmmMpSyncData->Counter == mNumberOfCpus) {
+  if (SmmCpuSyncGetArrivedCpuCount (mSmmMpSyncData->SyncContext) == mNumberOfCpus) {
     return TRUE;
   }
 
@@ -269,14 +159,14 @@ AllCpusInSmmExceptBlockedDisabled (
   GetSmmDelayedBlockedDisabledCount (NULL, &BlockedCount, &DisabledCount);
 
   //
-  // *mSmmMpSyncData->Counter might be updated by all APs concurrently. The value
+  // The CPU arrival count might be updated by all APs concurrently. The value
   // can be dynamic changed. If some Aps enter the SMI after the BlockedCount &
-  // DisabledCount check, then the *mSmmMpSyncData->Counter will be increased, thus
-  // leading the *mSmmMpSyncData->Counter + BlockedCount + DisabledCount > mNumberOfCpus.
+  // DisabledCount check, then the CPU arrival count will be increased, thus
+  // leading the retrieved CPU arrival count + BlockedCount + DisabledCount > mNumberOfCpus.
   // since the BlockedCount & DisabledCount are local variable, it's ok here only for
   // the checking of all CPUs In Smm.
   //
-  if (*mSmmMpSyncData->Counter + BlockedCount + DisabledCount >= mNumberOfCpus) {
+  if (SmmCpuSyncGetArrivedCpuCount (mSmmMpSyncData->SyncContext) + BlockedCount + DisabledCount >= mNumberOfCpus) {
     return TRUE;
   }
 
@@ -356,7 +246,7 @@ SmmWaitForApArrival (
   DelayedCount = 0;
   BlockedCount = 0;
 
-  ASSERT (*mSmmMpSyncData->Counter <= mNumberOfCpus);
+  ASSERT (SmmCpuSyncGetArrivedCpuCount (mSmmMpSyncData->SyncContext) <= mNumberOfCpus);
 
   LmceEn     = FALSE;
   LmceSignal = FALSE;
@@ -407,7 +297,7 @@ SmmWaitForApArrival (
   //    - In relaxed flow, CheckApArrival() will check SMI disabling status before calling this function.
   //    In both cases, adding SMI-disabling checking code increases overhead.
   //
-  if (*mSmmMpSyncData->Counter < mNumberOfCpus) {
+  if (SmmCpuSyncGetArrivedCpuCount (mSmmMpSyncData->SyncContext) < mNumberOfCpus) {
     //
     // Send SMI IPIs to bring outside processors in
     //
@@ -570,6 +460,7 @@ BSPHandler (
   IN      SMM_CPU_SYNC_MODE  SyncMode
   )
 {
+  UINTN          CpuCount;
   UINTN          Index;
   MTRR_SETTINGS  Mtrrs;
   UINTN          ApCount;
@@ -577,7 +468,8 @@ BSPHandler (
   UINTN          PresentCount;
 
   ASSERT (CpuIndex == mSmmMpSyncData->BspIndex);
-  ApCount = 0;
+  CpuCount = 0;
+  ApCount  = 0;
 
   PERF_FUNCTION_BEGIN ();
 
@@ -619,15 +511,18 @@ BSPHandler (
     SmmWaitForApArrival ();
 
     //
-    // Lock the counter down and retrieve the number of APs
+    // Lock door for late coming CPU checkin and retrieve the Arrived number of APs
     //
     *mSmmMpSyncData->AllCpusInSync = TRUE;
-    ApCount                        = LockdownSemaphore (mSmmMpSyncData->Counter) - 1;
+
+    SmmCpuSyncLockDoor (mSmmMpSyncData->SyncContext, CpuIndex, &CpuCount);
+
+    ApCount = CpuCount - 1;
 
     //
     // Wait for all APs to get ready for programming MTRRs
     //
-    WaitForAllAPs (ApCount);
+    SmmCpuSyncWaitForAPs (mSmmMpSyncData->SyncContext, ApCount, CpuIndex);
 
     if (SmmCpuFeaturesNeedConfigureMtrrs ()) {
       //
@@ -636,7 +531,7 @@ BSPHandler (
       ReleaseAllAPs ();
 
       //
-      // WaitForSemaphore() may wait for ever if an AP happens to enter SMM at
+      // SmmCpuSyncWaitForAPs() may wait for ever if an AP happens to enter SMM at
       // exactly this point. Please make sure PcdCpuSmmMaxSyncLoops has been set
       // to a large enough value to avoid this situation.
       // Note: For HT capable CPUs, threads within a core share the same set of MTRRs.
@@ -648,7 +543,7 @@ BSPHandler (
       //
       // Wait for all APs to complete their MTRR saving
       //
-      WaitForAllAPs (ApCount);
+      SmmCpuSyncWaitForAPs (mSmmMpSyncData->SyncContext, ApCount, CpuIndex);
 
       //
       // Let all processors program SMM MTRRs together
@@ -656,7 +551,7 @@ BSPHandler (
       ReleaseAllAPs ();
 
       //
-      // WaitForSemaphore() may wait for ever if an AP happens to enter SMM at
+      // SmmCpuSyncWaitForAPs() may wait for ever if an AP happens to enter SMM at
       // exactly this point. Please make sure PcdCpuSmmMaxSyncLoops has been set
       // to a large enough value to avoid this situation.
       //
@@ -665,7 +560,7 @@ BSPHandler (
       //
       // Wait for all APs to complete their MTRR programming
       //
-      WaitForAllAPs (ApCount);
+      SmmCpuSyncWaitForAPs (mSmmMpSyncData->SyncContext, ApCount, CpuIndex);
     }
   }
 
@@ -701,10 +596,14 @@ BSPHandler (
   //
   if ((SyncMode != SmmCpuSyncModeTradition) && !SmmCpuFeaturesNeedConfigureMtrrs ()) {
     //
-    // Lock the counter down and retrieve the number of APs
+    // Lock door for late coming CPU checkin and retrieve the Arrived number of APs
     //
     *mSmmMpSyncData->AllCpusInSync = TRUE;
-    ApCount                        = LockdownSemaphore (mSmmMpSyncData->Counter) - 1;
+
+    SmmCpuSyncLockDoor (mSmmMpSyncData->SyncContext, CpuIndex, &CpuCount);
+
+    ApCount = CpuCount - 1;
+
     //
     // Make sure all APs have their Present flag set
     //
@@ -731,7 +630,7 @@ BSPHandler (
   //
   // Wait for all APs to complete their pending tasks
   //
-  WaitForAllAPs (ApCount);
+  SmmCpuSyncWaitForAPs (mSmmMpSyncData->SyncContext, ApCount, CpuIndex);
 
   if (SmmCpuFeaturesNeedConfigureMtrrs ()) {
     //
@@ -748,7 +647,7 @@ BSPHandler (
     //
     // Wait for all APs to complete MTRR programming
     //
-    WaitForAllAPs (ApCount);
+    SmmCpuSyncWaitForAPs (mSmmMpSyncData->SyncContext, ApCount, CpuIndex);
   }
 
   //
@@ -776,7 +675,7 @@ BSPHandler (
   // Gather APs to exit SMM synchronously. Note the Present flag is cleared by now but
   // WaitForAllAps does not depend on the Present flag.
   //
-  WaitForAllAPs (ApCount);
+  SmmCpuSyncWaitForAPs (mSmmMpSyncData->SyncContext, ApCount, CpuIndex);
 
   //
   // At this point, all APs should have exited from APHandler().
@@ -802,7 +701,7 @@ BSPHandler (
   //
   // Allow APs to check in from this point on
   //
-  *mSmmMpSyncData->Counter                  = 0;
+  SmmCpuSyncContextReset (mSmmMpSyncData->SyncContext);
   *mSmmMpSyncData->AllCpusInSync            = FALSE;
   mSmmMpSyncData->AllApArrivedWithException = FALSE;
 
@@ -872,17 +771,17 @@ APHandler (
         //
         // Give up since BSP is unable to enter SMM
         // and signal the completion of this AP
-        // Reduce the mSmmMpSyncData->Counter!
+        // Reduce the CPU arrival count!
         //
-        WaitForSemaphore (mSmmMpSyncData->Counter);
+        SmmCpuSyncCheckOutCpu (mSmmMpSyncData->SyncContext, CpuIndex);
         return;
       }
     } else {
       //
       // Don't know BSP index. Give up without sending IPI to BSP.
-      // Reduce the mSmmMpSyncData->Counter!
+      // Reduce the CPU arrival count!
       //
-      WaitForSemaphore (mSmmMpSyncData->Counter);
+      SmmCpuSyncCheckOutCpu (mSmmMpSyncData->SyncContext, CpuIndex);
       return;
     }
   }
@@ -902,14 +801,14 @@ APHandler (
     //
     // Notify BSP of arrival at this point
     //
-    ReleaseSemaphore (mSmmMpSyncData->CpuData[BspIndex].Run);
+    SmmCpuSyncReleaseBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex);
   }
 
   if (SmmCpuFeaturesNeedConfigureMtrrs ()) {
     //
     // Wait for the signal from BSP to backup MTRRs
     //
-    WaitForSemaphore (mSmmMpSyncData->CpuData[CpuIndex].Run);
+    SmmCpuSyncWaitForBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex);
 
     //
     // Backup OS MTRRs
@@ -919,12 +818,12 @@ APHandler (
     //
     // Signal BSP the completion of this AP
     //
-    ReleaseSemaphore (mSmmMpSyncData->CpuData[BspIndex].Run);
+    SmmCpuSyncReleaseBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex);
 
     //
     // Wait for BSP's signal to program MTRRs
     //
-    WaitForSemaphore (mSmmMpSyncData->CpuData[CpuIndex].Run);
+    SmmCpuSyncWaitForBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex);
 
     //
     // Replace OS MTRRs with SMI MTRRs
@@ -934,14 +833,14 @@ APHandler (
     //
     // Signal BSP the completion of this AP
     //
-    ReleaseSemaphore (mSmmMpSyncData->CpuData[BspIndex].Run);
+    SmmCpuSyncReleaseBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex);
   }
 
   while (TRUE) {
     //
     // Wait for something to happen
     //
-    WaitForSemaphore (mSmmMpSyncData->CpuData[CpuIndex].Run);
+    SmmCpuSyncWaitForBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex);
 
     //
     // Check if BSP wants to exit SMM
@@ -981,12 +880,12 @@ APHandler (
     //
     // Notify BSP the readiness of this AP to program MTRRs
     //
-    ReleaseSemaphore (mSmmMpSyncData->CpuData[BspIndex].Run);
+    SmmCpuSyncReleaseBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex);
 
     //
     // Wait for the signal from BSP to program MTRRs
     //
-    WaitForSemaphore (mSmmMpSyncData->CpuData[CpuIndex].Run);
+    SmmCpuSyncWaitForBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex);
 
     //
     // Restore OS MTRRs
@@ -998,12 +897,12 @@ APHandler (
   //
   // Notify BSP the readiness of this AP to Reset states/semaphore for this processor
   //
-  ReleaseSemaphore (mSmmMpSyncData->CpuData[BspIndex].Run);
+  SmmCpuSyncReleaseBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex);
 
   //
   // Wait for the signal from BSP to Reset states/semaphore for this processor
   //
-  WaitForSemaphore (mSmmMpSyncData->CpuData[CpuIndex].Run);
+  SmmCpuSyncWaitForBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex);
 
   //
   // Reset states/semaphore for this processor
@@ -1013,7 +912,7 @@ APHandler (
   //
   // Notify BSP the readiness of this AP to exit SMM
   //
-  ReleaseSemaphore (mSmmMpSyncData->CpuData[BspIndex].Run);
+  SmmCpuSyncReleaseBsp (mSmmMpSyncData->SyncContext, CpuIndex, BspIndex);
 }
 
 /**
@@ -1297,7 +1196,7 @@ InternalSmmStartupThisAp (
     *mSmmMpSyncData->CpuData[CpuIndex].Status = EFI_NOT_READY;
   }
 
-  ReleaseSemaphore (mSmmMpSyncData->CpuData[CpuIndex].Run);
+  SmmCpuSyncReleaseOneAp (mSmmMpSyncData->SyncContext, CpuIndex, gSmmCpuPrivate->SmmCoreEntryContext.CurrentlyExecutingCpu);
 
   if (Token == NULL) {
     AcquireSpinLock (mSmmMpSyncData->CpuData[CpuIndex].Busy);
@@ -1701,10 +1600,11 @@ SmiRendezvous (
   } else {
     //
     // Signal presence of this processor
-    // mSmmMpSyncData->Counter is increased here!
-    // "ReleaseSemaphore (mSmmMpSyncData->Counter) == 0" means BSP has already ended the synchronization.
+    // CPU check in here!
+    // "SmmCpuSyncCheckInCpu (mSmmMpSyncData->SyncContext, CpuIndex)" return error means failed
+    // to check in CPU. BSP has already ended the synchronization.
     //
-    if (ReleaseSemaphore (mSmmMpSyncData->Counter) == 0) {
+    if (RETURN_ERROR (SmmCpuSyncCheckInCpu (mSmmMpSyncData->SyncContext, CpuIndex))) {
       //
       // BSP has already ended the synchronization, so QUIT!!!
       // Existing AP is too late now to enter SMI since BSP has already ended the synchronization!!!
@@ -1799,8 +1699,6 @@ SmiRendezvous (
         APHandler (CpuIndex, ValidSmi, mSmmMpSyncData->EffectiveSyncMode);
       }
     }
-
-    ASSERT (*mSmmMpSyncData->CpuData[CpuIndex].Run == 0);
 
     //
     // Wait for BSP's signal to exit SMI
@@ -1927,8 +1825,6 @@ InitializeSmmCpuSemaphores (
   ZeroMem (SemaphoreBlock, TotalSize);
 
   SemaphoreAddr                                   = (UINTN)SemaphoreBlock;
-  mSmmCpuSemaphores.SemaphoreGlobal.Counter       = (UINT32 *)SemaphoreAddr;
-  SemaphoreAddr                                  += SemaphoreSize;
   mSmmCpuSemaphores.SemaphoreGlobal.InsideSmm     = (BOOLEAN *)SemaphoreAddr;
   SemaphoreAddr                                  += SemaphoreSize;
   mSmmCpuSemaphores.SemaphoreGlobal.AllCpusInSync = (BOOLEAN *)SemaphoreAddr;
@@ -1941,8 +1837,6 @@ InitializeSmmCpuSemaphores (
 
   SemaphoreAddr                          = (UINTN)SemaphoreBlock + GlobalSemaphoresSize;
   mSmmCpuSemaphores.SemaphoreCpu.Busy    = (SPIN_LOCK *)SemaphoreAddr;
-  SemaphoreAddr                         += ProcessorCount * SemaphoreSize;
-  mSmmCpuSemaphores.SemaphoreCpu.Run     = (UINT32 *)SemaphoreAddr;
   SemaphoreAddr                         += ProcessorCount * SemaphoreSize;
   mSmmCpuSemaphores.SemaphoreCpu.Present = (BOOLEAN *)SemaphoreAddr;
 
@@ -1962,6 +1856,8 @@ InitializeMpSyncData (
   VOID
   )
 {
+  RETURN_STATUS  Status;
+
   UINTN  CpuIndex;
 
   if (mSmmMpSyncData != NULL) {
@@ -1981,14 +1877,21 @@ InitializeMpSyncData (
 
     mSmmMpSyncData->EffectiveSyncMode = mCpuSmmSyncMode;
 
-    mSmmMpSyncData->Counter       = mSmmCpuSemaphores.SemaphoreGlobal.Counter;
+    Status = SmmCpuSyncContextInit (gSmmCpuPrivate->SmmCoreEntryContext.NumberOfCpus, &mSmmMpSyncData->SyncContext);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "InitializeMpSyncData: SmmCpuSyncContextInit return error %r!\n", Status));
+      CpuDeadLoop ();
+      return;
+    }
+
+    ASSERT (mSmmMpSyncData->SyncContext != NULL);
+
     mSmmMpSyncData->InsideSmm     = mSmmCpuSemaphores.SemaphoreGlobal.InsideSmm;
     mSmmMpSyncData->AllCpusInSync = mSmmCpuSemaphores.SemaphoreGlobal.AllCpusInSync;
     ASSERT (
-      mSmmMpSyncData->Counter != NULL && mSmmMpSyncData->InsideSmm != NULL &&
+      mSmmMpSyncData->InsideSmm != NULL &&
       mSmmMpSyncData->AllCpusInSync != NULL
       );
-    *mSmmMpSyncData->Counter       = 0;
     *mSmmMpSyncData->InsideSmm     = FALSE;
     *mSmmMpSyncData->AllCpusInSync = FALSE;
 
@@ -1997,12 +1900,9 @@ InitializeMpSyncData (
     for (CpuIndex = 0; CpuIndex < gSmmCpuPrivate->SmmCoreEntryContext.NumberOfCpus; CpuIndex++) {
       mSmmMpSyncData->CpuData[CpuIndex].Busy =
         (SPIN_LOCK *)((UINTN)mSmmCpuSemaphores.SemaphoreCpu.Busy + mSemaphoreSize * CpuIndex);
-      mSmmMpSyncData->CpuData[CpuIndex].Run =
-        (UINT32 *)((UINTN)mSmmCpuSemaphores.SemaphoreCpu.Run + mSemaphoreSize * CpuIndex);
       mSmmMpSyncData->CpuData[CpuIndex].Present =
         (BOOLEAN *)((UINTN)mSmmCpuSemaphores.SemaphoreCpu.Present + mSemaphoreSize * CpuIndex);
       *(mSmmMpSyncData->CpuData[CpuIndex].Busy)    = 0;
-      *(mSmmMpSyncData->CpuData[CpuIndex].Run)     = 0;
       *(mSmmMpSyncData->CpuData[CpuIndex].Present) = FALSE;
     }
   }

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/MpService.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/MpService.c
@@ -1325,7 +1325,7 @@ InternalSmmStartupAllAPs (
       // Decrease the count to mark this processor(AP or BSP) as finished.
       //
       if (ProcToken != NULL) {
-        WaitForSemaphore (&ProcToken->RunningApCount);
+        InterlockedDecrement (&ProcToken->RunningApCount);
       }
     }
   }

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.h
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.h
@@ -55,6 +55,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/PerformanceLib.h>
 #include <Library/CpuPageTableLib.h>
 #include <Library/MmSaveStateLib.h>
+#include <Library/SmmCpuSyncLib.h>
 
 #include <AcpiCpuData.h>
 #include <CpuHotPlugData.h>
@@ -413,7 +414,6 @@ typedef struct {
   SPIN_LOCK                     *Busy;
   volatile EFI_AP_PROCEDURE2    Procedure;
   volatile VOID                 *Parameter;
-  volatile UINT32               *Run;
   volatile BOOLEAN              *Present;
   PROCEDURE_TOKEN               *Token;
   EFI_STATUS                    *Status;
@@ -431,7 +431,6 @@ typedef struct {
   // so that UC cache-ability can be set together.
   //
   SMM_CPU_DATA_BLOCK            *CpuData;
-  volatile UINT32               *Counter;
   volatile UINT32               BspIndex;
   volatile BOOLEAN              *InsideSmm;
   volatile BOOLEAN              *AllCpusInSync;
@@ -441,6 +440,7 @@ typedef struct {
   volatile BOOLEAN              AllApArrivedWithException;
   EFI_AP_PROCEDURE              StartupProcedure;
   VOID                          *StartupProcArgs;
+  SMM_CPU_SYNC_CONTEXT          *SyncContext;
 } SMM_DISPATCHER_MP_SYNC_DATA;
 
 #define SMM_PSD_OFFSET  0xfb00
@@ -449,7 +449,6 @@ typedef struct {
 /// All global semaphores' pointer
 ///
 typedef struct {
-  volatile UINT32     *Counter;
   volatile BOOLEAN    *InsideSmm;
   volatile BOOLEAN    *AllCpusInSync;
   SPIN_LOCK           *PFLock;
@@ -461,7 +460,6 @@ typedef struct {
 ///
 typedef struct {
   SPIN_LOCK           *Busy;
-  volatile UINT32     *Run;
   volatile BOOLEAN    *Present;
   SPIN_LOCK           *Token;
 } SMM_CPU_SEMAPHORE_CPU;

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf
@@ -105,6 +105,7 @@
   CpuPageTableLib
   MmSaveStateLib
   MmMemoryProtectionHobLib                   ## MU_CHANGE
+  SmmCpuSyncLib
 
 [Protocols]
   gEfiSmmAccess2ProtocolGuid               ## CONSUMES

--- a/UefiCpuPkg/UefiCpuPkg.dec
+++ b/UefiCpuPkg/UefiCpuPkg.dec
@@ -64,6 +64,9 @@
   ## @libraryclass   Provides functions for manipulating smram savestate registers.
   MmSaveStateLib|Include/Library/MmSaveStateLib.h
 
+  ## @libraryclass   Provides functions for SMM CPU Sync Operation.
+  SmmCpuSyncLib|Include/Library/SmmCpuSyncLib.h
+
 [LibraryClasses.RISCV64]
   ##  @libraryclass  Provides functions to manage MMU features on RISCV64 CPUs.
   ##

--- a/UefiCpuPkg/UefiCpuPkg.dsc
+++ b/UefiCpuPkg/UefiCpuPkg.dsc
@@ -71,6 +71,7 @@
   PciExpressLib|MdePkg/Library/BasePciExpressLib/BasePciExpressLib.inf
   SmmCpuPlatformHookLib|UefiCpuPkg/Library/SmmCpuPlatformHookLibNull/SmmCpuPlatformHookLibNull.inf
   SmmCpuFeaturesLib|UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLib.inf
+  SmmCpuSyncLib|UefiCpuPkg/Library/SmmCpuSyncLib/SmmCpuSyncLib.inf
   PeCoffGetEntryPointLib|MdePkg/Library/BasePeCoffGetEntryPointLib/BasePeCoffGetEntryPointLib.inf
   PeCoffExtraActionLib|MdePkg/Library/BasePeCoffExtraActionLibNull/BasePeCoffExtraActionLibNull.inf
   TpmMeasurementLib|MdeModulePkg/Library/TpmMeasurementLibNull/TpmMeasurementLibNull.inf
@@ -191,6 +192,7 @@
   UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLib.inf
   UefiCpuPkg/Library/SmmCpuFeaturesLib/SmmCpuFeaturesLibStm.inf
   UefiCpuPkg/Library/SmmCpuFeaturesLib/StandaloneMmCpuFeaturesLib.inf
+  UefiCpuPkg/Library/SmmCpuSyncLib/SmmCpuSyncLib.inf
   UefiCpuPkg/Library/CcExitLibNull/CcExitLibNull.inf
   UefiCpuPkg/PiSmmCommunication/PiSmmCommunicationPei.inf
   UefiCpuPkg/PiSmmCommunication/PiSmmCommunicationSmm.inf


### PR DESCRIPTION
## Description

SmmCpuSyncLib was introduced in EDK2 to move cpu synchronization tasks into their own library, out of the existing consuming code. 
 
A newer version of platform reference code relies on this change. The platform reference code provides its own instance of the SmmCpuSyncLib to handle some additional conditions.


- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [x] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Booted platform consuming these changes to windows.

## Integration Instructions
SmmCpuSyncLib is a new library class added to UefiCpuPkg.

Existing projects consuming PiSmmCpuDxeSmm.inf will need to add a library instance for SmmCpuSyncLib to their dsc file.
`SmmCpuSyncLib|UefiCpuPkg/Library/SmmCpuSyncLib/SmmCpuSyncLib.inf`
