### PR TITLE
Fix Possible Allocation of Pages While They Are Being Freed

### DIFF
--- a/MdeModulePkg/Core/Dxe/Mem/Page.c
+++ b/MdeModulePkg/Core/Dxe/Mem/Page.c
@@ -955,7 +955,7 @@ CoreConvertPagesEx (
     // freeing to be allocated before we're done freeing it if CoreFreeMemoryMapStack()
     // is called after AddRange(). So, if we are freeing, let's free the memory map
     // stack before adding memory we're converting to the free list.
-    if (NewType == EfiConventionalMemory) {
+    if (ChangingType && (NewType == EfiConventionalMemory)) {
       //
       // Move any map descriptor stack to general pool
       //
@@ -996,7 +996,7 @@ CoreConvertPagesEx (
     // converting to also be allocated in the below call. To avoid this case, we should
     // call CoreFreeMemoryMapStack() after we've called AddRange() to mark this memory
     // as allocated.
-    if (NewType != EfiConventionalMemory) {
+    if (!ChangingType || (ChangingType && (NewType != EfiConventionalMemory))) {
       //
       // Move any map descriptor stack to general pool
       //


### PR DESCRIPTION
## Description

FreeMemoryMapStack() within CoreConvertPagesEx() may allocate pages which, if the converted memory is being freed (implied by the new type being EfiConventionalMemory), could cause the memory currently being freed to be allocated during the convert process it if CoreFreeMemoryMapStack() is called after AddRange(). So, if the convert is being done due to a free pages call, free the memory map stack before adding memory to the free list.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on Q35

## Integration Instructions

N/A