### PR TITLE
MdeModulePkg/HiiDatabaseDxe: Correcting a Codeql change

### DIFF
--- a/MdeModulePkg/Universal/HiiDatabaseDxe/Database.c
+++ b/MdeModulePkg/Universal/HiiDatabaseDxe/Database.c
@@ -749,49 +749,49 @@ FindQuestionDefaultSetting (
         VariableStorage = NULL;
       }
     }
+  }
 
-    //
-    // The matched variable storage is not found.
-    //
-    if (VariableStorage == NULL) {
-      return EFI_NOT_FOUND;
-    }
+  //
+  // The matched variable storage is not found.
+  //
+  if (VariableStorage == NULL) {
+    return EFI_NOT_FOUND;
+  }
 
-    //
-    // Find the question default value from the variable storage
-    //
-    VariableHeader = FindVariableData (VariableStorage, &EfiVarStore->Guid, EfiVarStore->Attributes, (CHAR16 *)EfiVarStore->Name);
-    if (VariableHeader == NULL) {
-      return EFI_NOT_FOUND;
-    }
+  //
+  // Find the question default value from the variable storage
+  //
+  VariableHeader = FindVariableData (VariableStorage, &EfiVarStore->Guid, EfiVarStore->Attributes, (CHAR16 *)EfiVarStore->Name);
+  if (VariableHeader == NULL) {
+    return EFI_NOT_FOUND;
+  }
 
-    StartBit   = 0;
-    EndBit     = 0;
-    ByteOffset = IfrQuestionHdr->VarStoreInfo.VarOffset;
+  StartBit   = 0;
+  EndBit     = 0;
+  ByteOffset = IfrQuestionHdr->VarStoreInfo.VarOffset;
+  if (BitFieldQuestion) {
+    BitOffset  = IfrQuestionHdr->VarStoreInfo.VarOffset;
+    ByteOffset = BitOffset / 8;
+    BitWidth   = Width;
+    StartBit   = BitOffset % 8;
+    EndBit     = StartBit + BitWidth - 1;
+    Width      = EndBit / 8 + 1;
+  }
+
+  if (VariableHeader->DataSize < ByteOffset + Width) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // Copy the question value
+  //
+  if (ValueBuffer != NULL) {
     if (BitFieldQuestion) {
-      BitOffset  = IfrQuestionHdr->VarStoreInfo.VarOffset;
-      ByteOffset = BitOffset / 8;
-      BitWidth   = Width;
-      StartBit   = BitOffset % 8;
-      EndBit     = StartBit + BitWidth - 1;
-      Width      = EndBit / 8 + 1;
-    }
-
-    if (VariableHeader->DataSize < ByteOffset + Width) {
-      return EFI_INVALID_PARAMETER;
-    }
-
-    //
-    // Copy the question value
-    //
-    if (ValueBuffer != NULL) {
-      if (BitFieldQuestion) {
-        CopyMem (&BufferValue, (UINT8 *)VariableHeader + sizeof (VARIABLE_HEADER) + VariableHeader->NameSize + ByteOffset, Width);
-        BitFieldVal = BitFieldRead32 (BufferValue, StartBit, EndBit);
-        CopyMem (ValueBuffer, &BitFieldVal, Width);
-      } else {
-        CopyMem (ValueBuffer, (UINT8 *)VariableHeader + sizeof (VARIABLE_HEADER) + VariableHeader->NameSize + IfrQuestionHdr->VarStoreInfo.VarOffset, Width);
-      }
+      CopyMem (&BufferValue, (UINT8 *)VariableHeader + sizeof (VARIABLE_HEADER) + VariableHeader->NameSize + ByteOffset, Width);
+      BitFieldVal = BitFieldRead32 (BufferValue, StartBit, EndBit);
+      CopyMem (ValueBuffer, &BitFieldVal, Width);
+    } else {
+      CopyMem (ValueBuffer, (UINT8 *)VariableHeader + sizeof (VARIABLE_HEADER) + VariableHeader->NameSize + IfrQuestionHdr->VarStoreInfo.VarOffset, Width);
     }
   }
 


### PR DESCRIPTION
# Description

Due to a change to address CodeQl issues, the HiiDatabase could not return a default values for IFRs.

It was tracked back to the conditional check encompassing too much of the code, and preventing the loop from iterating through all the possible variable storage 

- [X] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Prior to this change, a platform loading defaults would not change all the settings, only the subset found in the first variable storage.

## Integration Instructions

n/a