### PR TITLE
Add SMM_REV_ID definition for STM header

### DIFF
--- a/MdePkg/Include/Register/Intel/StmApi.h
+++ b/MdePkg/Include/Register/Intel/StmApi.h
@@ -18,6 +18,9 @@
 
 #pragma pack (1)
 
+// MU_CHANGE: Added SMM_REV_ID definition, according to STM spec
+#define STM_SMM_REV_ID   0x80010100
+
 /**
   STM Header Structures
 **/

--- a/MdePkg/Include/Register/Intel/StmApi.h
+++ b/MdePkg/Include/Register/Intel/StmApi.h
@@ -19,7 +19,7 @@
 #pragma pack (1)
 
 // MU_CHANGE: Added SMM_REV_ID definition, according to STM spec
-#define STM_SMM_REV_ID   0x80010100
+#define STM_SMM_REV_ID  0x80010100
 
 /**
   STM Header Structures


### PR DESCRIPTION
## Description

The `SMM_REV_ID` is defined in the STM specification: https://www.intel.com/content/www/us/en/content-details/671521/smi-transfer-monitor-stm-developer-or-user-guide.html?wapkw=stm, section 10.1.1.

This change adds it into the `StmApi.h` for potential STM usage.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Header file update only. No functional changes.

## Integration Instructions

N/A