### PR TITLE
[CHERRY-PICK] MdeModulePkg/Bus/Usb/UsbNetwork: Check array index range before access

### DIFF
--- a/MdeModulePkg/Bus/Usb/UsbNetwork/UsbCdcEcm/UsbEcmFunction.c
+++ b/MdeModulePkg/Bus/Usb/UsbNetwork/UsbCdcEcm/UsbEcmFunction.c
@@ -769,7 +769,7 @@ ConvertFilter (
 
   Count = sizeof (gTable)/sizeof (gTable[0]);
 
-  for (Index = 0; (gTable[Index].Src != 0) && (Index < Count); Index++) {
+  for (Index = 0; (Index < Count) && (gTable[Index].Src != 0); Index++) {
     if (gTable[Index].Src & Value) {
       *CdcFilter |= gTable[Index].Dst;
     }

--- a/MdeModulePkg/Bus/Usb/UsbNetwork/UsbCdcNcm/UsbNcmFunction.c
+++ b/MdeModulePkg/Bus/Usb/UsbNetwork/UsbCdcNcm/UsbNcmFunction.c
@@ -855,7 +855,7 @@ ConvertFilter (
 
   Count = sizeof (gTable)/sizeof (gTable[0]);
 
-  for (Index = 0; (gTable[Index].Src != 0) && (Index < Count); Index++) {
+  for (Index = 0; (Index < Count) && (gTable[Index].Src != 0); Index++) {
     if (gTable[Index].Src & Value) {
       *CdcFilter |= gTable[Index].Dst;
     }

--- a/MdeModulePkg/Bus/Usb/UsbNetwork/UsbRndis/UsbRndisFunction.c
+++ b/MdeModulePkg/Bus/Usb/UsbNetwork/UsbRndis/UsbRndisFunction.c
@@ -803,7 +803,7 @@ ConvertFilter (
 
   Count = sizeof (gTable)/sizeof (gTable[0]);
 
-  for (Index = 0; (gTable[Index].Src != 0) && (Index < Count); Index++) {
+  for (Index = 0; (Index < Count) && (gTable[Index].Src != 0); Index++) {
     if (gTable[Index].Src & Value) {
       *CdcFilter |= gTable[Index].Dst;
     }


### PR DESCRIPTION
## Description

Checks that an offset used to access array elements is within
the expected range before accessing the array item.

Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Ray Ni <ray.ni@intel.com>
Cc: Rebecca Cran <rebecca@bsdio.com>
Cc: Richard Ho <richardho@ami.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>
(cherry picked from commit 1f161a7915e1c2c65bfaf7091712e9628107b707)

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- CodeQL locally and in CI.
- MdeModulePkg build and CI.

## Integration Instructions

N/A