### PR TITLE
CryptoPkg: Add Shared Crypto FDF include file

### DIFF
--- a/CryptoPkg/SharedCrypto.BuildRules.fdf.inc
+++ b/CryptoPkg/SharedCrypto.BuildRules.fdf.inc
@@ -1,0 +1,74 @@
+## @file
+# Shared Crypto FDF include file.
+#
+# These rules are used to define how an FFS file is constructed.
+#
+# The Mu Shared Crypto project (https://github.com/microsoft/mu_crypto_release) provides binary images in the form
+# of .efi binaries. These are used for the PE32 section in FFS files. This FDF include file can be included in a FDF
+# file to define how FFS files should be created for Shared Crypto.
+#
+# This file can be included using `!include CryptoPkg/SharedCrypto.BuildRules.fdf.inc` in the platform FDF file
+# after the last `FV` section and before the other build rules defined in the platform FDF file begin.
+#
+# **IMPORTANT** - You should review these rules and ensure they meet your platform's requirements. You should also
+# ensure they do not conflict with any other bulid rules that may already be defined in the platform FDF file. This
+# file is not required to use Shared Crypto. It is provided for convenience and reference.
+#
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+
+[Rule.Common.PEIM.BINARY]
+  FILE PEIM = $(NAMED_GUID) {
+    PEI_DEPEX PEI_DEPEX Optional      |.depex
+    PE32      PE32     Align = Auto   |.efi
+    UI        STRING="$(MODULE_NAME)" Optional
+    VERSION   STRING="$(INF_VERSION)" Optional BUILD_NUM=$(BUILD_NUMBER)
+  }
+
+[Rule.Common.DXE_DRIVER.BINARY]
+  FILE DRIVER = $(NAMED_GUID) {
+    DXE_DEPEX DXE_DEPEX Optional      |.depex
+    PE32      PE32                    |.efi
+    UI        STRING="$(MODULE_NAME)" Optional
+    VERSION   STRING="$(INF_VERSION)" Optional BUILD_NUM=$(BUILD_NUMBER)
+  }
+
+[Rule.Common.DXE_RUNTIME_DRIVER.BINARY]
+  FILE DRIVER = $(NAMED_GUID) {
+    DXE_DEPEX DXE_DEPEX Optional      |.depex
+    PE32      PE32                    |.efi
+    UI        STRING="$(MODULE_NAME)" Optional
+    VERSION   STRING="$(INF_VERSION)" Optional BUILD_NUM=$(BUILD_NUMBER)
+  }
+
+[Rule.Common.UEFI_DRIVER.BINARY]
+  FILE DRIVER = $(NAMED_GUID) {
+    DXE_DEPEX DXE_DEPEX Optional      |.depex
+    PE32      PE32                    |.efi
+    UI        STRING="$(MODULE_NAME)" Optional
+    VERSION   STRING="$(INF_VERSION)" Optional BUILD_NUM=$(BUILD_NUMBER)
+  }
+
+[Rule.Common.MM_STANDALONE.BINARY]
+  FILE MM_STANDALONE = $(NAMED_GUID) {
+    SMM_DEPEX SMM_DEPEX Optional      |.depex
+    PE32      PE32                    |.efi
+    UI        STRING="$(MODULE_NAME)" Optional
+    VERSION   STRING="$(INF_VERSION)" Optional BUILD_NUM=$(BUILD_NUMBER)
+  }
+
+[Rule.Common.UEFI_APPLICATION.BINARY]
+  FILE APPLICATION = $(NAMED_GUID) {
+    PE32      PE32                    |.efi
+    UI        STRING="$(MODULE_NAME)" Optional
+    VERSION   STRING="$(INF_VERSION)" Optional BUILD_NUM=$(BUILD_NUMBER)
+  }
+
+[Rule.Common.DXE_SMM_DRIVER.BINARY]
+  FILE SMM = $(NAMED_GUID) {
+    SMM_DEPEX SMM_DEPEX Optional      |.depex
+    PE32      PE32                    |.efi
+    UI        STRING="$(MODULE_NAME)" Optional
+    VERSION   STRING="$(INF_VERSION)" Optional BUILD_NUM=$(BUILD_NUMBER)
+  }


### PR DESCRIPTION
## Description

Adds a file that can be included by platforms to satisfy the build
rules needed to construct FFS files from the .efi files provided by
shared crypto.

It is also provided as a reference for the rules needed to use the
files in a platform.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `QemuQ35Pkg` and `QemuSbsaPkg` build with the build rules directly in their
  FDF file removed and this file included.

## Integration Instructions

Users of Mu Shared Crypto may find this file useful to directly include in a
FDF file or as a reference for the build rules needed to use Shared Crypto.

This file can be included using `!include CryptoPkg/SharedCrypto.BuildRules.fdf.inc`
in the platform FDF file after the last `FV` section and before the other build rules
defined in the platform FDF file begin.

**IMPORTANT** - You should review these rules and ensure they meet your platform's
requirements. You should also ensure they do not conflict with any other bulid rules
that may already be defined in the platform FDF file. This file is not required to
use Shared Crypto. It is provided for convenience and reference.