### PR TITLE
Variable Performance Measurements

### DIFF
--- a/MdeModulePkg/Library/DxeCorePerformanceLib/DxeCorePerformanceLib.c
+++ b/MdeModulePkg/Library/DxeCorePerformanceLib/DxeCorePerformanceLib.c
@@ -1016,7 +1016,7 @@ InsertFpdtRecord (
       }
     } else if (PerfId == 0) {
       //
-      // Get ProgressID form the String Token.
+      // Get ProgressID from the String Token.
       //
       Status = GetFpdtRecordId (Attribute, CallerIdentifier, String, &ProgressId);
       if (EFI_ERROR (Status)) {
@@ -1249,6 +1249,28 @@ InsertFpdtRecord (
         FpdtRecordPtr.DynamicStringEvent->Timestamp       = TimeStamp;
         CopyMem (&FpdtRecordPtr.DynamicStringEvent->Guid, &ModuleGuid, sizeof (FpdtRecordPtr.DynamicStringEvent->Guid));
         CopyStringIntoPerfRecordAndUpdateLength (FpdtRecordPtr.DynamicStringEvent->String, StringPtr, &FpdtRecordPtr.DynamicStringEvent->Header.Length);
+      }
+
+      break;
+
+    // MU_CHANGE
+    case PERF_VARIABLE_START_ID:
+    case PERF_VARIABLE_END_ID:
+      if ((String != NULL) && (AsciiStrLen (String) != 0)) {
+        StringPtr = String;
+      } else {
+        StringPtr = "unknown name";
+      }
+
+      if (!PcdGetBool (PcdEdkiiFpdtStringRecordEnableOnly)) {
+        FpdtRecordPtr.GuidQwordStringEvent->Header.Type     = FPDT_GUID_QWORD_STRING_EVENT_TYPE;
+        FpdtRecordPtr.GuidQwordStringEvent->Header.Length   = sizeof (FPDT_GUID_QWORD_STRING_EVENT_RECORD);
+        FpdtRecordPtr.GuidQwordStringEvent->Header.Revision = FPDT_RECORD_REVISION_1;
+        FpdtRecordPtr.GuidQwordStringEvent->ProgressID      = PerfId;
+        FpdtRecordPtr.GuidQwordStringEvent->Timestamp       = TimeStamp;
+        FpdtRecordPtr.GuidQwordStringEvent->Qword           = Address;
+        CopyMem (&FpdtRecordPtr.GuidQwordStringEvent->Guid, Guid, sizeof (EFI_GUID));
+        CopyStringIntoPerfRecordAndUpdateLength (FpdtRecordPtr.GuidQwordStringEvent->String, StringPtr, &FpdtRecordPtr.GuidQwordStringEvent->Header.Length);
       }
 
       break;
@@ -2004,4 +2026,39 @@ LogPerformanceMeasurementEnabled (
   }
 
   return FALSE;
+}
+
+/**
+  Create performance record with event description and a timestamp.
+
+  @param CallerIdentifier  - Image handle or pointer to caller ID GUID
+  @param Guid              - Pointer to a GUID
+  @param String            - Pointer to a unicode string describing the measurement
+  @param Address           - Pointer to a location in memory relevant to the measurement
+  @param Identifier        - Performance identifier describing the type of measurement
+
+  @retval RETURN_SUCCESS           - Successfully created performance record
+  @retval RETURN_OUT_OF_RESOURCES  - Ran out of space to store the records
+  @retval RETURN_INVALID_PARAMETER - Invalid parameter passed to function - NULL
+                                     pointer or invalid PerfId
+
+**/
+RETURN_STATUS
+EFIAPI
+LogPerformanceMeasurementUnicode (
+  IN CONST VOID    *CallerIdentifier,
+  IN CONST VOID    *Guid     OPTIONAL,
+  IN CONST CHAR16  *String   OPTIONAL,
+  IN UINT64        Address  OPTIONAL,
+  IN UINT32        Identifier
+  )
+{
+  CHAR8       AsciiString[STRING_SIZE];
+  EFI_STATUS  Status = ReplaceUnicodeStrToAsciiStrS (String, AsciiString, STRING_SIZE, '?');
+
+  if (Status != RETURN_SUCCESS) {
+    return Status;
+  }
+
+  return (RETURN_STATUS)CreatePerformanceMeasurement (CallerIdentifier, Guid, (const CHAR8 *)AsciiString, 0, Address, Identifier, PerfEntry);
 }

--- a/MdeModulePkg/Library/DxePerformanceLib/DxePerformanceLib.c
+++ b/MdeModulePkg/Library/DxePerformanceLib/DxePerformanceLib.c
@@ -14,11 +14,18 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <PiDxe.h>
 
 #include <Guid/PerformanceMeasurement.h>
+#include <Guid/ExtendedFirmwarePerformance.h>
 
 #include <Library/PerformanceLib.h>
 #include <Library/DebugLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/PcdLib.h>
+#include <Library/BaseLib.h>
+
+//
+// Data for FPDT performance records.
+//
+#define  STRING_SIZE  (FPDT_STRING_EVENT_RECORD_NAME_LENGTH * sizeof (CHAR8))
 
 //
 // The cached Performance Protocol and PerformanceEx Protocol interface.
@@ -405,6 +412,52 @@ LogPerformanceMeasurement (
 
   if (mPerformanceMeasurement != NULL) {
     Status = mPerformanceMeasurement->CreatePerformanceMeasurement (CallerIdentifier, Guid, String, 0, Address, Identifier, PerfEntry);
+  } else {
+    ASSERT (FALSE);
+  }
+
+  return (RETURN_STATUS)Status;
+}
+
+/**
+  Create performance record with event description and a timestamp.
+
+  @param CallerIdentifier  - Image handle or pointer to caller ID GUID
+  @param Guid              - Pointer to a GUID
+  @param String            - Pointer to a unicode string describing the measurement
+  @param Address           - Pointer to a location in memory relevant to the measurement
+  @param Identifier        - Performance identifier describing the type of measurement
+
+  @retval RETURN_SUCCESS           - Successfully created performance record
+  @retval RETURN_OUT_OF_RESOURCES  - Ran out of space to store the records
+  @retval RETURN_INVALID_PARAMETER - Invalid parameter passed to function - NULL
+                                     pointer or invalid PerfId
+
+**/
+RETURN_STATUS
+EFIAPI
+LogPerformanceMeasurementUnicode (
+  IN CONST VOID    *CallerIdentifier,
+  IN CONST VOID    *Guid     OPTIONAL,
+  IN CONST CHAR16  *String   OPTIONAL,
+  IN UINT64        Address  OPTIONAL,
+  IN UINT32        Identifier
+  )
+{
+  CHAR8       AsciiString[STRING_SIZE];
+  EFI_STATUS  Status = ReplaceUnicodeStrToAsciiStrS (String, AsciiString, STRING_SIZE, '?');
+
+  if (Status != RETURN_SUCCESS) {
+    return Status;
+  }
+
+  Status = GetPerformanceMeasurementProtocol ();
+  if (EFI_ERROR (Status)) {
+    return RETURN_OUT_OF_RESOURCES;
+  }
+
+  if (mPerformanceMeasurement != NULL) {
+    Status = mPerformanceMeasurement->CreatePerformanceMeasurement (CallerIdentifier, Guid, AsciiString, 0, Address, Identifier, PerfEntry);
   } else {
     ASSERT (FALSE);
   }

--- a/MdeModulePkg/Library/PeiPerformanceLib/PeiPerformanceLib.c
+++ b/MdeModulePkg/Library/PeiPerformanceLib/PeiPerformanceLib.c
@@ -26,6 +26,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/PcdLib.h>
 #include <Library/BaseMemoryLib.h>
 
+//
+// Data for FPDT performance records.
+//
 #define  STRING_SIZE          (FPDT_STRING_EVENT_RECORD_NAME_LENGTH * sizeof (CHAR8))
 #define  PEI_MAX_RECORD_SIZE  (sizeof (FPDT_DUAL_GUID_STRING_EVENT_RECORD) + STRING_SIZE)
 
@@ -474,6 +477,28 @@ InsertFpdtRecord (
 
       break;
 
+    // MU_CHANGE
+    case PERF_VARIABLE_START_ID:
+    case PERF_VARIABLE_END_ID:
+      if ((String != NULL) && (AsciiStrLen (String) != 0)) {
+        StringPtr = String;
+      } else {
+        StringPtr = "unknown name";
+      }
+
+      if (!PcdGetBool (PcdEdkiiFpdtStringRecordEnableOnly)) {
+        FpdtRecordPtr.GuidQwordStringEvent->Header.Type     = FPDT_GUID_QWORD_STRING_EVENT_TYPE;
+        FpdtRecordPtr.GuidQwordStringEvent->Header.Length   = sizeof (FPDT_GUID_QWORD_STRING_EVENT_RECORD);
+        FpdtRecordPtr.GuidQwordStringEvent->Header.Revision = FPDT_RECORD_REVISION_1;
+        FpdtRecordPtr.GuidQwordStringEvent->ProgressID      = PerfId;
+        FpdtRecordPtr.GuidQwordStringEvent->Timestamp       = TimeStamp;
+        FpdtRecordPtr.GuidQwordStringEvent->Qword           = Address;
+        CopyMem (&FpdtRecordPtr.GuidQwordStringEvent->Guid, Guid, sizeof (EFI_GUID));
+        CopyStringIntoPerfRecordAndUpdateLength (FpdtRecordPtr.GuidQwordStringEvent->String, StringPtr, &FpdtRecordPtr.GuidQwordStringEvent->Header.Length);
+      }
+
+      break;
+
     default:
       if (Attribute != PerfEntry) {
         if ((String != NULL) && (AsciiStrLen (String) != 0)) {
@@ -846,6 +871,41 @@ LogPerformanceMeasurement (
   )
 {
   return (RETURN_STATUS)InsertFpdtRecord (CallerIdentifier, Guid, String, 0, Address, (UINT16)Identifier, PerfEntry);
+}
+
+/**
+  Create performance record with event description and a timestamp.
+
+  @param CallerIdentifier  - Image handle or pointer to caller ID GUID
+  @param Guid              - Pointer to a GUID
+  @param String            - Pointer to a unicode string describing the measurement
+  @param Address           - Pointer to a location in memory relevant to the measurement
+  @param Identifier        - Performance identifier describing the type of measurement
+
+  @retval RETURN_SUCCESS           - Successfully created performance record
+  @retval RETURN_OUT_OF_RESOURCES  - Ran out of space to store the records
+  @retval RETURN_INVALID_PARAMETER - Invalid parameter passed to function - NULL
+                                     pointer or invalid PerfId
+
+**/
+RETURN_STATUS
+EFIAPI
+LogPerformanceMeasurementUnicode (
+  IN CONST VOID    *CallerIdentifier,
+  IN CONST VOID    *Guid     OPTIONAL,
+  IN CONST CHAR16  *String   OPTIONAL,
+  IN UINT64        Address  OPTIONAL,
+  IN UINT32        Identifier
+  )
+{
+  CHAR8       AsciiString[STRING_SIZE];
+  EFI_STATUS  Status = ReplaceUnicodeStrToAsciiStrS (String, AsciiString, STRING_SIZE, '?');
+
+  if (Status != RETURN_SUCCESS) {
+    return Status;
+  }
+
+  return (RETURN_STATUS)InsertFpdtRecord (CallerIdentifier, Guid, AsciiString, 0, Address, (UINT16)Identifier, PerfEntry);
 }
 
 /**

--- a/MdeModulePkg/Library/SmmCorePerformanceLib/SmmCorePerformanceLib.c
+++ b/MdeModulePkg/Library/SmmCorePerformanceLib/SmmCorePerformanceLib.c
@@ -23,6 +23,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include "SmmCorePerformanceLibInternal.h"
 
+//
+// Data for FPDT performance records.
+//
 #define STRING_SIZE              (FPDT_STRING_EVENT_RECORD_NAME_LENGTH * sizeof (CHAR8))
 #define FIRMWARE_RECORD_BUFFER   0x1000
 #define CACHE_HANDLE_GUID_COUNT  0x100
@@ -722,6 +725,28 @@ InsertFpdtRecord (
         FpdtRecordPtr.DynamicStringEvent->Timestamp       = TimeStamp;
         CopyMem (&FpdtRecordPtr.DynamicStringEvent->Guid, &ModuleGuid, sizeof (FpdtRecordPtr.DynamicStringEvent->Guid));
         CopyStringIntoPerfRecordAndUpdateLength (FpdtRecordPtr.DynamicStringEvent->String, StringPtr, &FpdtRecordPtr.DynamicStringEvent->Header.Length);
+      }
+
+      break;
+
+    // MU_CHANGE
+    case PERF_VARIABLE_START_ID:
+    case PERF_VARIABLE_END_ID:
+      if ((String != NULL) && (AsciiStrLen (String) != 0)) {
+        StringPtr = String;
+      } else {
+        StringPtr = "unknown name";
+      }
+
+      if (!PcdGetBool (PcdEdkiiFpdtStringRecordEnableOnly)) {
+        FpdtRecordPtr.GuidQwordStringEvent->Header.Type     = FPDT_GUID_QWORD_STRING_EVENT_TYPE;
+        FpdtRecordPtr.GuidQwordStringEvent->Header.Length   = sizeof (FPDT_GUID_QWORD_STRING_EVENT_RECORD);
+        FpdtRecordPtr.GuidQwordStringEvent->Header.Revision = FPDT_RECORD_REVISION_1;
+        FpdtRecordPtr.GuidQwordStringEvent->ProgressID      = PerfId;
+        FpdtRecordPtr.GuidQwordStringEvent->Timestamp       = TimeStamp;
+        FpdtRecordPtr.GuidQwordStringEvent->Qword           = Address;
+        CopyMem (&FpdtRecordPtr.GuidQwordStringEvent->Guid, Guid, sizeof (EFI_GUID));
+        CopyStringIntoPerfRecordAndUpdateLength (FpdtRecordPtr.GuidQwordStringEvent->String, StringPtr, &FpdtRecordPtr.GuidQwordStringEvent->Header.Length);
       }
 
       break;
@@ -1473,6 +1498,41 @@ LogPerformanceMeasurement (
   )
 {
   return (RETURN_STATUS)CreatePerformanceMeasurement (CallerIdentifier, Guid, String, 0, Address, Identifier, PerfEntry);
+}
+
+/**
+  Create performance record with event description and a timestamp.
+
+  @param CallerIdentifier  - Image handle or pointer to caller ID GUID
+  @param Guid              - Pointer to a GUID
+  @param String            - Pointer to a unicode string describing the measurement
+  @param Address           - Pointer to a location in memory relevant to the measurement
+  @param Identifier        - Performance identifier describing the type of measurement
+
+  @retval RETURN_SUCCESS           - Successfully created performance record
+  @retval RETURN_OUT_OF_RESOURCES  - Ran out of space to store the records
+  @retval RETURN_INVALID_PARAMETER - Invalid parameter passed to function - NULL
+                                     pointer or invalid PerfId
+
+**/
+RETURN_STATUS
+EFIAPI
+LogPerformanceMeasurementUnicode (
+  IN CONST VOID    *CallerIdentifier,
+  IN CONST VOID    *Guid     OPTIONAL,
+  IN CONST CHAR16  *String   OPTIONAL,
+  IN UINT64        Address  OPTIONAL,
+  IN UINT32        Identifier
+  )
+{
+  CHAR8       AsciiString[STRING_SIZE] = { 0 };
+  EFI_STATUS  Status                   = ReplaceUnicodeStrToAsciiStrS (String, AsciiString, STRING_SIZE, '?');
+
+  if (Status != RETURN_SUCCESS) {
+    return Status;
+  }
+
+  return (RETURN_STATUS)InsertFpdtRecord (CallerIdentifier, Guid, AsciiString, 0, Address, (UINT16)Identifier, PerfEntry);
 }
 
 /**

--- a/MdeModulePkg/Library/SmmPerformanceLib/SmmPerformanceLib.c
+++ b/MdeModulePkg/Library/SmmPerformanceLib/SmmPerformanceLib.c
@@ -19,6 +19,14 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/PcdLib.h>
 #include <Library/BaseMemoryLib.h>
 
+#include <Library/BaseLib.h>
+#include <Guid/ExtendedFirmwarePerformance.h>
+ 
+//
+// Data for FPDT performance records.
+//
+#define STRING_SIZE  (FPDT_STRING_EVENT_RECORD_NAME_LENGTH * sizeof (CHAR8))
+
 //
 // The cached SMM Performance Protocol and SMM PerformanceEx Protocol interface.
 EDKII_PERFORMANCE_MEASUREMENT_PROTOCOL  *mPerformanceMeasurement = NULL;
@@ -458,6 +466,52 @@ PerformanceMeasurementEnabled (
   )
 {
   return mPerformanceMeasurementEnabled;
+}
+
+/**
+  Create performance record with event description and a timestamp.
+
+  @param CallerIdentifier  - Image handle or pointer to caller ID GUID
+  @param Guid              - Pointer to a GUID
+  @param String            - Pointer to a unicode string describing the measurement
+  @param Address           - Pointer to a location in memory relevant to the measurement
+  @param Identifier        - Performance identifier describing the type of measurement
+
+  @retval RETURN_SUCCESS           - Successfully created performance record
+  @retval RETURN_OUT_OF_RESOURCES  - Ran out of space to store the records
+  @retval RETURN_INVALID_PARAMETER - Invalid parameter passed to function - NULL
+                                     pointer or invalid PerfId
+
+**/
+RETURN_STATUS
+EFIAPI
+LogPerformanceMeasurementUnicode (
+  IN CONST VOID    *CallerIdentifier,
+  IN CONST VOID    *Guid     OPTIONAL,
+  IN CONST CHAR16  *String   OPTIONAL,
+  IN UINT64        Address  OPTIONAL,
+  IN UINT32        Identifier
+  )
+{
+  CHAR8       AsciiString[STRING_SIZE];
+  EFI_STATUS  Status = UnicodeStrToAsciiStrS (String, AsciiString, STRING_SIZE);
+
+  if (Status != RETURN_SUCCESS) {
+    return Status;
+  }
+
+  Status = GetPerformanceMeasurementProtocol ();
+  if (EFI_ERROR (Status)) {
+    return RETURN_OUT_OF_RESOURCES;
+  }
+
+  if (mPerformanceMeasurement != NULL) {
+    Status = mPerformanceMeasurement->CreatePerformanceMeasurement (CallerIdentifier, Guid, AsciiString, 0, Address, Identifier, PerfEntry);
+  } else {
+    ASSERT (FALSE);
+  }
+
+  return (RETURN_STATUS)Status;
 }
 
 /**

--- a/MdeModulePkg/Library/VarCheckLib/VarCheckLib.c
+++ b/MdeModulePkg/Library/VarCheckLib/VarCheckLib.c
@@ -509,6 +509,8 @@ VarCheckLibVariablePropertySet (
 
   Status = EFI_SUCCESS;
 
+  DEBUG (( DEBUG_VARIABLE, "FunctionName(%a) VariableName(%s) VendorGuid(%g)\n", __FUNCTION__, Name, Guid ));
+
   //
   // Get the pointer of property data for set.
   //

--- a/MdeModulePkg/Library/VariablePolicyLib/VariablePolicyLib.c
+++ b/MdeModulePkg/Library/VariablePolicyLib/VariablePolicyLib.c
@@ -406,6 +406,17 @@ RegisterVariablePolicy (
     return EFI_ALREADY_STARTED;
   }
 
+  // MU_CHANGE
+  DEBUG(( DEBUG_VARIABLE, "Enter: FunctionName(%a) VariableName(%s) VendorGuid(%g) MinSize(%d) MaxSize(%d) AttrMustHave(0x%x) AttrCantHave(0x%x) LockType(0x%x)\n",
+    __FUNCTION__,
+    (NewPolicy->Size == NewPolicy->OffsetToName) ? L"" : GET_POLICY_NAME(NewPolicy),
+    NewPolicy->Namespace,
+    NewPolicy->MinSize,
+    NewPolicy->MaxSize,
+    NewPolicy->AttributesMustHave,
+    NewPolicy->AttributesCantHave,
+    NewPolicy->LockPolicyType ));
+
   // If none exists, create it.
   // If we need more space, allocate that now.
   Status = SafeUint32Add (mCurrentTableUsage, NewPolicy->Size, &NewSize);

--- a/MdeModulePkg/Universal/Variable/Pei/Variable.c
+++ b/MdeModulePkg/Universal/Variable/Pei/Variable.c
@@ -1042,6 +1042,15 @@ PeiGetVariable (
     return EFI_NOT_FOUND;
   }
 
+  // MU_CHANGE
+  DEBUG ((DEBUG_VARIABLE, "Enter: FunctionName(%a) VariableName(%s) VendorGuid(%g) &Attributes(0x%p) DataSize(0x%Lx) &Data(%p) \n",
+    __FUNCTION__,
+    VariableName,
+    VariableGuid,
+    Attributes,
+    (UINT64)*DataSize,
+    Data));
+
   VariableHeader = NULL;
 
   //
@@ -1074,6 +1083,13 @@ PeiGetVariable (
   }
 
   *DataSize = VarDataSize;
+
+  // MU_CHANGE
+  DEBUG ((DEBUG_VARIABLE, "Exit: FunctionName(%a) VariableName(%s) VendorGuid(%g) Attributes(0x%x)\n",
+    __FUNCTION__,
+    VariableName,
+    VariableGuid,
+    (Attributes != NULL) ? *Attributes : 0));
 
   return Status;
 }

--- a/MdeModulePkg/Universal/Variable/Pei/VariablePei.inf
+++ b/MdeModulePkg/Universal/Variable/Pei/VariablePei.inf
@@ -41,6 +41,7 @@
   PeiServicesLib
   SafeIntLib
   VariableFlashInfoLib
+  PerformanceLib
 
 [Guids]
   ## CONSUMES             ## GUID # Variable store header

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.c
@@ -2570,7 +2570,16 @@ VariableServiceGetVariable (
     return EFI_NOT_FOUND;
   }
 
-  AcquireLockOnlyAtBootTime (&mVariableModuleGlobal->VariableGlobal.VariableServicesLock);
+  // MU_CHANGE
+  DEBUG ((DEBUG_VARIABLE, "Enter: FunctionName(%a) VariableName(%s) VendorGuid(%g) &Attributes(0x%p) DataSize(0x%Lx) &Data(%p) \n",
+    __FUNCTION__,
+    VariableName,
+    VendorGuid,
+    Attributes,
+    (UINT64)*DataSize,
+    Data));
+
+  AcquireLockOnlyAtBootTime(&mVariableModuleGlobal->VariableGlobal.VariableServicesLock);
 
   Status = FindVariable (VariableName, VendorGuid, &Variable, &mVariableModuleGlobal->VariableGlobal, FALSE);
   if (EFI_ERROR (Status) || (Variable.CurrPtr == NULL)) {
@@ -2610,6 +2619,14 @@ Done:
   }
 
   ReleaseLockOnlyAtBootTime (&mVariableModuleGlobal->VariableGlobal.VariableServicesLock);
+
+  // MU_CHANGE
+  DEBUG ((DEBUG_VARIABLE, "Exit: FunctionName(%a) VariableName(%s) VendorGuid(%g) Attributes(0x%x)\n",
+    __FUNCTION__,
+    VariableName,
+    VendorGuid,
+    (Attributes != NULL) ? *Attributes : 0));
+
   return Status;
 }
 
@@ -2769,6 +2786,15 @@ VariableServiceSetVariable (
   if ((DataSize != 0) && (Data == NULL)) {
     return EFI_INVALID_PARAMETER;
   }
+
+  // MU_CHANGE
+  DEBUG((DEBUG_VARIABLE, "Enter: FunctionName(%a) VariableName(%s) VendorGuid(%g) Attributes(0x%x) DataSize(0x%Lx) *Data(%p) \n",
+    __FUNCTION__,
+    VariableName,
+    VendorGuid,
+    Attributes,
+    (UINT64)DataSize,
+    Data));
 
   //
   // Check for reserverd bit in variable attribute.

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
@@ -79,6 +79,7 @@
   SafeIntLib
   MemoryTypeInfoSecVarCheckLib  # MU_CHANGE TCBZ1086 - Mitigate potential system brick due to UEFI MemoryTypeInformation var changes
   DeviceStateLib  # MU_CHANGE - Check device state before locking variable policy
+  PerformanceLib # MU_CHANGE - Measure performance of variable services
 
 [Protocols]
   gEfiFirmwareVolumeBlockProtocolGuid           ## CONSUMES

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.inf
@@ -86,6 +86,7 @@
   SafeIntLib
   AdvLoggerAccessLib                            ## MU_CHANGE
   MemoryTypeInfoSecVarCheckLib  # MU_CHANGE TCBZ1086 - Mitigate potential system brick due to UEFI MemoryTypeInformation var changes
+  PerformanceLib
 
 [Protocols]
   gEfiSmmFirmwareVolumeBlockProtocolGuid        ## CONSUMES

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
@@ -36,6 +36,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/UefiLib.h>
 #include <Library/BaseLib.h>
 #include <Library/MmUnblockMemoryLib.h>
+#include <Library/PerformanceLib.h> // MU_CHANGE
 
 #include <Guid/EventGroup.h>
 #include <Guid/SmmVariableCommon.h>
@@ -628,13 +629,17 @@ FindVariableInRuntimeCache (
   }
 
   // MU_CHANGE
-  DEBUG ((DEBUG_VARIABLE, "Enter: FunctionName(%a) VariableName(%s) VendorGuid(%g) &Attributes(0x%p) DataSize(0x%Lx) &Data(%p) \n",
+  DEBUG ((DEBUG_VARIABLE, "Enter: FunctionName(%a) FunctionPointer(%p) VariableName(%s) VendorGuid(%g) &Attributes(0x%p) DataSize(0x%Lx) &Data(%p) \n",
     __FUNCTION__,
+    FindVariableInRuntimeCache,
     VariableName,
     VendorGuid,
     Attributes,
     (UINT64)*DataSize,
     Data));
+
+  // MU_CHANGE
+  PERF_VARIABLE_BEGIN(VendorGuid, VariableName, FindVariableInRuntimeCache);
 
   ZeroMem (&RtPtrTrack, sizeof (RtPtrTrack));
 
@@ -715,6 +720,9 @@ Done:
         *Attributes));
     }
   }
+
+  // MU_CHANGE
+  PERF_VARIABLE_END(VendorGuid, VariableName, FindVariableInRuntimeCache);
 
   mVariableRuntimeCacheReadLock = FALSE;
 

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
@@ -627,6 +627,15 @@ FindVariableInRuntimeCache (
     return EFI_INVALID_PARAMETER;
   }
 
+  // MU_CHANGE
+  DEBUG ((DEBUG_VARIABLE, "Enter: FunctionName(%a) VariableName(%s) VendorGuid(%g) &Attributes(0x%p) DataSize(0x%Lx) &Data(%p) \n",
+    __FUNCTION__,
+    VariableName,
+    VendorGuid,
+    Attributes,
+    (UINT64)*DataSize,
+    Data));
+
   ZeroMem (&RtPtrTrack, sizeof (RtPtrTrack));
 
   //
@@ -697,6 +706,13 @@ Done:
   if ((Status == EFI_SUCCESS) || (Status == EFI_BUFFER_TOO_SMALL)) {
     if ((Attributes != NULL) && (RtPtrTrack.CurrPtr != NULL)) {
       *Attributes = RtPtrTrack.CurrPtr->Attributes;
+
+      // MU_CHANGE
+      DEBUG ((DEBUG_VARIABLE, "Exit: FunctionName(%a) VariableName(%s) VendorGuid(%g) Attributes(0x%x)\n",
+        __FUNCTION__,
+        VariableName,
+        VendorGuid,
+        *Attributes));
     }
   }
 

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf
@@ -64,6 +64,7 @@
   PcdLib
   MmUnblockMemoryLib
   DeviceStateLib # MU_CHANGE - Check device state before locking variable policy
+  PerformanceLib  # MU_CHANGE - Measure performance of variable services
 
 [Protocols]
   gEfiVariableWriteArchProtocolGuid             ## PRODUCES

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
@@ -82,6 +82,7 @@
   VariablePolicyLib
   VariablePolicyHelperLib
   MemoryTypeInfoSecVarCheckLib                 # MU_CHANGE TCBZ1086 - Mitigate potential system brick due to UEFI MemoryTypeInformation var changes
+  PerformanceLib
 
 [Protocols]
   gEfiSmmFirmwareVolumeBlockProtocolGuid        ## CONSUMES

--- a/MdePkg/Include/Library/BaseLib.h
+++ b/MdePkg/Include/Library/BaseLib.h
@@ -1606,6 +1606,56 @@ UnicodeStrToAsciiStrS (
   );
 
 /**
+  Convert a Null-terminated Unicode string to a Null-terminated
+  ASCII string and allows for replacement of character instead of Asserting.
+
+  This function is similar to AsciiStrCpyS.
+
+  This function converts the content of the Unicode string Source
+  to the ASCII string Destination by copying the lower 8 bits of
+  each Unicode character. The function terminates the ASCII string
+  Destination by appending a Null-terminator character at the end.
+
+  The caller is responsible to make sure Destination points to a buffer with size
+  equal or greater than ((StrLen (Source) + 1) * sizeof (CHAR8)) in bytes.
+
+  If any Unicode characters in Source the resultant string will replace that character
+  with user given character.
+
+  If Source is not aligned on a 16-bit boundary, then return RETURN_ACCESS_DENIED.
+
+  If an error is returned, then the Destination is unmodified.
+
+  @param  Source            The pointer to a Null-terminated Unicode string.
+  @param  Destination       The pointer to a Null-terminated ASCII string.
+  @param  DestMax           The maximum number of Destination Ascii
+                            char, including terminating null char.
+  @param  ReplacementChar   The char to replace the upper 8 bits with
+
+  @retval RETURN_SUCCESS           String is converted.
+  @retval RETURN_BUFFER_TOO_SMALL  If DestMax is NOT greater than StrLen(Source).
+  @retval RETURN_INVALID_PARAMETER If Destination is NULL.
+                                   If Source is NULL.
+                                   If PcdMaximumAsciiStringLength is not zero,
+                                    and DestMax is greater than
+                                    PcdMaximumAsciiStringLength.
+                                   If PcdMaximumUnicodeStringLength is not zero,
+                                    and DestMax is greater than
+                                    PcdMaximumUnicodeStringLength.
+                                   If DestMax is 0.
+  @retval RETURN_ACCESS_DENIED     If Source and Destination overlap.
+
+**/
+RETURN_STATUS
+EFIAPI
+ReplaceUnicodeStrToAsciiStrS (
+  IN      CONST CHAR16  *Source,
+  OUT     CHAR8         *Destination,
+  IN      UINTN         DestMax,
+  IN      CONST CHAR8   ReplacementChar
+);
+
+/**
   Convert not more than Length successive characters from a Null-terminated
   Unicode string to a Null-terminated Ascii string. If no null char is copied
   from Source, then Destination[Length] is always set to null.

--- a/MdePkg/Include/Library/PerformanceLib.h
+++ b/MdePkg/Include/Library/PerformanceLib.h
@@ -40,7 +40,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define PERF_INMODULE_END_ID       0x41
 #define PERF_CROSSMODULE_START_ID  0x50
 #define PERF_CROSSMODULE_END_ID    0x51
-
+// MU_CHANGE
+#define PERF_VARIABLE_START_ID     0x60
+#define PERF_VARIABLE_END_ID       0x61
 //
 // Declare bits for PcdPerformanceLibraryPropertyMask and
 // also used as the Type parameter of LogPerformanceMeasurementEnabled().
@@ -345,6 +347,31 @@ LogPerformanceMeasurement (
   IN CONST VOID   *Guid     OPTIONAL,
   IN CONST CHAR8  *String   OPTIONAL,
   IN UINT64       Address   OPTIONAL,
+  IN UINT32       Identifier
+  );
+
+  /**
+  Create performance record with event description and a timestamp.
+
+  @param CallerIdentifier  - Image handle or pointer to caller ID GUID
+  @param Guid              - Pointer to a GUID
+  @param String            - Pointer to a unicode string describing the measurement
+  @param Address           - Pointer to a location in memory relevant to the measurement
+  @param Identifier        - Performance identifier describing the type of measurement
+
+  @retval RETURN_SUCCESS           - Successfully created performance record
+  @retval RETURN_OUT_OF_RESOURCES  - Ran out of space to store the records
+  @retval RETURN_INVALID_PARAMETER - Invalid parameter passed to function - NULL
+                                     pointer or invalid PerfId
+
+**/
+RETURN_STATUS
+EFIAPI
+LogPerformanceMeasurementUnicode (
+  IN CONST VOID   *CallerIdentifier,
+  IN CONST VOID   *Guid     OPTIONAL,
+  IN CONST CHAR16 *String   OPTIONAL,
+  IN UINT64       Address  OPTIONAL,
   IN UINT32       Identifier
   );
 
@@ -760,5 +787,37 @@ LogPerformanceMeasurement (
   PERF_CODE_BEGIN ();          \
   Expression                   \
   PERF_CODE_END ()
+
+// MU_CHANGE
+/**
+  Begin Macro to measure the performance of a Variable Access.
+
+  If the PERFORMANCE_LIBRARY_PROPERTY_MEASUREMENT_ENABLED bit of PcdPerformanceLibraryPropertyMask is set,
+  and the BIT6 (disable PERF_GENERAL_TYPE) of PcdPerformanceLibraryPropertyMask is not set.
+  then LogPerformanceMeasurement() is called.
+
+**/
+#define PERF_VARIABLE_BEGIN(Guid, Variable, Function)                                                                    \
+  do {                                                                                                                   \
+      if (PerformanceMeasurementEnabled ()) {                                                                            \
+        LogPerformanceMeasurementUnicode (&gEfiCallerIdGuid, Guid, Variable, (UINT64)Function, PERF_VARIABLE_START_ID);  \
+      }                                                                                                                  \
+  } while (FALSE)
+
+// MU_CHANGE
+/**
+  End Macro to measure the performance of a Variable Access.
+
+  If the PERFORMANCE_LIBRARY_PROPERTY_MEASUREMENT_ENABLED bit of PcdPerformanceLibraryPropertyMask is set,
+  and the BIT6 (disable PERF_GENERAL_TYPE) of PcdPerformanceLibraryPropertyMask is not set.
+  then LogPerformanceMeasurement() is called.
+
+**/
+#define PERF_VARIABLE_END(Guid, Variable, Function)                                                                  \
+  do {                                                                                                               \
+    if (PerformanceMeasurementEnabled ()) {                                                                          \
+      LogPerformanceMeasurementUnicode (&gEfiCallerIdGuid, Guid, Variable, (UINT64)Function, PERF_VARIABLE_END_ID);  \
+    }                                                                                                                \
+  } while (FALSE)
 
 #endif

--- a/MdePkg/Library/BaseLib/SafeString.c
+++ b/MdePkg/Library/BaseLib/SafeString.c
@@ -2708,6 +2708,119 @@ UnicodeStrToAsciiStrS (
 }
 
 /**
+  Convert a Null-terminated Unicode string to a Null-terminated
+  ASCII string and allows for replacement of character instead of Asserting.
+
+  This function is similar to AsciiStrCpyS.
+
+  This function converts the content of the Unicode string Source
+  to the ASCII string Destination by copying the lower 8 bits of
+  each Unicode character. The function terminates the ASCII string
+  Destination by appending a Null-terminator character at the end.
+
+  The caller is responsible to make sure Destination points to a buffer with size
+  equal or greater than ((StrLen (Source) + 1) * sizeof (CHAR8)) in bytes.
+
+  If any Unicode characters in Source the resultant string will replace that character
+  with user given character.
+
+  If Source is not aligned on a 16-bit boundary, then assert() 
+
+  If an error is returned, then the Destination is unmodified.
+
+  @param  Source            The pointer to a Null-terminated Unicode string.
+  @param  Destination       The pointer to a Null-terminated ASCII string.
+  @param  DestMax           The maximum number of Destination Ascii
+                            char, including terminating null char.
+  @param  ReplacementChar   The char to replace the upper 8 bits with
+
+  @retval RETURN_SUCCESS           String is converted.
+  @retval RETURN_BUFFER_TOO_SMALL  If DestMax is NOT greater than StrLen(Source).
+  @retval RETURN_INVALID_PARAMETER If Destination is NULL.
+                                   If Source is NULL.
+                                   If PcdMaximumAsciiStringLength is not zero,
+                                    and DestMax is greater than
+                                    PcdMaximumAsciiStringLength.
+                                   If PcdMaximumUnicodeStringLength is not zero,
+                                    and DestMax is greater than
+                                    PcdMaximumUnicodeStringLength. 
+                                   If DestMax is 0.
+  @retval RETURN_ACCESS_DENIED     If Source and Destination overlap.
+
+**/
+RETURN_STATUS
+EFIAPI
+ ReplaceUnicodeStrToAsciiStrS (
+  IN      CONST CHAR16  *Source,
+  OUT     CHAR8         *Destination,
+  IN      UINTN         DestMax,
+  IN      CONST CHAR8   ReplacementChar
+  )
+{
+  UINTN  SourceLen;
+
+  ASSERT (((UINTN)Source & BIT0) == 0);
+
+  //
+  // 1. Neither Destination nor Source shall be a null pointer.
+  //
+  SAFE_STRING_CONSTRAINT_CHECK ((Destination != NULL), RETURN_INVALID_PARAMETER);
+  SAFE_STRING_CONSTRAINT_CHECK ((Source != NULL), RETURN_INVALID_PARAMETER);
+
+  //
+  // 2. DestMax shall not be greater than ASCII_RSIZE_MAX or RSIZE_MAX.
+  //
+  if (ASCII_RSIZE_MAX != 0) {
+    SAFE_STRING_CONSTRAINT_CHECK ((DestMax <= ASCII_RSIZE_MAX), RETURN_INVALID_PARAMETER);
+  }
+
+  if (RSIZE_MAX != 0) {
+    SAFE_STRING_CONSTRAINT_CHECK ((DestMax <= RSIZE_MAX), RETURN_INVALID_PARAMETER);
+  }
+
+  //
+  // 3. DestMax shall not equal zero.
+  //
+  SAFE_STRING_CONSTRAINT_CHECK ((DestMax != 0), RETURN_INVALID_PARAMETER);
+
+  //
+  // 4. DestMax shall be greater than StrnLenS (Source, DestMax).
+  //
+  SourceLen = StrnLenS (Source, DestMax);
+  SAFE_STRING_CONSTRAINT_CHECK ((DestMax > SourceLen), RETURN_BUFFER_TOO_SMALL);
+
+  //
+  // 5. Copying shall not take place between objects that overlap.
+  //
+  SAFE_STRING_CONSTRAINT_CHECK (!InternalSafeStringIsOverlap (Destination, DestMax, (VOID *)Source, (SourceLen + 1) * sizeof (CHAR16)), RETURN_ACCESS_DENIED);
+
+  //
+  // convert string
+  //
+  while (*Source != '\0') {
+    //
+    // If any Unicode characters in Source contain
+    // non-zero value in the upper 8 bits, then replace.
+    //
+
+    // if two bytes are greater than 256
+    if (*Source > 0x100) {
+      *(Destination) = ReplacementChar;
+    } else {
+      // chops off the upper 8 bits
+      *(Destination) = (CHAR8)*Source;
+    }
+
+    *(Destination++);
+    *(Source++);
+  }
+
+  *Destination = '\0';
+
+  return RETURN_SUCCESS;
+}
+
+/**
   Convert not more than Length successive characters from a Null-terminated
   Unicode string to a Null-terminated Ascii string. If no null char is copied
   from Source, then Destination[Length] is always set to null.

--- a/MdePkg/Library/BasePerformanceLibNull/PerformanceLib.c
+++ b/MdePkg/Library/BasePerformanceLibNull/PerformanceLib.c
@@ -326,6 +326,34 @@ LogPerformanceMeasurement (
 }
 
 /**
+  Create performance record with event description and a timestamp.
+
+  @param CallerIdentifier  - Image handle or pointer to caller ID GUID
+  @param Guid              - Pointer to a GUID
+  @param String            - Pointer to a string describing the measurement
+  @param Address           - Pointer to a location in memory relevant to the measurement
+  @param Identifier        - Performance identifier describing the type of measurement
+
+  @retval RETURN_SUCCESS           - Successfully created performance record
+  @retval RETURN_OUT_OF_RESOURCES  - Ran out of space to store the records
+  @retval RETURN_INVALID_PARAMETER - Invalid parameter passed to function - NULL
+                                     pointer or invalid PerfId
+
+**/
+RETURN_STATUS
+EFIAPI
+LogPerformanceMeasurementUnicode (
+  IN CONST VOID   *CallerIdentifier OPTIONAL,
+  IN CONST VOID   *Guid     OPTIONAL,
+  IN CONST CHAR16  *String   OPTIONAL,
+  IN UINT64       Address   OPTIONAL,
+  IN UINT32       Identifier
+  )
+{
+  return RETURN_SUCCESS;
+}
+
+/**
   Check whether the specified performance measurement can be logged.
 
   This function returns TRUE when the PERFORMANCE_LIBRARY_PROPERTY_MEASUREMENT_ENABLED bit of PcdPerformanceLibraryPropertyMask is set


### PR DESCRIPTION
## Description

Adds Debug Logs and Performance Measurements to track variable usage throughout various phases of UEFI.

This along with a script (not yet published) may be used to track variable usage and performance on a system.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [X] Includes documentation?
  - internal documentation not yet published 

## How This Was Tested
N/A

## Integration Instructions

N/A