### PR TITLE
[CHERRY-PICK] MdePkg/SmBios.h: Add New ProcessorUpgrade definitions for SMBIOS Type4

### DIFF
--- a/MdePkg/Include/IndustryStandard/SmBios.h
+++ b/MdePkg/Include/IndustryStandard/SmBios.h
@@ -880,7 +880,14 @@ typedef enum {
   ProcessorUpgradeSocketBGA1190   = 0x4D,
   ProcessorUpgradeSocketBGA4129   = 0x4E,
   ProcessorUpgradeSocketLGA4710   = 0x4F,
-  ProcessorUpgradeSocketLGA7529   = 0x50
+  ProcessorUpgradeSocketLGA7529   = 0x50,
+  ProcessorUpgradeSocketBGA1964   = 0x51,
+  ProcessorUpgradeSocketBGA1792   = 0x52,
+  ProcessorUpgradeSocketBGA2049   = 0x53,
+  ProcessorUpgradeSocketBGA2551   = 0x54,
+  ProcessorUpgradeSocketLGA1851   = 0x55,
+  ProcessorUpgradeSocketBGA2114   = 0x56,
+  ProcessorUpgradeSocketBGA2833   = 0x57
 } PROCESSOR_UPGRADE;
 
 ///


### PR DESCRIPTION
## Description

The patch adds new ProcessorUpgrade definitions for SMBIOS Type4 based on SMBIOS 3.8.0.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Builds and boots on intel platforms.

## Integration Instructions

N/A