### PR TITLE
Set EFI_MEMORY_SP as System Memory

### DIFF
--- a/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
+++ b/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
@@ -2627,8 +2627,10 @@ CoreInitializeGcdServices (
 
           // MU_CHANGE BEGIN: Add EFI_MEMORY_SP
 
+          // Mark special purpose memory as system memory, if it was system memory in the HOB
+          // However, if this is also marked as persistent, let persistent take precedence
           if ((ResourceHob->ResourceAttribute & EFI_RESOURCE_ATTRIBUTE_SPECIAL_PURPOSE) == EFI_RESOURCE_ATTRIBUTE_SPECIAL_PURPOSE) {
-            GcdMemoryType = EfiGcdMemoryTypeReserved;
+            GcdMemoryType = EfiGcdMemoryTypeSystemMemory;
           }
 
           // MU_CHANGE END: Add EFI_MEMORY_SP


### PR DESCRIPTION
## Description

When supplying DxeCore with a resource descriptor HOB, a platform can choose which memory type to specify. For EFI_MEMORY_SP resource descriptor HOBs, instead of blindly setting GcdReserved as the memory type, respect what the resource descriptor HOB specified. Closes #884.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on virtual platforms with CXL memory attached.

## Integration Instructions

N/A.