### PR TITLE
Map Legacy BIOS Memory RWX When Entering Compatibility Mode

### DIFF
--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -3559,7 +3559,7 @@ UninstallMemoryAttributeProtocol (
 }
 
 /**
-  Maps memory below 1MB (legacy BIOS memory) as readable, writeable, and executable.
+  Maps memory below 640K (legacy BIOS write-back memory) as readable, writeable, and executable.
 **/
 STATIC
 VOID
@@ -3569,11 +3569,14 @@ MapLegacyBiosMemoryRWX (
 {
   EFI_STATUS  Status;
 
+  // https://wiki.osdev.org/Memory_Map_(x86)
+  //
+  // Map the legacy BIOS write-back memory as RWX.
   if (gCpu != NULL) {
     Status = gCpu->SetMemoryAttributes (
                      gCpu,
                      0x0,
-                     0x100000,
+                     0xa0000,
                      0
                      );
   }

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -3559,6 +3559,29 @@ UninstallMemoryAttributeProtocol (
 }
 
 /**
+  Maps memory below 1MB (legacy BIOS memory) as readable, writeable, and executable.
+**/
+STATIC
+VOID
+MapLegacyBiosMemoryRWX (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+
+  if (gCpu != NULL) {
+    Status = gCpu->SetMemoryAttributes (
+                     gCpu,
+                     0x0,
+                     0x100000,
+                     0
+                     );
+  }
+
+  ASSERT_EFI_ERROR (Status);
+}
+
+/**
   Sets the NX compatibility global to FALSE so future checks to
   IsEnhancedMemoryProtectionActive() will return FALSE.
 **/
@@ -3578,6 +3601,7 @@ ActivateCompatibilityMode (
 
   DisableNullDetection ();
   UninstallMemoryAttributeProtocol ();
+  MapLegacyBiosMemoryRWX ();
 }
 
 /**

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -3567,7 +3567,7 @@ MapLegacyBiosMemoryRWX (
   VOID
   )
 {
-  EFI_STATUS  Status;
+  EFI_STATUS  Status = EFI_SUCCESS;
 
   // https://wiki.osdev.org/Memory_Map_(x86)
   //


### PR DESCRIPTION
## Description

The Linux distro used in Mariner 2 has logic [directly carves memory from the legacy BIOS region](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fmicrosoft%2FCBL-Mariner-Linux-Kernel%2Fblob%2Fedab6ad780cfa0be041a08a79b600443fde10c7f%2Farch%2Fx86%2Fboot%2Fcompressed%2Fpgtable_64.c%23L38&data=05%7C02%7CTaylor.Beebe%40microsoft.com%7Cd6a0f39431794d716fc608dc55c9f96b%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C638479573168984897%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C0%7C%7C%7C&sdata=2YR1egvp4z%2BCmMu5aeQnZvZegQTRhdVO0vTzIF5cBAc%3D&reserved=0) and copies the trampoline code into it for execution. Mariner 2 will trigger memory protection compatibility mode due to the absence of the NX_COMPAT flag in Shim, but because the UEFI allocator is not used for this allocation, the memory attributes won't be updated to make the region executable. To resolve this, compatibility mode will now map the writable legacy BIOS region (0x0-0xa0000) as RWX to resolve this issue with Mariner 2 and other Linux distros older than a couple of years.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on Q35 by booting with a recent a Mariner 2 image.

## Integration Instructions

N/A