### PR TITLE
MdeModulePkg/HiiDatabaseDxe: Fix linker error

### DIFF
--- a/MdeModulePkg/Universal/HiiDatabaseDxe/Image.c
+++ b/MdeModulePkg/Universal/HiiDatabaseDxe/Image.c
@@ -291,9 +291,9 @@ Output1bitPixel (
       Byte = *(Data + OffsetY + Xpos);
       for (Index = 0; Index < 8; Index++) {
         if ((Byte & (1 << Index)) != 0) {
-          BitMapPtr[Ypos * Image->Width + Xpos * 8 + (8 - Index - 1)] = PaletteValue[1];
+          CopyMem (&BitMapPtr[Ypos * Image->Width + Xpos * 8 + (8 - Index - 1)], &PaletteValue[1], sizeof (*BitMapPtr));
         } else {
-          BitMapPtr[Ypos * Image->Width + Xpos * 8 + (8 - Index - 1)] = PaletteValue[0];
+          CopyMem (&BitMapPtr[Ypos * Image->Width + Xpos * 8 + (8 - Index - 1)], &PaletteValue[0], sizeof (*BitMapPtr));
         }
       }
     }
@@ -305,9 +305,9 @@ Output1bitPixel (
       Byte = *(Data + OffsetY + Xpos);
       for (Index = 0; Index < Image->Width % 8; Index++) {
         if ((Byte & (1 << (8 - Index - 1))) != 0) {
-          BitMapPtr[Ypos * Image->Width + Xpos * 8 + Index] = PaletteValue[1];
+          CopyMem (&BitMapPtr[Ypos * Image->Width + Xpos * 8 + Index], &PaletteValue[1], sizeof (*BitMapPtr));
         } else {
-          BitMapPtr[Ypos * Image->Width + Xpos * 8 + Index] = PaletteValue[0];
+          CopyMem (&BitMapPtr[Ypos * Image->Width + Xpos * 8 + Index], &PaletteValue[0], sizeof (*BitMapPtr));
         }
       }
     }
@@ -379,8 +379,8 @@ Output4bitPixel (
     //
     for (Xpos = 0; Xpos < Image->Width / 2; Xpos++) {
       Byte = *(Data + OffsetY + Xpos);
-      BitMapPtr[Ypos * Image->Width + Xpos * 2]     = PaletteValue[Byte >> 4];
-      BitMapPtr[Ypos * Image->Width + Xpos * 2 + 1] = PaletteValue[Byte & 0x0F];
+      CopyMem (&BitMapPtr[Ypos * Image->Width + Xpos * 2], &PaletteValue[Byte >> 4], sizeof (*BitMapPtr));
+      CopyMem (&BitMapPtr[Ypos * Image->Width + Xpos * 2 + 1], &PaletteValue[Byte & 0x0F], sizeof (*BitMapPtr));
     }
 
     if (Image->Width % 2 != 0) {
@@ -388,7 +388,7 @@ Output4bitPixel (
       // Padding bits in this byte should be ignored.
       //
       Byte = *(Data + OffsetY + Xpos);
-      BitMapPtr[Ypos * Image->Width + Xpos * 2]     = PaletteValue[Byte >> 4];
+      CopyMem (&BitMapPtr[Ypos * Image->Width + Xpos * 2], &PaletteValue[Byte >> 4], sizeof (*BitMapPtr));
     }
   }
 }
@@ -457,7 +457,7 @@ Output8bitPixel (
     //
     for (Xpos = 0; Xpos < Image->Width; Xpos++) {
       Byte = *(Data + OffsetY + Xpos);
-      BitMapPtr[OffsetY + Xpos] = PaletteValue[Byte];
+      CopyMem (&BitMapPtr[OffsetY + Xpos], &PaletteValue[Byte], sizeof (*BitMapPtr));
     }
   }
 
@@ -558,13 +558,13 @@ ImageToBlt (
     OffsetY1 = Width * Ypos;
     OffsetY2 = ImageOut->Width * (BltY + Ypos);
     for (Xpos = 0; Xpos < Width; Xpos++) {
-      SrcPixel = BltBuffer[OffsetY1 + Xpos];
+      CopyMem (&SrcPixel, &BltBuffer[OffsetY1 + Xpos], sizeof (SrcPixel));
       if (Transparent) {
-        if (CompareMem (&SrcPixel, &ZeroPixel, 3) != 0) {
-          ImageOut->Image.Bitmap[OffsetY2 + BltX + Xpos] = SrcPixel;
+        if (CompareMem (&SrcPixel, &ZeroPixel, 3) != 0) { \
+          CopyMem (&ImageOut->Image.Bitmap[OffsetY2 + BltX + Xpos], &SrcPixel, sizeof (SrcPixel));
         }
       } else {
-        ImageOut->Image.Bitmap[OffsetY2 + BltX + Xpos] = SrcPixel;
+        CopyMem (&ImageOut->Image.Bitmap[OffsetY2 + BltX + Xpos], &SrcPixel, sizeof (SrcPixel));
       }
     }
   }
@@ -1374,7 +1374,7 @@ HiiDrawImage (
         OffsetY1 = Image->Width * Ypos;
         OffsetY2 = Width * Ypos;
         for (Xpos = 0; Xpos < Width; Xpos++) {
-          BltBuffer[OffsetY2 + Xpos] = Image->Bitmap[OffsetY1 + Xpos];
+          CopyMem (&BltBuffer[OffsetY2 + Xpos], &Image->Bitmap[OffsetY1 + Xpos], sizeof (*BltBuffer));
         }
       }
     }


### PR DESCRIPTION
## Description

Fix issue where memcpy() instrinsic is being used after recent MSVC
linker update in windows-2022 VM image from:

Previous:
- VM version: 20220509.1
- MSVC version: 14.31.31103

New:
- VM version: 20220511.2
- MSVC version: 14.32.31326

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

- MSVC build

## Integration Instructions

- N/A