### PR TITLE
[Rebase & FF] 202405: Unit Test Infrastructure 

### DIFF
--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/Variable.c
@@ -3204,7 +3204,7 @@ ReclaimForOS (
   EFI_STATUS      Status;
   UINTN           RemainingCommonRuntimeVariableSpace;
   UINTN           RemainingHwErrVariableSpace;
-  STATIC BOOLEAN  Reclaimed;
+  static BOOLEAN  Reclaimed; // MU_CHANGE: Use lowercase static for static lifetime
 
   //
   // This function will be called only once at EndOfDxe or ReadyToBoot event.

--- a/MdePkg/Include/Base.h
+++ b/MdePkg/Include/Base.h
@@ -283,8 +283,13 @@ struct _LIST_ENTRY {
 
 ///
 /// Datum is scoped to the current file or function.
+/// MU_CHANGE: To support GoogleTest compiling static functions, do away with static in that case
 ///
+#ifndef GOOGLETEST_HOST_UNIT_TEST_BUILD
 #define STATIC  static
+#else
+#define STATIC
+#endif
 
 ///
 /// Undeclared type.

--- a/MdePkg/Include/Library/DebugLib.h
+++ b/MdePkg/Include/Library/DebugLib.h
@@ -629,4 +629,81 @@ UnitTestDebugAssert (
     BASE_CR (Record, TYPE, Field)
 #endif
 
+/**
+  Log a formatted hexdump as the debug message on the specified debug
+  error level.
+  The hexdump is split into lines of 16 dumped bytes. Each line is
+  prefixed with a caller-provided string and offset. The full hexdump
+  is bracketed, and its byte ascii char also print. If the byte value
+  is not the ascii code, it will print as '.'
+  @param[in] ErrorLevel        The error level of the debug message.
+  @param[in] Offset            Offset to be display after PrefixFormat.
+                               Offset will be increased for each print line.
+  @param[in] Data              The data to dump.
+  @param[in] DataSize          Number of bytes in Data.
+  @param[in] LinePrefixFormat  Format string describing the prefix that is
+                               printed at the beginning of each dump line,
+                               including the bracket lines.
+  @param[in] ...               Arguments for LinePrefixFormat.
+**/
+#if !defined (MDEPKG_NDEBUG)
+#define DUMP_HEX(ErrorLevel,                                                      \
+                 Offset,                                                          \
+                 Data,                                                            \
+                 DataSize,                                                        \
+                 LinePrefixFormat,                                                \
+                 ...)                                                             \
+    do {                                                                            \
+      if (DebugPrintEnabled () && DebugPrintLevelEnabled (ErrorLevel))  {           \
+        UINT8 *_DataToDump;                                                         \
+        UINT8 _Val[50];                                                             \
+        UINT8 _Str[20];                                                             \
+        UINT8 _TempByte;                                                            \
+        UINTN _Size;                                                                \
+        UINTN _DumpHexIndex;                                                        \
+        UINTN _LocalOffset;                                                         \
+        UINTN _LocalDataSize;                                                       \
+        CONST CHAR8 *_Hex = "0123456789ABCDEF";                                     \
+        _LocalOffset = (Offset);                                                    \
+        _LocalDataSize = (DataSize);                                                \
+        _DataToDump = (UINT8 *)(Data);                                              \
+                                                                                    \
+        ASSERT (_DataToDump != NULL);                                               \
+                                                                                    \
+        while (_LocalDataSize != 0) {                                               \
+          _Size = 16;                                                               \
+          if (_Size > _LocalDataSize) {                                             \
+            _Size = _LocalDataSize;                                                 \
+          }                                                                         \
+                                                                                    \
+          for (_DumpHexIndex = 0; _DumpHexIndex < _Size; _DumpHexIndex += 1) {      \
+            _TempByte            = (UINT8) _DataToDump[_DumpHexIndex];              \
+            _Val[_DumpHexIndex * 3 + 0]  = (UINT8) _Hex[_TempByte >> 4];            \
+            _Val[_DumpHexIndex * 3 + 1]  = (UINT8) _Hex[_TempByte & 0xF];           \
+            _Val[_DumpHexIndex * 3 + 2]  =                                          \
+              (CHAR8) ((_DumpHexIndex == 7) ? '-' : ' ');                           \
+            _Str[_DumpHexIndex]          =                                          \
+              (CHAR8) ((_TempByte < ' ' || _TempByte > '~') ? '.' : _TempByte);     \
+          }                                                                         \
+                                                                                    \
+          _Val[_DumpHexIndex * 3]  = 0;                                             \
+          _Str[_DumpHexIndex]      = 0;                                             \
+                                                                                    \
+          DebugPrint(ErrorLevel, LinePrefixFormat, ##__VA_ARGS__);                  \
+          DebugPrint(ErrorLevel, "%08X: %-48a *%a*\r\n", _LocalOffset, _Val, _Str); \
+          _DataToDump = (UINT8 *)(((UINTN)_DataToDump) + _Size);                    \
+          _LocalOffset += _Size;                                                    \
+          _LocalDataSize -= _Size;                                                  \
+        }                                                                           \
+      }                                                                             \
+    } while (FALSE)
+#else
+#define DUMP_HEX(ErrorLevel,       \
+                 Offset,           \
+                 Data,             \
+                 DataSize,         \
+                 LinePrefixFormat, \
+                 ...)
 #endif
+
+#endif // __DEBUG_LIB_H__

--- a/MdePkg/Include/Library/UnitTestLib.h
+++ b/MdePkg/Include/Library/UnitTestLib.h
@@ -441,6 +441,61 @@ SaveFrameworkState (
     return UNIT_TEST_ERROR_TEST_FAILED;                                                         \
   }
 
+// MU_CHANGE [BEGIN] - Add test asserts that allow cleanup
+
+/**
+  The following macros are almost identical to the UT_ASSERT_* macros, but rather than returning
+  immediately, they jump to a `Cleanup` label for late memory cleanup before exiting.
+**/
+#define UT_CLEANUP_ASSERT_TRUE(Expression)                                                         \
+  if(!UnitTestAssertTrue ((Expression), __FUNCTION__, DEBUG_LINE_NUMBER, __FILE__, #Expression)) { \
+    TestResult = UNIT_TEST_ERROR_TEST_FAILED;                                                      \
+    goto Cleanup;                                                                                  \
+  }
+
+#define UT_CLEANUP_ASSERT_FALSE(Expression)                                                         \
+  if(!UnitTestAssertFalse ((Expression), __FUNCTION__, DEBUG_LINE_NUMBER, __FILE__, #Expression)) { \
+    TestResult = UNIT_TEST_ERROR_TEST_FAILED;                                                       \
+    goto Cleanup;                                                                                   \
+  }
+
+#define UT_CLEANUP_ASSERT_EQUAL(ValueA, ValueB)                                                                                \
+  if(!UnitTestAssertEqual ((UINT64)(ValueA), (UINT64)(ValueB), __FUNCTION__, DEBUG_LINE_NUMBER, __FILE__, #ValueA, #ValueB)) { \
+    TestResult = UNIT_TEST_ERROR_TEST_FAILED;                                                                                  \
+    goto Cleanup;                                                                                                              \
+  }
+
+#define UT_CLEANUP_ASSERT_MEM_EQUAL(BufferA, BufferB, Length)                                                                                                      \
+  if(!UnitTestAssertMemEqual ((VOID *)(UINTN)(BufferA), (VOID *)(UINTN)(BufferB), (UINTN)Length, __FUNCTION__, DEBUG_LINE_NUMBER, __FILE__, #BufferA, #BufferB)) { \
+    TestResult = UNIT_TEST_ERROR_TEST_FAILED;                                                                                                                      \
+    goto Cleanup;                                                                                                                                                  \
+  }
+
+#define UT_CLEANUP_ASSERT_NOT_EQUAL(ValueA, ValueB)                                                                               \
+  if(!UnitTestAssertNotEqual ((UINT64)(ValueA), (UINT64)(ValueB), __FUNCTION__, DEBUG_LINE_NUMBER, __FILE__, #ValueA, #ValueB)) { \
+    TestResult = UNIT_TEST_ERROR_TEST_FAILED;                                                                                     \
+    goto Cleanup;                                                                                                                 \
+  }
+
+#define UT_CLEANUP_ASSERT_NOT_EFI_ERROR(Status)                                                   \
+  if(!UnitTestAssertNotEfiError ((Status), __FUNCTION__, DEBUG_LINE_NUMBER, __FILE__, #Status)) { \
+    TestResult = UNIT_TEST_ERROR_TEST_FAILED;                                                     \
+    goto Cleanup;                                                                                 \
+  }
+
+#define UT_CLEANUP_ASSERT_STATUS_EQUAL(Status, Expected)                                                      \
+  if(!UnitTestAssertStatusEqual ((Status), (Expected), __FUNCTION__, DEBUG_LINE_NUMBER, __FILE__, #Status)) { \
+    TestResult = UNIT_TEST_ERROR_TEST_FAILED;                                                                 \
+    goto Cleanup;                                                                                             \
+  }
+
+#define UT_CLEANUP_ASSERT_NOT_NULL(Pointer)                                                     \
+  if(!UnitTestAssertNotNull ((Pointer), __FUNCTION__, DEBUG_LINE_NUMBER, __FILE__, #Pointer)) { \
+    TestResult = UNIT_TEST_ERROR_TEST_FAILED;                                                   \
+    goto Cleanup;                                                                               \
+  }
+// MU_CHANGE [END] - Add test asserts that allow cleanup
+
 /**
   This macro uses the framework assertion logic to check whether a function call
   triggers an ASSERT() condition.  The BaseLib SetJump()/LongJump() services

--- a/UnitTestFrameworkPkg/Library/CmockaLib/CmockaLib.inf
+++ b/UnitTestFrameworkPkg/Library/CmockaLib/CmockaLib.inf
@@ -29,7 +29,7 @@
   MSFT:*_*_*_CC_FLAGS     == /c -DHAVE_VSNPRINTF -DHAVE_SNPRINTF /Zi
   MSFT:NOOPT_*_*_CC_FLAGS =  /Od
 
-  GCC:*_*_*_CC_FLAGS     == -g -DHAVE_SIGNAL_H
+  GCC:*_*_*_CC_FLAGS     == -g -DHAVE_SIGNAL_H -DHAVE_STRSIGNAL
   GCC:NOOPT_*_*_CC_FLAGS =  -O0
   GCC:*_*_IA32_CC_FLAGS  =  -m32
   GCC:*_*_X64_CC_FLAGS   =  -m64

--- a/UnitTestFrameworkPkg/Library/UnitTestLib/AssertCmocka.c
+++ b/UnitTestFrameworkPkg/Library/UnitTestLib/AssertCmocka.c
@@ -49,6 +49,7 @@ UnitTestAssertTrue (
   CHAR8  TempStr[MAX_STRING_SIZE];
 
   snprintf (TempStr, sizeof (TempStr), "UT_ASSERT_TRUE(%s:%x)", Description, Expression);
+  printf ("%s:%d %s\n", FileName, (INT32)LineNumber, TempStr);     // MU_CHANGE - Report source of ASSERTs in tests
   _assert_true (Expression, TempStr, FileName, (INT32)LineNumber);
 
   return Expression;

--- a/UnitTestFrameworkPkg/ReadMe.md
+++ b/UnitTestFrameworkPkg/ReadMe.md
@@ -1658,8 +1658,8 @@ the following, please make sure they live in the correct place.
 
 Code/Test                                   | Location
 ---------                                   | --------
-Host-Based Library Implementations                 | Host-Based Implementations of common libraries (eg. MemoryAllocationLibHost) should live in the same package that declares the library interface in its .DEC file in the `*Pkg/HostLibrary` directory. Should have 'Host' in the name.
-Host-Based Mocks and Stubs  | Mock and Stub libraries should live in the `UefiTestFrameworkPkg/StubLibrary` with either 'Mock' or 'Stub' in the library name.
+Host-Based Library Implementations                 | Host-Based Implementations of common libraries (eg. MemoryAllocationLibHost) should live in the same package that declares the library interface in its .DEC file in the `*Pkg/Test/Library` directory. Should have 'Host' in the name.
+Host-Based Mocks and Stubs  | Mock and Stub libraries that require test infrastructure should live in the `UefiTestFrameworkPkg/Library` with either 'Mock' or 'Stub' in the library name.
 
 ### If still in doubt
 

--- a/UnitTestFrameworkPkg/ReadMe.md
+++ b/UnitTestFrameworkPkg/ReadMe.md
@@ -1366,6 +1366,10 @@ After that, the following commands will set up the build and run the host-based 
 # stuart_setup -c ./.pytool/CISettings.py TOOL_CHAIN_TAG=<GCC5, VS2019, etc.>
 stuart_setup -c ./.pytool/CISettings.py TOOL_CHAIN_TAG=VS2019
 
+# Mu specific step to clone mu repos required for ci check
+# stuart_ci_setup -c ./.pytool/CISettings.py TOOL_CHAIN_TAG=<GCC5, VS2019, etc.>
+stuart_ci_setup -c ./.pytool/CISettings.py TOOL_CHAIN_TAG=VS2019
+
 # Update all binary dependencies
 # stuart_update -c ./.pytool/CISettings.py TOOL_CHAIN_TAG=<GCC5, VS2019, etc.>
 stuart_update -c ./.pytool/CISettings.py TOOL_CHAIN_TAG=VS2019

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
@@ -43,7 +43,7 @@
   #
   # MSFT
   #
-  MSFT:*_*_*_CC_FLAGS               = /EHs
+  MSFT:*_*_*_CC_FLAGS               = /EHs -D GOOGLETEST_HOST_UNIT_TEST_BUILD=1 # MU_CHANGE: Allow GoogleTest to Test STATIC Functions
   MSFT:*_*_*_DLINK_FLAGS            == /out:"$(BIN_DIR)\$(MODULE_NAME_GUID).exe" /pdb:"$(BIN_DIR)\$(MODULE_NAME_GUID).pdb" /IGNORE:4001 /NOLOGO /SUBSYSTEM:CONSOLE /DEBUG /STACK:0x40000,0x40000 /WHOLEARCHIVE
   MSFT:*_*_IA32_DLINK_FLAGS         = /MACHINE:I386
   MSFT:*_*_X64_DLINK_FLAGS          = /MACHINE:AMD64
@@ -61,6 +61,7 @@
   #
   # GCC
   #
+  GCC:*_*_*_CC_FLAGS       = -D GOOGLETEST_HOST_UNIT_TEST_BUILD=1 # MU_CHANGE: Allow GoogleTest to Test STATIC Functions
   GCC:*_*_IA32_DLINK_FLAGS == -o $(BIN_DIR)/$(MODULE_NAME_GUID) -m32 -no-pie
   GCC:*_*_X64_DLINK_FLAGS  == -o $(BIN_DIR)/$(MODULE_NAME_GUID) -m64 -no-pie
   #
@@ -73,6 +74,7 @@
   #
   # Need to do this link via gcc and not ld as the pathing to libraries changes from OS version to OS version
   #
+  XCODE:*_*_*_CC_FLAGS      = -D GOOGLETEST_HOST_UNIT_TEST_BUILD=1 # MU_CHANGE: Allow GoogleTest to Test STATIC Functions
   XCODE:*_*_IA32_DLINK_PATH == gcc
   XCODE:*_*_IA32_CC_FLAGS = -I$(WORKSPACE)/EmulatorPkg/Unix/Host/X11IncludeHack
   XCODE:*_*_IA32_DLINK_FLAGS == -arch i386 -o $(BIN_DIR)/$(MODULE_NAME_GUID) -L/usr/X11R6/lib -lXext -lX11 -framework Carbon


### PR DESCRIPTION
## Description
Add support for including files using the static keyword in GoogleTest.
Add macro to dump hex

---

Cherry picked and squashed from the following commits:
9cc548e633 (dropped - not needed)
863474b44e
fedcaf9176
0a17e75b38
a40a022ba0
49d6c72306 (dropped - duplicate)
579d2956d4 (dropped - duplicate)
c9d33ba79c
6e76157d91

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Changes from release/202311

## Integration Instructions

N/A