### PR TITLE
[REBASE & FF] Add GoogleTest Mocks and STATIC Testing Ability

### DIFF
--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.c
@@ -3364,7 +3364,7 @@ ReclaimForOS (
   UINTN       RemainingCommonRuntimeVariableSpace;
   // MS_CHANGE Starts: HwError record quota state should not trigger variable store reclaim
   // UINTN                          RemainingHwErrVariableSpace;
-  STATIC BOOLEAN  Reclaimed;
+  static BOOLEAN  Reclaimed; // MU_CHANGE: Use lowercase static for static lifetime
 
   //
   // This function will be called only once at EndOfDxe or ReadyToBoot event.

--- a/MdePkg/Include/Base.h
+++ b/MdePkg/Include/Base.h
@@ -283,8 +283,13 @@ struct _LIST_ENTRY {
 
 ///
 /// Datum is scoped to the current file or function.
+/// To support GoogleTest compiling static functions, do away with static in that case
 ///
+#ifndef GOOGLETEST_HOST_UNIT_TEST_BUILD
 #define STATIC  static
+#else
+#define STATIC
+#endif
 
 ///
 /// Undeclared type.

--- a/MdePkg/Test/MdePkgHostTest.dsc
+++ b/MdePkg/Test/MdePkgHostTest.dsc
@@ -52,4 +52,4 @@
   MdePkg/Test/Mock/Library/GoogleTest/MockIoLib/MockIoLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockSmmServicesTableLib/MockSmmServicesTableLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockMmServicesTableLib/MockMmServicesTableLib.inf
-
+  MdePkg/Test/Mock/Library/GoogleTest/MockUefiRuntimeLib/MockUefiRuntimeLib.inf

--- a/MdePkg/Test/MdePkgHostTest.dsc
+++ b/MdePkg/Test/MdePkgHostTest.dsc
@@ -53,3 +53,4 @@
   MdePkg/Test/Mock/Library/GoogleTest/MockSmmServicesTableLib/MockSmmServicesTableLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockMmServicesTableLib/MockMmServicesTableLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockUefiRuntimeLib/MockUefiRuntimeLib.inf
+  MdePkg/Test/Mock/Library/GoogleTest/MockMemoryAllocationLib/MockMemoryAllocationLib.inf

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockMemoryAllocationLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockMemoryAllocationLib.h
@@ -1,0 +1,166 @@
+/** @file
+  Google Test mocks for MemoryAllocationLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_MEMORY_ALLOCATION_LIB_H_
+#define MOCK_MEMORY_ALLOCATION_LIB_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+extern "C" {
+  #include <PiPei.h>
+  #include <PiDxe.h>
+  #include <PiSmm.h>
+  #include <PiMm.h>
+  #include <Uefi.h>
+  #include <Library/MemoryAllocationLib.h>
+}
+
+struct MockMemoryAllocationLib {
+  MOCK_INTERFACE_DECLARATION (MockMemoryAllocationLib);
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    AllocatePages,
+    (IN UINTN  Pages)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    AllocateRuntimePages,
+    (IN UINTN  Pages)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    AllocateReservedPages,
+    (IN UINTN  Pages)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    FreePages,
+    (IN VOID   *Buffer,
+     IN UINTN  Pages)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    AllocateAlignedPages,
+    (IN UINTN  Pages,
+     IN UINTN  Alignment)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    AllocateAlignedRuntimePages,
+    (IN UINTN  Pages,
+     IN UINTN  Alignment)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    AllocateAlignedReservedPages,
+    (IN UINTN  Pages,
+     IN UINTN  Alignment)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    FreeAlignedPages,
+    (IN VOID   *Buffer,
+     IN UINTN  Pages)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    AllocatePool,
+    (IN UINTN  AllocationSize)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    AllocateRuntimePool,
+    (IN UINTN  AllocationSize)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    AllocateReservedPool,
+    (IN UINTN  AllocationSize)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    AllocateZeroPool,
+    (IN UINTN  AllocationSize)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    AllocateRuntimeZeroPool,
+    (IN UINTN  AllocationSize)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    AllocateReservedZeroPool,
+    (IN UINTN  AllocationSize)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    AllocateCopyPool,
+    (IN       UINTN  AllocationSize,
+     IN CONST VOID   *Buffer)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    AllocateRuntimeCopyPool,
+    (IN       UINTN  AllocationSize,
+     IN CONST VOID   *Buffer)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    AllocateReservedCopyPool,
+    (IN       UINTN  AllocationSize,
+     IN CONST VOID   *Buffer)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    ReallocatePool,
+    (IN UINTN  OldSize,
+     IN UINTN  NewSize,
+     IN VOID   *OldBuffer OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    ReallocateRuntimePool,
+    (IN UINTN  OldSize,
+     IN UINTN  NewSize,
+     IN VOID   *OldBuffer OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    ReallocateReservedPool,
+    (IN UINTN  OldSize,
+     IN UINTN  NewSize,
+     IN VOID   *OldBuffer OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    FreePool,
+    (IN VOID  *Buffer)
+    );
+};
+
+#endif

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiBootServicesTableLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiBootServicesTableLib.h
@@ -49,6 +49,15 @@ struct MockUefiBootServicesTableLib {
 
   MOCK_FUNCTION_DECLARATION (
     EFI_STATUS,
+    gBS_InstallProtocolInterface,
+    (IN OUT EFI_HANDLE      *UserHandle,
+     IN EFI_GUID            *Protocol,
+     IN EFI_INTERFACE_TYPE  InterfaceType,
+     IN VOID                *Interface)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
     gBS_HandleProtocol,
     (IN  EFI_HANDLE Handle,
      IN  EFI_GUID   *Protocol,

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiRuntimeLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiRuntimeLib.h
@@ -1,0 +1,156 @@
+/** @file
+  Google Test mocks for UefiRuntimeLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_UEFI_RUNTIME_LIB_H_
+#define MOCK_UEFI_RUNTIME_LIB_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+extern "C" {
+  #include <PiPei.h>
+  #include <PiDxe.h>
+  #include <PiSmm.h>
+  #include <PiMm.h>
+  #include <Uefi.h>
+  #include <Library/UefiRuntimeLib.h>
+}
+
+struct MockUefiRuntimeLib {
+  MOCK_INTERFACE_DECLARATION (MockUefiRuntimeLib);
+
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    EfiAtRuntime,
+    ()
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    EfiGoneVirtual,
+    ()
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiGetTime,
+    (OUT EFI_TIME               *Time,
+     OUT EFI_TIME_CAPABILITIES  *Capabilities OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiSetTime,
+    (IN EFI_TIME  *Time)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiGetWakeupTime,
+    (OUT BOOLEAN   *Enabled,
+     OUT BOOLEAN   *Pending,
+     OUT EFI_TIME  *Time)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiSetWakeupTime,
+    (IN BOOLEAN   Enable,
+     IN EFI_TIME  *Time OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiGetVariable,
+    (IN     CHAR16    *VariableName,
+     IN     EFI_GUID  *VendorGuid,
+     OUT    UINT32    *Attributes OPTIONAL,
+     IN OUT UINTN     *DataSize,
+     OUT    VOID      *Data)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiGetNextVariableName,
+    (IN OUT UINTN     *VariableNameSize,
+     IN OUT CHAR16    *VariableName,
+     IN OUT EFI_GUID  *VendorGuid)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiSetVariable,
+    (IN CHAR16    *VariableName,
+     IN EFI_GUID  *VendorGuid,
+     IN UINT32    Attributes,
+     IN UINTN     DataSize,
+     IN VOID      *Data)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiGetNextHighMonotonicCount,
+    (OUT UINT32  *HighCount)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiConvertPointer,
+    (IN     UINTN  DebugDisposition,
+     IN OUT VOID   **Address)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiConvertFunctionPointer,
+    (IN     UINTN  DebugDisposition,
+     IN OUT VOID   **Address)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiSetVirtualAddressMap,
+    (IN       UINTN                  MemoryMapSize,
+     IN       UINTN                  DescriptorSize,
+     IN       UINT32                 DescriptorVersion,
+     IN CONST EFI_MEMORY_DESCRIPTOR  *VirtualMap)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiConvertList,
+    (IN     UINTN       DebugDisposition,
+     IN OUT LIST_ENTRY  *ListHead)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiUpdateCapsule,
+    (IN EFI_CAPSULE_HEADER    **CapsuleHeaderArray,
+     IN UINTN                 CapsuleCount,
+     IN EFI_PHYSICAL_ADDRESS  ScatterGatherList OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiQueryCapsuleCapabilities,
+    (IN  EFI_CAPSULE_HEADER  **CapsuleHeaderArray,
+     IN  UINTN               CapsuleCount,
+     OUT UINT64              *MaximumCapsuleSize,
+     OUT EFI_RESET_TYPE      *ResetType)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiQueryVariableInfo,
+    (IN  UINT32  Attributes,
+     OUT UINT64  *MaximumVariableStorageSize,
+     OUT UINT64  *RemainingVariableStorageSize,
+     OUT UINT64  *MaximumVariableSize)
+    );
+};
+
+#endif

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockMemoryAllocationLib/MockMemoryAllocationLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockMemoryAllocationLib/MockMemoryAllocationLib.cpp
@@ -1,0 +1,36 @@
+/** @file
+  Google Test mocks for MemoryAllocationLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <GoogleTest/Library/MockMemoryAllocationLib.h>
+
+//
+// Global Variables that are not const
+//
+
+MOCK_INTERFACE_DEFINITION (MockMemoryAllocationLib);
+
+MOCK_FUNCTION_DEFINITION (MockMemoryAllocationLib, AllocatePages, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMemoryAllocationLib, AllocateRuntimePages, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMemoryAllocationLib, AllocateReservedPages, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMemoryAllocationLib, FreePages, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMemoryAllocationLib, AllocateAlignedPages, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMemoryAllocationLib, AllocateAlignedRuntimePages, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMemoryAllocationLib, AllocateAlignedReservedPages, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMemoryAllocationLib, FreeAlignedPages, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMemoryAllocationLib, AllocatePool, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMemoryAllocationLib, AllocateRuntimePool, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMemoryAllocationLib, AllocateReservedPool, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMemoryAllocationLib, AllocateZeroPool, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMemoryAllocationLib, AllocateRuntimeZeroPool, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMemoryAllocationLib, AllocateReservedZeroPool, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMemoryAllocationLib, AllocateCopyPool, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMemoryAllocationLib, AllocateRuntimeCopyPool, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMemoryAllocationLib, AllocateReservedCopyPool, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMemoryAllocationLib, ReallocatePool, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMemoryAllocationLib, ReallocateRuntimePool, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMemoryAllocationLib, ReallocateReservedPool, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMemoryAllocationLib, FreePool, 1, EFIAPI);

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockMemoryAllocationLib/MockMemoryAllocationLib.inf
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockMemoryAllocationLib/MockMemoryAllocationLib.inf
@@ -1,0 +1,34 @@
+## @file
+# Google Test mocks for MemoryAllocationLib
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MockMemoryAllocationLib
+  FILE_GUID                      = 8161cd6f-a2ab-5d7e-afbe-6db7c1cf706c
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = MemoryAllocationLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  MockMemoryAllocationLib.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHs /bigobj

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockUefiBootServicesTableLib/MockUefiBootServicesTableLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockUefiBootServicesTableLib/MockUefiBootServicesTableLib.cpp
@@ -10,56 +10,94 @@ MOCK_INTERFACE_DEFINITION (MockUefiBootServicesTableLib);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_GetMemoryMap, 5, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_CreateEvent, 5, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_CloseEvent, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_InstallProtocolInterface, 4, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_HandleProtocol, 3, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_LocateProtocol, 3, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_CreateEventEx, 6, EFIAPI);
 
+extern "C" {
+  EFI_STATUS
+  EFIAPI
+  gBS_InstallMultipleProtocolInterfaces (
+    IN OUT EFI_HANDLE  *Handle,
+    ...
+    )
+  {
+    VA_LIST     Args;
+    EFI_STATUS  Status;
+    EFI_GUID    *Protocol;
+    VOID        *Interface;
+    UINTN       Index;
+
+    VA_START (Args, Handle);
+    for (Index = 0, Status = EFI_SUCCESS; !EFI_ERROR (Status); Index++) {
+      //
+      // If protocol is NULL, then it's the end of the list
+      //
+      Protocol = VA_ARG (Args, EFI_GUID *);
+      if (Protocol == NULL) {
+        break;
+      }
+
+      Interface = VA_ARG (Args, VOID *);
+
+      //
+      // Install it
+      //
+      Status = gBS_InstallProtocolInterface (Handle, Protocol, EFI_NATIVE_INTERFACE, Interface);
+    }
+
+    VA_END (Args);
+    return Status;
+  }
+}
+
 static EFI_BOOT_SERVICES  LocalBs = {
-  { 0, 0, 0, 0, 0 },    // EFI_TABLE_HEADER
-  NULL,                 // EFI_RAISE_TPL
-  NULL,                 // EFI_RESTORE_TPL
-  NULL,                 // EFI_ALLOCATE_PAGES
-  NULL,                 // EFI_FREE_PAGES
-  gBS_GetMemoryMap,     // EFI_GET_MEMORY_MAP
-  NULL,                 // EFI_ALLOCATE_POOL
-  NULL,                 // EFI_FREE_POOL
-  gBS_CreateEvent,      // EFI_CREATE_EVENT
-  NULL,                 // EFI_SET_TIMER
-  NULL,                 // EFI_WAIT_FOR_EVENT
-  NULL,                 // EFI_SIGNAL_EVENT
-  gBS_CloseEvent,       // EFI_CLOSE_EVENT
-  NULL,                 // EFI_CHECK_EVENT
-  NULL,                 // EFI_INSTALL_PROTOCOL_INTERFACE
-  NULL,                 // EFI_REINSTALL_PROTOCOL_INTERFACE
-  NULL,                 // EFI_UNINSTALL_PROTOCOL_INTERFACE
-  gBS_HandleProtocol,   // EFI_HANDLE_PROTOCOL
-  NULL,                 // VOID
-  NULL,                 // EFI_REGISTER_PROTOCOL_NOTIFY
-  NULL,                 // EFI_LOCATE_HANDLE
-  NULL,                 // EFI_LOCATE_DEVICE_PATH
-  NULL,                 // EFI_INSTALL_CONFIGURATION_TABLE
-  NULL,                 // EFI_IMAGE_LOAD
-  NULL,                 // EFI_IMAGE_START
-  NULL,                 // EFI_EXIT
-  NULL,                 // EFI_IMAGE_UNLOAD
-  NULL,                 // EFI_EXIT_BOOT_SERVICES
-  NULL,                 // EFI_GET_NEXT_MONOTONIC_COUNT
-  NULL,                 // EFI_STALL
-  NULL,                 // EFI_SET_WATCHDOG_TIMER
-  NULL,                 // EFI_CONNECT_CONTROLLER
-  NULL,                 // EFI_DISCONNECT_CONTROLLER
-  NULL,                 // EFI_OPEN_PROTOCOL
-  NULL,                 // EFI_CLOSE_PROTOCOL
-  NULL,                 // EFI_OPEN_PROTOCOL_INFORMATION
-  NULL,                 // EFI_PROTOCOLS_PER_HANDLE
-  NULL,                 // EFI_LOCATE_HANDLE_BUFFER
-  gBS_LocateProtocol,   // EFI_LOCATE_PROTOCOL
-  NULL,                 // EFI_INSTALL_MULTIPLE_PROTOCOL_INTERFACES
-  NULL,                 // EFI_UNINSTALL_MULTIPLE_PROTOCOL_INTERFACES
-  NULL,                 // EFI_CALCULATE_CRC32
-  NULL,                 // EFI_COPY_MEM
-  NULL,                 // EFI_SET_MEM
-  gBS_CreateEventEx     // EFI_CREATE_EVENT_EX
+  { 0, 0, 0, 0, 0 },                     // EFI_TABLE_HEADER
+  NULL,                                  // EFI_RAISE_TPL
+  NULL,                                  // EFI_RESTORE_TPL
+  NULL,                                  // EFI_ALLOCATE_PAGES
+  NULL,                                  // EFI_FREE_PAGES
+  gBS_GetMemoryMap,                      // EFI_GET_MEMORY_MAP
+  NULL,                                  // EFI_ALLOCATE_POOL
+  NULL,                                  // EFI_FREE_POOL
+  gBS_CreateEvent,                       // EFI_CREATE_EVENT
+  NULL,                                  // EFI_SET_TIMER
+  NULL,                                  // EFI_WAIT_FOR_EVENT
+  NULL,                                  // EFI_SIGNAL_EVENT
+  gBS_CloseEvent,                        // EFI_CLOSE_EVENT
+  NULL,                                  // EFI_CHECK_EVENT
+  gBS_InstallProtocolInterface,          // EFI_INSTALL_PROTOCOL_INTERFACE
+  NULL,                                  // EFI_REINSTALL_PROTOCOL_INTERFACE
+  NULL,                                  // EFI_UNINSTALL_PROTOCOL_INTERFACE
+  gBS_HandleProtocol,                    // EFI_HANDLE_PROTOCOL
+  NULL,                                  // VOID
+  NULL,                                  // EFI_REGISTER_PROTOCOL_NOTIFY
+  NULL,                                  // EFI_LOCATE_HANDLE
+  NULL,                                  // EFI_LOCATE_DEVICE_PATH
+  NULL,                                  // EFI_INSTALL_CONFIGURATION_TABLE
+  NULL,                                  // EFI_IMAGE_LOAD
+  NULL,                                  // EFI_IMAGE_START
+  NULL,                                  // EFI_EXIT
+  NULL,                                  // EFI_IMAGE_UNLOAD
+  NULL,                                  // EFI_EXIT_BOOT_SERVICES
+  NULL,                                  // EFI_GET_NEXT_MONOTONIC_COUNT
+  NULL,                                  // EFI_STALL
+  NULL,                                  // EFI_SET_WATCHDOG_TIMER
+  NULL,                                  // EFI_CONNECT_CONTROLLER
+  NULL,                                  // EFI_DISCONNECT_CONTROLLER
+  NULL,                                  // EFI_OPEN_PROTOCOL
+  NULL,                                  // EFI_CLOSE_PROTOCOL
+  NULL,                                  // EFI_OPEN_PROTOCOL_INFORMATION
+  NULL,                                  // EFI_PROTOCOLS_PER_HANDLE
+  NULL,                                  // EFI_LOCATE_HANDLE_BUFFER
+  gBS_LocateProtocol,                    // EFI_LOCATE_PROTOCOL
+  gBS_InstallMultipleProtocolInterfaces, // EFI_INSTALL_MULTIPLE_PROTOCOL_INTERFACES
+  NULL,                                  // EFI_UNINSTALL_MULTIPLE_PROTOCOL_INTERFACES
+  NULL,                                  // EFI_CALCULATE_CRC32
+  NULL,                                  // EFI_COPY_MEM
+  NULL,                                  // EFI_SET_MEM
+  gBS_CreateEventEx                      // EFI_CREATE_EVENT_EX
 };
 
 extern "C" {

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockUefiRuntimeLib/MockUefiRuntimeLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockUefiRuntimeLib/MockUefiRuntimeLib.cpp
@@ -1,0 +1,32 @@
+/** @file
+  Google Test mocks for UefiRuntimeLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <GoogleTest/Library/MockUefiRuntimeLib.h>
+
+//
+// Global Variables that are not const
+//
+
+MOCK_INTERFACE_DEFINITION (MockUefiRuntimeLib);
+
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeLib, EfiAtRuntime, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeLib, EfiGoneVirtual, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeLib, EfiGetTime, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeLib, EfiSetTime, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeLib, EfiGetWakeupTime, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeLib, EfiSetWakeupTime, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeLib, EfiGetVariable, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeLib, EfiGetNextVariableName, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeLib, EfiSetVariable, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeLib, EfiGetNextHighMonotonicCount, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeLib, EfiConvertPointer, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeLib, EfiConvertFunctionPointer, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeLib, EfiSetVirtualAddressMap, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeLib, EfiConvertList, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeLib, EfiUpdateCapsule, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeLib, EfiQueryCapsuleCapabilities, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeLib, EfiQueryVariableInfo, 4, EFIAPI);

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockUefiRuntimeLib/MockUefiRuntimeLib.inf
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockUefiRuntimeLib/MockUefiRuntimeLib.inf
@@ -1,0 +1,34 @@
+## @file
+# Google Test mocks for UefiRuntimeLib
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MockUefiRuntimeLib
+  FILE_GUID                      = c24d945e-e203-5e04-b7f2-0c9dd0cbc862
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = UefiRuntimeLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  MockUefiRuntimeLib.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHs /bigobj

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
@@ -43,7 +43,7 @@
   #
   # MSFT
   #
-  MSFT:*_*_*_CC_FLAGS               = /EHs
+  MSFT:*_*_*_CC_FLAGS               = /EHs -D GOOGLETEST_HOST_UNIT_TEST_BUILD=1
   MSFT:*_*_*_DLINK_FLAGS            == /out:"$(BIN_DIR)\$(MODULE_NAME_GUID).exe" /pdb:"$(BIN_DIR)\$(MODULE_NAME_GUID).pdb" /IGNORE:4001 /NOLOGO /SUBSYSTEM:CONSOLE /DEBUG /STACK:0x40000,0x40000 /NODEFAULTLIB:libcmt.lib libcmtd.lib
   MSFT:*_*_IA32_DLINK_FLAGS         = /MACHINE:I386
   MSFT:*_*_X64_DLINK_FLAGS          = /MACHINE:AMD64
@@ -61,6 +61,7 @@
   #
   # GCC
   #
+  GCC:*_*_*_CC_FLAGS       = -D GOOGLETEST_HOST_UNIT_TEST_BUILD=1
   GCC:*_*_IA32_DLINK_FLAGS == -o $(BIN_DIR)/$(MODULE_NAME_GUID) -m32 -no-pie
   GCC:*_*_X64_DLINK_FLAGS  == -o $(BIN_DIR)/$(MODULE_NAME_GUID) -m64 -no-pie
   GCC:*_*_*_DLINK2_FLAGS   == -lgcov -lpthread -lstdc++ -lm
@@ -68,6 +69,7 @@
   #
   # Need to do this link via gcc and not ld as the pathing to libraries changes from OS version to OS version
   #
+  XCODE:*_*_*_CC_FLAGS      = -D GOOGLETEST_HOST_UNIT_TEST_BUILD=1
   XCODE:*_*_IA32_DLINK_PATH == gcc
   XCODE:*_*_IA32_CC_FLAGS = -I$(WORKSPACE)/EmulatorPkg/Unix/Host/X11IncludeHack
   XCODE:*_*_IA32_DLINK_FLAGS == -arch i386 -o $(BIN_DIR)/$(MODULE_NAME_GUID) -L/usr/X11R6/lib -lXext -lX11 -framework Carbon


### PR DESCRIPTION
## Description

This PR adds GoogleTest mocks needed for some AdvancedLogger GoogleTests. It also adds the capability to test STATIC functions by undefining the STATIC keyword if a HOST_APPLICATION is being built. The statement is that a HOST_APPLICATION is running with the minimal set of dependencies and should not run into symbol collision.

These will be sent to edk2, but feedback is wanted first, as well as getting the dependent Advanced Logger PR in. If this patch is approved, UnitTestFrameworkPkg's README will also be updated in edk2. This is not done here as that would create a lot of conflicts.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [x] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested with the Advanced Logger GoogleTests

## Integration Instructions
 
Follow the UnitTestFrameworkPkg README.md for instructions on using GoogleTest mocks. To test STATIC functions, compile the relevant C files with your GoogleTest C++ files and you will be able to access the formerly STATIC functions in your test.

Interface tests (that load a library instead of compiling the C files) will still not be able to access STATIC functions. This is intentional as interface tests should be testing a library interface (the class itself) not an instance.
