### PR TITLE
BmpCheckPlugin: Pass build vars to FDF parser

### DIFF
--- a/BaseTools/Plugin/BmpCheck/BmpCheckPlugin.py
+++ b/BaseTools/Plugin/BmpCheck/BmpCheckPlugin.py
@@ -132,10 +132,13 @@ class BmpCheckPlugin(IUefiBuildPlugin):
                 self.logger.info("No FDF found- BMP check skipped")
                 return 0
             # parse the DSC and the FDF
+            env_vars = thebuilder.env.GetAllBuildKeyValues()
             dp.SetEdk2Path(edk2)
-            dp.SetInputVars(thebuilder.env.GetAllBuildKeyValues()).ParseFile(ActiveDsc)  # parse the DSC for build vars
+            dp.SetInputVars(env_vars).ParseFile(ActiveDsc)
+
+            env_vars.update(dp.LocalVars)
             fp.SetEdk2Path(edk2)
-            fp.SetInputVars(dp.LocalVars).ParseFile(ActiveFdf)  # give FDF parser the vars from DSC
+            fp.SetInputVars(env_vars).ParseFile(ActiveFdf)  # give FDF parser the vars from DSC
 
             # for each FV section in the DSC
             for FV_name in fp.FVs:


### PR DESCRIPTION
## Description

Updates the BmpCheckPlugin to pass build and DSC local variables
to the FDF parser.

Error example:

```
FileNotFoundError:
$(SHARED_CRYPTO_PATH)/Driver/Bin/CryptoDriver.DXE.inc.fdf
```

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- Repro problem using the plugin with shared crypto set as a
  build variable (`SHARED_CRYPTO_PATH`) before the change.
- Verify the plugin succeeds after the change.

## Integration Instructions

Update to the Mu Basecore revision if an error from BmpCheckPlugin
similar to the one in the error example given in the description
is observed.