### PR TITLE
Add the EFI_RESOURCE_ATTRIBUTE_SPECIAL_PURPOSE attribute.

### DIFF
--- a/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
+++ b/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
@@ -16,6 +16,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #define MINIMUM_INITIAL_MEMORY_SIZE  0x10000
 
+// MU_CHANGE BEGIN: Add EFI_MEMORY_SP
+
 #define MEMORY_ATTRIBUTE_MASK  (EFI_RESOURCE_ATTRIBUTE_PRESENT             |        \
                                        EFI_RESOURCE_ATTRIBUTE_INITIALIZED         | \
                                        EFI_RESOURCE_ATTRIBUTE_TESTED              | \
@@ -26,7 +28,10 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
                                        EFI_RESOURCE_ATTRIBUTE_16_BIT_IO           | \
                                        EFI_RESOURCE_ATTRIBUTE_32_BIT_IO           | \
                                        EFI_RESOURCE_ATTRIBUTE_64_BIT_IO           | \
-                                       EFI_RESOURCE_ATTRIBUTE_PERSISTENT          )
+                                       EFI_RESOURCE_ATTRIBUTE_PERSISTENT          | \
+                                       EFI_RESOURCE_ATTRIBUTE_SPECIAL_PURPOSE     )
+
+// MU_CHANGE END: Add EFI_MEMORY_SP
 
 #define TESTED_MEMORY_ATTRIBUTES  (EFI_RESOURCE_ATTRIBUTE_PRESENT     |     \
                                        EFI_RESOURCE_ATTRIBUTE_INITIALIZED | \
@@ -92,6 +97,7 @@ GCD_ATTRIBUTE_CONVERSION_ENTRY  mAttributeConversionTable[] = {
   { EFI_RESOURCE_ATTRIBUTE_TESTED,                  EFI_MEMORY_TESTED,        FALSE },
   { EFI_RESOURCE_ATTRIBUTE_PERSISTABLE,             EFI_MEMORY_NV,            TRUE  },
   { EFI_RESOURCE_ATTRIBUTE_MORE_RELIABLE,           EFI_MEMORY_MORE_RELIABLE, TRUE  },
+  { EFI_RESOURCE_ATTRIBUTE_SPECIAL_PURPOSE,         EFI_MEMORY_SP,            TRUE  }, // MU_CHANGE: Add EFI_MEMORY_SP
   { 0,                                              0,                        FALSE }
 };
 
@@ -702,6 +708,14 @@ ConverToCpuArchAttributes (
   } else if ((Attributes & EFI_MEMORY_WP) == EFI_MEMORY_WP) {
     CpuArchAttributes |= EFI_MEMORY_WP;
   }
+
+  // MU_CHANGE BEGIN: Add EFI_MEMORY_SP
+
+  if ((Attributes & EFI_MEMORY_SP) == EFI_MEMORY_SP) {
+    CpuArchAttributes |= EFI_MEMORY_SP;
+  }
+
+  // MU_CHANGE END: Add EFI_MEMORY_SP
 
   return CpuArchAttributes;
 }
@@ -2610,6 +2624,14 @@ CoreInitializeGcdServices (
           if ((ResourceHob->ResourceAttribute & MEMORY_ATTRIBUTE_MASK) == PRESENT_MEMORY_ATTRIBUTES) {
             GcdMemoryType = EfiGcdMemoryTypeReserved;
           }
+
+          // MU_CHANGE BEGIN: Add EFI_MEMORY_SP
+
+          if ((ResourceHob->ResourceAttribute & EFI_RESOURCE_ATTRIBUTE_SPECIAL_PURPOSE) == EFI_RESOURCE_ATTRIBUTE_SPECIAL_PURPOSE) {
+            GcdMemoryType = EfiGcdMemoryTypeReserved;
+          }
+
+          // MU_CHANGE END: Add EFI_MEMORY_SP
 
           if ((ResourceHob->ResourceAttribute & EFI_RESOURCE_ATTRIBUTE_PERSISTENT) == EFI_RESOURCE_ATTRIBUTE_PERSISTENT) {
             GcdMemoryType = EfiGcdMemoryTypePersistent;

--- a/MdePkg/Include/Pi/PiHob.h
+++ b/MdePkg/Include/Pi/PiHob.h
@@ -297,6 +297,8 @@ typedef UINT32 EFI_RESOURCE_ATTRIBUTE_TYPE;
 #define EFI_RESOURCE_ATTRIBUTE_READ_ONLY_PROTECTED    0x00040000
 #define EFI_RESOURCE_ATTRIBUTE_READ_ONLY_PROTECTABLE  0x00080000
 
+#define EFI_RESOURCE_ATTRIBUTE_ENCRYPTED        0x04000000
+#define EFI_RESOURCE_ATTRIBUTE_SPECIAL_PURPOSE  0x08000000
 //
 // Physical memory relative reliability attribute. This
 // memory provides higher reliability relative to other


### PR DESCRIPTION
## Description

Add the EFI_RESOURCE_ATTRIBUTE_SPECIAL_PURPOSE resource attribute as per the PI 1.8 spec. This flag is used to indicate that the memory should be treated as special purpose memory (SPM).

Also adds GCD code that marks the SPM with the EFI_MEMORY_SP bit in the memory map and sets the GCD memory type to EfiGcdMemoryTypeSystemMemory.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - This change impacts how special purpose memory is represented in HOBs and in the memory map.
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

stuart_ci_build passed clean.

Manual testing using UEFI firmware on a device showed the expected behavior when HOBs are marked with EFI_RESOURCE_ATTRIBUTE_SPECIAL_PURPOSE.

## Integration Instructions

N/A