### PR TITLE
[CHERRY-PICK] Add NO_STACK_COOKIE to Module Entry Points

### DIFF
--- a/MdePkg/Include/Library/PeimEntryPoint.h
+++ b/MdePkg/Include/Library/PeimEntryPoint.h
@@ -27,6 +27,7 @@ extern CONST UINT32  _gPeimRevision;
   @retval  EFI_SUCCESS   The PEIM executed normally.
   @retval  !EFI_SUCCESS  The PEIM failed to execute normally.
 **/
+NO_STACK_COOKIE // MU_CHANGE: Project Mu Runtime Randomized Stack Cookie Support
 EFI_STATUS
 EFIAPI
 _ModuleEntryPoint (

--- a/MdePkg/Include/Library/StandaloneMmDriverEntryPoint.h
+++ b/MdePkg/Include/Library/StandaloneMmDriverEntryPoint.h
@@ -45,6 +45,7 @@ extern CONST UINT8  _gDriverUnloadImageCount;
                                      ProcessModuleEntryPointList().
 
 **/
+NO_STACK_COOKIE // MU_CHANGE: Project Mu Runtime Randomized Stack Cookie Support
 EFI_STATUS
 EFIAPI
 _ModuleEntryPoint (

--- a/MdePkg/Include/Library/UefiApplicationEntryPoint.h
+++ b/MdePkg/Include/Library/UefiApplicationEntryPoint.h
@@ -31,6 +31,7 @@ extern CONST UINT32  _gUefiDriverRevision;
   @retval  Other                     Return value from ProcessModuleEntryPointList().
 
 **/
+NO_STACK_COOKIE // MU_CHANGE: Project Mu Runtime Randomized Stack Cookie Support
 EFI_STATUS
 EFIAPI
 _ModuleEntryPoint (

--- a/MdePkg/Include/Library/UefiDriverEntryPoint.h
+++ b/MdePkg/Include/Library/UefiDriverEntryPoint.h
@@ -48,6 +48,7 @@ extern CONST UINT8  _gDriverUnloadImageCount;
   @retval  Other                     Return value from ProcessModuleEntryPointList().
 
 **/
+NO_STACK_COOKIE // MU_CHANGE: Project Mu Runtime Randomized Stack Cookie Support
 EFI_STATUS
 EFIAPI
 _ModuleEntryPoint (

--- a/MdePkg/Library/PeimEntryPoint/PeimEntryPoint.c
+++ b/MdePkg/Library/PeimEntryPoint/PeimEntryPoint.c
@@ -24,6 +24,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
   @retval  EFI_SUCCESS   The PEIM executed normally.
   @retval  !EFI_SUCCESS  The PEIM failed to execute normally.
 **/
+NO_STACK_COOKIE // MU_CHANGE: Project Mu Runtime Randomized Stack Cookie Support
 EFI_STATUS
 EFIAPI
 _ModuleEntryPoint (

--- a/MdePkg/Library/StandaloneMmDriverEntryPoint/StandaloneMmDriverEntryPoint.c
+++ b/MdePkg/Library/StandaloneMmDriverEntryPoint/StandaloneMmDriverEntryPoint.c
@@ -78,6 +78,7 @@ _DriverUnloadHandler (
                                      ProcessModuleEntryPointList().
 
 **/
+NO_STACK_COOKIE // MU_CHANGE: Project Mu Runtime Randomized Stack Cookie Support
 EFI_STATUS
 EFIAPI
 _ModuleEntryPoint (

--- a/MdePkg/Library/UefiApplicationEntryPoint/ApplicationEntryPoint.c
+++ b/MdePkg/Library/UefiApplicationEntryPoint/ApplicationEntryPoint.c
@@ -29,6 +29,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
   @retval  Other                     Return value from ProcessModuleEntryPointList().
 
 **/
+NO_STACK_COOKIE // MU_CHANGE: Project Mu Runtime Randomized Stack Cookie Support
 EFI_STATUS
 EFIAPI
 _ModuleEntryPoint (

--- a/MdePkg/Library/UefiDriverEntryPoint/DriverEntryPoint.c
+++ b/MdePkg/Library/UefiDriverEntryPoint/DriverEntryPoint.c
@@ -80,6 +80,7 @@ _DriverUnloadHandler (
   @retval  Other                     Return value from ProcessModuleEntryPointList().
 
 **/
+NO_STACK_COOKIE // MU_CHANGE: Project Mu Runtime Randomized Stack Cookie Support
 EFI_STATUS
 EFIAPI
 _ModuleEntryPoint (


### PR DESCRIPTION
## Description

When the DXE dispatcher dispatches an EFI module, execution starts with the ModuleEntryPoint of the EFI. If the stack cookie value is randomized during the library constructor process and the ModuleEntryPoint includes a stack cookie check, then the value of the stack cookie will change between the start and end of the ModuleEntryPoint function and cause a stack cookie check failure. With this change, the following is the structure which ensures the stack cookie check will not erroneously fail:

```
NO_STACK_COOKIE
ModuleEntryPoint (

  NO_STACK_COOKIE 
  ProcessLibraryConstructorList (

    NO_STACK_COOKIE 
    InitializeStackCookie ()
  )
)
```

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested by booting to shell on Q35 built with GCC and VS2022, and by booting SBSA built with GCC.

## Integration Instructions

N/A