### PR TITLE
[CHERRY-PICK] [Release/202311] UnitTestFrameworkPkg: Fix Google Test components with multiple files

### DIFF
--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
@@ -43,8 +43,8 @@
   #
   # MSFT
   #
-  MSFT:*_*_*_CC_FLAGS               = /EHs -D GOOGLETEST_HOST_UNIT_TEST_BUILD=1
-  MSFT:*_*_*_DLINK_FLAGS            == /out:"$(BIN_DIR)\$(MODULE_NAME_GUID).exe" /pdb:"$(BIN_DIR)\$(MODULE_NAME_GUID).pdb" /IGNORE:4001 /NOLOGO /SUBSYSTEM:CONSOLE /DEBUG /STACK:0x40000,0x40000 /NODEFAULTLIB:libcmt.lib libcmtd.lib
+  MSFT:*_*_*_CC_FLAGS               = /EHsc
+  MSFT:*_*_*_DLINK_FLAGS            == /out:"$(BIN_DIR)\$(MODULE_NAME_GUID).exe" /pdb:"$(BIN_DIR)\$(MODULE_NAME_GUID).pdb" /IGNORE:4001 /NOLOGO /SUBSYSTEM:CONSOLE /DEBUG /STACK:0x40000,0x40000 /WHOLEARCHIVE
   MSFT:*_*_IA32_DLINK_FLAGS         = /MACHINE:I386
   MSFT:*_*_X64_DLINK_FLAGS          = /MACHINE:AMD64
 
@@ -64,7 +64,12 @@
   GCC:*_*_*_CC_FLAGS       = -D GOOGLETEST_HOST_UNIT_TEST_BUILD=1
   GCC:*_*_IA32_DLINK_FLAGS == -o $(BIN_DIR)/$(MODULE_NAME_GUID) -m32 -no-pie
   GCC:*_*_X64_DLINK_FLAGS  == -o $(BIN_DIR)/$(MODULE_NAME_GUID) -m64 -no-pie
-  GCC:*_*_*_DLINK2_FLAGS   == -lgcov -lpthread -lstdc++ -lm
+  #
+  # Surround our static libraries with whole-archive, so constructor-based test registration works properly.
+  # Note that we need to --no-whole-archive before linking system libraries.
+  #
+  GCC:*_*_*_DLINK_FLAGS    = -Wl,--whole-archive
+  GCC:*_*_*_DLINK2_FLAGS   == -Wl,--no-whole-archive -lgcov -lpthread -lstdc++ -lm
 
   #
   # Need to do this link via gcc and not ld as the pathing to libraries changes from OS version to OS version

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
@@ -43,7 +43,9 @@
   #
   # MSFT
   #
-  MSFT:*_*_*_CC_FLAGS               = /EHsc
+  # MU_CHANGE [BEGIN] - Allow GoogleTest to Test STATIC Functions
+  MSFT:*_*_*_CC_FLAGS               = /EHsc -D GOOGLETEST_HOST_UNIT_TEST_BUILD=1
+  # MU_CHANGE [END] - Allow GoogleTest to Test STATIC Functions
   MSFT:*_*_*_DLINK_FLAGS            == /out:"$(BIN_DIR)\$(MODULE_NAME_GUID).exe" /pdb:"$(BIN_DIR)\$(MODULE_NAME_GUID).pdb" /IGNORE:4001 /NOLOGO /SUBSYSTEM:CONSOLE /DEBUG /STACK:0x40000,0x40000 /WHOLEARCHIVE
   MSFT:*_*_IA32_DLINK_FLAGS         = /MACHINE:I386
   MSFT:*_*_X64_DLINK_FLAGS          = /MACHINE:AMD64


### PR DESCRIPTION
# Preface

REF: https://bugzilla.tianocore.org/show_bug.cgi?id=4610

Google Test hides test registration in global constructors on global objects. Global constructors are traditionally implemented by placing references to the global constructor's symbol in special sections (traditionally named .ctors or .init_array). These sections are not explicitly referenced by the linker, and libc only looks at special start and end symbols (and calls them).

This works fine if you're linking a program manually using

    gcc a.o b.o c.o -o test_suite

but fails miserably when using static libraries (such as what EDK2 does), because traditional static archive symbol resolution rules don't allow for object files to be pulled in to the link if there isn't an undefined symbol reference to that .o elsewhere.

Fix it by passing --whole-archive (GCC) and /WHOLEARCHIVE (MSVC). These options force the linker to pull in the entire static library, thus including previously-unreferenced constructors and making sure multi-file gtest EDK2 components work.

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Michael Kubacki <mikuback@linux.microsoft.com>
Cc: Sean Brogan <sean.brogan@microsoft.com>

Reviewed-by: Cc: Michael D Kinney <michael.d.kinney@intel.com>

## Description

This corrects an issue with MSVC where unit tests are not being linked correctly - thus creating unit tests with zero tests

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
  - This will cause unit tests to actually run with MSVC
- [ ] Includes documentation?

## How This Was Tested

Local builds with Host Based Unit Tests

## Integration Instructions

N/A