### PR TITLE
[Rebase & FF] 202405: MdeModulePkg: BdsDxe: Introduce infinite boot retries

### DIFF
--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -1185,6 +1185,15 @@
   # @Prompt Delay access XHCI register after it issues HCRST (us)
   gEfiMdeModulePkgTokenSpaceGuid.PcdDelayXhciHCReset|2000|UINT16|0x30001060
 
+  # MU_CHANGE [BEGIN] - Support indefinite boot retries
+  # # Some platforms require that all EfiLoadOptions are retried until one of the options 
+  # # succeeds. When True, this Pcd will force Bds to retry all the valid EfiLoadOptions 
+  # # indefinitely until one of the options succeeds. 
+  # #   TRUE  - Efi boot options will be retried indefinitely.
+  # #   FALSE - Efi boot options will not be retried.
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSupportInfiniteBootRetries|FALSE|BOOLEAN|0x40000152
+  # MU_CHANGE [END]
+
 [PcdsFixedAtBuild, PcdsPatchableInModule]
   ## Dynamic type PCD can be registered callback function for Pcd setting action.
   #  PcdMaxPeiPcdCallBackNumberPerPcdEntry indicates the maximum number of callback function

--- a/MdeModulePkg/Universal/BdsDxe/BdsDxe.inf
+++ b/MdeModulePkg/Universal/BdsDxe/BdsDxe.inf
@@ -98,6 +98,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdTestKeyUsed                       ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdCapsuleOnDiskSupport              ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdPlatformRecoverySupport           ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSupportInfiniteBootRetries	      ## CONSUMES // MU_CHANGE
 
 [Depex]
   TRUE


### PR DESCRIPTION
## Description

This adds support for infinitely retrying boot options if all fail. This for cases where the underlying hardware may require another component to enable network or PCI and so UEFI must continuously retry the boot options until a viable option has been enabled. The support is PCD based so only platforms that require this support should enable it.

This change cherry-picks and squashes the following commits from release/202311:
https://github.com/microsoft/mu_basecore/commit/3b51a4a9323c4df53fc5c615f3cd532987e6adbb
https://github.com/microsoft/mu_basecore/commit/df800a222322a76cf92c038c744deefb03829135

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Not tested...

## Integration Instructions

N/A
