### PR TITLE
Generate Random Stack Cookie Values in Module Build Path

### DIFF
--- a/BaseTools/Source/Python/build/build.py
+++ b/BaseTools/Source/Python/build/build.py
@@ -1974,6 +1974,7 @@ class Build():
                         self.Progress,
                         self.ModuleFile
                         )
+                GenerateStackCookieValues() # MU_CHANGE [BEGIN]: Add build-time random stack cookie support
                 self.Fdf = Wa.FdfFile
                 self.LoadFixAddress = Wa.Platform.LoadFixAddress
                 Wa.CreateMakeFile(False)

--- a/BaseTools/Source/Python/build/build.py
+++ b/BaseTools/Source/Python/build/build.py
@@ -1870,7 +1870,7 @@ class Build():
                         self.UniFlag,
                         self.Progress
                         )
-                GenerateStackCookieValues() # MU_CHANGE [BEGIN]: Add build-time random stack cookie support
+                GenerateStackCookieValues() # MU_CHANGE: Add build-time random stack cookie support
                 self.Fdf = Wa.FdfFile
                 self.LoadFixAddress = Wa.Platform.LoadFixAddress
                 self.BuildReport.AddPlatformReport(Wa)
@@ -1974,7 +1974,7 @@ class Build():
                         self.Progress,
                         self.ModuleFile
                         )
-                GenerateStackCookieValues() # MU_CHANGE [BEGIN]: Add build-time random stack cookie support
+                GenerateStackCookieValues() # MU_CHANGE: Add build-time random stack cookie support
                 self.Fdf = Wa.FdfFile
                 self.LoadFixAddress = Wa.Platform.LoadFixAddress
                 Wa.CreateMakeFile(False)
@@ -2225,7 +2225,7 @@ class Build():
                 self.UniFlag,
                 self.Progress
                 )        
-        GenerateStackCookieValues() # MU_CHANGE [BEGIN]: Add build-time random stack cookie support
+        GenerateStackCookieValues() # MU_CHANGE: Add build-time random stack cookie support
         self.Fdf = Wa.FdfFile
         self.LoadFixAddress = Wa.Platform.LoadFixAddress
         self.BuildReport.AddPlatformReport(Wa)


### PR DESCRIPTION
## Description

If only a single module was being built instead of a platform DSC, the build scripts would not generate the random stack cookie values. On clean builds, this causes an error to be reported during the autogen process.

This PR updates build.py so the code path taken on module builds will generate the random stack cookie values.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested by specifying a build module on Q35.

## Integration Instructions

N/A