### PR TITLE
Add a Deprecated Build Option To Allow Incompatible AARCH64 Platforms To Opt Out of 64k Runtime Granularity

### DIFF
--- a/MdePkg/Include/AArch64/ProcessorBind.h
+++ b/MdePkg/Include/AArch64/ProcessorBind.h
@@ -159,9 +159,17 @@ typedef INT64 INTN;
 
 ///
 /// Page allocation granularity for AARCH64
+/// MU_CHANGE BEGIN: Enable Deprecated 4k Granularity Mode for Platforms
+/// that do not support 64k runtime allocation
 ///
 #define DEFAULT_PAGE_ALLOCATION_GRANULARITY  (0x1000)
+#ifdef __DEPRECATED_AARCH64_4K_RUNTIME_GRANULARITY
+#define RUNTIME_PAGE_ALLOCATION_GRANULARITY  (0x1000)
+#else
 #define RUNTIME_PAGE_ALLOCATION_GRANULARITY  (0x10000)
+#endif
+
+// MU_CHANGE END
 
 //
 // Modifier to ensure that all protocol member functions and EFI intrinsics


### PR DESCRIPTION
## Description

Some AARCH64 platforms are incompatible with 64k runtime granularity. This PR adds a build option that is consumed to enable a deprecated option to set the runtime page allocation granularity to 4k. This option should not be used except for old platforms that cannot be updated to comply with 64k runtime granularity. Using this option breaks compatibility with the UEFI spec.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested with setting flag and unsetting.

## Integration Instructions

Do not use this option without an old platform that cannot support 64k. For those platforms, set the following in the platform DSC:

```c
MSFT:*_*_*_CC_FLAGS = /D __DEPRECATED_AARCH64_4K_RUNTIME_GRANULARITY
GCC:*_*_*_CC_FLAGS = -D __DEPRECATED_AARCH64_4K_RUNTIME_GRANULARITY
```
