### PR TITLE
[CHERRY-PICK] [Release/202302] NetworkPkg TcpDxe: Fixed system stuck on PXE boot flow in iPXE environment

### DIFF
--- a/NetworkPkg/TcpDxe/TcpDriver.c
+++ b/NetworkPkg/TcpDxe/TcpDriver.c
@@ -509,7 +509,7 @@ TcpDestroyService (
     //
     // Destroy the instance of the hashing protocol for this controller.
     //
-    Status = Hash2ServiceBinding->DestroyChild (Hash2ServiceBinding, &mHash2ServiceHandle);
+    Status = Hash2ServiceBinding->DestroyChild (Hash2ServiceBinding, mHash2ServiceHandle);
     if (EFI_ERROR (Status)) {
       return EFI_UNSUPPORTED;
     }


### PR DESCRIPTION
## Description

This bug fix is based on the following commit "NetworkPkg TcpDxe: SECURITY PATCH"
REF: 1904a64

Issue Description:
An "Invalid handle" error was detected during runtime when attempting to destroy a child instance of the hashing protocol. The problematic code segment was:

NetworkPkg\TcpDxe\TcpDriver.c
Status = Hash2ServiceBinding->DestroyChild(Hash2ServiceBinding, ​&mHash2ServiceHandle);

Root Cause Analysis:
The root cause of the error was the passing of an incorrect parameter type, a pointer to an EFI_HANDLE instead of an EFI_HANDLE itself, to the DestroyChild function. This mismatch resulted in the function receiving an invalid handle.

Implemented Solution:
To resolve this issue, the function call was corrected to pass mHash2ServiceHandle directly:

NetworkPkg\TcpDxe\TcpDriver.c
Status = Hash2ServiceBinding->DestroyChild(Hash2ServiceBinding, mHash2ServiceHandle);

This modification ensures the correct handle type is used, effectively rectifying the "Invalid handle" error.

Verification:
Testing has been conducted, confirming the efficacy of the fix. Additionally, the BIOS can boot into the OS in an iPXE environment.

Cc: Doug Flick [MSFT] <doug.edk2@gmail.com>


Reviewed-by: Saloni Kasbekar <saloni.kasbekar@intel.com>

- [ X] Impacts functionality?
  - Corrects handle passed to DestroyChild(..)
- [ ] Impacts security?
  - N/A
- [ ] Breaking change?
  - N/A
- [ ] Includes tests?
  - N/A
- [ ] Includes documentation?
  - N/A

## How This Was Tested

"Testing has been conducted, confirming the efficacy of the fix. Additionally, the BIOS can boot into the OS in an iPXE environment."

iPXE booted successfully

## Integration Instructions

N/A