### PR TITLE
[CHERRY-PICK] MdePkg/IndustryStandard: Add _PSD/_CPC/Coord types definitions

### DIFF
--- a/MdePkg/Include/IndustryStandard/Acpi30.h
+++ b/MdePkg/Include/IndustryStandard/Acpi30.h
@@ -17,6 +17,20 @@
 
 #define ACPI_EXTENDED_ADDRESS_SPACE_DESCRIPTOR  0x8B
 
+///
+/// C-state Coordination Types
+/// See s8.4.2.2 _CSD (C-State Dependency)
+///
+#define ACPI_AML_COORD_TYPE_SW_ALL  0xFC
+#define ACPI_AML_COORD_TYPE_SW_ANY  0xFD
+#define ACPI_AML_COORD_TYPE_HW_ALL  0xFE
+
+///
+/// _PSD Revision for ACPI 3.0
+// See s8.4.4.5 _PSD (P-State Dependency)
+///
+#define EFI_ACPI_3_0_AML_PSD_REVISION  0
+
 //
 // Ensure proper structure formats
 //

--- a/MdePkg/Include/IndustryStandard/Acpi40.h
+++ b/MdePkg/Include/IndustryStandard/Acpi40.h
@@ -10,6 +10,11 @@
 
 #include <IndustryStandard/Acpi30.h>
 
+///
+/// _PSD Revision for ACPI 4.0
+///
+#define EFI_ACPI_4_0_AML_PSD_REVISION  0
+
 //
 // Ensure proper structure formats
 //

--- a/MdePkg/Include/IndustryStandard/Acpi50.h
+++ b/MdePkg/Include/IndustryStandard/Acpi50.h
@@ -23,6 +23,16 @@
 #define ACPI_GPIO_CONNECTION_DESCRIPTOR                0x8C
 #define ACPI_GENERIC_SERIAL_BUS_CONNECTION_DESCRIPTOR  0x8E
 
+///
+/// _PSD Revision for ACPI 5.0
+///
+#define EFI_ACPI_5_0_AML_PSD_REVISION  0
+
+///
+/// _CPC Revision for ACPI 5.0
+///
+#define EFI_ACPI_5_0_AML_CPC_REVISION  1
+
 #pragma pack(1)
 
 ///

--- a/MdePkg/Include/IndustryStandard/Acpi51.h
+++ b/MdePkg/Include/IndustryStandard/Acpi51.h
@@ -13,6 +13,16 @@
 
 #include <IndustryStandard/Acpi50.h>
 
+///
+/// _PSD Revision for ACPI 5.1
+///
+#define EFI_ACPI_5_1_AML_PSD_REVISION  0
+
+///
+/// _CPC Revision for ACPI 5.1
+///
+#define EFI_ACPI_5_1_AML_CPC_REVISION  2
+
 //
 // Ensure proper structure formats
 //

--- a/MdePkg/Include/IndustryStandard/Acpi60.h
+++ b/MdePkg/Include/IndustryStandard/Acpi60.h
@@ -12,6 +12,16 @@
 
 #include <IndustryStandard/Acpi51.h>
 
+///
+/// _PSD Revision for ACPI 6.0
+///
+#define EFI_ACPI_6_0_AML_PSD_REVISION  0
+
+///
+/// _CPC Revision for ACPI 6.0
+///
+#define EFI_ACPI_6_0_AML_CPC_REVISION  2
+
 //
 // Ensure proper structure formats
 //

--- a/MdePkg/Include/IndustryStandard/Acpi61.h
+++ b/MdePkg/Include/IndustryStandard/Acpi61.h
@@ -12,6 +12,16 @@
 
 #include <IndustryStandard/Acpi60.h>
 
+///
+/// _PSD Revision for ACPI 6.1
+///
+#define EFI_ACPI_6_1_AML_PSD_REVISION  0
+
+///
+/// _CPC Revision for ACPI 6.1
+///
+#define EFI_ACPI_6_1_AML_CPC_REVISION  2
+
 //
 // Ensure proper structure formats
 //

--- a/MdePkg/Include/IndustryStandard/Acpi62.h
+++ b/MdePkg/Include/IndustryStandard/Acpi62.h
@@ -29,6 +29,16 @@
 #define ACPI_PIN_GROUP_FUNCTION_DESCRIPTOR       0x91
 #define ACPI_PIN_GROUP_CONFIGURATION_DESCRIPTOR  0x92
 
+///
+/// _PSD Revision for ACPI 6.2
+///
+#define EFI_ACPI_6_2_AML_PSD_REVISION  0
+
+///
+/// _CPC Revision for ACPI 6.2
+///
+#define EFI_ACPI_6_2_AML_CPC_REVISION  3
+
 #pragma pack(1)
 
 ///

--- a/MdePkg/Include/IndustryStandard/Acpi63.h
+++ b/MdePkg/Include/IndustryStandard/Acpi63.h
@@ -12,6 +12,16 @@
 
 #include <IndustryStandard/Acpi62.h>
 
+///
+/// _PSD Revision for ACPI 6.3
+///
+#define EFI_ACPI_6_3_AML_PSD_REVISION  0
+
+///
+/// _CPC Revision for ACPI 6.3
+///
+#define EFI_ACPI_6_3_AML_CPC_REVISION  3
+
 //
 // Ensure proper structure formats
 //

--- a/MdePkg/Include/IndustryStandard/Acpi64.h
+++ b/MdePkg/Include/IndustryStandard/Acpi64.h
@@ -12,6 +12,16 @@
 
 #include <IndustryStandard/Acpi63.h>
 
+///
+/// _PSD Revision for ACPI 6.4
+///
+#define EFI_ACPI_6_4_AML_PSD_REVISION  0
+
+///
+/// _CPC Revision for ACPI 6.4
+///
+#define EFI_ACPI_6_4_AML_CPC_REVISION  3
+
 //
 // Ensure proper structure formats
 //

--- a/MdePkg/Include/IndustryStandard/Acpi65.h
+++ b/MdePkg/Include/IndustryStandard/Acpi65.h
@@ -19,6 +19,16 @@
 #pragma pack(1)
 
 ///
+/// _PSD Revision for ACPI 6.5
+///
+#define EFI_ACPI_6_5_AML_PSD_REVISION  0
+
+///
+/// _CPC Revision for ACPI 6.5
+///
+#define EFI_ACPI_6_5_AML_CPC_REVISION  3
+
+///
 /// ACPI 6.5 Generic Address Space definition
 ///
 typedef struct {


### PR DESCRIPTION
## Description

Additional defines for dealing with Cstates and Pstate dependencies.

Comes from Acpi specification. 

Add definitions for:
- _PSD version: added in ACPI 3.0
- C-state Coordination Types: added in ACPI 3.0
- _CPC version: added in ACPI 5.0

Reviewed-by: Sami Mujawar <sami.mujawar@arm.com>
Reviewed-by: Liming Gao <gaoliming@byosoft.com.cn>

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

N/A

## Integration Instructions

N/A