### PR TITLE
MdeModulePkg/MemoryProtectionSupport: Fix GCC type mismatch warnings

### DIFF
--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -111,7 +111,6 @@ IsImageRecordCodeSectionValid (
   @return image record
 **/
 IMAGE_PROPERTIES_RECORD *
-EFIAPI
 FindImageRecord (
   IN EFI_PHYSICAL_ADDRESS  ImageBase,
   IN UINT64                ImageSize
@@ -280,7 +279,6 @@ SetUefiImageMemoryAttributes (
   Disable NULL pointer detection.
 **/
 VOID
-EFIAPI
 DisableNullDetection (
   VOID
   );


### PR DESCRIPTION
## Description

Updates the function signature in declarations to match that used in
the definitions. As used, these functions do not need `EFIAPI`.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

GCC compilation with `-Wlto-type-mismatch`.

## Integration Instructions

N/A