### PR TITLE
[CHERRY-PICK] [RELEASE/202311] Pulling PixieFail changes from EDK2 for CVE-2023-45237 and CVE-2023-45236

### DIFF
--- a/MdePkg/Test/MdePkgHostTest.dsc
+++ b/MdePkg/Test/MdePkgHostTest.dsc
@@ -46,6 +46,7 @@
   MdePkg/Library/BaseLib/UnitTestHostBaseLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockUefiLib/MockUefiLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockUefiRuntimeServicesTableLib/MockUefiRuntimeServicesTableLib.inf
+  MdePkg/Test/Mock/Library/GoogleTest/MockUefiBootServicesTableLib/MockUefiBootServicesTableLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockPeiServicesLib/MockPeiServicesLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockHobLib/MockHobLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockUefiBootServicesTableLib/MockUefiBootServicesTableLib.inf

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiBootServicesTableLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiBootServicesTableLib.h
@@ -84,4 +84,4 @@ struct MockUefiBootServicesTableLib {
     );
 };
 
-#endif
+#endif // MOCK_UEFI_BOOT_SERVICES_TABLE_LIB_H_

--- a/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockHash2.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockHash2.h
@@ -5,8 +5,8 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
-#ifndef MOCK_HASH2_H
-#define MOCK_HASH2_H
+#ifndef MOCK_HASH2_H_
+#define MOCK_HASH2_H_
 
 #include <Library/GoogleTestLib.h>
 #include <Library/FunctionMockLib.h>
@@ -64,4 +64,4 @@ extern "C" {
   extern EFI_HASH2_PROTOCOL  *gHash2Protocol;
 }
 
-#endif // MOCK_HASH2_H
+#endif // MOCK_HASH2_H_

--- a/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockRng.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockRng.h
@@ -5,8 +5,8 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
-#ifndef MOCK_RNG_H
-#define MOCK_RNG_H
+#ifndef MOCK_RNG_H_
+#define MOCK_RNG_H_
 
 #include <Library/GoogleTestLib.h>
 #include <Library/FunctionMockLib.h>
@@ -45,4 +45,4 @@ extern "C" {
   extern EFI_RNG_PROTOCOL  *gRngProtocol;
 }
 
-#endif // MOCK_RNG_H
+#endif // MOCK_RNG_H_

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockUefiBootServicesTableLib/MockUefiBootServicesTableLib.inf
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockUefiBootServicesTableLib/MockUefiBootServicesTableLib.inf
@@ -1,8 +1,9 @@
 ## @file
-# Google Test mocks for UefiBootServicesTableLib
+#  Mock implementation of the UEFI Boot Services Table Library.
 #
-# Copyright (c) Microsoft Corporation.
-# SPDX-License-Identifier: BSD-2-Clause-Patent
+#  Copyright (c) Microsoft Corporation.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
 ##
 
 [Defines]
@@ -11,23 +12,21 @@
   FILE_GUID                      = 0BAFDBA6-411A-4094-931B-C29B98483043
   MODULE_TYPE                    = HOST_APPLICATION
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = UefiBootServicesTableLib
+  LIBRARY_CLASS                  = UefiBootServicesTableLib|HOST_APPLICATION
 
 #
-# The following information is for reference only and not required by the build tools.
-#
-#  VALID_ARCHITECTURES           = IA32 X64
+#  VALID_ARCHITECTURES           = IA32 X64 EBC
 #
 
 [Sources]
   MockUefiBootServicesTableLib.cpp
 
+[LibraryClasses]
+  GoogleTestLib
+
 [Packages]
   MdePkg/MdePkg.dec
   UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
-
-[LibraryClasses]
-  GoogleTestLib
 
 [BuildOptions]
   MSFT:*_*_*_CC_FLAGS = /EHsc

--- a/NetworkPkg/Dhcp4Dxe/Dhcp4Driver.c
+++ b/NetworkPkg/Dhcp4Dxe/Dhcp4Driver.c
@@ -1,6 +1,7 @@
 /** @file
 
 Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/

--- a/NetworkPkg/Dhcp6Dxe/Dhcp6Driver.c
+++ b/NetworkPkg/Dhcp6Dxe/Dhcp6Driver.c
@@ -3,7 +3,7 @@
   implementation for Dhcp6 Driver.
 
   Copyright (c) 2009 - 2018, Intel Corporation. All rights reserved.<BR>
-
+  Copyright (c) Microsoft Corporation
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/

--- a/NetworkPkg/DnsDxe/DnsDhcp.c
+++ b/NetworkPkg/DnsDxe/DnsDhcp.c
@@ -2,6 +2,7 @@
 Functions implementation related with DHCPv4/v6 for DNS driver.
 
 Copyright (c) 2015 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/

--- a/NetworkPkg/DnsDxe/DnsImpl.c
+++ b/NetworkPkg/DnsDxe/DnsImpl.c
@@ -2,6 +2,7 @@
 DnsDxe support functions implementation.
 
 Copyright (c) 2016 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/

--- a/NetworkPkg/HttpBootDxe/HttpBootDhcp6.c
+++ b/NetworkPkg/HttpBootDxe/HttpBootDhcp6.c
@@ -2,6 +2,7 @@
   Functions implementation related with DHCPv6 for HTTP boot driver.
 
 Copyright (c) 2015 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/

--- a/NetworkPkg/IScsiDxe/IScsiCHAP.c
+++ b/NetworkPkg/IScsiDxe/IScsiCHAP.c
@@ -3,6 +3,7 @@
   Configuration.
 
 Copyright (c) 2004 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/

--- a/NetworkPkg/IScsiDxe/IScsiMisc.c
+++ b/NetworkPkg/IScsiDxe/IScsiMisc.c
@@ -2,6 +2,7 @@
   Miscellaneous routines for iSCSI driver.
 
 Copyright (c) 2004 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/

--- a/NetworkPkg/IScsiDxe/IScsiMisc.h
+++ b/NetworkPkg/IScsiDxe/IScsiMisc.h
@@ -2,6 +2,7 @@
   Miscellaneous definitions for iSCSI driver.
 
 Copyright (c) 2004 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/

--- a/NetworkPkg/Include/Library/NetLib.h
+++ b/NetworkPkg/Include/Library/NetLib.h
@@ -3,6 +3,7 @@
   It provides basic functions for the UEFI network stack.
 
 Copyright (c) 2005 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -577,17 +578,19 @@ NetPutUint32 (
   IN     UINT32  Data
   );
 
-/*
-Generate a Random output data given a length.
+/**
+  Generate a Random output data given a length.
 
-@param[out] Output - The buffer to store the generated random data.
-@param[in] OutputLength - The length of the output buffer.
+  @param[out] Output - The buffer to store the generated random data.
+  @param[in] OutputLength - The length of the output buffer.
 
-@retval EFI_SUCCESS           On Success
-@retval EFI_INVALID_PARAMETER Pointer is null or size is zero
-@retval EFI_NOT_FOUND         RNG protocol not found
-@Retval Others                Error from RngProtocol->GetRNG()
-*/
+  @retval EFI_SUCCESS           On Success
+  @retval EFI_INVALID_PARAMETER Pointer is null or size is zero
+  @retval EFI_NOT_FOUND         RNG protocol not found
+  @retval Others                Error from RngProtocol->GetRNG()
+
+  @return Status code
+**/
 EFI_STATUS
 EFIAPI
 PseudoRandom (
@@ -595,13 +598,17 @@ PseudoRandom (
   IN   UINTN  OutputLength
   );
 
-/*
-Generate a 32-bit pseudo-random number.
+/**
+  Generate a 32-bit pseudo-random number.
 
-@param[out] Output - The buffer to store the generated random number.
+  @param[out] Output - The buffer to store the generated random number.
 
-@return EFI_SUCCESS on success, error code on failure.
-*/
+  @retval EFI_SUCCESS           On Success
+  @retval EFI_NOT_FOUND         RNG protocol not found
+  @retval Others                Error from RngProtocol->GetRNG()
+
+  @return Status code
+**/
 EFI_STATUS
 EFIAPI
 PseudoRandomU32 (

--- a/NetworkPkg/Ip4Dxe/Ip4Driver.c
+++ b/NetworkPkg/Ip4Dxe/Ip4Driver.c
@@ -2,6 +2,7 @@
   The driver binding and service binding protocol for IP4 driver.
 
 Copyright (c) 2005 - 2019, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation
 (C) Copyright 2015 Hewlett-Packard Development Company, L.P.<BR>
 
 SPDX-License-Identifier: BSD-2-Clause-Patent

--- a/NetworkPkg/Ip6Dxe/Ip6Driver.c
+++ b/NetworkPkg/Ip6Dxe/Ip6Driver.c
@@ -3,7 +3,7 @@
 
   Copyright (c) 2009 - 2019, Intel Corporation. All rights reserved.<BR>
   (C) Copyright 2015 Hewlett-Packard Development Company, L.P.<BR>
-
+  Copyright (c) Microsoft Corporation
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/

--- a/NetworkPkg/Ip6Dxe/Ip6If.c
+++ b/NetworkPkg/Ip6Dxe/Ip6If.c
@@ -2,7 +2,7 @@
   Implement IP6 pseudo interface.
 
   Copyright (c) 2009 - 2018, Intel Corporation. All rights reserved.<BR>
-
+  Copyright (c) Microsoft Corporation
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/

--- a/NetworkPkg/Ip6Dxe/Ip6Nd.c
+++ b/NetworkPkg/Ip6Dxe/Ip6Nd.c
@@ -2,7 +2,7 @@
   Implementation of Neighbor Discovery support routines.
 
   Copyright (c) 2009 - 2018, Intel Corporation. All rights reserved.<BR>
-
+  Copyright (c) Microsoft Corporation
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/

--- a/NetworkPkg/Ip6Dxe/Ip6Nd.h
+++ b/NetworkPkg/Ip6Dxe/Ip6Nd.h
@@ -2,7 +2,7 @@
   Definition of Neighbor Discovery support routines.
 
   Copyright (c) 2009 - 2012, Intel Corporation. All rights reserved.<BR>
-
+  Copyright (c) Microsoft Corporation
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/

--- a/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
+++ b/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
@@ -3,6 +3,7 @@
 
 Copyright (c) 2005 - 2018, Intel Corporation. All rights reserved.<BR>
 (C) Copyright 2015 Hewlett Packard Enterprise Development LP<BR>
+Copyright (c) Microsoft Corporation
 SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -129,22 +130,23 @@ GLOBAL_REMOVE_IF_UNREFERENCED VLAN_DEVICE_PATH  mNetVlanDevicePathTemplate = {
 };
 
 //
-// These represent UEFI SPEC & NIST SP-800-90 approved algorithms that should be supported by the RNG protocol
-// and are generally considered secure. This list enforces a minimum set of secure algorithms that must
-// be supported by the RNG protocol.
+// These represent UEFI SPEC defined algorithms that should be supported by
+// the RNG protocol and are generally considered secure.
 //
-// The order of the algorithms in this array is important. The first algorithm that is supported by the RNG
-// protocol will be used to generate the seed for the random number generator.
-// If your platform needs to use a specific algorithm to generate the seed for the random number generator,
+// The order of the algorithms in this array is important. This order is the order
+// in which the algorithms will be tried by the RNG protocol.
+// If your platform needs to use a specific algorithm for the random number generator,
 // then you should place that algorithm first in the array.
 //
 GLOBAL_REMOVE_IF_UNREFERENCED EFI_GUID  *mSecureHashAlgorithms[] = {
   &gEfiRngAlgorithmSp80090Ctr256Guid,  // SP800-90A DRBG CTR using AES-256
   &gEfiRngAlgorithmSp80090Hmac256Guid, // SP800-90A DRBG HMAC using SHA-256
-  &gEfiRngAlgorithmSp80090Hash256Guid  // SP800-90A DRBG Hash using SHA-256
+  &gEfiRngAlgorithmSp80090Hash256Guid, // SP800-90A DRBG Hash using SHA-256
+  &gEfiRngAlgorithmArmRndr,            // unspecified SP800-90A DRBG via ARM RNDR register
+  &gEfiRngAlgorithmRaw,                // Raw data from NRBG (or TRNG)
 };
 
-#define mSecureHashAlgorithmsSize  (sizeof (mSecureHashAlgorithms) / sizeof (EFI_GUID *))
+#define SECURE_HASH_ALGORITHMS_SIZE  (sizeof (mSecureHashAlgorithms) / sizeof (EFI_GUID *))
 
 /**
   Locate the handles that support SNP, then open one of them
@@ -902,17 +904,19 @@ Ip6Swap128 (
   return Ip6;
 }
 
-/*
-Generate a Random output data given a length.
+/**
+  Generate a Random output data given a length.
 
-@param[out] Output - The buffer to store the generated random data.
-@param[in] OutputLength - The length of the output buffer.
+  @param[out] Output - The buffer to store the generated random data.
+  @param[in] OutputLength - The length of the output buffer.
 
-@retval EFI_SUCCESS           On Success
-@retval EFI_INVALID_PARAMETER Pointer is null or size is zero
-@retval EFI_NOT_FOUND         RNG protocol not found
-@Retval Others                Error from RngProtocol->GetRNG()
-*/
+  @retval EFI_SUCCESS           On Success
+  @retval EFI_INVALID_PARAMETER Pointer is null or size is zero
+  @retval EFI_NOT_FOUND         RNG protocol not found
+  @retval Others                Error from RngProtocol->GetRNG()
+
+  @return Status code
+**/
 EFI_STATUS
 EFIAPI
 PseudoRandom (
@@ -922,6 +926,7 @@ PseudoRandom (
 {
   EFI_RNG_PROTOCOL  *RngProtocol;
   EFI_STATUS        Status;
+  UINTN             AlgorithmIndex;
 
   if ((Output == NULL) || (OutputLength == 0)) {
     return EFI_INVALID_PARAMETER;
@@ -935,8 +940,8 @@ PseudoRandom (
   }
 
   if (PcdGetBool (PcdEnforceSecureRngAlgorithms)) {
-    for (UINTN i = 0; i < mSecureHashAlgorithmsSize; i++) {
-      Status = RngProtocol->GetRNG (RngProtocol, mSecureHashAlgorithms[i], OutputLength, (UINT8 *)Output);
+    for (AlgorithmIndex = 0; AlgorithmIndex < SECURE_HASH_ALGORITHMS_SIZE; AlgorithmIndex++) {
+      Status = RngProtocol->GetRNG (RngProtocol, mSecureHashAlgorithms[AlgorithmIndex], OutputLength, (UINT8 *)Output);
       if (!EFI_ERROR (Status)) {
         //
         // Secure Algorithm was supported on this platform
@@ -946,7 +951,7 @@ PseudoRandom (
         //
         // Secure Algorithm was not supported on this platform
         //
-        DEBUG ((DEBUG_ERROR, "Failed to generate random data using secure algorithm %d: %r\n", i, Status));
+        DEBUG ((DEBUG_ERROR, "Failed to generate random data using secure algorithm %d: %r\n", AlgorithmIndex, Status));
 
         //
         // Try the next secure algorithm
@@ -956,7 +961,7 @@ PseudoRandom (
         //
         // Some other error occurred
         //
-        DEBUG ((DEBUG_ERROR, "Failed to generate random data using secure algorithm %d: %r\n", i, Status));
+        DEBUG ((DEBUG_ERROR, "Failed to generate random data using secure algorithm %d: %r\n", AlgorithmIndex, Status));
         ASSERT_EFI_ERROR (Status);
         return Status;
       }
@@ -983,16 +988,17 @@ PseudoRandom (
   return EFI_SUCCESS;
 }
 
-/*
-Generate a 32-bit pseudo-random number.
+/**
+  Generate a 32-bit pseudo-random number.
 
-@param[out] Output - The buffer to store the generated random number.
+  @param[out] Output - The buffer to store the generated random number.
 
-@retval EFI_SUCCESS           On Success
-@retval EFI_INVALID_PARAMETER Pointer is null or size is zero
-@retval EFI_NOT_FOUND         RNG protocol not found
-@Retval Others                Error from RngProtocol->GetRNG()
-*/
+  @retval EFI_SUCCESS           On Success
+  @retval EFI_NOT_FOUND         RNG protocol not found
+  @retval Others                Error from RngProtocol->GetRNG()
+
+  @return Status code
+**/
 EFI_STATUS
 EFIAPI
 PseudoRandomU32 (

--- a/NetworkPkg/Library/DxeNetLib/DxeNetLib.inf
+++ b/NetworkPkg/Library/DxeNetLib/DxeNetLib.inf
@@ -3,6 +3,7 @@
 #
 #  Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
 #  (C) Copyright 2015 Hewlett Packard Enterprise Development LP<BR>
+#  Copyright (c) Microsoft Corporation
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -49,10 +50,12 @@
   gEfiSmbiosTableGuid                           ## SOMETIMES_CONSUMES  ## SystemTable
   gEfiSmbios3TableGuid                          ## SOMETIMES_CONSUMES  ## SystemTable
   gEfiAdapterInfoMediaStateGuid                 ## SOMETIMES_CONSUMES
+  gEfiRngAlgorithmRaw                           ## CONSUMES
   gEfiRngAlgorithmSp80090Ctr256Guid             ## CONSUMES
   gEfiRngAlgorithmSp80090Hmac256Guid            ## CONSUMES
   gEfiRngAlgorithmSp80090Hash256Guid            ## CONSUMES
-  
+  gEfiRngAlgorithmArmRndr                       ## CONSUMES
+
 [Protocols]
   gEfiSimpleNetworkProtocolGuid                 ## SOMETIMES_CONSUMES
   gEfiManagedNetworkProtocolGuid                ## SOMETIMES_CONSUMES
@@ -65,3 +68,6 @@
 
 [FixedPcd]
   gEfiNetworkPkgTokenSpaceGuid.PcdEnforceSecureRngAlgorithms ## CONSUMES
+
+[Depex]
+  gEfiRngProtocolGuid

--- a/NetworkPkg/NetworkPkg.dec
+++ b/NetworkPkg/NetworkPkg.dec
@@ -5,6 +5,7 @@
 #
 # Copyright (c) 2009 - 2021, Intel Corporation. All rights reserved.<BR>
 # (C) Copyright 2015-2020 Hewlett Packard Enterprise Development LP<BR>
+# Copyright (c) Microsoft Corporation
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #

--- a/NetworkPkg/SecurityFixes.yaml
+++ b/NetworkPkg/SecurityFixes.yaml
@@ -114,32 +114,9 @@ CVE_2023_45235:
     - http://www.openwall.com/lists/oss-security/2024/01/16/2
     - http://packetstormsecurity.com/files/176574/PixieFail-Proof-Of-Concepts.html
     - https://blog.quarkslab.com/pixiefail-nine-vulnerabilities-in-tianocores-edk-ii-ipv6-network-stack.html
-CVE_2023_45236:
-  commit_titles:
-    - "SECURITY PATCH - TCBZ4541 - Patch"
-  cve: CVE-2023-45236
-  date_reported: 2023-08-28 13:56 UTC
-  description: "Bug 08 - edk2/NetworkPkg: Predictable TCP Initial Sequence Numbers"
-  note:
-  files_impacted:
-    - NetworkPkg/Include/Library/NetLib.h
-    - NetworkPkg/Library/DxeNetLib/DxeNetLib.c
-    - NetworkPkg/TcpDxe/TcpDriver.c
-    - NetworkPkg/TcpDxe/TcpDxe.inf
-    - NetworkPkg/TcpDxe/TcpFunc.h
-    - NetworkPkg/TcpDxe/TcpInput.c
-    - NetworkPkg/TcpDxe/TcpMain.h
-    - NetworkPkg/TcpDxe/TcpMisc.c
-    - NetworkPkg/TcpDxe/TcpTimer.c
-  links:
-    - https://bugzilla.tianocore.org/show_bug.cgi?id=4541
-    - https://nvd.nist.gov/vuln/detail/CVE-2023-45236
-    - http://www.openwall.com/lists/oss-security/2024/01/16/2
-    - http://packetstormsecurity.com/files/176574/PixieFail-Proof-Of-Concepts.html
-    - https://blog.quarkslab.com/pixiefail-nine-vulnerabilities-in-tianocores-edk-ii-ipv6-network-stack.html
 CVE_2023_45237:
   commit_titles:
-    - "NetworkPkg: SECURITY PATCH 4542 - CVE 2023-45237 "
+    - "NetworkPkg:: SECURITY PATCH CVE 2023-45237"
   cve: CVE-2023-45237
   date_reported: 2023-08-28 13:56 UTC
   description: "Bug 09 - Use of a Weak PseudoRandom Number Generator"

--- a/NetworkPkg/SecurityFixes.yaml
+++ b/NetworkPkg/SecurityFixes.yaml
@@ -114,6 +114,28 @@ CVE_2023_45235:
     - http://www.openwall.com/lists/oss-security/2024/01/16/2
     - http://packetstormsecurity.com/files/176574/PixieFail-Proof-Of-Concepts.html
     - https://blog.quarkslab.com/pixiefail-nine-vulnerabilities-in-tianocores-edk-ii-ipv6-network-stack.html
+CVE_2023_45236:
+  commit_titles:
+    - "NetworkPkg: TcpDxe: SECURITY PATCH CVE-2023-45236 Patch"
+  cve: CVE-2023-45236
+  date_reported: 2023-08-28 13:56 UTC
+  description: "Bug 08 - edk2/NetworkPkg: Predictable TCP Initial Sequence Numbers"
+  note:
+  files_impacted:
+    - NetworkPkg/Include/Library/NetLib.h
+    - NetworkPkg/TcpDxe/TcpDriver.c
+    - NetworkPkg/TcpDxe/TcpDxe.inf
+    - NetworkPkg/TcpDxe/TcpFunc.h
+    - NetworkPkg/TcpDxe/TcpInput.c
+    - NetworkPkg/TcpDxe/TcpMain.h
+    - NetworkPkg/TcpDxe/TcpMisc.c
+    - NetworkPkg/TcpDxe/TcpTimer.c
+  links:
+    - https://bugzilla.tianocore.org/show_bug.cgi?id=4541
+    - https://nvd.nist.gov/vuln/detail/CVE-2023-45236
+    - http://www.openwall.com/lists/oss-security/2024/01/16/2
+    - http://packetstormsecurity.com/files/176574/PixieFail-Proof-Of-Concepts.html
+    - https://blog.quarkslab.com/pixiefail-nine-vulnerabilities-in-tianocores-edk-ii-ipv6-network-stack.html
 CVE_2023_45237:
   commit_titles:
     - "NetworkPkg:: SECURITY PATCH CVE 2023-45237"

--- a/NetworkPkg/TcpDxe/TcpDriver.c
+++ b/NetworkPkg/TcpDxe/TcpDriver.c
@@ -2,7 +2,7 @@
   The driver binding and service binding protocol for the TCP driver.
 
   Copyright (c) 2009 - 2018, Intel Corporation. All rights reserved.<BR>
-
+  Copyright (c) Microsoft Corporation
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -171,23 +171,6 @@ TcpDriverEntryPoint (
   EFI_STATUS  Status;
   UINT32      Random;
 
-  //
-  // Initialize the Secret used for hashing TCP sequence numbers
-  //
-  // Normally this should be regenerated periodically, but since
-  // this is only used for UEFI networking and not a general purpose
-  // operating system, it is not necessary to regenerate it.
-  //
-  Status = PseudoRandomU32 (&mTcpGlobalSecret);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a failed to generate random number: %r\n", __func__, Status));
-    return Status;
-  }
-
-  //
-  // Get a random number used to generate a random port number
-  // Intentionally not linking this to mTcpGlobalSecret to avoid leaking information about the secret
-  //
   Status = PseudoRandomU32 (&Random);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a Failed to generate random number: %r\n", __func__, Status));

--- a/NetworkPkg/TcpDxe/TcpDriver.c
+++ b/NetworkPkg/TcpDxe/TcpDriver.c
@@ -171,6 +171,23 @@ TcpDriverEntryPoint (
   EFI_STATUS  Status;
   UINT32      Random;
 
+  //
+  // Initialize the Secret used for hashing TCP sequence numbers
+  //
+  // Normally this should be regenerated periodically, but since
+  // this is only used for UEFI networking and not a general purpose
+  // operating system, it is not necessary to regenerate it.
+  //
+  Status = PseudoRandomU32 (&mTcpGlobalSecret);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a failed to generate random number: %r\n", __func__, Status));
+    return Status;
+  }
+
+  //
+  // Get a random number used to generate a random port number
+  // Intentionally not linking this to mTcpGlobalSecret to avoid leaking information about the secret
+  //
   Status = PseudoRandomU32 (&Random);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a Failed to generate random number: %r\n", __func__, Status));

--- a/NetworkPkg/TcpDxe/TcpDxe.inf
+++ b/NetworkPkg/TcpDxe/TcpDxe.inf
@@ -6,6 +6,7 @@
 #  stack has been loaded in system. This driver supports both IPv4 and IPv6 network stack.
 #
 #  Copyright (c) 2009 - 2018, Intel Corporation. All rights reserved.<BR>
+#  Copyright (c) Microsoft Corporation
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #

--- a/NetworkPkg/TcpDxe/TcpDxe.inf
+++ b/NetworkPkg/TcpDxe/TcpDxe.inf
@@ -87,5 +87,8 @@
   gEfiHashAlgorithmMD5Guid                      ## CONSUMES
   gEfiHashAlgorithmSha256Guid                   ## CONSUMES
 
+[Depex]
+  gEfiHash2ServiceBindingProtocolGuid
+
 [UserExtensions.TianoCore."ExtraFiles"]
   TcpDxeExtra.uni

--- a/NetworkPkg/TcpDxe/TcpFunc.h
+++ b/NetworkPkg/TcpDxe/TcpFunc.h
@@ -2,7 +2,7 @@
   Declaration of external functions shared in TCP driver.
 
   Copyright (c) 2009 - 2014, Intel Corporation. All rights reserved.<BR>
-
+  Copyright (c) Microsoft Corporation
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/

--- a/NetworkPkg/TcpDxe/TcpMain.h
+++ b/NetworkPkg/TcpDxe/TcpMain.h
@@ -3,7 +3,7 @@
   It is the common head file for all Tcp*.c in TCP driver.
 
   Copyright (c) 2009 - 2016, Intel Corporation. All rights reserved.<BR>
-
+  Copyright (c) Microsoft Corporation
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/

--- a/NetworkPkg/TcpDxe/TcpMisc.c
+++ b/NetworkPkg/TcpDxe/TcpMisc.c
@@ -3,7 +3,7 @@
 
   (C) Copyright 2014 Hewlett-Packard Development Company, L.P.<BR>
   Copyright (c) 2009 - 2017, Intel Corporation. All rights reserved.<BR>
-
+  Copyright (c) Microsoft Corporation
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -27,20 +27,26 @@ LIST_ENTRY  mTcpListenQue = {
 TCP_SEQNO  mTcpGlobalSecret;
 
 //
+// Union to hold either an IPv4 or IPv6 address
+// This is used to simplify the ISN hash computation
+//
+typedef union {
+  UINT8    IPv4[4];
+  UINT8    IPv6[16];
+} NETWORK_ADDRESS;
+
+//
 // The ISN is computed by hashing this structure
 // It is initialized with the local and remote IP addresses and ports
 // and the secret
 //
 //
 typedef struct {
-  UINT16       LocalPort;
-  UINT16       RemotePort;
-  union {
-    UINT8    IPv4[4];
-    UINT8    IPv6[16];
-  } LocalAddress,
-    RemoteAddress;
-  TCP_SEQNO    Secret;
+  UINT16             LocalPort;
+  UINT16             RemotePort;
+  NETWORK_ADDRESS    LocalAddress;
+  NETWORK_ADDRESS    RemoteAddress;
+  TCP_SEQNO          Secret;
 } ISN_HASH_CTX;
 
 CHAR16  *mTcpStateName[] = {

--- a/NetworkPkg/TcpDxe/TcpTimer.c
+++ b/NetworkPkg/TcpDxe/TcpTimer.c
@@ -2,7 +2,7 @@
   TCP timer related functions.
 
   Copyright (c) 2009 - 2010, Intel Corporation. All rights reserved.<BR>
-
+  Copyright (c) Microsoft Corporation
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/

--- a/NetworkPkg/Test/NetworkPkgHostTest.dsc
+++ b/NetworkPkg/Test/NetworkPkgHostTest.dsc
@@ -30,6 +30,7 @@
   NetworkPkg/UefiPxeBcDxe/GoogleTest/UefiPxeBcDxeGoogleTest.inf {
     <LibraryClasses>
       UefiRuntimeServicesTableLib|MdePkg/Test/Mock/Library/GoogleTest/MockUefiRuntimeServicesTableLib/MockUefiRuntimeServicesTableLib.inf
+      UefiBootServicesTableLib|MdePkg/Test/Mock/Library/GoogleTest/MockUefiBootServicesTableLib/MockUefiBootServicesTableLib.inf
   }
 
 # Despite these library classes being listed in [LibraryClasses] below, they are not needed for the host-based unit tests.

--- a/NetworkPkg/Udp4Dxe/Udp4Driver.c
+++ b/NetworkPkg/Udp4Dxe/Udp4Driver.c
@@ -1,6 +1,7 @@
 /** @file
 
 Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/

--- a/NetworkPkg/Udp6Dxe/Udp6Driver.c
+++ b/NetworkPkg/Udp6Dxe/Udp6Driver.c
@@ -2,7 +2,7 @@
   Driver Binding functions and Service Binding functions for the Network driver module.
 
   Copyright (c) 2009 - 2018, Intel Corporation. All rights reserved.<BR>
-
+  Copyright (c) Microsoft Corporation
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/

--- a/NetworkPkg/UefiPxeBcDxe/GoogleTest/UefiPxeBcDxeGoogleTest.inf
+++ b/NetworkPkg/UefiPxeBcDxe/GoogleTest/UefiPxeBcDxeGoogleTest.inf
@@ -23,6 +23,7 @@ VERSION_STRING = 1.0
   PxeBcDhcp6GoogleTest.h
   ../PxeBcDhcp6.c
   ../PxeBcSupport.c
+  ../../../MdePkg/Test/Mock/Library/GoogleTest/Protocol/MockRng.cpp
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp4.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp4.c
@@ -2,7 +2,7 @@
   Functions implementation related with DHCPv4 for UefiPxeBc Driver.
 
   Copyright (c) 2009 - 2018, Intel Corporation. All rights reserved.<BR>
-
+  Copyright (c) Microsoft Corporation
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcDriver.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcDriver.c
@@ -3,6 +3,7 @@
 
   (C) Copyright 2014 Hewlett-Packard Development Company, L.P.<BR>
   Copyright (c) 2007 - 2019, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) Microsoft Corporation
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 


### PR DESCRIPTION


## Description

This pulls in the changes from EDK2 that were made during the upstreaming of CVE-2023-45237 and CVE-2023-45236

The notable changes are:
 - Updates to the Unit Tests to get them to pass due to the underlying code being altered to use Hash2 Protocol and RngProtocol
 - Addition of the following algorithms to be more inclusive to ARM platforms
           - &gEfiRngAlgorithmArmRndr,            // unspecified SP800-90A DRBG via ARM RNDR register
           - &gEfiRngAlgorithmRaw,                // Raw data from NRBG (or TRNG)

- [X] Impacts functionality?
  - gEfiRngAlgorithmArmRndr and gEfiRngAlgorithmRaw allow the platform to be more inclusive of ARM and if they provide these guids they no longer need to depend on DEFAULT 
- [X] Impacts security?
  - As mentioned before - allows for the ARM platforms to be more specific than before
- [ ] Breaking change?
- [X] Includes tests?
  - Updates the Unit tests to pass due to the new dependencies 
- [ ] Includes documentation?
  - File containing what CVEs were patched
  
## How This Was Tested
Local unit test

## Integration Instructions

If the platform was setting PcdEnforceSecureRngAlgorithms before they may not be required to do so now that the new algorithms are included