### PR TITLE
[Rebase & FF] 202405: Introduce Memory Type Information Change library

### DIFF
--- a/MdeModulePkg/Include/Guid/MemoryTypeInformation.h
+++ b/MdeModulePkg/Include/Guid/MemoryTypeInformation.h
@@ -26,6 +26,13 @@
 
 extern EFI_GUID  gEfiMemoryTypeInformationGuid;
 
+// MU_CHANGE Begin: Minimum Allocation Guid
+#define EFI_MEMORY_TYPE_MINIMUM_ALLOCATION_GUID \
+  { 0xE4FFE60B, 0x2499, 0x4848, { 0x88, 0x9A, 0xF4, 0x24, 0xC1, 0xC9, 0xC3, 0x47 }}
+
+extern EFI_GUID  gEfiMemoryTypeMinimumAllocationGuid;
+// MU_CHANGE End: Minimum Allocation Guid
+
 typedef struct {
   UINT32    Type;           ///< EFI memory type defined in UEFI specification.
   UINT32    NumberOfPages;  ///< The pages of this type memory.

--- a/MdeModulePkg/Include/Library/MemoryTypeInformationChangeLib.h
+++ b/MdeModulePkg/Include/Library/MemoryTypeInformationChangeLib.h
@@ -1,0 +1,33 @@
+/** @file MemoryTypeInformationChangeLib.h
+
+Used to report when memory type information changes from previous boot.
+
+Copyright (c) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+MU_CHANGE new file
+
+*/
+
+#ifndef MEMORY_TYPE_INFORMATION_CHANGE_LIB_
+#define MEMORY_TYPE_INFORMATION_CHANGE_LIB_
+
+/**
+  Report the change in memory type allocations.
+
+  @param[in] Type                   EFI memory type defined in UEFI specification
+  @param[in] PreviousNumberOfPages  Number of pages retrieved from
+                                    gEfiMemoryTypeInformationGuid HOB
+  @param[in] NextNumberOfPages      Number of pages calculated to be used on next boot
+
+  @retval    Status                 Status of the report
+**/
+RETURN_STATUS
+EFIAPI
+ReportMemoryTypeInformationChange (
+  IN UINT32  Type,
+  IN UINT32  PreviousNumberOfPages,
+  IN UINT32  NextNumberOfPages
+  );
+
+#endif //MEMORY_TYPE_INFORMATION_CHANGE_LIB_

--- a/MdeModulePkg/Library/MemoryTypeInfoSecVarCheckLib/MemoryTypeInfoSecVarCheckLib.c
+++ b/MdeModulePkg/Library/MemoryTypeInfoSecVarCheckLib/MemoryTypeInfoSecVarCheckLib.c
@@ -1,0 +1,207 @@
+/** @file
+  Implementation functions and structures for MemoryTypeInformation VarCheck library.
+
+Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (C) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+// MU_CHANGE TCBZ1086 [WHOLE FILE] - Mitigate potential system brick due to uefi MemoryTypeInformation var changes
+
+#include <Uefi/UefiBaseType.h>
+#include <Library/VarCheckLib.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/SafeIntLib.h>
+#include <Library/PcdLib.h>
+
+#include <Guid/MemoryTypeInformation.h>
+
+#define   EFI_MEMORY_TYPE_INFORMATION_VARIABLE_INFO_COUNT  6
+#define   EFI_MEMORY_TYPE_INFORMATION_VARIABLE_SIZE        (sizeof(EFI_MEMORY_TYPE_INFORMATION) * EFI_MEMORY_TYPE_INFORMATION_VARIABLE_INFO_COUNT)
+
+VAR_CHECK_VARIABLE_PROPERTY  mMemoryTypeInfoVariableProperty = {
+  VAR_CHECK_VARIABLE_PROPERTY_REVISION,
+  0,
+  EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS,
+  sizeof (EFI_MEMORY_TYPE_INFORMATION),
+  sizeof (EFI_MEMORY_TYPE_INFORMATION) * (EfiMaxMemoryType + 1)
+};
+
+/**
+  SetVariable check handler for MemoryTypeInformation variable.
+
+  @param[in] VariableName       Name of Variable to set.
+  @param[in] VendorGuid         Variable vendor GUID.
+  @param[in] Attributes         Attribute value of the variable.
+  @param[in] DataSize           Size of Data to set.
+  @param[in] Data               Data pointer.
+
+  @retval EFI_SUCCESS           The SetVariable check result was success.
+  @retval EFI_INVALID_PARAMETER An invalid combination of attribute bits, name, GUID,
+                                DataSize and Data value was supplied.
+
+**/
+EFI_STATUS
+EFIAPI
+MemoryTypeInfoVarCheckHandler (
+  IN CHAR16    *VariableName,
+  IN EFI_GUID  *VendorGuid,
+  IN UINT32    Attributes,
+  IN UINTN     DataSize,
+  IN VOID      *Data
+  )
+{
+  EFI_MEMORY_TYPE_INFORMATION  *MemoryTypeInfo;
+  UINTN                        Count;
+  UINTN                        Index;
+  UINTN                        Index2;
+  UINTN                        TotalPages = 0;
+
+  if ((StrCmp (VariableName, EFI_MEMORY_TYPE_INFORMATION_VARIABLE_NAME) != 0) ||
+      !CompareGuid (VendorGuid, &gEfiMemoryTypeInformationGuid))
+  {
+    //
+    // It is not MemoryTypeInformation variable.
+    //
+    return EFI_SUCCESS;
+  }
+
+  if ((((Attributes & EFI_VARIABLE_APPEND_WRITE) == 0) && (DataSize == 0)) ||
+      (Attributes == 0))
+  {
+    //
+    // Do not check variable deletion.
+    //
+    return EFI_SUCCESS;
+  }
+
+  //
+  // Check DataSize.
+  //
+  if (DataSize != EFI_MEMORY_TYPE_INFORMATION_VARIABLE_SIZE) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a() - DataSize = 0x%x Expected = 0x%x\n",
+      __func__,
+      DataSize,
+      EFI_MEMORY_TYPE_INFORMATION_VARIABLE_SIZE
+      ));
+    return EFI_SECURITY_VIOLATION;
+  }
+
+  //
+  // Get entry Count.
+  //
+  Count          = EFI_MEMORY_TYPE_INFORMATION_VARIABLE_INFO_COUNT;
+  MemoryTypeInfo = (EFI_MEMORY_TYPE_INFORMATION *)Data;
+
+  //
+  // Check last entry's Type.
+  //
+  if (MemoryTypeInfo[Count - 1].Type != EfiMaxMemoryType) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a() - Last(0x%x) entry's Type(0x%x) != EfiMaxMemoryType\n",
+      __func__,
+      Count - 1,
+      MemoryTypeInfo[Count - 1].Type
+      ));
+    return EFI_SECURITY_VIOLATION;
+  }
+
+  if (Count >= 2) {
+    for (Index = 0; Index < Count - 1; Index++) {
+      //
+      // Check the Type.
+      //
+      if (MemoryTypeInfo[Index].Type > EfiMaxMemoryType) {
+        //
+        // The Type is invalid.
+        //
+        DEBUG ((
+          DEBUG_ERROR,
+          "ERROR: %a() - 0x%x entry's Type(0x%x) is invalid\n",
+          __func__,
+          Index,
+          MemoryTypeInfo[Index].Type
+          ));
+        return EFI_SECURITY_VIOLATION;
+      }
+
+      for (Index2 = Index + 1; Index2 < Count; Index2++) {
+        if (MemoryTypeInfo[Index].Type == MemoryTypeInfo[Index2].Type) {
+          //
+          // Two entries have same Type.
+          //
+          DEBUG ((
+            DEBUG_ERROR,
+            "ERROR: %a() - 0x%x entry and 0x%x entry have same Type(0x%x)\n",
+            __func__,
+            Index,
+            Index2,
+            MemoryTypeInfo[Index].Type
+            ));
+          return EFI_SECURITY_VIOLATION;
+        }
+      }
+
+      if (EFI_ERROR (SafeUintnAdd (TotalPages, MemoryTypeInfo[Index].NumberOfPages, &TotalPages))) {
+        DEBUG ((
+          DEBUG_ERROR,
+          "ERROR: %a() - Math error at entry 0x%x\n",
+          __func__,
+          Index
+          ));
+        return EFI_SECURITY_VIOLATION;
+      }
+    }
+  }
+
+  //
+  // Compare the pages to the upper bound and reject if too large.
+  if (TotalPages > PcdGet32 (PcdMaxMemoryTypeInfoPages)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "ERROR: %a() - Total pages requested 0x%x exceeds max allowed(0x%x)\n",
+      __func__,
+      TotalPages,
+      PcdGet32 (PcdMaxMemoryTypeInfoPages)
+      ));
+    return EFI_SECURITY_VIOLATION;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Constructor function of MemoryTypeInfoSecVarCheckLib to set property and
+  register SetVariable check handler for MemoryTypeInformation variable.
+
+  @retval RETURN_SUCCESS       The constructor executed correctly.
+
+**/
+RETURN_STATUS
+EFIAPI
+MemoryTypeInfoSecVarCheckLibConstructor (
+  VOID
+  )
+{
+  DEBUG ((DEBUG_INFO, "%a()\n", __func__));
+  EFI_STATUS  Status;
+
+  Status = VarCheckLibVariablePropertySet (
+             EFI_MEMORY_TYPE_INFORMATION_VARIABLE_NAME,
+             &gEfiMemoryTypeInformationGuid,
+             &mMemoryTypeInfoVariableProperty
+             );
+  ASSERT_EFI_ERROR (Status);
+  Status = VarCheckLibRegisterSetVariableCheckHandler (
+             MemoryTypeInfoVarCheckHandler
+             );
+  ASSERT_EFI_ERROR (Status);
+
+  return RETURN_SUCCESS;
+}

--- a/MdeModulePkg/Library/MemoryTypeInfoSecVarCheckLib/MemoryTypeInfoSecVarCheckLib.inf
+++ b/MdeModulePkg/Library/MemoryTypeInfoSecVarCheckLib/MemoryTypeInfoSecVarCheckLib.inf
@@ -1,0 +1,45 @@
+## @file
+#  NULL class library to register var check handler and variable property set for MemoryTypeInformation variable.
+#
+#  Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
+#  Copyright (C) Microsoft Corporation.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+# MU_CHANGE TCBZ1086 [WHOLE FILE] - Mitigate potential system brick due to uefi MemoryTypeInformation var changes
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MemoryTypeInfoSecVarCheckLib
+  FILE_GUID                      = C69D75E8-E39F-4F79-9D74-50B8C759D09B
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = MemoryTypeInfoSecVarCheckLib|DXE_RUNTIME_DRIVER DXE_SMM_DRIVER MM_STANDALONE
+  CONSTRUCTOR                    = MemoryTypeInfoSecVarCheckLibConstructor
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  MemoryTypeInfoSecVarCheckLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  VarCheckLib
+  SafeIntLib
+
+[Guids]
+  gEfiMemoryTypeInformationGuid  ## CONSUMES ## Variable:L"MemoryTypeInformation"
+
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdMaxMemoryTypeInfoPages            ## CONSUMES

--- a/MdeModulePkg/Library/MemoryTypeInformationChangeLibNull/MemoryTypeInformationChangeLibNull.c
+++ b/MdeModulePkg/Library/MemoryTypeInformationChangeLibNull/MemoryTypeInformationChangeLibNull.c
@@ -1,0 +1,32 @@
+/** @file -- MemoryTypeInformationChangeLibNull.c
+ Null library, returns success.
+
+Copyright (c) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+MU_CHANGE NEW FILE
+**/
+
+#include <Library/BaseLib.h>
+#include <Library/MemoryTypeInformationChangeLib.h>
+
+/**
+  Report the change in memory type allocations.
+
+  @param[in] Type                   EFI memory type defined in UEFI specification
+  @param[in] PreviousNumberOfPages  Number of pages retrieved from
+                                    gEfiMemoryTypeInformationGuid HOB
+  @param[in] NextNumberOfPages      Number of pages calculated to be used on next boot
+
+  @retval    Status                 Status of the report
+**/
+RETURN_STATUS
+EFIAPI
+ReportMemoryTypeInformationChange (
+  IN UINT32  Type,
+  IN UINT32  PreviousNumberOfPages,
+  IN UINT32  NextNumberOfPages
+  )
+{
+  return RETURN_SUCCESS;
+}

--- a/MdeModulePkg/Library/MemoryTypeInformationChangeLibNull/MemoryTypeInformationChangeLibNull.inf
+++ b/MdeModulePkg/Library/MemoryTypeInformationChangeLibNull/MemoryTypeInformationChangeLibNull.inf
@@ -1,0 +1,26 @@
+## @file MemoryTypeInformationChangeLibNull.inf
+# Null library, returns success.
+##
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+# MU_CHANGE NEW FILE
+
+[Defines]
+  INF_VERSION         = 0x00010017
+  BASE_NAME           = MemoryTypeInformationChangeLibNull
+  FILE_GUID           = eb4cc801-4301-43ba-979a-d4153c55f43c
+  VERSION_STRING      = 1.0
+  MODULE_TYPE         = BASE
+  LIBRARY_CLASS       = MemoryTypeInformationChangeLib
+
+[Sources]
+  MemoryTypeInformationChangeLibNull.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[LibraryClasses]
+  BaseLib

--- a/MdeModulePkg/Library/UefiBootManagerLib/BmMisc.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmMisc.c
@@ -115,6 +115,69 @@ BmMatchDevicePaths (
   return FALSE;
 }
 
+// MU_CHANGE Begin: Minimum Allocation
+
+/**
+  This routine returns the minimum allocation for the given memory type.
+
+  @param Type     MemoryType to get the minimum allocation for.
+
+  @return The minimum allocation (in pages) for this memory type, or 0 if
+          no minimum is provided.
+**/
+UINT32
+GetMinimumAllocation (
+  IN UINT32  Type
+  )
+{
+  EFI_HOB_GUID_TYPE            *GuidHob;
+  EFI_MEMORY_TYPE_INFORMATION  *MinimumMemoryAllocations;
+  UINTN                        VariableSize;
+  UINTN                        Index;
+  UINT32                       MinAllocation;
+
+  //
+  // Get the Minimum Allocation for each Memory Type from Hob if they exist.
+  // PEI is responsible for creating the MinimumAllocation Hob if platform
+  // needs a minimum allocation.
+  //
+  GuidHob = GetFirstGuidHob (&gEfiMemoryTypeMinimumAllocationGuid);
+  if (GuidHob == NULL) {
+    //
+    // If no hob exists, platform does not specify a minimum allocation - so return zero.
+    //
+    return 0;
+  }
+
+  VariableSize             = GET_GUID_HOB_DATA_SIZE (GuidHob);
+  MinimumMemoryAllocations = AllocateCopyPool (VariableSize, GET_GUID_HOB_DATA (GuidHob));
+  if (MinimumMemoryAllocations == NULL) {
+    ASSERT_EFI_ERROR (EFI_OUT_OF_RESOURCES);
+    return 0;
+  }
+
+  MinAllocation = 0;
+  for (Index = 0; MinimumMemoryAllocations[Index].Type != EfiMaxMemoryType; Index++) {
+    if (MinimumMemoryAllocations[Index].Type == Type) {
+      break;
+    }
+  }
+
+  if (MinimumMemoryAllocations[Index].Type == EfiMaxMemoryType) {
+    MinAllocation = 0;
+  } else {
+    MinAllocation = MinimumMemoryAllocations[Index].NumberOfPages;
+  }
+
+  if (MinimumMemoryAllocations != NULL) {
+    FreePool (MinimumMemoryAllocations);
+  }
+
+  return MinAllocation;
+}
+
+// MU_CHANGE End: Minimum Allocation
+
 /**
   This routine adjust the memory information for different memory type and
   save them into the variables for next boot. It resets the system when
@@ -138,6 +201,7 @@ BmSetMemoryTypeInformationVariable (
   UINTN                        Index1;
   UINT32                       Previous;
   UINT32                       Current;
+  UINT32                       Minimum; // MU_CHANGE
   UINT32                       Next;
   EFI_HOB_GUID_TYPE            *GuidHob;
   BOOLEAN                      MemoryTypeInformationModified;
@@ -208,9 +272,11 @@ BmSetMemoryTypeInformationVariable (
   //
   // Use a heuristic to adjust the Memory Type Information for the next boot
   //
-  DEBUG ((DEBUG_INFO, "Memory  Previous  Current    Next   \n"));
-  DEBUG ((DEBUG_INFO, " Type    Pages     Pages     Pages  \n"));
-  DEBUG ((DEBUG_INFO, "======  ========  ========  ========\n"));
+  // MU_CHANGE: Begin Minimum Allocation
+  DEBUG ((DEBUG_INFO, "Memory  Previous  Current   Minimum    Next\n"));
+  DEBUG ((DEBUG_INFO, " Type    Pages     Pages     Pages     Pages\n"));
+  DEBUG ((DEBUG_INFO, "======  ========  ========  ========  =======\n"));
+  // MU_CHANGE: End Minimum Allocation
 
   for (Index = 0; PreviousMemoryTypeInformation[Index].Type != EfiMaxMemoryType; Index++) {
     for (Index1 = 0; CurrentMemoryTypeInformation[Index1].Type != EfiMaxMemoryType; Index1++) {
@@ -249,12 +315,32 @@ BmSetMemoryTypeInformationVariable (
       Next = 4;
     }
 
+    // MU_CHANGE Begin: Minimum Allocation
+    // If platform has expressed a minimum allocation requirement, apply it here.
+    Minimum = GetMinimumAllocation (PreviousMemoryTypeInformation[Index].Type);
+    if (Next < Minimum) {
+      Next = Minimum;
+    }
+
+    // MU_CHANGE End: Minimum Allocation
+
     if (Next != Previous) {
       PreviousMemoryTypeInformation[Index].NumberOfPages = Next;
       MemoryTypeInformationModified                      = TRUE;
+
+      // MU_CHANGE Begin: MemoryTypeInformationChangeLib
+      //
+      // Log telemetry with ReportMemoryTypeInformationChange
+      //
+      ReportMemoryTypeInformationChange (
+        PreviousMemoryTypeInformation[Index].Type,
+        Previous,
+        Next
+        );
+      // MU_CHANGE End: MemoryTypeInformationChangeLib
     }
 
-    DEBUG ((DEBUG_INFO, "  %02x    %08x  %08x  %08x\n", PreviousMemoryTypeInformation[Index].Type, Previous, Current, Next));
+    DEBUG ((DEBUG_INFO, "  %02x    %08x  %08x  %08x  %08x\n", PreviousMemoryTypeInformation[Index].Type, Previous, Current, Minimum, Next)); // MU_CHANGE
   }
 
   //

--- a/MdeModulePkg/Library/UefiBootManagerLib/InternalBm.h
+++ b/MdeModulePkg/Library/UefiBootManagerLib/InternalBm.h
@@ -53,6 +53,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/DebugLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/UefiBootServicesTableLib.h>
+#include <Library/MemoryTypeInformationChangeLib.h> // MU_CHANGE
 #include <Library/UefiRuntimeServicesTableLib.h>
 #include <Library/UefiLib.h>
 #include <Library/MemoryAllocationLib.h>

--- a/MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
+++ b/MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
@@ -63,6 +63,7 @@
   HiiLib
   SortLib
   VariablePolicyHelperLib
+  MemoryTypeInformationChangeLib # MU_CHANGE
 
 [Guids]
   ## SOMETIMES_CONSUMES ## SystemTable (The identifier of memory type information type in system table)
@@ -70,6 +71,7 @@
   ## SOMETIMES_CONSUMES ## Variable:L"MemoryTypeInformation."
   ## SOMETIMES_PRODUCES ## Variable:L"MemoryTypeInformation."
   gEfiMemoryTypeInformationGuid
+  gEfiMemoryTypeMinimumAllocationGuid ## SOMETIMES_CONSUMES ## HOB # MU_CHANGE
 
   ## SOMETIMES_PRODUCES ## Variable:L"BootCurrent" (The boot option of current boot)
   ## SOMETIMES_CONSUMES ## Variable:L"BootXX" (Boot option variable)

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -1204,6 +1204,12 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdSupportInfiniteBootRetries|FALSE|BOOLEAN|0x40000152
   # MU_CHANGE [END]
 
+  # MU_CHANGE TCBZ1086 [BEGIN] - Mitigate potential system brick due to uefi MemoryTypeInformation var changes
+  ## Maximum total pages that can be reserved by MemoryTypeInfo buckets.
+  # Size in pages. Current default is roughly 1.6GB.
+  gEfiMdeModulePkgTokenSpaceGuid.PcdMaxMemoryTypeInfoPages            |0x60000|UINT32|0x40000150
+  # MU_CHANGE TCBZ1086 [END]
+  
 [PcdsFixedAtBuild, PcdsPatchableInModule]
   ## Dynamic type PCD can be registered callback function for Pcd setting action.
   #  PcdMaxPeiPcdCallBackNumberPerPcdEntry indicates the maximum number of callback function

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -179,6 +179,11 @@
   #
   AdvLoggerAccessLib|Include/Library/AdvLoggerAccessLib.h
 
+  ## MU_CHANGE
+  ## @libraryclass  This library is used to report memory type information change
+  ##                across a reboot.
+  MemoryTypeInformationChangeLib|Include/Library/MemoryTypeInformationChangeLib.h
+
 [Guids]
   ## MdeModule package token space guid
   # Include/Guid/MdeModulePkgTokenSpace.h
@@ -227,6 +232,11 @@
   ## Hob and Variable guid specify the platform memory type information.
   #  Include/Guid/MemoryTypeInformation.h
   gEfiMemoryTypeInformationGuid  = { 0x4C19049F, 0x4137, 0x4DD3, { 0x9C, 0x10, 0x8B, 0x97, 0xA8, 0x3F, 0xFD, 0xFA }}
+
+  ## MU_CHANGE
+  ## Hob and Variable guid specify the minimum allocations for memory types.
+  #  Include/Guid/MemoryTypeInformation.h
+  gEfiMemoryTypeMinimumAllocationGuid = { 0xE4FFE60B, 0x2499, 0x4848, { 0x88, 0x9A, 0xF4, 0x24, 0xC1, 0xC9, 0xC3, 0x47 }}
 
   ## Capsule update hob and variable guid
   #  Include/Guid/CapsuleVendor.h

--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -63,6 +63,7 @@
   DxeServicesTableLib|MdePkg/Library/DxeServicesTableLib/DxeServicesTableLib.inf
   UefiBootManagerLib|MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
   VariablePolicyLib|MdeModulePkg/Library/VariablePolicyLib/VariablePolicyLib.inf
+  MemoryTypeInformationChangeLib|MdeModulePkg/Library/MemoryTypeInformationChangeLibNull/MemoryTypeInformationChangeLibNull.inf  # MU_CHANGE
   #
   # Generic Modules
   #
@@ -227,6 +228,7 @@
   MdeModulePkg/Application/DumpDynPcd/DumpDynPcd.inf
   MdeModulePkg/Application/MemoryProfileInfo/MemoryProfileInfo.inf
   MdeModulePkg/Library/ParallelLzmaCustomDecompressLib/ParallelLzmaCustomDecompressLib.inf       ## MU_CHANGE
+  MdeModulePkg/Library/MemoryTypeInformationChangeLibNull/MemoryTypeInformationChangeLibNull.inf ## MU_CHANGE
   MdeModulePkg/Library/UefiSortLib/UefiSortLib.inf
   MdeModulePkg/Logo/Logo.inf
   MdeModulePkg/Logo/LogoDxe.inf

--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -111,6 +111,7 @@
   VariableFlashInfoLib|MdeModulePkg/Library/BaseVariableFlashInfoLib/BaseVariableFlashInfoLib.inf
   IpmiCommandLib|MdeModulePkg/Library/BaseIpmiCommandLibNull/BaseIpmiCommandLibNull.inf
   SpiHcPlatformLib|MdeModulePkg/Library/BaseSpiHcPlatformLibNull/BaseSpiHcPlatformLibNull.inf
+   MemoryTypeInfoSecVarCheckLib|MdeModulePkg/Library/MemoryTypeInfoSecVarCheckLib/MemoryTypeInfoSecVarCheckLib.inf     # MU_CHANGE TCBZ1086
 
   AdvLoggerAccessLib|MdeModulePkg/Library/AdvLoggerAccessLibNull/AdvLoggerAccessLib.inf       ## MU_CHANGE
 
@@ -247,6 +248,7 @@
   MdeModulePkg/Library/BaseMemoryAllocationLibNull/BaseMemoryAllocationLibNull.inf
   MdeModulePkg/Library/VariablePolicyHelperLib/VariablePolicyHelperLib.inf
   MdeModulePkg/Library/ImagePropertiesRecordLib/ImagePropertiesRecordLib.inf
+  MdeModulePkg/Library/MemoryTypeInfoSecVarCheckLib/MemoryTypeInfoSecVarCheckLib.inf     # MU_CHANGE TCBZ1086
 
   MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridgeDxe.inf
   MdeModulePkg/Bus/Pci/PciSioSerialDxe/PciSioSerialDxe.inf

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
@@ -75,6 +75,7 @@
   VariablePolicyLib
   VariablePolicyHelperLib
   SafeIntLib
+  MemoryTypeInfoSecVarCheckLib  # MU_CHANGE TCBZ1086 - Mitigate potential system brick due to UEFI MemoryTypeInformation var changes
 
 [Protocols]
   gEfiFirmwareVolumeBlockProtocolGuid           ## CONSUMES

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.inf
@@ -85,6 +85,7 @@
   VariablePolicyHelperLib
   SafeIntLib
   AdvLoggerAccessLib                            ## MU_CHANGE
+  MemoryTypeInfoSecVarCheckLib  # MU_CHANGE TCBZ1086 - Mitigate potential system brick due to UEFI MemoryTypeInformation var changes
 
 [Protocols]
   gEfiSmmFirmwareVolumeBlockProtocolGuid        ## CONSUMES

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
@@ -81,6 +81,7 @@
   VariableFlashInfoLib
   VariablePolicyLib
   VariablePolicyHelperLib
+  MemoryTypeInfoSecVarCheckLib                 # MU_CHANGE TCBZ1086 - Mitigate potential system brick due to UEFI MemoryTypeInformation var changes
 
 [Protocols]
   gEfiSmmFirmwareVolumeBlockProtocolGuid        ## CONSUMES

--- a/NetworkPkg/NetworkPkg.dsc
+++ b/NetworkPkg/NetworkPkg.dsc
@@ -39,6 +39,7 @@
   UefiRuntimeServicesTableLib|MdePkg/Library/UefiRuntimeServicesTableLib/UefiRuntimeServicesTableLib.inf
   UefiHiiServicesLib|MdeModulePkg/Library/UefiHiiServicesLib/UefiHiiServicesLib.inf
   UefiBootManagerLib|MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
+  MemoryTypeInformationChangeLib|MdeModulePkg/Library/MemoryTypeInformationChangeLibNull/MemoryTypeInformationChangeLibNull.inf  # MU_CHANGE
   TimerLib|MdePkg/Library/BaseTimerLibNullTemplate/BaseTimerLibNullTemplate.inf
   PerformanceLib|MdePkg/Library/BasePerformanceLibNull/BasePerformanceLibNull.inf
   PeCoffGetEntryPointLib|MdePkg/Library/BasePeCoffGetEntryPointLib/BasePeCoffGetEntryPointLib.inf

--- a/ShellPkg/ShellPkg.dsc
+++ b/ShellPkg/ShellPkg.dsc
@@ -59,6 +59,7 @@
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
 
   UefiBootManagerLib|MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
+  MemoryTypeInformationChangeLib|MdeModulePkg/Library/MemoryTypeInformationChangeLibNull/MemoryTypeInformationChangeLibNull.inf # MU_CHANGE
   HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
   PerformanceLib|MdePkg/Library/BasePerformanceLibNull/BasePerformanceLibNull.inf
   DxeServicesTableLib|MdePkg/Library/DxeServicesTableLib/DxeServicesTableLib.inf


### PR DESCRIPTION
## Description

This change introduces memory type information change library, cherry-picked from:
https://github.com/microsoft/mu_basecore/commit/2821836b4fd445ecc759f960cda484b0a940a922
48f36a45b1
60aade9b06
7e9ca42054

This adds the MemoryTypeInformationChangeLib which provides a mechanism for a platform to record memory bucket resizes whichever way suits them. UefiBootManagerLib makes a call to ReportMemoryTypeInformationChange so that a platform can receive it if desired. If a platform does not need to specially record this, the null instance of the library may be used.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [x] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Not tested.

## Integration Instructions

For platforms using UefiBootManagerLib that do not need to record memory bucket size changes specially, include the following in the platform DSC:

```
MemoryTypeInformationChangeLib|MdeModulePkg/Library/MemoryTypeInformationChangeLibNull/MemoryTypeInformationChangeLibNull.inf
```

A platform may override this library to report this via SEL or some other platform defined mechanism.