### PR TITLE
MuCodeQlQueries.qls: Pin to the 0.9.12 codeq/cpp-queries pack

### DIFF
--- a/BaseTools/Plugin/CodeQL/MuCodeQlQueries.qls
+++ b/BaseTools/Plugin/CodeQL/MuCodeQlQueries.qls
@@ -2,7 +2,7 @@
 - description: Project Mu UEFI (C++) queries
 
 - queries: '.'
-  from: codeql/cpp-queries
+  from: codeql/cpp-queries@0.9.12
 
 ##########################################################################################
 # "Core" Queries - Part of Core SDL

--- a/BaseTools/Plugin/CodeQL/codeqlcli_ext_dep.yaml
+++ b/BaseTools/Plugin/CodeQL/codeqlcli_ext_dep.yaml
@@ -8,6 +8,13 @@
 # In an environment where a platform might build in different operating systems, it is recommended to set
 # the scope for the appropriate CodeQL external dependency based on the host operating system being used.
 #
+# ****VERSION UPDATE INSTRUCTIONS****
+#
+# When updating the CodeQL CLI used here, update the corresponding codeql/cpp-queries version in MuCodeQlQueries.qls.
+# Visit the `qlpack.yml` in the release branch for the CodeQL CLI to get the version to use there. For example, the
+# CodeQL CLI 2.17.3 file is https://github.com/github/codeql/blob/codeql-cli-2.17.3/cpp/ql/src/qlpack.yml and the
+# pack version there is 0.9.12.
+#
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##

--- a/BaseTools/Plugin/CodeQL/codeqlcli_linux_ext_dep.yaml
+++ b/BaseTools/Plugin/CodeQL/codeqlcli_linux_ext_dep.yaml
@@ -6,6 +6,13 @@
 # systems, it is recommended to set the scope for the appropriate CodeQL external dependency based on the
 # host operating system being used.
 #
+# ****VERSION UPDATE INSTRUCTIONS****
+#
+# When updating the CodeQL CLI used here, update the corresponding codeql/cpp-queries version in MuCodeQlQueries.qls.
+# Visit the `qlpack.yml` in the release branch for the CodeQL CLI to get the version to use there. For example, the
+# CodeQL CLI 2.17.3 file is https://github.com/github/codeql/blob/codeql-cli-2.17.3/cpp/ql/src/qlpack.yml and the
+# pack version there is 0.9.12.
+#
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##

--- a/BaseTools/Plugin/CodeQL/codeqlcli_windows_ext_dep.yaml
+++ b/BaseTools/Plugin/CodeQL/codeqlcli_windows_ext_dep.yaml
@@ -6,6 +6,13 @@
 # systems, it is recommended to set the scope for the appropriate CodeQL external dependency based on the
 # host operating system being used.
 #
+# ****VERSION UPDATE INSTRUCTIONS****
+#
+# When updating the CodeQL CLI used here, update the corresponding codeql/cpp-queries version in MuCodeQlQueries.qls.
+# Visit the `qlpack.yml` in the release branch for the CodeQL CLI to get the version to use there. For example, the
+# CodeQL CLI 2.17.3 file is https://github.com/github/codeql/blob/codeql-cli-2.17.3/cpp/ql/src/qlpack.yml and the
+# pack version there is 0.9.12.
+#
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##


### PR DESCRIPTION
## Description

The `codeql/cpp-queries` pack used in MuCodeQlQueries.qls was versioned
0.9.12 for the CodeQL CLI v2.17.3 release currently used.

https://github.com/github/codeql/blob/codeql-cli/v2.17.3/cpp/ql/src/qlpack.yml

This change pins that pack version to prevent the CodeQL CLI and
pack from getting out of sync until explicitly updated.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Verified the CodeQL query pack version listed is pulled.

## Integration Instructions

- N/A - No change to queries used. Should prevent breaks in the future where
  the latest queries are no longer compatible with the current CodeQL CLI used.