### PR TITLE
Add ARM and AARCH64 MSCVC Support to StackCheckLib

### DIFF
--- a/MdePkg/Library/StackCheckLib/AArch64/StackCookieInterrupt.S
+++ b/MdePkg/Library/StackCheckLib/AArch64/StackCookieInterrupt.S
@@ -17,5 +17,5 @@
 //------------------------------------------------------------------------------
 .global ASM_PFX(TriggerStackCookieInterrupt)
 ASM_PFX(TriggerStackCookieInterrupt):
-    smc FixedPcdGet8 (PcdStackCookieExceptionVector)
+    svc FixedPcdGet8 (PcdStackCookieExceptionVector)
     ret

--- a/MdePkg/Library/StackCheckLib/AArch64/StackCookieInterrupt.asm
+++ b/MdePkg/Library/StackCheckLib/AArch64/StackCookieInterrupt.asm
@@ -1,0 +1,25 @@
+;------------------------------------------------------------------------------
+; AArch64/StackCookieInterrupt.asm
+;
+; Copyright (c) Microsoft Corporation. All rights reserved.
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;------------------------------------------------------------------------------
+
+    EXPORT TriggerStackCookieInterrupt
+
+    AREA |.text|, CODE, READONLY
+
+;------------------------------------------------------------------------------
+; Calls an interrupt using the vector specified by PcdStackCookieExceptionVector
+;
+; VOID
+; TriggerStackCookieInterrupt (
+;   VOID
+;   );
+;------------------------------------------------------------------------------
+TriggerStackCookieInterrupt PROC
+    SVC     FixedPcdGet8 (PcdStackCookieExceptionVector)
+    RET
+TriggerStackCookieInterrupt ENDP
+
+    END

--- a/MdePkg/Library/StackCheckLib/Arm/StackCookieInterrupt.asm
+++ b/MdePkg/Library/StackCheckLib/Arm/StackCookieInterrupt.asm
@@ -1,0 +1,25 @@
+;------------------------------------------------------------------------------
+; Arm/StackCookieInterrupt.asm
+;
+; Copyright (c) Microsoft Corporation. All rights reserved.
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;------------------------------------------------------------------------------
+
+    EXPORT TriggerStackCookieInterrupt
+   
+    AREA |.text|, CODE, READONLY
+
+;------------------------------------------------------------------------------
+; Calls an interrupt using the vector specified by PcdStackCookieExceptionVector
+;
+; VOID
+; TriggerStackCookieInterrupt (
+;   VOID
+;   );
+;------------------------------------------------------------------------------
+TriggerStackCookieInterrupt PROC
+    SWI     FixedPcdGet8 (PcdStackCookieExceptionVector)
+    BX      LR
+TriggerStackCookieInterrupt ENDP
+
+    END

--- a/MdePkg/Library/StackCheckLib/StackCheckLibDynamicInit.inf
+++ b/MdePkg/Library/StackCheckLib/StackCheckLibDynamicInit.inf
@@ -29,10 +29,12 @@
   IA32/StackCookieInterrupt.nasm
 
 [Sources.ARM]
-  Arm/StackCookieInterrupt.S |GCC
+  Arm/StackCookieInterrupt.S   |GCC
+  Arm/StackCookieInterrupt.asm |MSFT
 
 [Sources.AARCH64]
-  AArch64/StackCookieInterrupt.S |GCC
+  AArch64/StackCookieInterrupt.S   |GCC
+  AArch64/StackCookieInterrupt.asm |MSFT
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/MdePkg/Library/StackCheckLib/StackCheckLibStaticInit.inf
+++ b/MdePkg/Library/StackCheckLib/StackCheckLibStaticInit.inf
@@ -26,10 +26,12 @@
   IA32/StackCookieInterrupt.nasm
 
 [Sources.ARM]
-  Arm/StackCookieInterrupt.S |GCC
+  Arm/StackCookieInterrupt.S   |GCC
+  Arm/StackCookieInterrupt.asm |MSFT
 
 [Sources.AARCH64]
-  AArch64/StackCookieInterrupt.S |GCC
+  AArch64/StackCookieInterrupt.S   |GCC
+  AArch64/StackCookieInterrupt.asm |MSFT
 
 [Packages]
   MdePkg/MdePkg.dec


### PR DESCRIPTION
## Description

This PR adds the required .asm files for compiling StackCheckLib with MSVC for an ARM or AARCH64 target. This PR also updates the stack check failure instruction for AARCH64 to SVC instead of SMC. Ref: https://developer.arm.com/documentation/dui0489/i/arm-and-thumb-instructions/svc?lang=en
 
- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested by building mu_crypto_release with VS2022.

## Integration Instructions

N/A