### PR TITLE
Add Error Message and ASSERT When Loading non-NX_COMPAT Image

### DIFF
--- a/MdeModulePkg/Core/Dxe/Image/Image.c
+++ b/MdeModulePkg/Core/Dxe/Image/Image.c
@@ -663,7 +663,16 @@ CoreLoadPeImage (
   // Or, if our memory protection policy specifies that we shouldn't allow such images, return a failure.
   if (!(Image->ImageContext.SupportsNx) && (Image->ImageContext.ImageType == EFI_IMAGE_SUBSYSTEM_EFI_APPLICATION)) {
     if (gDxeMps.ImageProtectionPolicy.Fields.BlockImagesWithoutNxFlag) {
-      return EFI_SECURITY_VIOLATION;
+      DEBUG ((DEBUG_ERROR, "\n"));
+      DEBUG ((DEBUG_ERROR, "The platform attempted to load an EFI application which does not have the NX_COMPAT DLL Charactersistic.\n"));
+      DEBUG ((DEBUG_ERROR, "This is not allowed by the platform memory protection policy and so the image will not be loaded.\n"));
+      DEBUG ((DEBUG_ERROR, "This can be fixed by setting the NX_COMPAT flag in the image's PE header after validating that the\n"));
+      DEBUG ((DEBUG_ERROR, "image is safe to run with enhanced memory protections enabled. The image can also be executed in compatibility\n"));
+      DEBUG ((DEBUG_ERROR, "mode by updating the platform DXE_MEMORY_PROTECTION_SETTINGS so ImageProtectionPolicy.BlockImagesWithoutNxFlag is 0.\n"));
+      DEBUG ((DEBUG_ERROR, "Compatibility mode reduces firmware security so careful consideration should be made.\n"));
+      Status = EFI_SECURITY_VIOLATION;
+      ASSERT_EFI_ERROR (Status);
+      return Status;
     }
 
     ActivateCompatibilityMode ();

--- a/MdeModulePkg/Core/Dxe/Image/Image.c
+++ b/MdeModulePkg/Core/Dxe/Image/Image.c
@@ -663,13 +663,15 @@ CoreLoadPeImage (
   // Or, if our memory protection policy specifies that we shouldn't allow such images, return a failure.
   if (!(Image->ImageContext.SupportsNx) && (Image->ImageContext.ImageType == EFI_IMAGE_SUBSYSTEM_EFI_APPLICATION)) {
     if (gDxeMps.ImageProtectionPolicy.Fields.BlockImagesWithoutNxFlag) {
-      DEBUG ((DEBUG_ERROR, "\n"));
-      DEBUG ((DEBUG_ERROR, "The platform attempted to load an EFI application which does not have the NX_COMPAT DLL Charactersistic.\n"));
-      DEBUG ((DEBUG_ERROR, "This is not allowed by the platform memory protection policy and so the image will not be loaded.\n"));
-      DEBUG ((DEBUG_ERROR, "This can be fixed by setting the NX_COMPAT flag in the image's PE header after validating that the\n"));
-      DEBUG ((DEBUG_ERROR, "image is safe to run with enhanced memory protections enabled. The image can also be executed in compatibility\n"));
-      DEBUG ((DEBUG_ERROR, "mode by updating the platform DXE_MEMORY_PROTECTION_SETTINGS so ImageProtectionPolicy.BlockImagesWithoutNxFlag is 0.\n"));
-      DEBUG ((DEBUG_ERROR, "Compatibility mode reduces firmware security so careful consideration should be made.\n"));
+      DEBUG ((DEBUG_ERROR, "\nThe platform attempted to load an EFI application which does not have the NX_COMPAT DLL\n"));
+      DEBUG ((DEBUG_ERROR, "Characteristic. This is not allowed by the platform memory protection policy so the\n"));
+      DEBUG ((DEBUG_ERROR, "image will not be loaded. This can be fixed by setting the NX_COMPAT flag in the image's\n"));
+      DEBUG ((DEBUG_ERROR, "PE header after validating that the image is safe to run with enhanced memory\n"));
+      DEBUG ((DEBUG_ERROR, "protection enabled (see https://microsoft.github.io/mu/WhatAndWhy/enhancedmemoryprotection\n"));
+      DEBUG ((DEBUG_ERROR, "for more info on this mode). The image can also be executed in compatibility mode by\n"));
+      DEBUG ((DEBUG_ERROR, "updating the platform DXE_MEMORY_PROTECTION_SETTINGS so BlockImagesWithoutNxFlag is 0.\n"));
+      DEBUG ((DEBUG_ERROR, "Compatibility mode reduces firmware security so careful consideration should be made\n"));
+      DEBUG ((DEBUG_ERROR, "before allowing it to be enabled.\n"));
       Status = EFI_SECURITY_VIOLATION;
       ASSERT_EFI_ERROR (Status);
       return Status;


### PR DESCRIPTION
## Description

When loading an image without the NX_COMPAT flag, the memory protection policy is queried to see if the image is allowed to load. If it is not, a security violation is returned which results in a single error message.

To make it more clear what happened and why, this PR adds a print explaining the reason behind blocking the image from loading and how to fix it. This PR also adds an ASSERT to stop DEBUG build execution when the security violation is encountered to ensure the violation isn't missed. Developers should either update the memory protection policy or the offending EFI app to resolve the ASSERT.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on Q35 by loading a non NX_COMPAT image.

## Integration Instructions

N/A