### PR TITLE
MdeModulePkg/Universal/Console/TerminalDxe: Increase FIFO and change polling rate. [Rebase & FF]

### DIFF
--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -2347,6 +2347,11 @@
   ## The value of rate limiter event for timeout check. Default value is 100(unit 1ms).
   # @Prompt The value is use for Usb Network rate limiting supported.
   gEfiMdeModulePkgTokenSpaceGuid.PcdUsbNetworkRateLimitingFactor|100|UINT32|0x10000028
+  
+  ## MU_CHANGE - Configuring timer interval in terminal DXE driver
+  ## This PCD determines the timer interval to be set when using serial console.
+  # @Prompt Sets the serial console timer interval, in the unit of 100ns.
+  gEfiMdeModulePkgTokenSpaceGuid.PcdTerminalKeyboardTimerInterval|0x00000000|UINT32|0x00030025
 
 [PcdsPatchableInModule]
   ## Specify memory size with page number for PEI code when

--- a/MdeModulePkg/Universal/Console/TerminalDxe/Terminal.h
+++ b/MdeModulePkg/Universal/Console/TerminalDxe/Terminal.h
@@ -35,26 +35,28 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/PcdLib.h>
 #include <Library/BaseLib.h>
 
-#define RAW_FIFO_MAX_NUMBER  255
-#define FIFO_MAX_NUMBER      128
+// MU_CHANGE Starts: Extending the FIFO buffer size beyond UINT8 width.
+#define RAW_FIFO_MAX_NUMBER  600
+#define FIFO_MAX_NUMBER      300
 
 typedef struct {
-  UINT8    Head;
-  UINT8    Tail;
-  UINT8    Data[RAW_FIFO_MAX_NUMBER + 1];
+  UINT16    Head;
+  UINT16    Tail;
+  UINT8     Data[RAW_FIFO_MAX_NUMBER + 1];
 } RAW_DATA_FIFO;
 
 typedef struct {
-  UINT8     Head;
-  UINT8     Tail;
+  UINT16    Head;
+  UINT16    Tail;
   UINT16    Data[FIFO_MAX_NUMBER + 1];
 } UNICODE_FIFO;
 
 typedef struct {
-  UINT8            Head;
-  UINT8            Tail;
+  UINT16           Head;
+  UINT16           Tail;
   EFI_INPUT_KEY    Data[FIFO_MAX_NUMBER + 1];
 } EFI_KEY_FIFO;
+// MU_CHANGE Ends
 
 typedef struct {
   UINTN    Columns;
@@ -884,7 +886,8 @@ SetTerminalDevicePath (
 EFI_STATUS
 GetOneKeyFromSerial (
   EFI_SERIAL_IO_PROTOCOL  *SerialIo,
-  UINT8                   *Input
+  UINT8                   *Output,
+  UINTN                   *Size   // MU_CHANGE Starts: Extending the FIFO buffer size beyond UINT8 width.
   );
 
 /**

--- a/MdeModulePkg/Universal/Console/TerminalDxe/TerminalConIn.c
+++ b/MdeModulePkg/Universal/Console/TerminalDxe/TerminalConIn.c
@@ -519,7 +519,7 @@ TerminalConInTimerHandler (
   EFI_STATUS              Status;
   TERMINAL_DEV            *TerminalDevice;
   UINT32                  Control;
-  UINT8                   Input;
+  UINT8                   Input[RAW_FIFO_MAX_NUMBER];
   EFI_SERIAL_IO_MODE      *Mode;
   EFI_SERIAL_IO_PROTOCOL  *SerialIo;
   UINTN                   SerialInTimeOut;
@@ -574,23 +574,27 @@ TerminalConInTimerHandler (
     // Fetch all the keys in the serial buffer,
     // and insert the byte stream into RawFIFO.
     //
-    while (!IsRawFiFoFull (TerminalDevice)) {
-      Status = GetOneKeyFromSerial (TerminalDevice->SerialIo, &Input);
-
-      if (EFI_ERROR (Status)) {
-        if (Status == EFI_DEVICE_ERROR) {
-          REPORT_STATUS_CODE_WITH_DEVICE_PATH (
-            EFI_ERROR_CODE | EFI_ERROR_MINOR,
-            (EFI_PERIPHERAL_REMOTE_CONSOLE | EFI_P_EC_INPUT_ERROR),
-            TerminalDevice->DevicePath
-            );
-        }
-
-        break;
+    // MU_CHANGE Starts: Keep getting all available serial keys until we exhaust the FIFO.
+    UINTN  Size = RAW_FIFO_MAX_NUMBER;
+    Status = GetOneKeyFromSerial (TerminalDevice->SerialIo, Input, &Size);
+    if (EFI_ERROR (Status)) {
+      if (Status == EFI_DEVICE_ERROR) {
+        REPORT_STATUS_CODE_WITH_DEVICE_PATH (
+          EFI_ERROR_CODE | EFI_ERROR_MINOR,
+          (EFI_PERIPHERAL_REMOTE_CONSOLE | EFI_P_EC_INPUT_ERROR),
+          TerminalDevice->DevicePath
+          );
       }
 
-      RawFiFoInsertOneKey (TerminalDevice, Input);
+      return;
     }
+
+    UINTN  i = 0;
+    while (i < Size && !IsRawFiFoFull (TerminalDevice)) {
+      RawFiFoInsertOneKey (TerminalDevice, Input[i++]);
+    }
+
+    // MU_CHANGE Ends
   }
 
   //
@@ -669,25 +673,26 @@ KeyNotifyProcessHandler (
 EFI_STATUS
 GetOneKeyFromSerial (
   EFI_SERIAL_IO_PROTOCOL  *SerialIo,
-  UINT8                   *Output
+  UINT8                   *Output,
+  // MU_CHANGE Starts: Extending the FIFO buffer size beyond UINT8 width.
+  UINTN                   *Size
   )
 {
   EFI_STATUS  Status;
-  UINTN       Size;
 
-  Size    = 1;
   *Output = 0;
 
   //
   // Read one key from serial I/O device.
   //
-  Status = SerialIo->Read (SerialIo, &Size, Output);
+  Status = SerialIo->Read (SerialIo, Size, Output);
+
+  if (Status == EFI_TIMEOUT) {
+    return EFI_SUCCESS;
+  }
 
   if (EFI_ERROR (Status)) {
-    if (Status == EFI_TIMEOUT) {
-      return EFI_NOT_READY;
-    }
-
+    // MU_CHANGE Ends.
     return EFI_DEVICE_ERROR;
   }
 
@@ -715,7 +720,7 @@ RawFiFoInsertOneKey (
   UINT8         Input
   )
 {
-  UINT8  Tail;
+  UINT16  Tail; // MU_CHANGE: Extending the FIFO buffer size beyond UINT8 width.
 
   Tail = TerminalDevice->RawFiFo->Tail;
 
@@ -728,7 +733,7 @@ RawFiFoInsertOneKey (
 
   TerminalDevice->RawFiFo->Data[Tail] = Input;
 
-  TerminalDevice->RawFiFo->Tail = (UINT8)((Tail + 1) % (RAW_FIFO_MAX_NUMBER + 1));
+  TerminalDevice->RawFiFo->Tail = (UINT16)((Tail + 1) % (RAW_FIFO_MAX_NUMBER + 1)); // MU_CHANGE: Extending the FIFO buffer size beyond UINT8 width.
 
   return TRUE;
 }
@@ -749,7 +754,7 @@ RawFiFoRemoveOneKey (
   UINT8         *Output
   )
 {
-  UINT8  Head;
+  UINT16  Head; // MU_CHANGE: Extending the FIFO buffer size beyond UINT8 width.
 
   Head = TerminalDevice->RawFiFo->Head;
 
@@ -763,7 +768,7 @@ RawFiFoRemoveOneKey (
 
   *Output = TerminalDevice->RawFiFo->Data[Head];
 
-  TerminalDevice->RawFiFo->Head = (UINT8)((Head + 1) % (RAW_FIFO_MAX_NUMBER + 1));
+  TerminalDevice->RawFiFo->Head = (UINT16)((Head + 1) % (RAW_FIFO_MAX_NUMBER + 1)); // MU_CHANGE: Extending the FIFO buffer size beyond UINT8 width.
 
   return TRUE;
 }
@@ -803,8 +808,8 @@ IsRawFiFoFull (
   TERMINAL_DEV  *TerminalDevice
   )
 {
-  UINT8  Tail;
-  UINT8  Head;
+  UINT16  Tail; // MU_CHANGE: Extending the FIFO buffer size beyond UINT8 width.
+  UINT16  Head; // MU_CHANGE: Extending the FIFO buffer size beyond UINT8 width.
 
   Tail = TerminalDevice->RawFiFo->Tail;
   Head = TerminalDevice->RawFiFo->Head;
@@ -833,7 +838,7 @@ EfiKeyFiFoForNotifyInsertOneKey (
   EFI_INPUT_KEY  *Input
   )
 {
-  UINT8  Tail;
+  UINT16  Tail; // MU_CHANGE: Extending the FIFO buffer size beyond UINT8 width.
 
   Tail = EfiKeyFiFo->Tail;
 
@@ -846,7 +851,7 @@ EfiKeyFiFoForNotifyInsertOneKey (
 
   CopyMem (&EfiKeyFiFo->Data[Tail], Input, sizeof (EFI_INPUT_KEY));
 
-  EfiKeyFiFo->Tail = (UINT8)((Tail + 1) % (FIFO_MAX_NUMBER + 1));
+  EfiKeyFiFo->Tail = (UINT16)((Tail + 1) % (FIFO_MAX_NUMBER + 1));  // MU_CHANGE: Extending the FIFO buffer size beyond UINT8 width.
 
   return TRUE;
 }
@@ -867,7 +872,7 @@ EfiKeyFiFoForNotifyRemoveOneKey (
   EFI_INPUT_KEY  *Output
   )
 {
-  UINT8  Head;
+  UINT16  Head; // MU_CHANGE: Extending the FIFO buffer size beyond UINT8 width.
 
   Head = EfiKeyFiFo->Head;
   ASSERT (Head < FIFO_MAX_NUMBER + 1);
@@ -883,7 +888,7 @@ EfiKeyFiFoForNotifyRemoveOneKey (
 
   CopyMem (Output, &EfiKeyFiFo->Data[Head], sizeof (EFI_INPUT_KEY));
 
-  EfiKeyFiFo->Head = (UINT8)((Head + 1) % (FIFO_MAX_NUMBER + 1));
+  EfiKeyFiFo->Head = (UINT16)((Head + 1) % (FIFO_MAX_NUMBER + 1));  // MU_CHANGE: Extending the FIFO buffer size beyond UINT8 width.
 
   return TRUE;
 }
@@ -923,8 +928,8 @@ IsEfiKeyFiFoForNotifyFull (
   EFI_KEY_FIFO  *EfiKeyFiFo
   )
 {
-  UINT8  Tail;
-  UINT8  Head;
+  UINT16  Tail; // MU_CHANGE: Extending the FIFO buffer size beyond UINT8 width.
+  UINT16  Head; // MU_CHANGE: Extending the FIFO buffer size beyond UINT8 width.
 
   Tail = EfiKeyFiFo->Tail;
   Head = EfiKeyFiFo->Head;
@@ -953,7 +958,7 @@ EfiKeyFiFoInsertOneKey (
   EFI_INPUT_KEY  *Key
   )
 {
-  UINT8                          Tail;
+  UINT16                         Tail;  // MU_CHANGE: Extending the FIFO buffer size beyond UINT8 width.
   LIST_ENTRY                     *Link;
   LIST_ENTRY                     *NotifyList;
   TERMINAL_CONSOLE_IN_EX_NOTIFY  *CurrentNotify;
@@ -997,7 +1002,7 @@ EfiKeyFiFoInsertOneKey (
 
   CopyMem (&TerminalDevice->EfiKeyFiFo->Data[Tail], Key, sizeof (EFI_INPUT_KEY));
 
-  TerminalDevice->EfiKeyFiFo->Tail = (UINT8)((Tail + 1) % (FIFO_MAX_NUMBER + 1));
+  TerminalDevice->EfiKeyFiFo->Tail = (UINT16)((Tail + 1) % (FIFO_MAX_NUMBER + 1));  // MU_CHANGE: Extending the FIFO buffer size beyond UINT8 width.
 
   return TRUE;
 }
@@ -1018,7 +1023,7 @@ EfiKeyFiFoRemoveOneKey (
   EFI_INPUT_KEY  *Output
   )
 {
-  UINT8  Head;
+  UINT16  Head; // MU_CHANGE: Extending the FIFO buffer size beyond UINT8 width.
 
   Head = TerminalDevice->EfiKeyFiFo->Head;
   ASSERT (Head < FIFO_MAX_NUMBER + 1);
@@ -1034,7 +1039,7 @@ EfiKeyFiFoRemoveOneKey (
 
   CopyMem (Output, &TerminalDevice->EfiKeyFiFo->Data[Head], sizeof (EFI_INPUT_KEY));
 
-  TerminalDevice->EfiKeyFiFo->Head = (UINT8)((Head + 1) % (FIFO_MAX_NUMBER + 1));
+  TerminalDevice->EfiKeyFiFo->Head = (UINT16)((Head + 1) % (FIFO_MAX_NUMBER + 1));  // MU_CHANGE: Extending the FIFO buffer size beyond UINT8 width.
 
   return TRUE;
 }
@@ -1074,8 +1079,8 @@ IsEfiKeyFiFoFull (
   TERMINAL_DEV  *TerminalDevice
   )
 {
-  UINT8  Tail;
-  UINT8  Head;
+  UINT16  Tail; // MU_CHANGE: Extending the FIFO buffer size beyond UINT8 width.
+  UINT16  Head; // MU_CHANGE: Extending the FIFO buffer size beyond UINT8 width.
 
   Tail = TerminalDevice->EfiKeyFiFo->Tail;
   Head = TerminalDevice->EfiKeyFiFo->Head;
@@ -1104,7 +1109,7 @@ UnicodeFiFoInsertOneKey (
   UINT16        Input
   )
 {
-  UINT8  Tail;
+  UINT16  Tail; // MU_CHANGE: Extending the FIFO buffer size beyond UINT8 width.
 
   Tail = TerminalDevice->UnicodeFiFo->Tail;
   ASSERT (Tail < FIFO_MAX_NUMBER + 1);
@@ -1118,7 +1123,7 @@ UnicodeFiFoInsertOneKey (
 
   TerminalDevice->UnicodeFiFo->Data[Tail] = Input;
 
-  TerminalDevice->UnicodeFiFo->Tail = (UINT8)((Tail + 1) % (FIFO_MAX_NUMBER + 1));
+  TerminalDevice->UnicodeFiFo->Tail = (UINT16)((Tail + 1) % (FIFO_MAX_NUMBER + 1)); // MU_CHANGE: Extending the FIFO buffer size beyond UINT8 width.
 
   return TRUE;
 }
@@ -1138,14 +1143,14 @@ UnicodeFiFoRemoveOneKey (
   UINT16        *Output
   )
 {
-  UINT8  Head;
+  UINT16  Head; // MU_CHANGE: Extending the FIFO buffer size beyond UINT8 width.
 
   Head = TerminalDevice->UnicodeFiFo->Head;
   ASSERT (Head < FIFO_MAX_NUMBER + 1);
 
   *Output = TerminalDevice->UnicodeFiFo->Data[Head];
 
-  TerminalDevice->UnicodeFiFo->Head = (UINT8)((Head + 1) % (FIFO_MAX_NUMBER + 1));
+  TerminalDevice->UnicodeFiFo->Head = (UINT16)((Head + 1) % (FIFO_MAX_NUMBER + 1)); // MU_CHANGE: Extending the FIFO buffer size beyond UINT8 width.
 }
 
 /**
@@ -1183,8 +1188,8 @@ IsUnicodeFiFoFull (
   TERMINAL_DEV  *TerminalDevice
   )
 {
-  UINT8  Tail;
-  UINT8  Head;
+  UINT16  Tail; // MU_CHANGE: Extending the FIFO buffer size beyond UINT8 width.
+  UINT16  Head; // MU_CHANGE: Extending the FIFO buffer size beyond UINT8 width.
 
   Tail = TerminalDevice->UnicodeFiFo->Tail;
   Head = TerminalDevice->UnicodeFiFo->Head;

--- a/MdeModulePkg/Universal/Console/TerminalDxe/TerminalDxe.inf
+++ b/MdeModulePkg/Universal/Console/TerminalDxe/TerminalDxe.inf
@@ -88,6 +88,8 @@
   gEfiMdePkgTokenSpaceGuid.PcdDefaultTerminalType           ## SOMETIMES_CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdErrorCodeSetVariable    ## CONSUMES
 
+  gEfiMdeModulePkgTokenSpaceGuid.PcdTerminalKeyboardTimerInterval ## CONSUMES MU_CHANGE
+
 # [Event]
 # # Relative timer event set by UnicodeToEfiKey(), used to be one 2 seconds input timeout.
 # EVENT_TYPE_RELATIVE_TIMER                   ## CONSUMES


### PR DESCRIPTION
## Description

Improve TerminalDxe. Extended the size of FIFO serial console to prevent loss of data for higher baud rate serial devices. Add PCD for terminal keyboard polling rate, to allow platform to modify rate at which serial devices are queried.

### Cherry-Pick the following commits:

[fd0bfd3a58](https://github.com/microsoft/mu_basecore/commit/fd0bfd3a58)
[51ba5af586](https://github.com/microsoft/mu_basecore/commit/51ba5af586)

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

N/A

## Integration Instructions

N/A