### PR TITLE
DscCompleteCheck: Bugfix ignorepaths config option

### DIFF
--- a/.pytool/Plugin/DscCompleteCheck/DscCompleteCheck.py
+++ b/.pytool/Plugin/DscCompleteCheck/DscCompleteCheck.py
@@ -73,21 +73,19 @@ class DscCompleteCheck(ICiBuildPlugin):
             return 0
 
         # Get INF Files
+        # MU_CHANGE [BEGIN] - Add git ignore syntax
         INFFiles = self.WalkDirectoryForExtension([".inf"], abs_pkg_path)
-        INFFiles = [Edk2pathObj.GetEdk2RelativePathFromAbsolutePath(
-            x) for x in INFFiles]  # make edk2relative path so can compare with DSC
 
         # remove ignores
-        # MU_CHANGE [BEGIN] - Add git ignore syntax
         ignored_paths = []
         if "IgnoreInf" in pkgconfig:
             ignore_filter = parse_gitignore_lines(
                 pkgconfig["IgnoreInf"],
                 "DSC Complete Check Config",
                 os.path.dirname(abs_pkg_path))
+            
+            # INFFiles must be a list of absolute paths
             ignored_paths = list(filter(ignore_filter, INFFiles))
-        # MU_CHANGE [END] - Add git ignore syntax
-
             for a in ignored_paths:  # MU_CHANGE - Add git ignore syntax
                 try:
                     tc.LogStdOut("Ignoring INF {0}".format(a))
@@ -97,6 +95,10 @@ class DscCompleteCheck(ICiBuildPlugin):
                         "DscCompleteCheck.IgnoreInf -> {0} not found in filesystem.  Invalid ignore file".format(a))
                     logging.info(
                         "DscCompleteCheck.IgnoreInf -> {0} not found in filesystem.  Invalid ignore file".format(a))
+
+        INFFiles = [Edk2pathObj.GetEdk2RelativePathFromAbsolutePath(
+            x) for x in INFFiles]  # make edk2relative path so can compare with DSC
+        # MU_CHANGE [END] - Add git ignore syntax
 
         # DSC Parser
         dp = DscParser().SetEdk2Path(Edk2pathObj)


### PR DESCRIPTION
## Description

The DscCompleteCheck has support for .gitignore style ignore paths in a package configuration file. Per
`edk2toollib.gitignore_parser.IgnoreRule.match()`, the path must be an absolute path, so this commit updates the DscCompleteCheck to wait to convert the file paths to edk2 relative paths until after the ignore paths have been processed.

See: https://github.com/tianocore/edk2-pytool-library/blob/83db1e007f6ca7bbc0f7a59e9565695134a8c269/edk2toollib/gitignore_parser.py#L178


- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Verified gitignore paths apply to packages that are not at the root of the directory.

## Integration Instructions

N/A