### PR TITLE
[REBASE && FF] Apply EFI_MEMORY_RP on Free Memory and Fix Unsafe Allocation Checking

### DIFF
--- a/MdeModulePkg/Core/Dxe/DxeMain.inf
+++ b/MdeModulePkg/Core/Dxe/DxeMain.inf
@@ -183,6 +183,7 @@
   gMemoryProtectionDebugProtocolGuid            ## SOMETIMES_PRODUCES        ## MS_CHANGE
   gEfiMemoryAttributeProtocolGuid               ## CONSUMES                  ## MS_CHANGE
   gMemoryProtectionSpecialRegionProtocolGuid    ## PRODUCES                  ## MU_CHANGE
+  gEdkiiGcdSyncCompleteProtocolGuid             ## CONSUMES                  ## MU_CHANGE
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdLoadFixAddressBootTimeCodePageNumber    ## SOMETIMES_CONSUMES

--- a/MdeModulePkg/Core/Dxe/Mem/HeapGuard.c
+++ b/MdeModulePkg/Core/Dxe/Mem/HeapGuard.c
@@ -252,8 +252,14 @@ FindGuardedMemoryMap (
                  &MapMemory,
                  FALSE
                  );
-      ASSERT_EFI_ERROR (Status);
-      ASSERT (MapMemory != 0);
+      // MU_CHANGE START: Check if memory was successfully allocated
+      if (EFI_ERROR (Status) || (MapMemory == 0)) {
+        ASSERT_EFI_ERROR (Status);
+        ASSERT (MapMemory != 0);
+        return 0;
+      }
+
+      // MU_CHANGE END
       // MU_CHANGE START: Apply Protection policy to the allocated memory
       ApplyMemoryProtectionPolicy (
         EfiConventionalMemory,
@@ -291,8 +297,14 @@ FindGuardedMemoryMap (
                  &MapMemory,
                  FALSE
                  );
-      ASSERT_EFI_ERROR (Status);
-      ASSERT (MapMemory != 0);
+      // MU_CHANGE START: Check if memory was successfully allocated
+      if (EFI_ERROR (Status) || (MapMemory == 0)) {
+        ASSERT_EFI_ERROR (Status);
+        ASSERT (MapMemory != 0);
+        return 0;
+      }
+
+      // MU_CHANGE END
       // MU_CHANGE START: Apply Protection policy to the allocated memory
       ApplyMemoryProtectionPolicy (
         EfiConventionalMemory,

--- a/MdeModulePkg/Core/Dxe/Mem/HeapGuard.c
+++ b/MdeModulePkg/Core/Dxe/Mem/HeapGuard.c
@@ -16,6 +16,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 GLOBAL_REMOVE_IF_UNREFERENCED BOOLEAN  mOnGuarding = FALSE;
 
+extern BOOLEAN  mPageAttributesInitialized; // MU_CHANGE
+
 //
 // Pointer to table tracking the Guarded memory with bitmap, in which  '1'
 // is used to indicate memory guarded. '0' might be free memory or Guard
@@ -252,6 +254,14 @@ FindGuardedMemoryMap (
                  );
       ASSERT_EFI_ERROR (Status);
       ASSERT (MapMemory != 0);
+      // MU_CHANGE START: Apply Protection policy to the allocated memory
+      ApplyMemoryProtectionPolicy (
+        EfiConventionalMemory,
+        EfiBootServicesData,
+        MapMemory,
+        ALIGN_VALUE (Size, EFI_PAGE_SIZE)
+        );
+      // MU_CHANGE END
 
       SetMem ((VOID *)(UINTN)MapMemory, Size, 0);
 
@@ -283,6 +293,14 @@ FindGuardedMemoryMap (
                  );
       ASSERT_EFI_ERROR (Status);
       ASSERT (MapMemory != 0);
+      // MU_CHANGE START: Apply Protection policy to the allocated memory
+      ApplyMemoryProtectionPolicy (
+        EfiConventionalMemory,
+        EfiBootServicesData,
+        MapMemory,
+        ALIGN_VALUE (Size, EFI_PAGE_SIZE)
+        );
+      // MU_CHANGE END
 
       SetMem ((VOID *)(UINTN)MapMemory, Size, 0);
       *GuardMap = MapMemory;
@@ -560,6 +578,13 @@ UnsetGuardPage (
     Attributes |= EFI_MEMORY_XP;
   }
 
+  // MU_CHANGE START: Add support for RP on free mem
+  if (gDxeMps.FreeMemoryReadProtected) {
+    Attributes |= EFI_MEMORY_RP;
+  }
+
+  // MU_CHANGE END
+
   //
   // Set flag to make sure allocating memory without GUARD for page table
   // operation; otherwise infinite loops could be caused.
@@ -690,10 +715,10 @@ IsHeapGuardEnabled (
   UINT8  GuardType
   )
 {
-  // MU_CHANGE START Update to work with memory protection settings HOB
+  // MU_CHANGE START: Update to work with memory protection settings HOB,
+  //                  remove freed memory guard.
   if ((GuardType & GUARD_HEAP_TYPE_PAGE && gDxeMps.HeapGuardPolicy.Fields.UefiPageGuard) ||
-      (GuardType & GUARD_HEAP_TYPE_POOL && gDxeMps.HeapGuardPolicy.Fields.UefiPoolGuard) ||
-      (GuardType & GUARD_HEAP_TYPE_FREED && gDxeMps.HeapGuardPolicy.Fields.UefiFreedMemoryGuard))
+      (GuardType & GUARD_HEAP_TYPE_POOL && gDxeMps.HeapGuardPolicy.Fields.UefiPoolGuard))
   {
     return TRUE;
   }

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
@@ -79,6 +79,9 @@ STATIC MEMORY_PROTECTION_DEBUG_PROTOCOL  mMemoryProtectionDebug =
   IsGuardPage,
   GetImageList
 };
+
+BOOLEAN  mPageAttributesInitialized = FALSE;
+
 // MS_CHANGE - END
 
 /**
@@ -504,7 +507,8 @@ GetPermissionAttributeForMemoryType (
   IN EFI_MEMORY_TYPE  MemoryType
   )
 {
-  // MU_CHANGE START Update to use memory protection settings HOB
+  // MU_CHANGE START: Update to use memory protection settings HOB,
+  //                  add support for RP on free memory.
   // UINT64 TestBit;
 
   // if ((UINT32)MemoryType >= MEMORY_TYPE_OS_RESERVED_MIN) {
@@ -521,15 +525,23 @@ GetPermissionAttributeForMemoryType (
   //   return 0;
   // }
 
+  UINT64  Attributes = 0;
+
   // Handle code allocations according to the NX_COMPAT DLL flag. If the flag is
   // set, the image should update the attributes of code type allocates when it's ready to execute them.
   if (!IsEnhancedMemoryProtectionActive ()) {
     return 0;
-  } else if (GetDxeMemoryTypeSettingFromBitfield (MemoryType, gDxeMps.NxProtectionPolicy)) {
-    return EFI_MEMORY_XP;
   }
 
-  return 0;
+  if (GetDxeMemoryTypeSettingFromBitfield (MemoryType, gDxeMps.NxProtectionPolicy)) {
+    Attributes |= EFI_MEMORY_XP;
+  }
+
+  if ((MemoryType == EfiConventionalMemory) && gDxeMps.FreeMemoryReadProtected && mPageAttributesInitialized) {
+    Attributes |= EFI_MEMORY_RP;
+  }
+
+  return Attributes;
 
   // MU_CHANGE END
 }
@@ -639,214 +651,216 @@ MergeMemoryMapForProtectionPolicy (
   return;
 }
 
-/**
-  Remove exec permissions from all regions whose type is identified by
-  the Dxe NX Protection Policy. // MU_CHANGE
-**/
-STATIC
-VOID
-InitializeDxeNxMemoryProtectionPolicy (
-  VOID
-  )
-{
-  UINTN                      MemoryMapSize;
-  UINTN                      MapKey;
-  UINTN                      DescriptorSize;
-  UINT32                     DescriptorVersion;
-  EFI_MEMORY_DESCRIPTOR      *MemoryMap;
-  EFI_MEMORY_DESCRIPTOR      *MemoryMapEntry;
-  EFI_MEMORY_DESCRIPTOR      *MemoryMapEnd;
-  EFI_STATUS                 Status;
-  UINT64                     Attributes;
-  LIST_ENTRY                 *Link;
-  EFI_GCD_MAP_ENTRY          *Entry;
-  EFI_PEI_HOB_POINTERS       Hob;
-  EFI_HOB_MEMORY_ALLOCATION  *MemoryHob;
-  EFI_PHYSICAL_ADDRESS       StackBase;
+// MU_CHANGE START: Comment out unused function
+// /**
+//   Remove exec permissions from all regions whose type is identified by
+//   the Dxe NX Protection Policy. // MU_CHANGE
+// **/
+// STATIC
+// VOID
+// InitializeDxeNxMemoryProtectionPolicy (
+//   VOID
+//   )
+// {
+//   UINTN                      MemoryMapSize;
+//   UINTN                      MapKey;
+//   UINTN                      DescriptorSize;
+//   UINT32                     DescriptorVersion;
+//   EFI_MEMORY_DESCRIPTOR      *MemoryMap;
+//   EFI_MEMORY_DESCRIPTOR      *MemoryMapEntry;
+//   EFI_MEMORY_DESCRIPTOR      *MemoryMapEnd;
+//   EFI_STATUS                 Status;
+//   UINT64                     Attributes;
+//   LIST_ENTRY                 *Link;
+//   EFI_GCD_MAP_ENTRY          *Entry;
+//   EFI_PEI_HOB_POINTERS       Hob;
+//   EFI_HOB_MEMORY_ALLOCATION  *MemoryHob;
+//   EFI_PHYSICAL_ADDRESS       StackBase;
 
-  //
-  // Get the EFI memory map.
-  //
-  MemoryMapSize = 0;
-  MemoryMap     = NULL;
+//   //
+//   // Get the EFI memory map.
+//   //
+//   MemoryMapSize = 0;
+//   MemoryMap     = NULL;
 
-  Status = gBS->GetMemoryMap (
-                  &MemoryMapSize,
-                  MemoryMap,
-                  &MapKey,
-                  &DescriptorSize,
-                  &DescriptorVersion
-                  );
-  ASSERT (Status == EFI_BUFFER_TOO_SMALL);
-  do {
-    MemoryMap = (EFI_MEMORY_DESCRIPTOR *)AllocatePool (MemoryMapSize);
-    // MU_CHANGE [BEGIN] - CodeQL change
-    if (MemoryMap == NULL) {
-      ASSERT (MemoryMap != NULL);
-      return;
-    }
+//   Status = gBS->GetMemoryMap (
+//                   &MemoryMapSize,
+//                   MemoryMap,
+//                   &MapKey,
+//                   &DescriptorSize,
+//                   &DescriptorVersion
+//                   );
+//   ASSERT (Status == EFI_BUFFER_TOO_SMALL);
+//   do {
+//     MemoryMap = (EFI_MEMORY_DESCRIPTOR *)AllocatePool (MemoryMapSize);
+//     // MU_CHANGE [BEGIN] - CodeQL change
+//     if (MemoryMap == NULL) {
+//       ASSERT (MemoryMap != NULL);
+//       return;
+//     }
 
-    // MU_CHANGE [END] - CodeQL change
-    Status = gBS->GetMemoryMap (
-                    &MemoryMapSize,
-                    MemoryMap,
-                    &MapKey,
-                    &DescriptorSize,
-                    &DescriptorVersion
-                    );
-    if (EFI_ERROR (Status)) {
-      FreePool (MemoryMap);
-    }
-  } while (Status == EFI_BUFFER_TOO_SMALL);
+//     // MU_CHANGE [END] - CodeQL change
+//     Status = gBS->GetMemoryMap (
+//                     &MemoryMapSize,
+//                     MemoryMap,
+//                     &MapKey,
+//                     &DescriptorSize,
+//                     &DescriptorVersion
+//                     );
+//     if (EFI_ERROR (Status)) {
+//       FreePool (MemoryMap);
+//     }
+//   } while (Status == EFI_BUFFER_TOO_SMALL);
 
-  ASSERT_EFI_ERROR (Status);
+//   ASSERT_EFI_ERROR (Status);
 
-  StackBase = 0;
-  // MU_CHANGE START Update to use memory protection settings HOB
-  // if (PcdGetBool (PcdCpuStackGuard)) {
-  if (gDxeMps.CpuStackGuard) {
-    // MU_CHANGE END
-    //
-    // Get the base of stack from Hob.
-    //
-    Hob.Raw = GetHobList ();
-    while ((Hob.Raw = GetNextHob (EFI_HOB_TYPE_MEMORY_ALLOCATION, Hob.Raw)) != NULL) {
-      MemoryHob = Hob.MemoryAllocation;
-      if (CompareGuid (&gEfiHobMemoryAllocStackGuid, &MemoryHob->AllocDescriptor.Name)) {
-        DEBUG ((
-          DEBUG_INFO,
-          "%a: StackBase = 0x%016lx  StackSize = 0x%016lx\n",
-          __func__,
-          MemoryHob->AllocDescriptor.MemoryBaseAddress,
-          MemoryHob->AllocDescriptor.MemoryLength
-          ));
+//   StackBase = 0;
+//   // MU_CHANGE START Update to use memory protection settings HOB
+//   // if (PcdGetBool (PcdCpuStackGuard)) {
+//   if (gDxeMps.CpuStackGuard) {
+//     // MU_CHANGE END
+//     //
+//     // Get the base of stack from Hob.
+//     //
+//     Hob.Raw = GetHobList ();
+//     while ((Hob.Raw = GetNextHob (EFI_HOB_TYPE_MEMORY_ALLOCATION, Hob.Raw)) != NULL) {
+//       MemoryHob = Hob.MemoryAllocation;
+//       if (CompareGuid (&gEfiHobMemoryAllocStackGuid, &MemoryHob->AllocDescriptor.Name)) {
+//         DEBUG ((
+//           DEBUG_INFO,
+//           "%a: StackBase = 0x%016lx  StackSize = 0x%016lx\n",
+//           __func__,
+//           MemoryHob->AllocDescriptor.MemoryBaseAddress,
+//           MemoryHob->AllocDescriptor.MemoryLength
+//           ));
 
-        StackBase = MemoryHob->AllocDescriptor.MemoryBaseAddress;
-        //
-        // Ensure the base of the stack is page-size aligned.
-        //
-        ASSERT ((StackBase & EFI_PAGE_MASK) == 0);
-        break;
-      }
+//         StackBase = MemoryHob->AllocDescriptor.MemoryBaseAddress;
+//         //
+//         // Ensure the base of the stack is page-size aligned.
+//         //
+//         ASSERT ((StackBase & EFI_PAGE_MASK) == 0);
+//         break;
+//       }
 
-      Hob.Raw = GET_NEXT_HOB (Hob);
-    }
+//       Hob.Raw = GET_NEXT_HOB (Hob);
+//     }
 
-    //
-    // Ensure the base of stack can be found from Hob when stack guard is
-    // enabled.
-    //
-    ASSERT (StackBase != 0);
-  }
+//     //
+//     // Ensure the base of stack can be found from Hob when stack guard is
+//     // enabled.
+//     //
+//     ASSERT (StackBase != 0);
+//   }
 
-  DEBUG ((
-    DEBUG_INFO,
-    "%a: applying strict permissions to active memory regions\n",
-    __func__
-    ));
+//   DEBUG ((
+//     DEBUG_INFO,
+//     "%a: applying strict permissions to active memory regions\n",
+//     __func__
+//     ));
 
-  MergeMemoryMapForProtectionPolicy (MemoryMap, &MemoryMapSize, DescriptorSize);
+//   MergeMemoryMapForProtectionPolicy (MemoryMap, &MemoryMapSize, DescriptorSize);
 
-  MemoryMapEntry = MemoryMap;
-  MemoryMapEnd   = (EFI_MEMORY_DESCRIPTOR *)((UINT8 *)MemoryMap + MemoryMapSize);
-  while ((UINTN)MemoryMapEntry < (UINTN)MemoryMapEnd) {
-    Attributes = GetPermissionAttributeForMemoryType (MemoryMapEntry->Type);
-    if (Attributes != 0) {
-      SetUefiImageMemoryAttributes (
-        MemoryMapEntry->PhysicalStart,
-        LShiftU64 (MemoryMapEntry->NumberOfPages, EFI_PAGE_SHIFT),
-        Attributes
-        );
+//   MemoryMapEntry = MemoryMap;
+//   MemoryMapEnd   = (EFI_MEMORY_DESCRIPTOR *)((UINT8 *)MemoryMap + MemoryMapSize);
+//   while ((UINTN)MemoryMapEntry < (UINTN)MemoryMapEnd) {
+//     Attributes = GetPermissionAttributeForMemoryType (MemoryMapEntry->Type);
+//     if (Attributes != 0) {
+//       SetUefiImageMemoryAttributes (
+//         MemoryMapEntry->PhysicalStart,
+//         LShiftU64 (MemoryMapEntry->NumberOfPages, EFI_PAGE_SHIFT),
+//         Attributes
+//         );
 
-      //
-      // Add EFI_MEMORY_RP attribute for page 0 if NULL pointer detection is
-      // enabled.
-      //
-      // MU_CHANGE START: We Enable NULL detection via the function EnableNullDetection
-      // if (MemoryMapEntry->PhysicalStart == 0 &&
-      //     // PcdGet8 (PcdNullPointerDetectionPropertyMask) != 0) {
-      //   ASSERT (MemoryMapEntry->NumberOfPages > 0);
-      //   SetUefiImageMemoryAttributes (
-      //     0,
-      //     EFI_PAGES_TO_SIZE (1),
-      //     EFI_MEMORY_RP | Attributes);
-      // }
-      // MU_CHANGE END
+//       //
+//       // Add EFI_MEMORY_RP attribute for page 0 if NULL pointer detection is
+//       // enabled.
+//       //
+//       // MU_CHANGE START: We Enable NULL detection via the function EnableNullDetection
+//       // if (MemoryMapEntry->PhysicalStart == 0 &&
+//       //     // PcdGet8 (PcdNullPointerDetectionPropertyMask) != 0) {
+//       //   ASSERT (MemoryMapEntry->NumberOfPages > 0);
+//       //   SetUefiImageMemoryAttributes (
+//       //     0,
+//       //     EFI_PAGES_TO_SIZE (1),
+//       //     EFI_MEMORY_RP | Attributes);
+//       // }
+//       // MU_CHANGE END
 
-      //
-      // Add EFI_MEMORY_RP attribute for the first page of the stack if stack
-      // guard is enabled.
-      //
-      if ((StackBase != 0) &&
-          ((StackBase >= MemoryMapEntry->PhysicalStart) &&
-           (StackBase <  MemoryMapEntry->PhysicalStart +
-            LShiftU64 (MemoryMapEntry->NumberOfPages, EFI_PAGE_SHIFT))) &&
-          // MU_CHANGE START Update to use memory protection settings HOB
-          // PcdGetBool (PcdCpuStackGuard)) {
-          gDxeMps.CpuStackGuard)
-      {
-        // MU_CHANGE END
-        SetUefiImageMemoryAttributes (
-          StackBase,
-          EFI_PAGES_TO_SIZE (1),
-          EFI_MEMORY_RP | Attributes
-          );
-      }
-    }
+//       //
+//       // Add EFI_MEMORY_RP attribute for the first page of the stack if stack
+//       // guard is enabled.
+//       //
+//       if ((StackBase != 0) &&
+//           ((StackBase >= MemoryMapEntry->PhysicalStart) &&
+//            (StackBase <  MemoryMapEntry->PhysicalStart +
+//             LShiftU64 (MemoryMapEntry->NumberOfPages, EFI_PAGE_SHIFT))) &&
+//           // MU_CHANGE START Update to use memory protection settings HOB
+//           // PcdGetBool (PcdCpuStackGuard)) {
+//           gDxeMps.CpuStackGuard)
+//       {
+//         // MU_CHANGE END
+//         SetUefiImageMemoryAttributes (
+//           StackBase,
+//           EFI_PAGES_TO_SIZE (1),
+//           EFI_MEMORY_RP | Attributes
+//           );
+//       }
+//     }
 
-    MemoryMapEntry = NEXT_MEMORY_DESCRIPTOR (MemoryMapEntry, DescriptorSize);
-  }
+//     MemoryMapEntry = NEXT_MEMORY_DESCRIPTOR (MemoryMapEntry, DescriptorSize);
+//   }
 
-  FreePool (MemoryMap);
+//   FreePool (MemoryMap);
 
-  //
-  // Apply the policy for RAM regions that we know are present and
-  // accessible, but have not been added to the UEFI memory map (yet).
-  //
-  if (GetPermissionAttributeForMemoryType (EfiConventionalMemory) != 0) {
-    DEBUG ((
-      DEBUG_INFO,
-      "%a: applying strict permissions to inactive memory regions\n",
-      __func__
-      ));
+//   //
+//   // Apply the policy for RAM regions that we know are present and
+//   // accessible, but have not been added to the UEFI memory map (yet).
+//   //
+//   if (GetPermissionAttributeForMemoryType (EfiConventionalMemory) != 0) {
+//     DEBUG ((
+//       DEBUG_INFO,
+//       "%a: applying strict permissions to inactive memory regions\n",
+//       __func__
+//       ));
 
-    CoreAcquireGcdMemoryLock ();
+//     CoreAcquireGcdMemoryLock ();
 
-    Link = mGcdMemorySpaceMap.ForwardLink;
-    while (Link != &mGcdMemorySpaceMap) {
-      Entry = CR (Link, EFI_GCD_MAP_ENTRY, Link, EFI_GCD_MAP_SIGNATURE);
+//     Link = mGcdMemorySpaceMap.ForwardLink;
+//     while (Link != &mGcdMemorySpaceMap) {
+//       Entry = CR (Link, EFI_GCD_MAP_ENTRY, Link, EFI_GCD_MAP_SIGNATURE);
 
-      if ((Entry->GcdMemoryType == EfiGcdMemoryTypeReserved) &&
-          (Entry->EndAddress < MAX_ADDRESS) &&
-          ((Entry->Capabilities & (EFI_MEMORY_PRESENT | EFI_MEMORY_INITIALIZED | EFI_MEMORY_TESTED)) ==
-           (EFI_MEMORY_PRESENT | EFI_MEMORY_INITIALIZED)))
-      {
-        Attributes = GetPermissionAttributeForMemoryType (EfiConventionalMemory) |
-                     (Entry->Attributes & EFI_CACHE_ATTRIBUTE_MASK);
+//       if ((Entry->GcdMemoryType == EfiGcdMemoryTypeReserved) &&
+//           (Entry->EndAddress < MAX_ADDRESS) &&
+//           ((Entry->Capabilities & (EFI_MEMORY_PRESENT | EFI_MEMORY_INITIALIZED | EFI_MEMORY_TESTED)) ==
+//            (EFI_MEMORY_PRESENT | EFI_MEMORY_INITIALIZED)))
+//       {
+//         Attributes = GetPermissionAttributeForMemoryType (EfiConventionalMemory) |
+//                      (Entry->Attributes & EFI_CACHE_ATTRIBUTE_MASK);
 
-        DEBUG ((
-          DEBUG_INFO,
-          "Untested GCD memory space region: - 0x%016lx - 0x%016lx (0x%016lx)\n",
-          Entry->BaseAddress,
-          Entry->EndAddress - Entry->BaseAddress + 1,
-          Attributes
-          ));
+//         DEBUG ((
+//           DEBUG_INFO,
+//           "Untested GCD memory space region: - 0x%016lx - 0x%016lx (0x%016lx)\n",
+//           Entry->BaseAddress,
+//           Entry->EndAddress - Entry->BaseAddress + 1,
+//           Attributes
+//           ));
 
-        ASSERT (gCpu != NULL);
-        gCpu->SetMemoryAttributes (
-                gCpu,
-                Entry->BaseAddress,
-                Entry->EndAddress - Entry->BaseAddress + 1,
-                Attributes
-                );
-      }
+//         ASSERT (gCpu != NULL);
+//         gCpu->SetMemoryAttributes (
+//                 gCpu,
+//                 Entry->BaseAddress,
+//                 Entry->EndAddress - Entry->BaseAddress + 1,
+//                 Attributes
+//                 );
+//       }
 
-      Link = Link->ForwardLink;
-    }
+//       Link = Link->ForwardLink;
+//     }
 
-    CoreReleaseGcdMemoryLock ();
-  }
-}
+//     CoreReleaseGcdMemoryLock ();
+//   }
+// }
+// MU_CHANGE END
 
 /**
   A notification for CPU_ARCH protocol.
@@ -879,12 +893,11 @@ MemoryProtectionCpuArchProtocolNotify (
   //
   // Apply the memory protection policy on non-BScode/RTcode regions.
   //
-  // MU_CHANGE START Update to use memory protection settings HOB
+  // MU_CHANGE START: This function is now called after the GCD sync process has completed
   // if (PcdGet64 (PcdDxeNxMemoryProtectionPolicy) != 0) {
-  if (gDxeMps.NxProtectionPolicy.Data) {
-    // MU_CHANGE END
-    InitializeDxeNxMemoryProtectionPolicy ();
-  }
+  //   InitializeDxeNxMemoryProtectionPolicy ();
+  // }
+  // MU_CHANGE END
 
   //
   // Call notify function meant for Heap Guard.
@@ -1104,14 +1117,15 @@ CoreInitializeMemoryProtection (
   )
 {
   EFI_STATUS  Status;
-  EFI_EVENT   Event;
-  EFI_EVENT   DisableNullDetectionEvent;
-  EFI_EVENT   EnableNullDetectionEvent;     // MU_CHANGE
-  EFI_EVENT   MemoryAttributeProtocolEvent; // MU_CHANGE
-  VOID        *Registration;
+  // MU_CHANGE START: Update to use memory protection settings HOB,
+  //                  add support for RP on free memory.
+  EFI_EVENT  DisableNullDetectionEvent;
+  EFI_EVENT  EnableNullDetectionEvent;
+  EFI_EVENT  MemoryAttributeProtocolEvent;
+  VOID       *Registration;
 
-  // mImageProtectionPolicy = gDxeMps.ImageProtectionPolicy; // MU_CHANGE
-
+  // mImageProtectionPolicy = gDxeMps.ImageProtectionPolicy;
+  // MU_CHANGE END
   InitializeListHead (&mProtectedImageRecordList);
 
   //
@@ -1120,37 +1134,37 @@ CoreInitializeMemoryProtection (
   // - EfiConventionalMemory and EfiBootServicesData should use the
   //   same attribute
   //
-  // MU_CHANGE START: We allow code types to have NX
+  // MU_CHANGE START: We allow code types to have NX and EfiBootServicesData to differ in attributes from
+  //                  EfiConventionalMemory
   // ASSERT ((GetPermissionAttributeForMemoryType (EfiBootServicesCode) & EFI_MEMORY_XP) == 0);
   // ASSERT ((GetPermissionAttributeForMemoryType (EfiRuntimeServicesCode) & EFI_MEMORY_XP) == 0);
   // ASSERT ((GetPermissionAttributeForMemoryType (EfiLoaderCode) & EFI_MEMORY_XP) == 0);
+  // ASSERT (
+  //   GetPermissionAttributeForMemoryType (EfiBootServicesData) ==
+  //   GetPermissionAttributeForMemoryType (EfiConventionalMemory)
+  //   );
   // MU_CHANGE END
-  ASSERT (
-    GetPermissionAttributeForMemoryType (EfiBootServicesData) ==
-    GetPermissionAttributeForMemoryType (EfiConventionalMemory)
-    );
 
-  Status = CoreCreateEvent (
-             EVT_NOTIFY_SIGNAL,
-             // MU_CHANGE START: Use Project Mu Arch Protocol Notify
-             TPL_CALLBACK - 1,
-             //  MemoryProtectionCpuArchProtocolNotify,
-             MemoryProtectionCpuArchProtocolNotifyMu,
-             // MU_CHANGE END
-             NULL,
-             &Event
-             );
-  ASSERT_EFI_ERROR (Status);
+  // MU_CHANGE START: Change ordering of GCD sync and memory protection initialization
+  // Status = CoreCreateEvent (
+  //            EVT_NOTIFY_SIGNAL,
+  //            TPL_CALLBACK,
+  //            MemoryProtectionCpuArchProtocolNotify,
+  //            NULL,
+  //            &Event
+  //            );
+  // ASSERT_EFI_ERROR (Status);
 
-  //
-  // Register for protocol notifactions on this event
-  //
-  Status = CoreRegisterProtocolNotify (
-             &gEfiCpuArchProtocolGuid,
-             Event,
-             &Registration
-             );
-  ASSERT_EFI_ERROR (Status);
+  // //
+  // // Register for protocol notifactions on this event
+  // //
+  // Status = CoreRegisterProtocolNotify (
+  //            &gEfiCpuArchProtocolGuid,
+  //            Event,
+  //            &Registration
+  //            );
+  // ASSERT_EFI_ERROR (Status);
+  // MU_CHANGE END
 
   // MU_CHANGE START: Register an event to populate the memory attribute protocol
   Status = CoreCreateEvent (
@@ -1172,6 +1186,13 @@ CoreInitializeMemoryProtection (
              );
   ASSERT_EFI_ERROR (Status);
   // MU_CHANGE END
+
+  // MU_CHANGE START: Add event to apply page attribues according to the memory protection policy
+  //                  after the GCD has synced.
+  Status = RegisterPageAccessAttributesUpdateOnGcdSyncComplete ();
+  ASSERT_EFI_ERROR (Status);
+  // MU_CHANGE END
+
   //
   // Register a callback to disable NULL pointer detection at EndOfDxe
   //
@@ -1313,7 +1334,10 @@ ApplyMemoryProtectionPolicy (
   // permission attributes, and it is the job of the driver that installs this
   // protocol to set the permissions on existing allocations.
   //
-  if (gCpu == NULL) {
+  // MU_CHANGE: Because GCD sync and memory protection initialization
+  //            ordering is reversed, check if the initialization routine
+  //            has run before allowing this function to execute.
+  if ((gCpu == NULL) || !mPageAttributesInitialized) {
     return EFI_SUCCESS;
   }
 

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.h
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.h
@@ -183,4 +183,17 @@ GetImageList (
   IN IMAGE_RANGE_PROTECTION_STATUS  ProtectedOrNonProtected
   );
 
+/**
+  Registers a callback on gEdkiiGcdSyncCompleteProtocolGuid to initialize
+  page attributes in accordance with to the memory protection policy.
+
+  @retval EFI_SUCCESS Event successfully registered
+  @retval other       Event was not registered
+**/
+EFI_STATUS
+EFIAPI
+RegisterPageAccessAttributesUpdateOnGcdSyncComplete (
+  VOID
+  );
+
 #endif

--- a/MdeModulePkg/Include/Guid/DxeMemoryProtectionSettings.h
+++ b/MdeModulePkg/Include/Guid/DxeMemoryProtectionSettings.h
@@ -1,6 +1,8 @@
 /** @file
-
 Defines memory protection settings guid and struct
+
+For information on the available settings, see:
+https://github.com/microsoft/mu_basecore/tree/HEAD/Docs/feature_memory_protection.md
 
 Copyright (C) Microsoft Corporation. All rights reserved.
 SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -22,10 +24,9 @@ typedef union {
 typedef union {
   UINT8    Data;
   struct {
-    UINT8    UefiPageGuard        : 1;
-    UINT8    UefiPoolGuard        : 1;
-    UINT8    UefiFreedMemoryGuard : 1;
-    UINT8    Direction            : 1;
+    UINT8    UefiPageGuard : 1;
+    UINT8    UefiPoolGuard : 1;
+    UINT8    Direction     : 1;
   } Fields;
 } DXE_HEAP_GUARD_POLICY;
 
@@ -65,7 +66,7 @@ typedef union {
 
 typedef UINT8 DXE_MEMORY_PROTECTION_SETTINGS_VERSION;
 
-#define DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION  6 // Current iteration of DXE_MEMORY_PROTECTION_SETTINGS
+#define DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION  7 // Current iteration of DXE_MEMORY_PROTECTION_SETTINGS
 
 //
 // Memory Protection Settings struct
@@ -82,6 +83,10 @@ typedef struct {
   //  TRUE  - UEFI Stack Guard will be enabled.
   //  FALSE - UEFI Stack Guard will be disabled.
   BOOLEAN                                   CpuStackGuard;
+
+  // If enabled, all EfiConventionalMemory will be marked with EFI_MEMORY_RP. This can
+  // be used in conjunction with the NX setting for EfiConventionalMemory.
+  BOOLEAN                                   FreeMemoryReadProtected;
 
   // Bitfield to control the NULL address detection in code for different phases.
   // If enabled, accessing NULL address in UEFI or SMM code can be caught by marking
@@ -107,7 +112,6 @@ typedef struct {
   //
   //  .UefiPageGuard         : Enable UEFI page guard.
   //  .UefiPoolGuard         : Enable UEFI pool guard.
-  //  .UefiFreedMemoryGuard  : Enable UEFI freed-memory guard (Use-After-Free memory detection).
   //  .Direction             : The direction of Guard Page for Pool Guard.
   //                           0 - The returned pool is near the tail guard page.
   //                           1 - The returned pool is near the head guard page.
@@ -153,8 +157,6 @@ typedef struct {
   //
   // If a bit is set, memory regions of the associated type will be mapped
   // non-executable. If a bit is cleared, nothing will be done to associated type of memory.
-  //
-  //  NOTE: - User MUST set the same NX protection for EfiBootServicesData and EfiConventionalMemory.
   DXE_HEAP_GUARD_MEMORY_TYPES    NxProtectionPolicy;
 
   // Indicates if stack cookie protection will be enabled
@@ -190,6 +192,7 @@ extern GUID  gDxeMemoryProtectionSettingsGuid;
           {                                                     \
             DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION,     \
             TRUE,   /* Stack Guard On */                        \
+            TRUE,   /* Free Memory Guard On*/                   \
             {                                                   \
               .Fields.UefiNullDetection               = 1,      \
               .Fields.DisableEndOfDxe                 = 0,      \
@@ -198,7 +201,6 @@ extern GUID  gDxeMemoryProtectionSettingsGuid;
             {                                                   \
               .Fields.UefiPageGuard                   = 1,      \
               .Fields.UefiPoolGuard                   = 1,      \
-              .Fields.UefiFreedMemoryGuard            = 0,      \
               .Fields.Direction                       = 0       \
             },                                                  \
             {                                                   \
@@ -280,6 +282,7 @@ extern GUID  gDxeMemoryProtectionSettingsGuid;
           {                                                     \
             DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION,     \
             TRUE,   /* Stack Guard On */                        \
+            TRUE,   /* Free Memory Guard On*/                   \
             {                                                   \
               .Fields.UefiNullDetection               = 1,      \
               .Fields.DisableEndOfDxe                 = 0,      \
@@ -288,7 +291,6 @@ extern GUID  gDxeMemoryProtectionSettingsGuid;
             {                                                   \
               .Fields.UefiPageGuard                   = 1,      \
               .Fields.UefiPoolGuard                   = 0,      \
-              .Fields.UefiFreedMemoryGuard            = 0,      \
               .Fields.Direction                       = 0       \
             },                                                  \
             {                                                   \
@@ -369,6 +371,7 @@ extern GUID  gDxeMemoryProtectionSettingsGuid;
           {                                                     \
             DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION,     \
             TRUE,   /* Stack Guard On */                        \
+            TRUE,   /* Free Memory Guard On*/                   \
             {                                                   \
               .Fields.UefiNullDetection               = 1,      \
               .Fields.DisableEndOfDxe                 = 0,      \
@@ -377,7 +380,6 @@ extern GUID  gDxeMemoryProtectionSettingsGuid;
             {                                                   \
               .Fields.UefiPageGuard                   = 0,      \
               .Fields.UefiPoolGuard                   = 0,      \
-              .Fields.UefiFreedMemoryGuard            = 0,      \
               .Fields.Direction                       = 0       \
             },                                                  \
             {                                                   \
@@ -456,7 +458,8 @@ extern GUID  gDxeMemoryProtectionSettingsGuid;
 #define DXE_MEMORY_PROTECTION_SETTINGS_OFF                      \
           {                                                     \
             DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION,     \
-            FALSE,   /* Stack Guard On */                       \
+            FALSE,   /* Stack Guard Off */                      \
+            FALSE,   /* Free Memory Guard Off */                \
             {                                                   \
               .Fields.UefiNullDetection               = 0,      \
               .Fields.DisableEndOfDxe                 = 0,      \
@@ -465,7 +468,6 @@ extern GUID  gDxeMemoryProtectionSettingsGuid;
             {                                                   \
               .Fields.UefiPageGuard                   = 0,      \
               .Fields.UefiPoolGuard                   = 0,      \
-              .Fields.UefiFreedMemoryGuard            = 0,      \
               .Fields.Direction                       = 0       \
             },                                                  \
             {                                                   \

--- a/MdeModulePkg/Include/Guid/MmMemoryProtectionSettings.h
+++ b/MdeModulePkg/Include/Guid/MmMemoryProtectionSettings.h
@@ -1,6 +1,8 @@
 /** @file
-
 Defines memory protection settings guid and struct
+
+For information on the available settings, see:
+https://github.com/microsoft/mu_basecore/tree/HEAD/Docs/feature_memory_protection.md
 
 Copyright (C) Microsoft Corporation. All rights reserved.
 SPDX-License-Identifier: BSD-2-Clause-Patent

--- a/MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.c
+++ b/MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.c
@@ -80,22 +80,6 @@ DxeMemoryProtectionSettingsConsistencyCheck (
   VOID
   )
 {
-  if ((gDxeMps.HeapGuardPolicy.Fields.UefiPoolGuard || gDxeMps.HeapGuardPolicy.Fields.UefiPageGuard) &&
-      gDxeMps.HeapGuardPolicy.Fields.UefiFreedMemoryGuard)
-  {
-    DEBUG ((
-      DEBUG_WARN,
-      "%a: - HeapGuardPolicy.UefiFreedMemoryGuard and \
-UEFI HeapGuardPolicy.UefiPoolGuard/HeapGuardPolicy.UefiPageGuard \
-cannot be active at the same time. Setting all three to ZERO in \
-the memory protection settings global.\n",
-      __FUNCTION__
-      ));
-    gDxeMps.HeapGuardPolicy.Fields.UefiPoolGuard        = 0;
-    gDxeMps.HeapGuardPolicy.Fields.UefiPageGuard        = 0;
-    gDxeMps.HeapGuardPolicy.Fields.UefiFreedMemoryGuard = 0;
-  }
-
   if (!gDxeMps.ImageProtectionPolicy.Data &&
       (gDxeMps.NxProtectionPolicy.Fields.EfiLoaderData       ||
        gDxeMps.NxProtectionPolicy.Fields.EfiBootServicesData ||

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -833,6 +833,10 @@
   ## Include/Protocol/UsbEthernetProtocol.h
   gEdkIIUsbEthProtocolGuid = { 0x8d8969cc, 0xfeb0, 0x4303, { 0xb2, 0x1a, 0x1f, 0x11, 0x6f, 0x38, 0x56, 0x43 } }
 
+  ## MU_CHANGE START: Add protocol to indicate the GCD sync has completed
+  ## Include/Protocol/Cpu.h
+  gEdkiiGcdSyncCompleteProtocolGuid = { 0x650B7F40, 0x6564, 0x4FA9, { 0x93, 0x75, 0xCD, 0x6B, 0x52, 0x1B, 0x6E, 0x50 }}
+  ## MU_CHANGE END
 [PcdsFeatureFlag]
   ## Indicates if the platform can support update capsule across a system reset.<BR><BR>
   #   TRUE  - Supports update capsule across a system reset.<BR>

--- a/MdePkg/Include/Library/DebugLib.h
+++ b/MdePkg/Include/Library/DebugLib.h
@@ -574,12 +574,9 @@ UnitTestDebugAssert (
   @param  Length   The number of bytes in the buffer to set.
 
 **/
-#define DEBUG_CLEAR_MEMORY(Address, Length)  \
-  do {                                       \
-    if (DebugClearMemoryEnabled ()) {        \
-      DebugClearMemory (Address, Length);    \
-    }                                        \
-  } while (FALSE)
+// MU_CHANGE START: Disable debug clear memory to support RP on free memory
+#define DEBUG_CLEAR_MEMORY(Address, Length)
+// MU_CHANGE END
 
 /**
   Macro that calls DebugAssert() if the containing record does not have a

--- a/MdePkg/Include/Protocol/Cpu.h
+++ b/MdePkg/Include/Protocol/Cpu.h
@@ -16,6 +16,13 @@
 #define EFI_CPU_ARCH_PROTOCOL_GUID \
   { 0x26baccb1, 0x6f42, 0x11d4, {0xbc, 0xe7, 0x0, 0x80, 0xc7, 0x3c, 0x88, 0x81 } }
 
+// MU_CHANGE START: Guid used to signal the completion of GCD sync
+#define GCD_SYNC_COMPLETE_PROTOCOL_GUID \
+  { 0x650B7F40, 0x6564, 0x4FA9, {0x93, 0x75, 0xCD, 0x6B, 0x52, 0x1B, 0x6E, 0x50 } }
+
+extern EFI_GUID  gEdkiiGcdSyncCompleteProtocolGuid;
+// MU_CHANGE_END
+
 typedef struct _EFI_CPU_ARCH_PROTOCOL EFI_CPU_ARCH_PROTOCOL;
 
 ///

--- a/UefiCpuPkg/CpuDxe/CpuDxe.c
+++ b/UefiCpuPkg/CpuDxe/CpuDxe.c
@@ -1046,6 +1046,15 @@ InitializeCpu (
   //
   RefreshGcdMemoryAttributes ();
 
+  // MU_CHANGE START: Install blank protocol to signal the end of the GCD sync
+  gBS->InstallMultipleProtocolInterfaces (
+         &ImageHandle,
+         &gEdkiiGcdSyncCompleteProtocolGuid,
+         NULL,
+         NULL
+         );
+  // MU_CHANGE END
+
   //
   // Add and allocate local APIC memory mapped space
   //

--- a/UefiCpuPkg/CpuDxe/CpuDxe.inf
+++ b/UefiCpuPkg/CpuDxe/CpuDxe.inf
@@ -68,6 +68,7 @@
   gEfiMemoryAttributeProtocolGuid               ## TCBZ3519 MU_CHANGE PRODUCES
   gEfiSmmBase2ProtocolGuid                      ## SOMETIMES_CONSUMES
   gMemoryProtectionNonstopModeProtocolGuid      ## MU_CHANGE: PRODUCES
+  gEdkiiGcdSyncCompleteProtocolGuid             ## MU_CHANGE: PRODUCES
 
 [Guids]
   gIdleLoopEventGuid                            ## CONSUMES           ## Event


### PR DESCRIPTION
This PR:
1. Adds the ability to apply EFI_MEMORY_RP on free memory
2. Fixes an unsafe allocation check so the logic branches if the allocation failed instead of just ASSERTing