### PR TITLE
[REBASE && FF] Consolidate MU_CHANGEs and Fix RP on Free Mem Bug

### DIFF
--- a/MdeModulePkg/Core/Dxe/DxeMain.h
+++ b/MdeModulePkg/Core/Dxe/DxeMain.h
@@ -2733,7 +2733,8 @@ CoreInitializeMemoryAttributesTable (
 **/
 VOID
 EFIAPI
-CoreInitializeMemoryProtection (
+// MU_CHANGE: Use Project Mu CoreInitializeMemoryProtection()
+CoreInitializeMemoryProtectionMu (
   VOID
   );
 

--- a/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
+++ b/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
@@ -484,7 +484,7 @@ DxeMain (
   MemoryProfileInstallProtocol ();
 
   CoreInitializeMemoryAttributesTable ();
-  CoreInitializeMemoryProtection ();
+  CoreInitializeMemoryProtectionMu (); // MU_CHANGE: Use Project Mu CoreInitializeMemoryProtection()
 
   //
   // Get persisted vector hand-off info from GUIDeed HOB again due to HobStart may be updated,

--- a/MdeModulePkg/Core/Dxe/Mem/HeapGuard.c
+++ b/MdeModulePkg/Core/Dxe/Mem/HeapGuard.c
@@ -16,7 +16,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 GLOBAL_REMOVE_IF_UNREFERENCED BOOLEAN  mOnGuarding = FALSE;
 
-extern BOOLEAN  mPageAttributesInitialized; // MU_CHANGE
+extern BOOLEAN  mGcdSyncComplete; // MU_CHANGE
 
 //
 // Pointer to table tracking the Guarded memory with bitmap, in which  '1'

--- a/MdeModulePkg/Core/Dxe/Mem/HeapGuard.c
+++ b/MdeModulePkg/Core/Dxe/Mem/HeapGuard.c
@@ -537,7 +537,11 @@ SetGuardPage (
 {
   EFI_STATUS  Status;
 
-  if (gCpu == NULL) {
+  // MU_CHANGE: Because the memory protection initialization routine
+  //            is no longer triggered by the CPU arch protocol, check
+  //            if the initialization routine has run before allowing
+  //            this function to execute.
+  if ((gCpu == NULL) || !mGcdSyncComplete) {
     return;
   }
 
@@ -573,7 +577,11 @@ UnsetGuardPage (
   UINT64      Attributes;
   EFI_STATUS  Status;
 
-  if (gCpu == NULL) {
+  // MU_CHANGE: Because the memory protection initialization routine
+  //            is no longer triggered by the CPU arch protocol, check
+  //            if the initialization routine has run before allowing
+  //            this function to execute.
+  if ((gCpu == NULL) || !mGcdSyncComplete) {
     return;
   }
 

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
@@ -70,7 +70,7 @@ UINT32  mImageProtectionPolicy;
 extern LIST_ENTRY  mGcdMemorySpaceMap;
 
 EFI_MEMORY_ATTRIBUTE_PROTOCOL  *mMemoryAttribute = NULL;          // MU_CHANGE
-extern BOOLEAN                 mPageAttributesInitialized;        // MU_CHANGE
+extern BOOLEAN                 mGcdSyncComplete;                  // MU_CHANGE
 
 STATIC LIST_ENTRY  mProtectedImageRecordList = INITIALIZE_LIST_HEAD_VARIABLE (mProtectedImageRecordList); // MU_CHANGE: Initialize at compile time
 
@@ -527,7 +527,7 @@ GetPermissionAttributeForMemoryType (
     Attributes |= EFI_MEMORY_XP;
   }
 
-  if ((MemoryType == EfiConventionalMemory) && gDxeMps.FreeMemoryReadProtected && mPageAttributesInitialized) {
+  if ((MemoryType == EfiConventionalMemory) && gDxeMps.FreeMemoryReadProtected) {
     Attributes |= EFI_MEMORY_RP;
   }
 
@@ -1173,7 +1173,7 @@ ApplyMemoryProtectionPolicy (
   // MU_CHANGE: Because GCD sync and memory protection initialization
   //            ordering is reversed, check if the initialization routine
   //            has run before allowing this function to execute.
-  if ((gCpu == NULL) || !mPageAttributesInitialized) {
+  if ((gCpu == NULL) || !mGcdSyncComplete) {
     return EFI_SUCCESS;
   }
 

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.h
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.h
@@ -130,21 +130,6 @@ MemoryProtectionCpuArchProtocolNotifyMu (
   );
 
 /**
-  A notification for the Memory Attribute Protocol.
-
-  @param[in]  Event                 Event whose notification function is being invoked.
-  @param[in]  Context               Pointer to the notification function's context,
-                                    which is implementation-dependent.
-
-**/
-VOID
-EFIAPI
-MemoryAttributeProtocolNotify (
-  IN EFI_EVENT  Event,
-  IN VOID       *Context
-  );
-
-/**
   Sets the NX compatibility global to FALSE so future checks to
   IsEnhancedMemoryProtectionActive() will return FALSE.
 **/
@@ -181,19 +166,6 @@ EFIAPI
 GetImageList (
   IN IMAGE_RANGE_DESCRIPTOR         **ImageList,
   IN IMAGE_RANGE_PROTECTION_STATUS  ProtectedOrNonProtected
-  );
-
-/**
-  Registers a callback on gEdkiiGcdSyncCompleteProtocolGuid to initialize
-  page attributes in accordance with to the memory protection policy.
-
-  @retval EFI_SUCCESS Event successfully registered
-  @retval other       Event was not registered
-**/
-EFI_STATUS
-EFIAPI
-RegisterPageAccessAttributesUpdateOnGcdSyncComplete (
-  VOID
   );
 
 #endif


### PR DESCRIPTION
Commit breakdown:
1. Many changes have been made to CoreInitializeMemoryProtection() to improve the security state. It's gotten to the point that the code has been essentially rewritten so to improve readability and maintainability, consolidate the changes to MemoryProtectionSupport.c (a Project Mu file). Creating a CoreInitializeMemoryProtectionMu() function also allows us to move other MU_CHANGEs to MemoryProtectionSupport.c .
2. mPageAttributesInitialized was used to signal that the memory protection initialization routine was complete so EFI_MEMORY_RP can be safely set on free memory. However, the blocker to setting EFI_MEMORY_RP on free memory is not the initialization of the page attributes, but the completion of the GCD sync. This change renames mPageAttributesInitialized to mGcdSyncComplete to better reflect the intent of the variable. Additionally, it makes more sense to not change what GetPermissionAttributeForMemoryType() returns based on the value of mGcdSyncComplete. Instead, it should always return the permission attributes which should be applied to the memory type but ApplyMemoryProtectionPolicy() should bail if the GCD sync has not been completed. 
3. There's a window between when the CPU Arch Protocol is published and the GCD sync is complete where guard pages could be set on allocated memory and unset on freed memory. These operations should not be done until the GCD sync is complete or some free memory may have EFI_MEMORY_RP applied before the memory protection logic expects.


**This PR was tested by running the DxePagingAuditTestApp on Q35 and SBSA platforms. Additionally tested by booting to Windows on Q35.**