### PR TITLE
Make DEBUG_ERROR Messages on Memory Protection Hob Mismatch More Explicit

### DIFF
--- a/MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.c
+++ b/MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.c
@@ -273,10 +273,15 @@ DxeMemoryProtectionHobLibConstructor (
   if (Ptr != NULL) {
     if (*((UINT8 *)GET_GUID_HOB_DATA (Ptr)) != (UINT8)DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION) {
       DEBUG ((
-        DEBUG_INFO,
-        "%a: - Version number of the Memory Protection Settings HOB is invalid.\n",
-        __FUNCTION__
+        DEBUG_ERROR,
+        "\nThe version number of the Memory Protection Settings HOB is invalid! Expected: %d, Actual: %d\n",
+        DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION,
+        *((UINT8 *)GET_GUID_HOB_DATA (Ptr))
         ));
+      DEBUG ((DEBUG_ERROR, "This usually happens when the Memory Protection Settings version was incremented\n"));
+      DEBUG ((DEBUG_ERROR, "but all modules have not been rebuilt with the new version number. Less likely but\n"));
+      DEBUG ((DEBUG_ERROR, "also possible is the HOB entry was corrupted or the producer of the HOB entry\n"));
+      DEBUG ((DEBUG_ERROR, "did not set the StructVersion field to DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION.\n"));
       ASSERT (FALSE);
       ZeroMem (&gDxeMps, sizeof (gDxeMps));
       return EFI_SUCCESS;

--- a/MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.c
+++ b/MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.c
@@ -279,7 +279,7 @@ DxeMemoryProtectionHobLibConstructor (
         *((UINT8 *)GET_GUID_HOB_DATA (Ptr))
         ));
       DEBUG ((DEBUG_ERROR, "This usually happens when the Memory Protection Settings version was incremented\n"));
-      DEBUG ((DEBUG_ERROR, "but all modules have not been rebuilt with the new version number. Less likely but\n"));
+      DEBUG ((DEBUG_ERROR, "and all modules have not been rebuilt with the new version number. Less likely but\n"));
       DEBUG ((DEBUG_ERROR, "also possible is the HOB entry was corrupted or the producer of the HOB entry\n"));
       DEBUG ((DEBUG_ERROR, "did not set the StructVersion field to DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION.\n"));
       ASSERT (FALSE);

--- a/MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.c
+++ b/MdeModulePkg/Library/MemoryProtectionHobLib/DxeMemoryProtectionHobLib.c
@@ -274,7 +274,7 @@ DxeMemoryProtectionHobLibConstructor (
     if (*((UINT8 *)GET_GUID_HOB_DATA (Ptr)) != (UINT8)DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION) {
       DEBUG ((
         DEBUG_ERROR,
-        "\nThe version number of the Memory Protection Settings HOB is invalid! Expected: %d, Actual: %d\n",
+        "\nThe version number of the DXE Memory Protection Settings HOB is invalid! Expected: %d, Actual: %d\n",
         DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION,
         *((UINT8 *)GET_GUID_HOB_DATA (Ptr))
         ));

--- a/MdeModulePkg/Library/MemoryProtectionHobLib/MmCommonMemoryProtectionHobLib.c
+++ b/MdeModulePkg/Library/MemoryProtectionHobLib/MmCommonMemoryProtectionHobLib.c
@@ -125,7 +125,7 @@ MmMemoryProtectionHobLibConstructorCommon (
     if (*((UINT8 *)GET_GUID_HOB_DATA (Ptr)) != (UINT8)MM_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION) {
       DEBUG ((
         DEBUG_ERROR,
-        "\nThe version number of the Memory Protection Settings HOB is invalid! Expected: %d, Actual: %d\n",
+        "\nThe version number of the MM Memory Protection Settings HOB is invalid! Expected: %d, Actual: %d\n",
         MM_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION,
         *((UINT8 *)GET_GUID_HOB_DATA (Ptr))
         ));

--- a/MdeModulePkg/Library/MemoryProtectionHobLib/MmCommonMemoryProtectionHobLib.c
+++ b/MdeModulePkg/Library/MemoryProtectionHobLib/MmCommonMemoryProtectionHobLib.c
@@ -124,10 +124,15 @@ MmMemoryProtectionHobLibConstructorCommon (
   if (Ptr != NULL) {
     if (*((UINT8 *)GET_GUID_HOB_DATA (Ptr)) != (UINT8)MM_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION) {
       DEBUG ((
-        DEBUG_INFO,
-        "%a: - Version number of the Memory Protection Settings HOB is invalid.\n",
-        __FUNCTION__
+        DEBUG_ERROR,
+        "\nThe version number of the Memory Protection Settings HOB is invalid! Expected: %d, Actual: %d\n",
+        MM_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION,
+        *((UINT8 *)GET_GUID_HOB_DATA (Ptr))
         ));
+      DEBUG ((DEBUG_ERROR, "This usually happens when the Memory Protection Settings version was incremented\n"));
+      DEBUG ((DEBUG_ERROR, "but all modules have not been rebuilt with the new version number. Less likely but\n"));
+      DEBUG ((DEBUG_ERROR, "also possible is the HOB entry was corrupted or the producer of the HOB entry\n"));
+      DEBUG ((DEBUG_ERROR, "did not set the StructVersion field to MM_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION.\n"));
       ASSERT (FALSE);
       ZeroMem (&gMmMps, sizeof (gMmMps));
       return EFI_SUCCESS;

--- a/MdeModulePkg/Library/MemoryProtectionHobLib/MmCommonMemoryProtectionHobLib.c
+++ b/MdeModulePkg/Library/MemoryProtectionHobLib/MmCommonMemoryProtectionHobLib.c
@@ -130,7 +130,7 @@ MmMemoryProtectionHobLibConstructorCommon (
         *((UINT8 *)GET_GUID_HOB_DATA (Ptr))
         ));
       DEBUG ((DEBUG_ERROR, "This usually happens when the Memory Protection Settings version was incremented\n"));
-      DEBUG ((DEBUG_ERROR, "but all modules have not been rebuilt with the new version number. Less likely but\n"));
+      DEBUG ((DEBUG_ERROR, "and all modules have not been rebuilt with the new version number. Less likely but\n"));
       DEBUG ((DEBUG_ERROR, "also possible is the HOB entry was corrupted or the producer of the HOB entry\n"));
       DEBUG ((DEBUG_ERROR, "did not set the StructVersion field to MM_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION.\n"));
       ASSERT (FALSE);


### PR DESCRIPTION
## Description

To reduce the deluge of questions whenever the memory protection settings version is rolled, this PR adds extra prints when it detects a version mismatch to make it more clear what the cause of the ASSERT was.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested by setting the version incorrectly

## Integration Instructions

N/A