### PR TITLE
[Rebase & FF] 202405: Ramdisk alignment

### DIFF
--- a/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
@@ -1398,7 +1398,8 @@ BmDestroyRamDisk (
 
   Status = mRamDisk->Unregister (RamDiskDevicePath);
   ASSERT_EFI_ERROR (Status);
-  FreePages (RamDiskBuffer, RamDiskSizeInPages);
+  // MU_CHANGE - Ramdisk is now allocated with alignment.
+  FreeAlignedPages (RamDiskBuffer, RamDiskSizeInPages);
 }
 
 /**
@@ -1446,10 +1447,17 @@ BmExpandLoadFile (
     return DuplicateDevicePath (DevicePathFromHandle (LoadFileHandle));
   }
 
+  // MU_CHANGE [BEGIN] - Ramdisk is now allocated with 2MB alignment.
+
   //
   // The load option resides in a RAM disk.
+  // Use a reasonable default of 2MB for alignment as the ramdisk device is
+  // implemented as an NVDIMM persistent memory and operating systems may
+  // wish to map this with huge page support.
   //
-  FileBuffer = AllocateReservedPages (EFI_SIZE_TO_PAGES (BufferSize));
+
+  FileBuffer = AllocateAlignedReservedPages (EFI_SIZE_TO_PAGES (BufferSize), SIZE_2MB);
+  // MU_CHANGE [END] - Ramdisk is now allocated with 2MB alignment.
   if (FileBuffer == NULL) {
     DEBUG_CODE_BEGIN ();
     EFI_DEVICE_PATH  *LoadFilePath;
@@ -1490,7 +1498,8 @@ BmExpandLoadFile (
 
   Status = LoadFile->LoadFile (LoadFile, FilePath, TRUE, &BufferSize, FileBuffer);
   if (EFI_ERROR (Status)) {
-    FreePages (FileBuffer, EFI_SIZE_TO_PAGES (BufferSize));
+    // MU_CHANGE - Ramdisk is now allocated with alignment.
+    FreeAlignedPages (FileBuffer, EFI_SIZE_TO_PAGES (BufferSize));
     return NULL;
   }
 


### PR DESCRIPTION
## Description

Map Ramdisk pages as 2MB aligned so that OSes can map them as large pages if desired.

Cherry-pick from: https://github.com/microsoft/mu_basecore/commit/3710476a755c93a026120c7e93284f9166cf17a7

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Not tested.

## Integration Instructions

N/A