### PR TITLE
BaseTools: InfBuildData: Fix Private dec data retrieval

### DIFF
--- a/BaseTools/Source/Python/Workspace/InfBuildData.py
+++ b/BaseTools/Source/Python/Workspace/InfBuildData.py
@@ -597,7 +597,7 @@ class InfBuildData(ModuleBuildClassObject):
         RecordList = self._RawData[MODEL_EFI_PROTOCOL, self._Arch, self._Platform]
         for Record in RecordList:
             CName = Record[0]
-            Value = _ProtocolValue(CName, self.Packages, self.MetaFile.Path)
+            Value = _ProtocolValue(CName, self.Packages, self.MetaFile.OriginalPath.Path) # MU_CHANGE: BZ4730
             if Value is None:
                 PackageList = "\n\t".join(str(P) for P in self.Packages)
                 EdkLogger.error('build', RESOURCE_NOT_AVAILABLE,
@@ -621,7 +621,7 @@ class InfBuildData(ModuleBuildClassObject):
         RecordList = self._RawData[MODEL_EFI_PPI, self._Arch, self._Platform]
         for Record in RecordList:
             CName = Record[0]
-            Value = _PpiValue(CName, self.Packages, self.MetaFile.Path)
+            Value = _PpiValue(CName, self.Packages, self.MetaFile.OriginalPath.Path) # MU_CHANGE: BZ4730
             if Value is None:
                 PackageList = "\n\t".join(str(P) for P in self.Packages)
                 EdkLogger.error('build', RESOURCE_NOT_AVAILABLE,
@@ -645,7 +645,7 @@ class InfBuildData(ModuleBuildClassObject):
         RecordList = self._RawData[MODEL_EFI_GUID, self._Arch, self._Platform]
         for Record in RecordList:
             CName = Record[0]
-            Value = GuidValue(CName, self.Packages, self.MetaFile.Path)
+            Value = GuidValue(CName, self.Packages, self.MetaFile.OriginalPath.Path) # MU_CHANGE: BZ4730
             if Value is None:
                 PackageList = "\n\t".join(str(P) for P in self.Packages)
                 EdkLogger.error('build', RESOURCE_NOT_AVAILABLE,
@@ -660,7 +660,7 @@ class InfBuildData(ModuleBuildClassObject):
             for TokenSpaceGuid, _, _, _, _, _, LineNo in RecordList:
                 # get the guid value
                 if TokenSpaceGuid not in RetVal:
-                    Value = GuidValue(TokenSpaceGuid, self.Packages, self.MetaFile.Path)
+                    Value = GuidValue(TokenSpaceGuid, self.Packages, self.MetaFile.OriginalPath.Path) # MU_CHANGE: BZ4730
                     if Value is None:
                         PackageList = "\n\t".join(str(P) for P in self.Packages)
                         EdkLogger.error('build', RESOURCE_NOT_AVAILABLE,
@@ -823,11 +823,11 @@ class InfBuildData(ModuleBuildClassObject):
                         Value = Token
                     else:
                         # get the GUID value now
-                        Value = _ProtocolValue(Token, self.Packages, self.MetaFile.Path)
+                        Value = _ProtocolValue(Token, self.Packages, self.MetaFile.OriginalPath.Path) # MU_CHANGE: BZ4730
                         if Value is None:
-                            Value = _PpiValue(Token, self.Packages, self.MetaFile.Path)
+                            Value = _PpiValue(Token, self.Packages, self.MetaFile.OriginalPath.Path) # MU_CHANGE: BZ4730
                             if Value is None:
-                                Value = GuidValue(Token, self.Packages, self.MetaFile.Path)
+                                Value = GuidValue(Token, self.Packages, self.MetaFile.OriginalPath.Path) # MU_CHANGE: BZ4730
 
                     if Value is None:
                         PackageList = "\n\t".join(str(P) for P in self.Packages)


### PR DESCRIPTION
## Description

Private package dec sections (such as guids [Guids.Common.Private], Ppis [Ppis.Common.Private], and protocols [Protocols.Common.Private]) become inaccessible for components of the same package if the module's EFI_GUID value is overwritten (Which is commonly done to build the same module multiple times with different settings)

BZ: https://bugzilla.tianocore.org/show_bug.cgi?id=4730

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Verified private guids continue to be accessible to modules in the same package, even when the EFI_GUID is changed in the dsc.

## Integration Instructions

N/A
