### PR TITLE
Adding a Exception Handler Library Hook Call

### DIFF
--- a/UefiCpuPkg/Include/Library/CpuExceptionHookLib.h
+++ b/UefiCpuPkg/Include/Library/CpuExceptionHookLib.h
@@ -1,0 +1,22 @@
+/** @file
+  Library which provides a hook that is called when a cpu exception occurs
+
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef CPU_EXCEPTION_HOOK_LIB_H_
+#define CPU_EXCEPTION_HOOK_LIB_H_
+
+#include <Uefi.h>
+#include <Protocol/DebugSupport.h>
+
+NO_STACK_COOKIE
+VOID
+EFIAPI
+CpuExceptionHookLib (
+  IN EFI_EXCEPTION_TYPE  ExceptionType,
+  IN EFI_SYSTEM_CONTEXT  SystemContext
+  );
+
+#endif

--- a/UefiCpuPkg/Include/Library/CpuExceptionHookLib.h
+++ b/UefiCpuPkg/Include/Library/CpuExceptionHookLib.h
@@ -12,10 +12,12 @@
 #include <Protocol/DebugSupport.h>
 
 /**
-  Get CpuCacheInfo data array. The array is sorted by CPU package ID, core type, cache level and cache type.
+  Hook function called when an exception has occured. The exception context is passed
+  to allow the add in functionality to use the exception context to perform platform
+  specific tasks.
 
   @param[in] ExceptionType       Cpu Exception Type which was triggered
-  @param[in] SystemContext       Pointer the the CPU Context when the exception was triggered. Hook library
+  @param[in] SystemContext       Pointer to the CPU Context when the exception was triggered. Hook library
                                  is responsible for determining the correct cpu architecture type.
 **/
 NO_STACK_COOKIE

--- a/UefiCpuPkg/Include/Library/CpuExceptionHookLib.h
+++ b/UefiCpuPkg/Include/Library/CpuExceptionHookLib.h
@@ -11,6 +11,13 @@
 #include <Uefi.h>
 #include <Protocol/DebugSupport.h>
 
+/**
+  Get CpuCacheInfo data array. The array is sorted by CPU package ID, core type, cache level and cache type.
+
+  @param[in] ExceptionType       Cpu Exception Type which was triggered
+  @param[in] SystemContext       Pointer the the CPU Context when the exception was triggered. Hook library
+                                 is responsible for determining the correct cpu architecture type.
+**/
 NO_STACK_COOKIE
 VOID
 EFIAPI

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeCpuExceptionHandlerLib.inf
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/DxeCpuExceptionHandlerLib.inf
@@ -64,5 +64,6 @@
   DebugLib
   CcExitLib
   DxeMemoryProtectionHobLib ## MU_CHANGE
+  CpuExceptionHookLib  # MU_CHANGE
 [BuildOptions]
   XCODE:*_*_X64_NASM_FLAGS = -D NO_ABSOLUTE_RELOCS_IN_TEXT

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/PeiCpuExceptionHandlerLib.inf
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/PeiCpuExceptionHandlerLib.inf
@@ -53,6 +53,7 @@
   MemoryAllocationLib
   SynchronizationLib
   CcExitLib
+  CpuExceptionHookLib  # MU_CHANGE
 
 [Pcd]
   #gEfiMdeModulePkgTokenSpaceGuid.PcdCpuStackGuard    # CONSUMES  # MU_CHANGE

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/PeiDxeSmmCpuException.c
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/PeiDxeSmmCpuException.c
@@ -9,6 +9,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/DebugLib.h>
 #include <Library/CcExitLib.h>
 #include "CpuExceptionCommon.h"
+// MU_CHANGE [BEGIN]
+#include <Library/CpuExceptionHookLib.h>
+// MU_CHANGE [END]
 
 /**
   Internal worker function for common exception handler.
@@ -150,6 +153,11 @@ CommonExceptionHandlerWorker (
     // Display ExceptionType, CPU information and Image information
     //
     DumpImageAndCpuContent (ExceptionType, SystemContext);
+    // MU_CHANGE [BEING]
+    // Call out to hook lib to allow platform specific action when an
+    // exception occurs.
+    CpuExceptionHookLib (ExceptionType, SystemContext);
+    // MU_CHANGE [END]
     //
     // Release Spinlock of output message
     //

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/SecPeiCpuException.c
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/SecPeiCpuException.c
@@ -9,6 +9,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <PiPei.h>
 #include <Library/CcExitLib.h>
 #include "CpuExceptionCommon.h"
+// MU_CHANGE [BEGIN]
+#include <Library/CpuExceptionHookLib.h>
+// MU_CHANGE [END]
 
 CONST UINTN  mDoFarReturnFlag = 0;
 
@@ -76,7 +79,11 @@ CommonExceptionHandler (
   // Display ExceptionType, CPU information and Image information
   //
   DumpImageAndCpuContent (ExceptionType, SystemContext);
-
+  // MU_CHANGE [BEING]
+  // Call out to hook lib to allow platform specific action when an
+  // exception occurs.
+  CpuExceptionHookLib (ExceptionType, SystemContext);
+  // MU_CHANGE [END]
   //
   // Enter a dead loop.
   //

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/SecPeiCpuException.c
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/SecPeiCpuException.c
@@ -79,7 +79,7 @@ CommonExceptionHandler (
   // Display ExceptionType, CPU information and Image information
   //
   DumpImageAndCpuContent (ExceptionType, SystemContext);
-  // MU_CHANGE [BEING]
+  // MU_CHANGE [BEGIN]
   // Call out to hook lib to allow platform specific action when an
   // exception occurs.
   CpuExceptionHookLib (ExceptionType, SystemContext);

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/SecPeiCpuExceptionHandlerLib.inf
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/SecPeiCpuExceptionHandlerLib.inf
@@ -49,6 +49,7 @@
   LocalApicLib
   PeCoffGetEntryPointLib
   CcExitLib
+  CpuExceptionHookLib  # MU_CHANGE
 
 [Pcd]
   #gEfiMdeModulePkgTokenSpaceGuid.PcdCpuStackGuard  # MU_CHANGE

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/SecPeiCpuExceptionHandlerLibMu.inf
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/SecPeiCpuExceptionHandlerLibMu.inf
@@ -52,7 +52,7 @@
   CcExitLib
   ResetSystemLib
   ExceptionPersistenceLib
-
+  CpuExceptionHookLib  # MU_CHANGE
 [Pcd]
   gUefiCpuPkgTokenSpaceGuid.PcdCpuStackSwitchExceptionList
   gUefiCpuPkgTokenSpaceGuid.PcdCpuKnownGoodStackSize

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/SecPeiCpuExceptionHandlerLibMu.inf
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/SecPeiCpuExceptionHandlerLibMu.inf
@@ -53,6 +53,7 @@
   ResetSystemLib
   ExceptionPersistenceLib
   CpuExceptionHookLib  # MU_CHANGE
+
 [Pcd]
   gUefiCpuPkgTokenSpaceGuid.PcdCpuStackSwitchExceptionList
   gUefiCpuPkgTokenSpaceGuid.PcdCpuKnownGoodStackSize

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/SmmCpuExceptionHandlerLib.inf
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/SmmCpuExceptionHandlerLib.inf
@@ -52,6 +52,7 @@
   PeCoffGetEntryPointLib
   DebugLib
   CcExitLib
+  CpuExceptionHookLib  # MU_CHANGE
 
 [Pcd]
   #gEfiMdeModulePkgTokenSpaceGuid.PcdCpuStackGuard  # MU_CHANGE

--- a/UefiCpuPkg/Library/CpuExceptionHookLibNull/CpuExceptionHookLibNull.c
+++ b/UefiCpuPkg/Library/CpuExceptionHookLibNull/CpuExceptionHookLibNull.c
@@ -1,5 +1,5 @@
 /** @file
-  Library provides a hook called when a stack cookie check fails.
+  Library which provides a hook that is called when a cpu exception occurs
 
   Copyright (c) Microsoft Corporation. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent

--- a/UefiCpuPkg/Library/CpuExceptionHookLibNull/CpuExceptionHookLibNull.c
+++ b/UefiCpuPkg/Library/CpuExceptionHookLibNull/CpuExceptionHookLibNull.c
@@ -10,7 +10,12 @@
 #include <Library/CpuExceptionHookLib.h>
 
 /**
-*/
+  Get CpuCacheInfo data array. The array is sorted by CPU package ID, core type, cache level and cache type.
+
+  @param[in] ExceptionType       Cpu Exception Type which was triggered
+  @param[in] SystemContext       Pointer the the CPU Context when the exception was triggered. Hook library
+                                 is responsible for determining the correct cpu architecture type.
+**/
 NO_STACK_COOKIE
 VOID
 EFIAPI

--- a/UefiCpuPkg/Library/CpuExceptionHookLibNull/CpuExceptionHookLibNull.c
+++ b/UefiCpuPkg/Library/CpuExceptionHookLibNull/CpuExceptionHookLibNull.c
@@ -1,0 +1,23 @@
+/** @file
+  Library provides a hook called when a stack cookie check fails.
+
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Base.h>
+#include <Uefi.h>
+#include <Library/CpuExceptionHookLib.h>
+
+/**
+*/
+NO_STACK_COOKIE
+VOID
+EFIAPI
+CpuExceptionHookLib (
+  IN EFI_EXCEPTION_TYPE  ExceptionType,
+  IN EFI_SYSTEM_CONTEXT  SystemContext
+  )
+{
+  return;
+}

--- a/UefiCpuPkg/Library/CpuExceptionHookLibNull/CpuExceptionHookLibNull.inf
+++ b/UefiCpuPkg/Library/CpuExceptionHookLibNull/CpuExceptionHookLibNull.inf
@@ -1,0 +1,21 @@
+## @file
+#  Library provides a hook called when a stack cookie check fails.
+#
+#  Copyright (c) Microsoft Corporation. All rights reserved.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = CpuExceptionHookLibNull
+  FILE_GUID                      = 34979EC6-7182-4C62-924D-C0955C9B0EE6
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = CpuExceptionHookLib
+
+[Sources]
+  CpuExceptionHookLibNull.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UefiCpuPkg/UefiCpuPkg.dec

--- a/UefiCpuPkg/Library/CpuExceptionHookLibNull/CpuExceptionHookLibNull.inf
+++ b/UefiCpuPkg/Library/CpuExceptionHookLibNull/CpuExceptionHookLibNull.inf
@@ -1,5 +1,5 @@
 ## @file
-#  Library provides a hook called when a stack cookie check fails.
+#  Library which provides a hook that is called when a cpu exception occurs
 #
 #  Copyright (c) Microsoft Corporation. All rights reserved.
 #  SPDX-License-Identifier: BSD-2-Clause-Patent

--- a/UefiCpuPkg/UefiCpuPkg.dec
+++ b/UefiCpuPkg/UefiCpuPkg.dec
@@ -67,6 +67,11 @@
   ## @libraryclass   Provides functions for SMM CPU Sync Operation.
   SmmCpuSyncLib|Include/Library/SmmCpuSyncLib.h
 
+# MU_CHANGE [BEGIN]
+  ## @libraryclass   Library to inject functionality for when a CPU exception occurs
+  CpuExceptionHookLib|Include/Library/CpuExceptionHookLib.h
+# MU_CHANGE [END]
+
 [LibraryClasses.RISCV64]
   ##  @libraryclass  Provides functions to manage MMU features on RISCV64 CPUs.
   ##

--- a/UefiCpuPkg/UefiCpuPkg.dsc
+++ b/UefiCpuPkg/UefiCpuPkg.dsc
@@ -137,7 +137,7 @@
   MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
 
 # MU_CHANGE [BEGIN]
-[LIbraryClasses.common] 
+[LibraryClasses.common] 
   CpuExceptionHookLib|UefiCpuPkg/Library/CpuExceptionHookLibNull/CpuExceptionHookLibNull.inf
 # MU_CHANGE [END]
 #

--- a/UefiCpuPkg/UefiCpuPkg.dsc
+++ b/UefiCpuPkg/UefiCpuPkg.dsc
@@ -136,6 +136,10 @@
   UefiApplicationEntryPoint|MdePkg/Library/UefiApplicationEntryPoint/UefiApplicationEntryPoint.inf
   MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
 
+# MU_CHANGE [BEGIN]
+[LIbraryClasses.common] 
+  CpuExceptionHookLib|UefiCpuPkg/Library/CpuExceptionHookLibNull/CpuExceptionHookLibNull.inf
+# MU_CHANGE [END]
 #
 # Drivers/Libraries within this package
 #
@@ -151,6 +155,9 @@
   #UefiCpuPkg/CpuIoPei/CpuIoPei.inf                           # MU_CHANGE - Move to X64, IA32 section.
   UefiCpuPkg/Library/SecPeiDxeTimerLibUefiCpu/SecPeiDxeTimerLibUefiCpu.inf
   #UefiCpuPkg/Application/Cpuid/Cpuid.inf                     # MU_CHANGE - Move to X64, IA32 section.
+# MU_CHANGE [BEGIN]
+  UefiCpuPkg/Library/CpuExceptionHookLibNull/CpuExceptionHookLibNull.inf
+# MU_CHANGE [END]
 [Components.IA32, Components.X64]
 # MU_CHANGE END
   UefiCpuPkg/Library/CpuTimerLib/BaseCpuTimerLib.inf


### PR DESCRIPTION
## Description

When a CPU exception occurs, adding a call to a Hook library to allow platforms to inject actions (with access to exception data) through an external library. 

Actions are injected through the use of a custom CpuExceptionHookLib instance. 

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [x] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested
Added hook library instance to Q35 platform and verified system was still able to boot (and print exception information) when NULL instance is used. 

## Integration Instructions
Platforms will need to introduce a CpuExceptionHookLib instance to their platform's dsc file. The default NULL version will suffice for existing platforms. 

`CpuExceptionHookLib|UefiCpuPkg/Library/CpuExceptionHookLibNull/CpuExceptionHookLibNull.inf`