### PR TITLE
[REBASE & FF] Add Enhanced Stack Cookie Support

### DIFF
--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -21,8 +21,9 @@
 #      - Add GCC and GCCNOLTO
 #      - Deprecate GCC48, GCC49 and GCC5.
 # 3.01 - Update toolchain for VS2022
+# 3.02 - Enable stack cookies for IA32, ARM, and AARCH64 builds for GCC and MSVC
 #
-#!VERSION=3.00
+#!VERSION=3.02
 
 IDENTIFIER = Default TOOL_CHAIN_CONF
 
@@ -634,9 +635,9 @@ NOOPT_VS2017_AARCH64_DLINK_FLAGS   = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /OPT:REF
 *_VS2019_IA32_PP_PATH      = DEF(VS2019_BIN_IA32)\cl.exe
 *_VS2019_IA32_ASM_PATH     = DEF(VS2019_BIN_IA32)\ml.exe
 
-  DEBUG_VS2019_IA32_CC_FLAGS    = /nologo /arch:IA32 /c /WX /GS- /W4 /Gs32768 /D UNICODE /O1b2 /GL /FIAutoGen.h /EHs-c- /GR- /GF /Gy /Z7 /Gw
-RELEASE_VS2019_IA32_CC_FLAGS    = /nologo /arch:IA32 /c /WX /GS- /W4 /Gs32768 /D UNICODE /O1b2 /GL /FIAutoGen.h /EHs-c- /GR- /GF /Gw
-NOOPT_VS2019_IA32_CC_FLAGS      = /nologo /arch:IA32 /c /WX /GS- /W4 /Gs32768 /D UNICODE /FIAutoGen.h /EHs-c- /GR- /GF /Gy /Z7 /Od
+  DEBUG_VS2019_IA32_CC_FLAGS    = /nologo /arch:IA32 /c /WX /GS /W4 /Gs32768 /D UNICODE /O1b2 /GL /FIAutoGen.h /EHs-c- /GR- /GF /Gy /Z7 /Gw
+RELEASE_VS2019_IA32_CC_FLAGS    = /nologo /arch:IA32 /c /WX /GS /W4 /Gs32768 /D UNICODE /O1b2 /GL /FIAutoGen.h /EHs-c- /GR- /GF /Gw
+NOOPT_VS2019_IA32_CC_FLAGS      = /nologo /arch:IA32 /c /WX /GS /W4 /Gs32768 /D UNICODE /FIAutoGen.h /EHs-c- /GR- /GF /Gy /Z7 /Od
 
   DEBUG_VS2019_IA32_ASM_FLAGS   = /nologo /c /WX /W3 /Cx /coff /Zd /Zi
 RELEASE_VS2019_IA32_ASM_FLAGS   = /nologo /c /WX /W3 /Cx /coff /Zd
@@ -664,9 +665,9 @@ NOOPT_VS2019_IA32_DLINK_FLAGS   = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /OPT:REF /O
 *_VS2019_X64_DLINK_PATH    = DEF(VS2019_BIN_X64)\link.exe
 *_VS2019_X64_ASLDLINK_PATH = DEF(VS2019_BIN_X64)\link.exe
 
-  DEBUG_VS2019_X64_CC_FLAGS     = /nologo /c /WX /GS- /W4 /Gs32768 /D UNICODE /O1b2s /GL /Gy /FIAutoGen.h /EHs-c- /GR- /GF /Z7 /Gw
-RELEASE_VS2019_X64_CC_FLAGS     = /nologo /c /WX /GS- /W4 /Gs32768 /D UNICODE /O1b2s /GL /Gy /FIAutoGen.h /EHs-c- /GR- /GF /Gw
-NOOPT_VS2019_X64_CC_FLAGS       = /nologo /c /WX /GS- /W4 /Gs32768 /D UNICODE /Gy /FIAutoGen.h /EHs-c- /GR- /GF /Z7 /Od
+  DEBUG_VS2019_X64_CC_FLAGS     = /nologo /c /WX /GS /W4 /Gs32768 /D UNICODE /O1b2s /GL /Gy /FIAutoGen.h /EHs-c- /GR- /GF /Z7 /Gw
+RELEASE_VS2019_X64_CC_FLAGS     = /nologo /c /WX /GS /W4 /Gs32768 /D UNICODE /O1b2s /GL /Gy /FIAutoGen.h /EHs-c- /GR- /GF /Gw
+NOOPT_VS2019_X64_CC_FLAGS       = /nologo /c /WX /GS /W4 /Gs32768 /D UNICODE /Gy /FIAutoGen.h /EHs-c- /GR- /GF /Z7 /Od
 
   DEBUG_VS2019_X64_ASM_FLAGS    = /nologo /c /WX /W3 /Cx /Zd /Zi
 RELEASE_VS2019_X64_ASM_FLAGS    = /nologo /c /WX /W3 /Cx /Zd
@@ -777,9 +778,9 @@ NOOPT_VS2019_AARCH64_DLINK_FLAGS   = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /OPT:REF
 *_VS2022_IA32_ASM_PATH     = DEF(VS2022_BIN_IA32)\ml.exe
 
       *_VS2022_IA32_MAKE_FLAGS  = /nologo
-  DEBUG_VS2022_IA32_CC_FLAGS    = /nologo /arch:IA32 /c /WX /GS- /W4 /Gs32768 /D UNICODE /O1b2 /GL /FIAutoGen.h /EHs-c- /GR- /GF /Gy /Z7 /Gw
-RELEASE_VS2022_IA32_CC_FLAGS    = /nologo /arch:IA32 /c /WX /GS- /W4 /Gs32768 /D UNICODE /O1b2 /GL /FIAutoGen.h /EHs-c- /GR- /GF /Gw
-NOOPT_VS2022_IA32_CC_FLAGS      = /nologo /arch:IA32 /c /WX /GS- /W4 /Gs32768 /D UNICODE /FIAutoGen.h /EHs-c- /GR- /GF /Gy /Z7 /Od
+  DEBUG_VS2022_IA32_CC_FLAGS    = /nologo /arch:IA32 /c /WX /GS /W4 /Gs32768 /D UNICODE /O1b2 /GL /FIAutoGen.h /EHs-c- /GR- /GF /Gy /Z7 /Gw
+RELEASE_VS2022_IA32_CC_FLAGS    = /nologo /arch:IA32 /c /WX /GS /W4 /Gs32768 /D UNICODE /O1b2 /GL /FIAutoGen.h /EHs-c- /GR- /GF /Gw
+NOOPT_VS2022_IA32_CC_FLAGS      = /nologo /arch:IA32 /c /WX /GS /W4 /Gs32768 /D UNICODE /FIAutoGen.h /EHs-c- /GR- /GF /Gy /Z7 /Od
 
   DEBUG_VS2022_IA32_ASM_FLAGS   = /nologo /c /WX /W3 /Cx /coff /Zd /Zi
 RELEASE_VS2022_IA32_ASM_FLAGS   = /nologo /c /WX /W3 /Cx /coff /Zd
@@ -807,9 +808,9 @@ NOOPT_VS2022_IA32_DLINK_FLAGS   = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /OPT:REF /O
 *_VS2022_X64_DLINK_PATH    = DEF(VS2022_BIN_X64)\link.exe
 *_VS2022_X64_ASLDLINK_PATH = DEF(VS2022_BIN_X64)\link.exe
 
-  DEBUG_VS2022_X64_CC_FLAGS     = /nologo /c /WX /GS- /W4 /Gs32768 /D UNICODE /O1b2s /GL /Gy /FIAutoGen.h /EHs-c- /GR- /GF /Z7 /Gw
-RELEASE_VS2022_X64_CC_FLAGS     = /nologo /c /WX /GS- /W4 /Gs32768 /D UNICODE /O1b2s /GL /Gy /FIAutoGen.h /EHs-c- /GR- /GF /Gw
-NOOPT_VS2022_X64_CC_FLAGS       = /nologo /c /WX /GS- /W4 /Gs32768 /D UNICODE /Gy /FIAutoGen.h /EHs-c- /GR- /GF /Z7 /Od
+  DEBUG_VS2022_X64_CC_FLAGS     = /nologo /c /WX /GS /W4 /Gs32768 /D UNICODE /O1b2s /GL /Gy /FIAutoGen.h /EHs-c- /GR- /GF /Z7 /Gw
+RELEASE_VS2022_X64_CC_FLAGS     = /nologo /c /WX /GS /W4 /Gs32768 /D UNICODE /O1b2s /GL /Gy /FIAutoGen.h /EHs-c- /GR- /GF /Gw
+NOOPT_VS2022_X64_CC_FLAGS       = /nologo /c /WX /GS /W4 /Gs32768 /D UNICODE /Gy /FIAutoGen.h /EHs-c- /GR- /GF /Z7 /Od
 
   DEBUG_VS2022_X64_ASM_FLAGS    = /nologo /c /WX /W3 /Cx /Zd /Zi
 RELEASE_VS2022_X64_ASM_FLAGS    = /nologo /c /WX /W3 /Cx /Zd
@@ -819,9 +820,9 @@ NOOPT_VS2022_X64_ASM_FLAGS      = /nologo /c /WX /W3 /Cx /Zd /Zi
 RELEASE_VS2022_X64_NASM_FLAGS   = -Ox -f win64
 NOOPT_VS2022_X64_NASM_FLAGS     = -O0 -f win64 -g
 
-  DEBUG_VS2022_X64_DLINK_FLAGS  = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /IGNORE:4281 /OPT:REF /OPT:ICF=10 /MAP /ALIGN:32 /SECTION:.xdata,D /SECTION:.pdata,D /Machine:X64 /LTCG /DLL /ENTRY:$(IMAGE_ENTRY_POINT) /SUBSYSTEM:EFI_BOOT_SERVICE_DRIVER /SAFESEH:NO /BASE:0 /DRIVER /DEBUG /ALIGN:4096 /DLL
-RELEASE_VS2022_X64_DLINK_FLAGS  = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /IGNORE:4281 /IGNORE:4254 /OPT:REF /OPT:ICF=10 /MAP /ALIGN:32 /SECTION:.xdata,D /SECTION:.pdata,D /Machine:X64 /LTCG /DLL /ENTRY:$(IMAGE_ENTRY_POINT) /SUBSYSTEM:EFI_BOOT_SERVICE_DRIVER /SAFESEH:NO /BASE:0 /DRIVER /MERGE:.rdata=.data /ALIGN:4096 /DLL
-NOOPT_VS2022_X64_DLINK_FLAGS    = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /IGNORE:4281 /OPT:REF /OPT:ICF=10 /MAP /ALIGN:32 /SECTION:.xdata,D /SECTION:.pdata,D /Machine:X64 /LTCG /DLL /ENTRY:$(IMAGE_ENTRY_POINT) /SUBSYSTEM:EFI_BOOT_SERVICE_DRIVER /SAFESEH:NO /BASE:0 /DRIVER /DEBUG /ALIGN:4096 /DLL
+  DEBUG_VS2022_X64_DLINK_FLAGS  = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /IGNORE:4281 /OPT:REF /OPT:ICF=10 /MAP /ALIGN:32 /SECTION:.xdata,D /SECTION:.pdata,D /Machine:X64 /LTCG /DLL /ENTRY:$(IMAGE_ENTRY_POINT) /SUBSYSTEM:EFI_BOOT_SERVICE_DRIVER /SAFESEH:NO /BASE:0 /DRIVER /DEBUG
+RELEASE_VS2022_X64_DLINK_FLAGS  = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /IGNORE:4281 /IGNORE:4254 /OPT:REF /OPT:ICF=10 /MAP /ALIGN:32 /SECTION:.xdata,D /SECTION:.pdata,D /Machine:X64 /LTCG /DLL /ENTRY:$(IMAGE_ENTRY_POINT) /SUBSYSTEM:EFI_BOOT_SERVICE_DRIVER /SAFESEH:NO /BASE:0 /DRIVER /MERGE:.rdata=.data
+NOOPT_VS2022_X64_DLINK_FLAGS    = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /IGNORE:4281 /OPT:REF /OPT:ICF=10 /MAP /ALIGN:32 /SECTION:.xdata,D /SECTION:.pdata,D /Machine:X64 /LTCG /DLL /ENTRY:$(IMAGE_ENTRY_POINT) /SUBSYSTEM:EFI_BOOT_SERVICE_DRIVER /SAFESEH:NO /BASE:0 /DRIVER /DEBUG
 
 #################
 # ARM definitions
@@ -893,7 +894,7 @@ NOOPT_*_*_OBJCOPY_ADDDEBUGFLAG     = --add-gnu-debuglink="$(DEBUG_DIR)/$(MODULE_
 *_*_*_DTCPP_PATH                   = DEF(DTCPP_BIN)
 *_*_*_DTC_PATH                     = DEF(DTC_BIN)
 
-DEFINE GCC_ALL_CC_FLAGS            = -g -Os -fshort-wchar -fno-builtin -fno-strict-aliasing -Wall -Werror -Wno-array-bounds -include AutoGen.h -fno-common
+DEFINE GCC_ALL_CC_FLAGS            = -g -Os -fshort-wchar -fno-builtin -fno-strict-aliasing -Wall -Werror -Wno-array-bounds -include AutoGen.h -fno-common -fstack-protector -mstack-protector-guard=global
 DEFINE GCC_ARM_CC_FLAGS            = DEF(GCC_ALL_CC_FLAGS) -mlittle-endian -mabi=aapcs -fno-short-enums -funsigned-char -ffunction-sections -fdata-sections -fomit-frame-pointer -Wno-address -mthumb -fno-pic -fno-pie
 DEFINE GCC_LOONGARCH64_CC_FLAGS    = DEF(GCC_ALL_CC_FLAGS) -mabi=lp64d -fno-asynchronous-unwind-tables -fno-plt -Wno-address -fno-short-enums -fsigned-char -ffunction-sections -fdata-sections
 DEFINE GCC_ARM_CC_XIPFLAGS         = -mno-unaligned-access
@@ -934,8 +935,8 @@ DEFINE GCC_DEPS_FLAGS              = -MMD -MF $@.deps
 
 DEFINE GCC48_ALL_CC_FLAGS            = DEF(GCC_ALL_CC_FLAGS) -ffunction-sections -fdata-sections -DSTRING_ARRAY_NAME=$(BASE_NAME)Strings
 DEFINE GCC48_IA32_X64_DLINK_COMMON   = -nostdlib -Wl,-n,-q,--gc-sections -z common-page-size=0x20
-DEFINE GCC48_IA32_CC_FLAGS           = DEF(GCC48_ALL_CC_FLAGS) -m32 -march=i586 -malign-double -fno-stack-protector -D EFI32 -fno-asynchronous-unwind-tables -Wno-address -fno-omit-frame-pointer
-DEFINE GCC48_X64_CC_FLAGS            = DEF(GCC48_ALL_CC_FLAGS) -m64 -fno-stack-protector "-DEFIAPI=__attribute__((ms_abi))" -maccumulate-outgoing-args -mno-red-zone -Wno-address -mcmodel=small -fpie -fno-asynchronous-unwind-tables -Wno-address  -fno-omit-frame-pointer
+DEFINE GCC48_IA32_CC_FLAGS           = DEF(GCC48_ALL_CC_FLAGS) -m32 -march=i586 -malign-double -D EFI32 -fno-asynchronous-unwind-tables -Wno-address -fno-omit-frame-pointer
+DEFINE GCC48_X64_CC_FLAGS            = DEF(GCC48_ALL_CC_FLAGS) -m64 "-DEFIAPI=__attribute__((ms_abi))" -maccumulate-outgoing-args -mno-red-zone -Wno-address -mcmodel=small -fpie -fno-asynchronous-unwind-tables -Wno-address  -fno-omit-frame-pointer
 DEFINE GCC48_IA32_X64_ASLDLINK_FLAGS = DEF(GCC48_IA32_X64_DLINK_COMMON) -Wl,--entry,ReferenceAcpiTable -u ReferenceAcpiTable
 DEFINE GCC48_IA32_X64_DLINK_FLAGS    = DEF(GCC48_IA32_X64_DLINK_COMMON) -Wl,--entry,$(IMAGE_ENTRY_POINT) -u $(IMAGE_ENTRY_POINT) -Wl,-Map,$(DEST_DIR_DEBUG)/$(BASE_NAME).map,--whole-archive
 DEFINE GCC48_IA32_DLINK2_FLAGS       = -Wl,--defsym=PECOFF_HEADER_SIZE=0x220 DEF(GCC_DLINK2_FLAGS_COMMON)

--- a/BaseTools/Source/Python/AutoGen/GenC.py
+++ b/BaseTools/Source/Python/AutoGen/GenC.py
@@ -21,6 +21,11 @@ from .StrGather import *
 from .GenPcdDb import CreatePcdDatabaseCode
 from .IdfClassObject import *
 
+# MU_CHANGE [BEGIN]: Add build-time random stack cookie support
+import json
+import secrets
+# MU_CHANGE [END]
+
 ## PCD type string
 gItemTypeStringDatabase  = {
     TAB_PCDS_FEATURE_FLAG       :   TAB_PCDS_FIXED_AT_BUILD,
@@ -698,10 +703,12 @@ SUP_MODULE_BASE  : TemplateString("""${BEGIN}
 }
 
 ## Library Constructor and Destructor Templates
+# MU_CHANGE [BEGIN]: Add StackCookieSupport marker for stack cookie support.
 gLibraryString = {
 SUP_MODULE_BASE  :   TemplateString("""
 ${BEGIN}${FunctionPrototype}${END}
 
+${StackCookieSupport}
 VOID
 EFIAPI
 ProcessLibrary${Type}List (
@@ -712,10 +719,10 @@ ${BEGIN}  RETURN_STATUS  Status;
 ${FunctionCall}${END}
 }
 """),
-
 'PEI'   :   TemplateString("""
 ${BEGIN}${FunctionPrototype}${END}
 
+${StackCookieSupport}
 VOID
 EFIAPI
 ProcessLibrary${Type}List (
@@ -731,6 +738,7 @@ ${FunctionCall}${END}
 'DXE'   :   TemplateString("""
 ${BEGIN}${FunctionPrototype}${END}
 
+${StackCookieSupport}
 VOID
 EFIAPI
 ProcessLibrary${Type}List (
@@ -742,10 +750,10 @@ ${BEGIN}  EFI_STATUS  Status;
 ${FunctionCall}${END}
 }
 """),
-
 'MM'   :   TemplateString("""
 ${BEGIN}${FunctionPrototype}${END}
 
+${StackCookieSupport}
 VOID
 EFIAPI
 ProcessLibrary${Type}List (
@@ -758,6 +766,7 @@ ${FunctionCall}${END}
 }
 """),
 }
+# MU_CHANGE [END]: Add StackCookieSupport marker for stack cookie support.
 
 gBasicHeaderFile = "Base.h"
 
@@ -1360,12 +1369,14 @@ def CreateLibraryConstructorCode(Info, AutoGenC, AutoGenH):
         ConstructorCallingList = []
     else:
         ConstructorCallingList = [str(ConstructorCallingString)]
-
+    # MU_CHANGE [BEGIN]: Add StackCookieSupport marker for stack cookie support.
     Dict = {
         'Type'              :   'Constructor',
         'FunctionPrototype' :   ConstructorPrototypeList,
-        'FunctionCall'      :   ConstructorCallingList
+        'FunctionCall'      :   ConstructorCallingList,
+        "StackCookieSupport":   "NO_STACK_COOKIE"
     }
+    # MU_CHANGE [END]: Add StackCookieSupport marker for stack cookie support.
     if Info.IsLibrary:
         AutoGenH.Append("${BEGIN}${FunctionPrototype}${END}", Dict)
     else:
@@ -1431,12 +1442,14 @@ def CreateLibraryDestructorCode(Info, AutoGenC, AutoGenH):
         DestructorCallingList = []
     else:
         DestructorCallingList = [str(DestructorCallingString)]
-
+    # MU_CHANGE [BEGIN]: Add StackCookieSupport marker for stack cookie support.
     Dict = {
         'Type'              :   'Destructor',
         'FunctionPrototype' :   DestructorPrototypeList,
-        'FunctionCall'      :   DestructorCallingList
+        'FunctionCall'      :   DestructorCallingList,
+        "StackCookieSupport":   ""
     }
+    # MU_CHANGE [END]: Add StackCookieSupport marker for stack cookie support.
     if Info.IsLibrary:
         AutoGenH.Append("${BEGIN}${FunctionPrototype}${END}", Dict)
     else:
@@ -2042,6 +2055,39 @@ def CreateFooterCode(Info, AutoGenC, AutoGenH):
 #
 def CreateCode(Info, AutoGenC, AutoGenH, StringH, UniGenCFlag, UniGenBinBuffer, StringIdf, IdfGenCFlag, IdfGenBinBuffer):
     CreateHeaderCode(Info, AutoGenC, AutoGenH)
+
+    # MU_CHANGE [BEGIN]: Add build-time random stack cookie support
+    if Info.ModuleType != SUP_MODULE_HOST_APPLICATION:
+        if Info.Arch not in ['X64', 'IA32', 'ARM', 'AARCH64']:
+            EdkLogger.error("build", AUTOGEN_ERROR, "Unsupported Arch %s" % Info.Arch, ExtraData="[%s]" % str(Info))
+        else:
+            Bitwidth = 64 if Info.Arch == 'X64' or Info.Arch == 'AARCH64' else 32
+
+        if GlobalData.gStackCookieValues64 == [] and os.path.exists(os.path.join(Info.PlatformInfo.BuildDir, "StackCookieValues64.json")):
+            with open (os.path.join(Info.PlatformInfo.BuildDir, "StackCookieValues64.json"), "r") as file:
+                GlobalData.gStackCookieValues64 = json.load(file)
+        if GlobalData.gStackCookieValues32 == [] and os.path.exists(os.path.join(Info.PlatformInfo.BuildDir, "StackCookieValues32.json")):
+            with open (os.path.join(Info.PlatformInfo.BuildDir, "StackCookieValues32.json"), "r") as file:
+                GlobalData.gStackCookieValues32 = json.load(file)
+
+        try:
+            if Bitwidth == 32:
+                CookieValue = int(GlobalData.gStackCookieValues32[hash(Info.Guid) % len(GlobalData.gStackCookieValues32)])
+            else:
+                CookieValue = int(GlobalData.gStackCookieValues64[hash(Info.Guid) % len(GlobalData.gStackCookieValues64)])
+        except:
+            EdkLogger.error("build", AUTOGEN_ERROR, "Failed to get Stack Cookie Value List! Generating random value.", ExtraData="[%s]" % str(Info))
+            if Bitwidth == 32:
+                CookieValue = secrets.randbelow (0xFFFFFFFF)
+            else:
+                CookieValue = secrets.randbelow (0xFFFFFFFFFFFFFFFF)
+
+        AutoGenH.Append((
+            '#define STACK_COOKIE_VALUE 0x%XULL\n' % CookieValue
+            if Bitwidth == 64 else
+            '#define STACK_COOKIE_VALUE 0x%X\n' % CookieValue
+        ))
+    # MU_CHANGE [END]
 
     CreateGuidDefinitionCode(Info, AutoGenC, AutoGenH)
     CreateProtocolDefinitionCode(Info, AutoGenC, AutoGenH)

--- a/BaseTools/Source/Python/Common/GlobalData.py
+++ b/BaseTools/Source/Python/Common/GlobalData.py
@@ -122,4 +122,7 @@ gEnableGenfdsMultiThread = True
 gSikpAutoGenCache = set()
 # Common lock for the file access in multiple process AutoGens
 file_lock = None
-
+# MU_CHANGE [BEGIN]: Add build-time random stack cookie support
+gStackCookieValues32 = []
+gStackCookieValues64 = []
+# MU_CHANGE [END]

--- a/BaseTools/Source/Python/build/build.py
+++ b/BaseTools/Source/Python/build/build.py
@@ -29,6 +29,10 @@ from linecache import getlines
 from subprocess import Popen,PIPE, STDOUT
 from collections import OrderedDict, defaultdict
 import pathlib
+# MU_CHANGE [BEGIN]: Add build-time random stack cookie support
+import json
+import secrets
+# MU_CHANGE [END]
 
 from AutoGen.PlatformAutoGen import PlatformAutoGen
 from AutoGen.ModuleAutoGen import ModuleAutoGen
@@ -283,6 +287,24 @@ def LaunchCommand(Command, WorkingDir,ModuleAuto = None):
         iau.CreateDepsInclude()
         iau.CreateDepsTarget()
     return "%dms" % (int(round((time.time() - BeginTime) * 1000)))
+
+# MU_CHANGE [BEGIN]: Add build-time random stack cookie support
+def GenerateStackCookieValues():
+    if GlobalData.gBuildDirectory == "":
+        return
+
+    # Check if the 32 bit values array needs to be created
+    if not os.path.exists(os.path.join(GlobalData.gBuildDirectory, "StackCookieValues32.json")):
+        StackCookieValues32 = [secrets.randbelow(0xFFFFFFFF) for _ in range(0, 100)]
+        with open (os.path.join(GlobalData.gBuildDirectory, "StackCookieValues32.json"), "w") as file:
+            json.dump(StackCookieValues32, file)
+
+    # Check if the 64 bit values array needs to be created
+    if not os.path.exists(os.path.join(GlobalData.gBuildDirectory, "StackCookieValues64.json")):
+        StackCookieValues64 = [secrets.randbelow(0xFFFFFFFFFFFFFFFF) for _ in range(0, 100)]
+        with open (os.path.join(GlobalData.gBuildDirectory, "StackCookieValues64.json"), "w") as file:
+            json.dump(StackCookieValues64, file)
+# MU_CHANGE [END]
 
 ## The smallest unit that can be built in multi-thread build mode
 #
@@ -1819,6 +1841,7 @@ class Build():
                         self.UniFlag,
                         self.Progress
                         )
+                GenerateStackCookieValues() # MU_CHANGE: Add build-time random stack cookie support
                 self.Fdf = Wa.FdfFile
                 self.LoadFixAddress = Wa.Platform.LoadFixAddress
                 self.BuildReport.AddPlatformReport(Wa)
@@ -1922,6 +1945,7 @@ class Build():
                         self.Progress,
                         self.ModuleFile
                         )
+                GenerateStackCookieValues() # MU_CHANGE: Add build-time random stack cookie support
                 self.Fdf = Wa.FdfFile
                 self.LoadFixAddress = Wa.Platform.LoadFixAddress
                 Wa.CreateMakeFile(False)
@@ -2172,6 +2196,7 @@ class Build():
                 self.UniFlag,
                 self.Progress
                 )
+        GenerateStackCookieValues() # MU_CHANGE: Add build-time random stack cookie support
         self.Fdf = Wa.FdfFile
         self.LoadFixAddress = Wa.Platform.LoadFixAddress
         self.BuildReport.AddPlatformReport(Wa)

--- a/CryptoPkg/CryptoPkg.dsc
+++ b/CryptoPkg/CryptoPkg.dsc
@@ -110,6 +110,7 @@
   HashApiLib|CryptoPkg/Library/BaseHashApiLib/BaseHashApiLib.inf
   OpensslLib|CryptoPkg/Library/OpensslLib/OpensslLib.inf
   IntrinsicLib|CryptoPkg/Library/IntrinsicLib/IntrinsicLib.inf
+  NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf # MU_CHANGE: /GS and -fstack-protector support
 
 [LibraryClasses.IA32, LibraryClasses.X64, LibraryClasses.AARCH64]
   RngLib|MdePkg/Library/BaseRngLib/BaseRngLib.inf
@@ -128,7 +129,7 @@
   NULL|MdePkg/Library/CompilerIntrinsicsLib/ArmCompilerIntrinsicsLib.inf
 
   # Add support for stack protector
-  NULL|MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf
+  # NULL|MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf # MU_CHANGE: Use Project Mu StackCheckLib
 
 # MU_CHANGE [BEGIN]: Remove ArmSoftFloatLib from LibraryClasses.ARM due to ArmPkg removal
 # [LibraryClasses.ARM]

--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -115,6 +115,7 @@
 
   AdvLoggerAccessLib|MdeModulePkg/Library/AdvLoggerAccessLibNull/AdvLoggerAccessLib.inf       ## MU_CHANGE
 
+  NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf # MU_CHANGE: /GS and -fstack-protector support
 [LibraryClasses.EBC.PEIM]
   IoLib|MdePkg/Library/PeiIoLibCpuIo/PeiIoLibCpuIo.inf
 
@@ -202,7 +203,7 @@
   # Since software stack checking may be heuristically enabled by the compiler
   # include BaseStackCheckLib unconditionally.
   #
-  NULL|MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf
+  # NULL|MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf # MU_CHANGE: Use Project Mu StackCheckLib
 
 [LibraryClasses.EBC, LibraryClasses.RISCV64, LibraryClasses.LOONGARCH64]
   LockBoxLib|MdeModulePkg/Library/LockBoxNullLib/LockBoxNullLib.inf

--- a/MdePkg/Include/Base.h
+++ b/MdePkg/Include/Base.h
@@ -206,6 +206,29 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #define PACKED
 
+// MU_CHANGE [START]: Stack Cookie Support.
+// Omit Function from Stack Overflow Protection.
+#ifndef NO_STACK_COOKIE
+  #if defined (__clang__)
+    #if __has_attribute (no_stack_protector)
+#define NO_STACK_COOKIE  __attribute__ ((no_stack_protector))
+    #else
+#define NO_STACK_COOKIE
+    #endif
+  #elif defined (__GNUC__)
+    #if (__GNUC__ > 10)
+#define NO_STACK_COOKIE  __attribute__ ((no_stack_protector))
+    #else
+#define NO_STACK_COOKIE
+    #endif
+  #elif defined (_MSC_VER)
+#define NO_STACK_COOKIE  __declspec(safebuffers)
+  #else
+#define NO_STACK_COOKIE
+  #endif
+#endif
+// MU_CHANGE [END]: Stack Cookie Support.
+
 ///
 /// 128 bit buffer containing a unique identifier value.
 /// Unless otherwise specified, aligned on a 64 bit boundary.

--- a/MdePkg/Include/Library/PeimEntryPoint.h
+++ b/MdePkg/Include/Library/PeimEntryPoint.h
@@ -27,6 +27,7 @@ extern CONST UINT32  _gPeimRevision;
   @retval  EFI_SUCCESS   The PEIM executed normally.
   @retval  !EFI_SUCCESS  The PEIM failed to execute normally.
 **/
+NO_STACK_COOKIE // MU_CHANGE: Project Mu Runtime Randomized Stack Cookie Support
 EFI_STATUS
 EFIAPI
 _ModuleEntryPoint (

--- a/MdePkg/Include/Library/StackCheckFailureHookLib.h
+++ b/MdePkg/Include/Library/StackCheckFailureHookLib.h
@@ -1,0 +1,20 @@
+/** @file
+  Library provides a hook called when a stack cookie check fails.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef STACK_COOKIE_FAILURE_HOOK_LIB_H_
+#define STACK_COOKIE_FAILURE_HOOK_LIB_H_
+
+#include <Uefi.h>
+
+NO_STACK_COOKIE
+VOID
+EFIAPI
+StackCheckFailureHook (
+  VOID  *FailureAddress
+  );
+
+#endif

--- a/MdePkg/Include/Library/StandaloneMmDriverEntryPoint.h
+++ b/MdePkg/Include/Library/StandaloneMmDriverEntryPoint.h
@@ -45,6 +45,7 @@ extern CONST UINT8  _gDriverUnloadImageCount;
                                      ProcessModuleEntryPointList().
 
 **/
+NO_STACK_COOKIE // MU_CHANGE: Project Mu Runtime Randomized Stack Cookie Support
 EFI_STATUS
 EFIAPI
 _ModuleEntryPoint (

--- a/MdePkg/Include/Library/UefiApplicationEntryPoint.h
+++ b/MdePkg/Include/Library/UefiApplicationEntryPoint.h
@@ -31,6 +31,7 @@ extern CONST UINT32  _gUefiDriverRevision;
   @retval  Other                     Return value from ProcessModuleEntryPointList().
 
 **/
+NO_STACK_COOKIE // MU_CHANGE: Project Mu Runtime Randomized Stack Cookie Support
 EFI_STATUS
 EFIAPI
 _ModuleEntryPoint (

--- a/MdePkg/Include/Library/UefiDriverEntryPoint.h
+++ b/MdePkg/Include/Library/UefiDriverEntryPoint.h
@@ -48,6 +48,7 @@ extern CONST UINT8  _gDriverUnloadImageCount;
   @retval  Other                     Return value from ProcessModuleEntryPointList().
 
 **/
+NO_STACK_COOKIE // MU_CHANGE: Project Mu Runtime Randomized Stack Cookie Support
 EFI_STATUS
 EFIAPI
 _ModuleEntryPoint (

--- a/MdePkg/Library/PeimEntryPoint/PeimEntryPoint.c
+++ b/MdePkg/Library/PeimEntryPoint/PeimEntryPoint.c
@@ -24,6 +24,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
   @retval  EFI_SUCCESS   The PEIM executed normally.
   @retval  !EFI_SUCCESS  The PEIM failed to execute normally.
 **/
+NO_STACK_COOKIE // MU_CHANGE: Project Mu Runtime Randomized Stack Cookie Support
 EFI_STATUS
 EFIAPI
 _ModuleEntryPoint (

--- a/MdePkg/Library/StackCheckFailureHookLibNull/StackCheckFailureHook.c
+++ b/MdePkg/Library/StackCheckFailureHookLibNull/StackCheckFailureHook.c
@@ -1,0 +1,22 @@
+/** @file
+  Library provides a hook called when a stack cookie check fails.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Base.h>
+#include <Uefi.h>
+
+/**
+  Initialize the security cookie.
+**/
+NO_STACK_COOKIE
+VOID
+EFIAPI
+StackCheckFailureHook (
+  VOID  *FailureAddress
+  )
+{
+  return;
+}

--- a/MdePkg/Library/StackCheckFailureHookLibNull/StackCheckFailureHookLibNull.inf
+++ b/MdePkg/Library/StackCheckFailureHookLibNull/StackCheckFailureHookLibNull.inf
@@ -1,0 +1,20 @@
+## @file
+#  Library provides a hook called when a stack cookie check fails.
+#
+#  Copyright (c) Microsoft Corporation.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = StackCheckFailureHookLibNull
+  FILE_GUID                      = 9ca2587c-d1f2-451a-989a-d49a9a0a613e
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = StackCheckFailureHookLib
+
+[Sources]
+  StackCheckFailureHook.c
+
+[Packages]
+  MdePkg/MdePkg.dec

--- a/MdePkg/Library/StackCheckLib/AArch64/StackCookieInterrupt.S
+++ b/MdePkg/Library/StackCheckLib/AArch64/StackCookieInterrupt.S
@@ -1,0 +1,21 @@
+//------------------------------------------------------------------------------
+// AArch64/StackCookieInterrupt.S
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//------------------------------------------------------------------------------
+
+    .text
+
+//------------------------------------------------------------------------------
+// Calls an interrupt using the vector specified by PcdStackCookieExceptionVector
+//
+// VOID
+// TriggerStackCookieInterrupt (
+//   VOID
+//   );
+//------------------------------------------------------------------------------
+.global ASM_PFX(TriggerStackCookieInterrupt)
+ASM_PFX(TriggerStackCookieInterrupt):
+    svc FixedPcdGet8 (PcdStackCookieExceptionVector)
+    ret

--- a/MdePkg/Library/StackCheckLib/AArch64/StackCookieInterrupt.asm
+++ b/MdePkg/Library/StackCheckLib/AArch64/StackCookieInterrupt.asm
@@ -1,0 +1,25 @@
+;------------------------------------------------------------------------------
+; AArch64/StackCookieInterrupt.asm
+;
+; Copyright (c) Microsoft Corporation. All rights reserved.
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;------------------------------------------------------------------------------
+
+    EXPORT TriggerStackCookieInterrupt
+
+    AREA |.text|, CODE, READONLY
+
+;------------------------------------------------------------------------------
+; Calls an interrupt using the vector specified by PcdStackCookieExceptionVector
+;
+; VOID
+; TriggerStackCookieInterrupt (
+;   VOID
+;   );
+;------------------------------------------------------------------------------
+TriggerStackCookieInterrupt PROC
+    SVC     FixedPcdGet8 (PcdStackCookieExceptionVector)
+    RET
+TriggerStackCookieInterrupt ENDP
+
+    END

--- a/MdePkg/Library/StackCheckLib/Arm/StackCookieInterrupt.S
+++ b/MdePkg/Library/StackCheckLib/Arm/StackCookieInterrupt.S
@@ -1,0 +1,21 @@
+//------------------------------------------------------------------------------
+// Arm/StackCookieInterrupt.S
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//------------------------------------------------------------------------------
+
+    .text
+
+//------------------------------------------------------------------------------
+// Calls an interrupt using the vector specified by PcdStackCookieExceptionVector
+//
+// VOID
+// TriggerStackCookieInterrupt (
+//   VOID
+//   );
+//------------------------------------------------------------------------------
+.global ASM_PFX(TriggerStackCookieInterrupt)
+ASM_PFX(TriggerStackCookieInterrupt):
+    swi FixedPcdGet8 (PcdStackCookieExceptionVector)
+    bx lr

--- a/MdePkg/Library/StackCheckLib/Arm/StackCookieInterrupt.asm
+++ b/MdePkg/Library/StackCheckLib/Arm/StackCookieInterrupt.asm
@@ -1,0 +1,25 @@
+;------------------------------------------------------------------------------
+; Arm/StackCookieInterrupt.asm
+;
+; Copyright (c) Microsoft Corporation. All rights reserved.
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;------------------------------------------------------------------------------
+
+    EXPORT TriggerStackCookieInterrupt
+   
+    AREA |.text|, CODE, READONLY
+
+;------------------------------------------------------------------------------
+; Calls an interrupt using the vector specified by PcdStackCookieExceptionVector
+;
+; VOID
+; TriggerStackCookieInterrupt (
+;   VOID
+;   );
+;------------------------------------------------------------------------------
+TriggerStackCookieInterrupt PROC
+    SWI     FixedPcdGet8 (PcdStackCookieExceptionVector)
+    BX      LR
+TriggerStackCookieInterrupt ENDP
+
+    END

--- a/MdePkg/Library/StackCheckLib/IA32/CheckCookieMsvc.nasm
+++ b/MdePkg/Library/StackCheckLib/IA32/CheckCookieMsvc.nasm
@@ -1,0 +1,43 @@
+;------------------------------------------------------------------------------
+; IA32/CheckCookieMsvc.nasm
+;
+; Copyright (c) Microsoft Corporation. All rights reserved.
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;------------------------------------------------------------------------------
+
+    DEFAULT REL
+    SECTION .text
+
+extern ASM_PFX(StackCheckFailure)
+extern ASM_PFX(__security_cookie)
+extern ASM_PFX(CpuDeadLoop)
+
+; Called when a buffer check fails. This functionality is dependent on MSVC
+; C runtime libraries and so is unsupported in UEFI.
+global ASM_PFX(__report_rangecheckfailure)
+ASM_PFX(__report_rangecheckfailure):
+    jmp ASM_PFX(CpuDeadLoop)
+    ret
+
+; The GS handler is for checking the stack cookie during SEH or
+; EH exceptions and is unsupported in UEFI.
+global ASM_PFX(__GSHandlerCheck)
+ASM_PFX(__GSHandlerCheck):
+    jmp ASM_PFX(CpuDeadLoop)
+    ret
+
+;------------------------------------------------------------------------------
+; Checks the stack cookie value against __security_cookie and calls the
+; stack cookie failure handler if there is a mismatch.
+;
+; VOID
+; EFIAPI
+; __security_check_cookie (
+;   IN UINTN CheckValue
+;   );
+;------------------------------------------------------------------------------
+global @__security_check_cookie@4
+@__security_check_cookie@4:
+    cmp     ecx, [ASM_PFX(__security_cookie)]
+    jne    ASM_PFX(StackCheckFailure)
+    ret

--- a/MdePkg/Library/StackCheckLib/IA32/StackCookieInterrupt.nasm
+++ b/MdePkg/Library/StackCheckLib/IA32/StackCookieInterrupt.nasm
@@ -1,0 +1,23 @@
+;------------------------------------------------------------------------------
+; IA32/StackCookieInterrupt.nasm
+;
+; Copyright (c) Microsoft Corporation. All rights reserved.
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;------------------------------------------------------------------------------
+
+    DEFAULT REL
+    SECTION .text
+
+;------------------------------------------------------------------------------
+; Checks the stack cookie value against __security_cookie and calls the
+; stack cookie failure handler if there is a mismatch.
+;
+; VOID
+; TriggerStackCookieInterrupt (
+;   VOID
+;   );
+;------------------------------------------------------------------------------
+global ASM_PFX(TriggerStackCookieInterrupt)
+ASM_PFX(TriggerStackCookieInterrupt):
+    int     FixedPcdGet8 (PcdStackCookieExceptionVector)
+    ret

--- a/MdePkg/Library/StackCheckLib/Readme.md
+++ b/MdePkg/Library/StackCheckLib/Readme.md
@@ -1,0 +1,124 @@
+# StackCheckLib
+
+## Table of Contents
+
+- [StackCheckLib](#stackchecklib)
+  - [Table of Contents](#table-of-contents)
+  - [Introduction and Library Instances](#introduction-and-library-instances)
+    - [StackCheckLibStaticInit](#stackchecklibstaticinit)
+    - [StackCheckLibDynamicInit](#stackchecklibdynamicinit)
+    - [StackCheckLibNull](#stackchecklibnull)
+  - [How Failures are Handled](#how-failures-are-handled)
+  - [Debugging Stack Cookie Check Failures](#debugging-stack-cookie-check-failures)
+  - [Usage](#usage)
+
+## Introduction and Library Instances
+
+`StackCheckLib` contains the required functionality for initializing the stack cookie
+value, checking the value, and triggering an interrupt when a mismatch occurs.
+The stack cookie is a random value placed on the stack between the stack variables
+and the return address so that continuously writing past the stack variables will
+cause the stack cookie to be overwritten. Before the function returns, the stack
+cookie value will be checked and if there is a mismatch then `StackCheckLib` handles
+the failure.
+
+Because UEFI doesn't use the C runtime libraries provided by MSVC, the stack
+check code is written in assembly within this library. GCC and Clang compilers
+have built-in support for stack cookie checking, so this library only handles failures.
+
+### StackCheckLibStaticInit
+
+`StackCheckLibStaticInit` is an instance of `StackCheckLib` which does not update the
+stack cookie value for the module at runtime. It's always preferable to use
+`StackCheckLibDynamicInit` for improved security but there are cases where the stack
+cookie global cannot be written to such as in execute-in-place (XIP) modules and during
+the Cache-as-RAM (CAR) phase of the boot process. The stack cookie value is initialized
+at compile time via Project Mu updates to the AutoGen process. Each module will define
+`STACK_COOKIE_VALUE` which is used for the module stack cookie value.
+
+### StackCheckLibDynamicInit
+
+`StackCheckLibDynamicInit` is an instance of `StackCheckLib` which updates the stack
+cookie value for the module at runtime. This is the preferred method for stack cookie
+initialization as it provides improved security. The stack cookie value is initialized
+at runtime by calling `GetRandomNumber32()` or `GetRandomNumber64()` to generate a random
+value via the platform's random number generator protocol. If the random number generator
+returns an error, then the value will still have the build-time randomized value to fall
+back on.
+
+### StackCheckLibNull
+
+`StackCheckLibNull` is an instance of `StackCheckLib` which does not perform any stack
+cookie checks. This is useful for modules which will fail if stack cookie checks are
+inserted. Of course, this is not recommended for production code.
+
+## How Failures are Handled
+
+When a stack cookie check fails, the `StackCheckLib` library will first call into a hook
+function `StackCheckFailureHook()` which only has a NULL implementation in Project Mu.
+The NULL implementation will simply print the failure address and return, but a platform
+can implement their own instance of this library which can perform additional actions
+before the system triggers an interrupt.
+
+After `StackCheckFailureHook()` returns, the library will trigger an interrupt with
+PcdStackCookieExceptionVector.
+
+- On IA32 and X64 platforms, PcdStackCookieExceptionVector is used as an index into the
+Interrupt Descriptor Table.
+- On ARM platforms, a software interrupt (`SWI`) is called with the value of
+PcdStackCookieExceptionVector. The value can be retrieved by the handler by reading
+bits [7:0] of the instruction opcode which will allow the handler to determine if the
+interrupt was triggered by the stack cookie check. Reference:
+[Arm A64 Instruction Set Architecture Version 2024-3](https://developer.arm.com/documentation/ddi0597/2024-03/Base-Instructions/SVC--Supervisor-Call-?lang=en)
+- On AARCH64 platforms, a supervisor call (`SVC`) is called with the value
+of PcdStackCookieExceptionVector. This value can similarly be retrieved by the
+handler to determine if the interrupt was triggered by the stack cookie check. Reference:
+[Arm A64 Instruction Set Architecture Version 2024-3](https://developer.arm.com/documentation/ddi0602/2024-03/Base-Instructions/SVC--Supervisor-Call-?lang=en)
+
+## Debugging Stack Cookie Check Failures
+
+Tracking down the origin of stack cookie failures can be difficult. Programmers may attempt
+printf debugging to determine which function has an overflow only to find that the failure
+disappears on the next boot. This curiosity is usually due to the black-box heuristic used
+by compilers to determine where to put stack cookie checks or compiler optimization features
+removing the failing check. The address where the failed stack cookie check occurred will
+be printed using DebugLib. If .map files are available, the address combined with the image
+offset can be used to determine the function which failed.
+
+GNU-based compilers have the `-fstack-protector-all` flag to force stack cookie checks on
+all functions which could create a more consistent environment for debugging assuming an
+earlier failure doesn't mask the targeted one and the flash space can accommodate the
+increased size.
+
+The Visual Studio (MSVC) toolchain has the ability to generate `.cod` files during compilation
+which interleave C and the generated assembly code. These files will contain the stack cookie
+checks and are useful for determining where the checks are placed. To generate these files,
+append `/FAcs` to the build options for each target module. The easiest way to do this is to
+update the tools_def file so the `<TARGET>_<TOOLCHAIN>_<ARCH>_CC_FLAGS` includes `/FAcs`.
+
+## Usage
+
+Project Mu updated the tools_def to add `/GS` to VS2022 and VS2019 IA32/X64 builds and
+`-fstack-protector` to GCC builds. This will cause stack cookie references to be inserted
+throughout the code. Every module should have a `StackCheckLib` instances linked to satisfy
+these references. So every module doesn't need to add `StackCheckLib` to the LibraryClasses
+section of the INF file, `StackCheckLib` instances should be linked as NULL in the platform
+DSC fies. The only exception to this is host-based unit tests as they will be compiled with
+the runtime libraries which already contain the stack cookie definitions and will collide
+with `StackCheckLib`.
+
+SEC and PEI_CORE modules should always use `StackCheckLibNull` and pre-memory modules
+should use `StackCheckLibStaticInit`. All other modules should use `StackCheckLibDynamicInit`.
+Below is an **example** of how to link the `StackCheckLib` instances in the platform DSC file
+but it may need customization based on the platform's requirements:
+
+```text
+[LibraryClasses.common.SEC, LibraryClasses.common.PEI_CORE]
+  NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
+
+[LibraryClasses.common.PEIM]
+  NULL|MdePkg/Library/StackCheckLib/StackCheckLibStaticInit.inf
+
+[LibraryClasses.common.MM_CORE_STANDALONE, LibraryClasses.common.MM_STANDALONE, LibraryClasses.common.DXE_CORE, LibraryClasses.common.SMM_CORE, LibraryClasses.common.DXE_SMM_DRIVER, LibraryClasses.common.DXE_DRIVER, LibraryClasses.common.DXE_RUNTIME_DRIVER, LibraryClasses.common.DXE_SAL_DRIVER, LibraryClasses.common.UEFI_DRIVER, LibraryClasses.common.UEFI_APPLICATION]
+  NULL|MdePkg/Library/StackCheckLib/StackCheckLibDynamicInit.inf
+```

--- a/MdePkg/Library/StackCheckLib/StackCheckLibCommon.c
+++ b/MdePkg/Library/StackCheckLib/StackCheckLibCommon.c
@@ -1,0 +1,50 @@
+/** @file
+  Provides the required functionality for handling stack
+  cookie check failures.
+
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Base.h>
+
+#include <Library/DebugLib.h>
+#include <Library/BaseLib.h>
+#include <Library/StackCheckFailureHookLib.h>
+
+/**
+  Calls an interrupt using the vector specified by PcdStackCookieExceptionVector
+**/
+VOID
+TriggerStackCookieInterrupt (
+  VOID
+  );
+
+#if defined (__GNUC__) || defined (__clang__)
+
+VOID  *__stack_chk_guard = (VOID *)(UINTN)STACK_COOKIE_VALUE;
+
+VOID
+__stack_chk_fail (
+  VOID
+  )
+{
+  DEBUG ((DEBUG_ERROR, "Stack cookie check failed at address 0x%llx!\n", RETURN_ADDRESS (0)));
+  StackCheckFailureHook (RETURN_ADDRESS (0));
+  TriggerStackCookieInterrupt ();
+}
+
+#elif defined (_MSC_VER)
+VOID  *__security_cookie = (VOID *)(UINTN)STACK_COOKIE_VALUE;
+
+VOID
+StackCheckFailure (
+  VOID  *ActualCookieValue
+  )
+{
+  DEBUG ((DEBUG_ERROR, "Stack cookie check failed at address 0x%llx!\n", RETURN_ADDRESS (0)));
+  StackCheckFailureHook (RETURN_ADDRESS (0));
+  TriggerStackCookieInterrupt ();
+}
+
+#endif

--- a/MdePkg/Library/StackCheckLib/StackCheckLibDynamicInit.c
+++ b/MdePkg/Library/StackCheckLib/StackCheckLibDynamicInit.c
@@ -1,0 +1,44 @@
+/** @file
+  Provides the required functionality for initializing
+  the stack cookie value.
+
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Base.h>
+#include <Uefi.h>
+
+#include <Library/RngLib.h>
+
+#if defined (__GNUC__) || defined (__clang__)
+extern VOID  *__stack_chk_guard;
+#elif defined (_MSC_VER)
+extern VOID  *__security_cookie;
+#endif
+
+/**
+  Initialize the security cookie.
+**/
+NO_STACK_COOKIE
+EFI_STATUS
+EFIAPI
+InitializeSecurityCookie (
+  VOID
+  )
+{
+  // Only generate a random value for MSVC builds. GCC builds which use
+  // -fstack-protector-strong or -fstack-protector-all may encounter a
+  // stack overflow with a random cookie value. The exact cause of this
+  // behavior needs to be investigated further.
+ #ifdef _MSC_VER
+  if (sizeof (UINTN) == sizeof (UINT64)) {
+    GetRandomNumber64 ((UINT64 *)&__security_cookie);
+  } else {
+    GetRandomNumber32 ((UINT32 *)&__security_cookie);
+  }
+
+ #endif
+
+  return EFI_SUCCESS;
+}

--- a/MdePkg/Library/StackCheckLib/StackCheckLibDynamicInit.inf
+++ b/MdePkg/Library/StackCheckLib/StackCheckLibDynamicInit.inf
@@ -1,0 +1,54 @@
+## @file
+#  Provides the required functionality for initializing and
+#  checking the stack cookie.
+#
+#  Copyright (c) Microsoft Corporation. All rights reserved.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = StackCheckLibDynamicInit
+  FILE_GUID                      = 495b10c8-7148-4b62-92b0-7cf4551df83d
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = NULL
+  CONSTRUCTOR                    = InitializeSecurityCookie
+
+[Sources]
+  StackCheckLibCommon.c
+  StackCheckLibDynamicInit.c
+
+[Sources.IA32]
+  IA32/CheckCookieMsvc.nasm | MSFT
+
+[Sources.X64]
+  X64/CheckCookieMsvc.nasm | MSFT
+
+[Sources.IA32, Sources.X64]
+  IA32/StackCookieInterrupt.nasm
+
+[Sources.ARM]
+  Arm/StackCookieInterrupt.S   |GCC
+  Arm/StackCookieInterrupt.asm |MSFT
+
+[Sources.AARCH64]
+  AArch64/StackCookieInterrupt.S   |GCC
+  AArch64/StackCookieInterrupt.asm |MSFT
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  RngLib
+  StackCheckFailureHookLib
+  BaseLib
+  DebugLib
+
+[FixedPcd]
+  gEfiMdePkgTokenSpaceGuid.PcdStackCookieExceptionVector
+
+# Disable LTO to ensure the linker doesn't optimize out the stack cookie
+[BuildOptions]
+  GCC:*_*_*_CC_FLAGS = -fno-lto
+  MSFT:*_*_*_CC_FLAGS = /GL-

--- a/MdePkg/Library/StackCheckLib/StackCheckLibStaticInit.inf
+++ b/MdePkg/Library/StackCheckLib/StackCheckLibStaticInit.inf
@@ -1,0 +1,50 @@
+## @file
+#  Provides the required functionality for checking the stack cookie.
+#
+#  Copyright (c) Microsoft Corporation. All rights reserved.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = StackCheckLibStaticInit
+  FILE_GUID                      = 2b24dc50-e33d-4c9f-8b62-e826f06e483f
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = NULL
+
+[Sources]
+  StackCheckLibCommon.c
+
+[Sources.IA32]
+  IA32/CheckCookieMsvc.nasm | MSFT
+
+[Sources.X64]
+  X64/CheckCookieMsvc.nasm | MSFT
+
+[Sources.IA32, Sources.X64]
+  IA32/StackCookieInterrupt.nasm
+
+[Sources.ARM]
+  Arm/StackCookieInterrupt.S   |GCC
+  Arm/StackCookieInterrupt.asm |MSFT
+
+[Sources.AARCH64]
+  AArch64/StackCookieInterrupt.S   |GCC
+  AArch64/StackCookieInterrupt.asm |MSFT
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  StackCheckFailureHookLib
+  BaseLib
+  DebugLib
+
+[FixedPcd]
+  gEfiMdePkgTokenSpaceGuid.PcdStackCookieExceptionVector
+
+# Disable LTO to ensure the linker doesn't optimize out the stack cookie
+[BuildOptions]
+  GCC:*_*_*_CC_FLAGS = -fno-lto
+  MSFT:*_*_*_CC_FLAGS = /GL-

--- a/MdePkg/Library/StackCheckLib/X64/CheckCookieMsvc.nasm
+++ b/MdePkg/Library/StackCheckLib/X64/CheckCookieMsvc.nasm
@@ -1,0 +1,43 @@
+;------------------------------------------------------------------------------
+; X64/CheckCookieMsvc.nasm
+;
+; Copyright (c) Microsoft Corporation. All rights reserved.
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;------------------------------------------------------------------------------
+
+    DEFAULT REL
+    SECTION .text
+
+extern ASM_PFX(StackCheckFailure)
+extern ASM_PFX(__security_cookie)
+extern ASM_PFX(CpuDeadLoop)
+
+; Called when a buffer check fails. This functionality is dependent on MSVC
+; C runtime libraries and so is unsupported in UEFI.
+global ASM_PFX(__report_rangecheckfailure)
+ASM_PFX(__report_rangecheckfailure):
+    jmp ASM_PFX(CpuDeadLoop)
+    ret
+
+; The GS handler is for checking the stack cookie during SEH or
+; EH exceptions and is unsupported in UEFI.
+global ASM_PFX(__GSHandlerCheck)
+ASM_PFX(__GSHandlerCheck):
+    jmp ASM_PFX(CpuDeadLoop)
+    ret
+
+;------------------------------------------------------------------------------
+; Checks the stack cookie value against __security_cookie and calls the
+; stack cookie failure handler if there is a mismatch.
+;
+; VOID
+; EFIAPI
+; __security_check_cookie (
+;   IN UINTN CheckValue
+;   );
+;------------------------------------------------------------------------------
+global ASM_PFX(__security_check_cookie)
+ASM_PFX(__security_check_cookie):
+    cmp     rcx, [ASM_PFX(__security_cookie)]
+    jne    ASM_PFX(StackCheckFailure)
+    ret

--- a/MdePkg/Library/StackCheckLibNull/IA32/StackCheckFunctionsMsvc.nasm
+++ b/MdePkg/Library/StackCheckLibNull/IA32/StackCheckFunctionsMsvc.nasm
@@ -1,0 +1,21 @@
+;------------------------------------------------------------------------------
+; IA32/StackCheckFunctionsMsvc.nasm
+;
+; Copyright (c) Microsoft Corporation.
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;------------------------------------------------------------------------------
+
+    DEFAULT REL
+    SECTION .text
+
+global ASM_PFX(__report_rangecheckfailure)
+ASM_PFX(__report_rangecheckfailure):
+    ret
+
+global ASM_PFX(__GSHandlerCheck)
+ASM_PFX(__GSHandlerCheck):
+    ret
+
+global @__security_check_cookie@4
+@__security_check_cookie@4:
+    ret

--- a/MdePkg/Library/StackCheckLibNull/StackCheckLibNull.c
+++ b/MdePkg/Library/StackCheckLibNull/StackCheckLibNull.c
@@ -1,0 +1,23 @@
+/** @file
+  Defines the stack cookie variable for GCC, Clang and MSVC compilers.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Uefi.h>
+
+#if defined (__GNUC__) || defined (__clang__)
+VOID  *__stack_chk_guard = (VOID *)(UINTN)0x0;
+
+VOID
+EFIAPI
+__stack_chk_fail (
+  VOID
+  )
+{
+}
+
+#elif defined (_MSC_VER)
+VOID  *__security_cookie = (VOID *)(UINTN)0x0;
+#endif

--- a/MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
+++ b/MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
@@ -1,0 +1,33 @@
+## @file
+#  Null library instance for StackCheckLib which can be included
+#  when a build needs to include stack check functions but does
+#  not want to generate stack check failures.
+#
+#  Copyright (c) Microsoft Corporation.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = StackCheckLibNull
+  FILE_GUID                      = f6ef2763-ca3b-4c6f-a931-2a48de3ce352
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = StackCheckLib
+
+[Sources]
+  StackCheckLibNull.c
+
+[Sources.IA32]
+  IA32/StackCheckFunctionsMsvc.nasm | MSFT
+
+[Sources.X64]
+  X64/StackCheckFunctionsMsvc.nasm | MSFT
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+# Disable LTO to ensure the linker doesn't optimize out the stack cookie
+[BuildOptions]
+  GCC:*_*_*_CC_FLAGS = -fno-lto
+  MSFT:*_*_*_CC_FLAGS = /GL-

--- a/MdePkg/Library/StackCheckLibNull/X64/StackCheckFunctionsMsvc.nasm
+++ b/MdePkg/Library/StackCheckLibNull/X64/StackCheckFunctionsMsvc.nasm
@@ -1,0 +1,21 @@
+;------------------------------------------------------------------------------
+; X64/StackCheckFunctionsMsvc.nasm
+;
+; Copyright (c) Microsoft Corporation.
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;------------------------------------------------------------------------------
+
+    DEFAULT REL
+    SECTION .text
+
+global ASM_PFX(__report_rangecheckfailure)
+ASM_PFX(__report_rangecheckfailure):
+    ret
+
+global ASM_PFX(__GSHandlerCheck)
+ASM_PFX(__GSHandlerCheck):
+    ret
+
+global ASM_PFX(__security_check_cookie)
+ASM_PFX(__security_check_cookie):
+    ret

--- a/MdePkg/Library/StandaloneMmDriverEntryPoint/StandaloneMmDriverEntryPoint.c
+++ b/MdePkg/Library/StandaloneMmDriverEntryPoint/StandaloneMmDriverEntryPoint.c
@@ -78,6 +78,7 @@ _DriverUnloadHandler (
                                      ProcessModuleEntryPointList().
 
 **/
+NO_STACK_COOKIE // MU_CHANGE: Project Mu Runtime Randomized Stack Cookie Support
 EFI_STATUS
 EFIAPI
 _ModuleEntryPoint (

--- a/MdePkg/Library/UefiApplicationEntryPoint/ApplicationEntryPoint.c
+++ b/MdePkg/Library/UefiApplicationEntryPoint/ApplicationEntryPoint.c
@@ -29,6 +29,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
   @retval  Other                     Return value from ProcessModuleEntryPointList().
 
 **/
+NO_STACK_COOKIE // MU_CHANGE: Project Mu Runtime Randomized Stack Cookie Support
 EFI_STATUS
 EFIAPI
 _ModuleEntryPoint (

--- a/MdePkg/Library/UefiDriverEntryPoint/DriverEntryPoint.c
+++ b/MdePkg/Library/UefiDriverEntryPoint/DriverEntryPoint.c
@@ -80,6 +80,7 @@ _DriverUnloadHandler (
   @retval  Other                     Return value from ProcessModuleEntryPointList().
 
 **/
+NO_STACK_COOKIE // MU_CHANGE: Project Mu Runtime Randomized Stack Cookie Support
 EFI_STATUS
 EFIAPI
 _ModuleEntryPoint (

--- a/MdePkg/MdePkg.dec
+++ b/MdePkg/MdePkg.dec
@@ -105,6 +105,11 @@
   ##
   PrintLib|Include/Library/PrintLib.h
 
+## MU_CHANGE [BEGIN]
+  ##  @libraryclass  Provides a hook called when a stack cookie check fails.
+  StackCheckFailureHookLib|Include/Library/StackCheckFailureHookLib.h
+## MU_CHANGE [END]
+
   ##  @libraryclass  Provides an ordered collection data structure.
   OrderedCollectionLib|Include/Library/OrderedCollectionLib.h
 

--- a/MdePkg/MdePkg.dec
+++ b/MdePkg/MdePkg.dec
@@ -2252,6 +2252,11 @@
   # @Prompt Speculation Barrier Type.
   gEfiMdePkgTokenSpaceGuid.PcdSpeculationBarrierType|0x01|UINT8|0x30001018
 
+  ## MU_CHANGE START: Add Stack Cookie Exception Vector
+  ## This PCD specifies the interrupt vector for stack cookie check failures
+  gEfiMdePkgTokenSpaceGuid.PcdStackCookieExceptionVector|0x42|UINT8|0x30001019
+  ## MU_CHANGE END
+
 [PcdsFixedAtBuild,PcdsPatchableInModule]
   ## Indicates the maximum length of unicode string used in the following
   #  BaseLib functions: StrLen(), StrSize(), StrCmp(), StrnCmp(), StrCpy(), StrnCpy()<BR><BR>

--- a/MdePkg/MdePkg.dsc
+++ b/MdePkg/MdePkg.dsc
@@ -34,6 +34,7 @@
 
 [LibraryClasses]
   SafeIntLib|MdePkg/Library/BaseSafeIntLib/BaseSafeIntLib.inf
+  NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf # MU_CHANGE: /GS and -fstack-protector support
 
 [Components]
   MdePkg/Library/UefiFileHandleLib/UefiFileHandleLib.inf
@@ -139,6 +140,10 @@
   MdePkg/Library/JedecJep106Lib/JedecJep106Lib.inf
   MdePkg/Library/BaseFdtLib/BaseFdtLib.inf
   MdePkg/Library/BaseMmuLibNull/BaseMmuLibNull.inf      ## MU_CHANGE
+  MdePkg/Library/StackCheckLib/StackCheckLibStaticInit.inf      ## MU_CHANGE
+  MdePkg/Library/StackCheckLib/StackCheckLibDynamicInit.inf     ## MU_CHANGE
+  MdePkg/Library/StackCheckFailureHookLibNull/StackCheckFailureHookLibNull.inf  ## MU_CHANGE
+  MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf        ## MU_CHANGE
 
 [Components.IA32, Components.X64, Components.ARM, Components.AARCH64]
   #

--- a/NetworkPkg/NetworkPkg.dsc
+++ b/NetworkPkg/NetworkPkg.dsc
@@ -62,6 +62,7 @@
   FileHandleLib|MdePkg/Library/UefiFileHandleLib/UefiFileHandleLib.inf
   FileExplorerLib|MdeModulePkg/Library/FileExplorerLib/FileExplorerLib.inf
   SortLib|MdeModulePkg/Library/UefiSortLib/UefiSortLib.inf
+  NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf # MU_CHANGE: /GS and -fstack-protector support
 
 [LibraryClasses.common.UEFI_DRIVER]
   HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
@@ -82,7 +83,7 @@
   #NULL|ArmPkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
   NULL|MdePkg/Library/CompilerIntrinsicsLib/ArmCompilerIntrinsicsLib.inf
   # MU_CHANGE [END]
-  NULL|MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf
+  # NULL|MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf        # MU_CHANGE: Use Project Mu StackCheckLib
   # ArmSoftFloatLib|ArmPkg/Library/ArmSoftFloatLib/ArmSoftFloatLib.inf # MU_CHANGE: Remove ArmPkg Dependencies
 
 [LibraryClasses.ARM]

--- a/PcAtChipsetPkg/PcAtChipsetPkg.dsc
+++ b/PcAtChipsetPkg/PcAtChipsetPkg.dsc
@@ -44,6 +44,7 @@
   LocalApicLib|UefiCpuPkg/Library/BaseXApicLib/BaseXApicLib.inf
   ReportStatusCodeLib|MdePkg/Library/BaseReportStatusCodeLibNull/BaseReportStatusCodeLibNull.inf
   HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
+  NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf # MU_CHANGE: /GS and -fstack-protector support
 
 [Components]
   PcAtChipsetPkg/HpetTimerDxe/HpetTimerDxe.inf

--- a/ShellPkg/ShellPkg.dsc
+++ b/ShellPkg/ShellPkg.dsc
@@ -66,6 +66,8 @@
   DxeServicesLib|MdePkg/Library/DxeServicesLib/DxeServicesLib.inf
   ReportStatusCodeLib|MdePkg/Library/BaseReportStatusCodeLibNull/BaseReportStatusCodeLibNull.inf
 
+  NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf # MU_CHANGE: /GS and -fstack-protector support
+
 [LibraryClasses.ARM,LibraryClasses.AARCH64]
   #
   # It is not possible to prevent the ARM compiler for generic intrinsic functions.
@@ -76,7 +78,7 @@
   NULL|MdePkg/Library/CompilerIntrinsicsLib/ArmCompilerIntrinsicsLib.inf  # MU_CHANGE
 
   # Add support for GCC stack protector
-  NULL|MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf
+  # NULL|MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf # MU_CHANGE: Use Project Mu StackCheckLib
 
 [PcdsFixedAtBuild]
   gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0xFF

--- a/StandaloneMmPkg/StandaloneMmPkg.dsc
+++ b/StandaloneMmPkg/StandaloneMmPkg.dsc
@@ -61,6 +61,7 @@
   StandaloneMmDriverEntryPoint|MdePkg/Library/StandaloneMmDriverEntryPoint/StandaloneMmDriverEntryPoint.inf
   VariableMmDependency|StandaloneMmPkg/Library/VariableMmDependency/VariableMmDependency.inf
   MmuLib|MdePkg/Library/BaseMmuLibNull/BaseMmuLibNull.inf   # MU_CHANGE
+  NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf # MU_CHANGE: /GS and -fstack-protector support
 
 [LibraryClasses.X64]                                                                                                    # MU_CHANGE
   StandaloneMmCoreEntryPoint|StandaloneMmPkg/Library/StandaloneMmCoreEntryPoint/StandaloneMmCoreEntryPoint.inf          # MU_CHANGE
@@ -77,8 +78,8 @@
 # MU_CHANGE [BEGIN]
   #NULL|ArmPkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
   NULL|MdePkg/Library/CompilerIntrinsicsLib/ArmCompilerIntrinsicsLib.inf
+  # NULL|MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf # MU_CHANGE: Use Project Mu StackCheckLib
 # MU_CHANGE [END]
-  NULL|MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf
 
 [LibraryClasses.common.MM_CORE_STANDALONE]
   HobLib|StandaloneMmPkg/Library/StandaloneMmCoreHobLib/StandaloneMmCoreHobLib.inf

--- a/UefiCpuPkg/UefiCpuPkg.dsc
+++ b/UefiCpuPkg/UefiCpuPkg.dsc
@@ -74,6 +74,12 @@
   HwResetSystemLib|MdeModulePkg/Library/BaseResetSystemLibNull/BaseResetSystemLibNull.inf
 # MU_CHANGE [END] - Add HwResetSystemLib
 
+# MU_CHANGE [BEGIN] - /GS and -fstack-protector support
+# ASM only SEC files cannot link against this in MSVC as it tries to link the ModuleEntryPoint, which doesn't exist
+[LibraryClasses.common.PEIM, LibraryClasses.common.DXE_DRIVER, LibraryClasses.common.DXE_SMM_DRIVER, LibraryClasses.common.MM_STANDALONE, LibraryClasses.common.UEFI_APPLICATION]
+  NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
+# MU_CHANGE [END] - /GS and -fstack-protector support
+
 [LibraryClasses.common.SEC]
   PlatformSecLib|UefiCpuPkg/Library/PlatformSecLibNull/PlatformSecLibNull.inf
   CpuExceptionHandlerLib|UefiCpuPkg/Library/CpuExceptionHandlerLib/SecPeiCpuExceptionHandlerLib.inf
@@ -171,8 +177,16 @@
   UefiCpuPkg/Library/AmdSvsmLibNull/AmdSvsmLibNull.inf
   UefiCpuPkg/PiSmmCommunication/PiSmmCommunicationPei.inf
   UefiCpuPkg/PiSmmCommunication/PiSmmCommunicationSmm.inf
-  UefiCpuPkg/SecCore/SecCore.inf
-  UefiCpuPkg/SecCore/SecCoreNative.inf
+  # MU_CHANGE [BEGIN]: /GS and -fstack-protector support
+  UefiCpuPkg/SecCore/SecCore.inf {
+    <LibraryClasses>
+      NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
+  }
+  UefiCpuPkg/SecCore/SecCoreNative.inf {
+    <LibraryClasses>
+      NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
+  }
+  # MU_CHANGE [END]: /GS and -fstack-protector support
   UefiCpuPkg/SecMigrationPei/SecMigrationPei.inf
   UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf
   UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf {

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkgCommon.dsc.inc
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkgCommon.dsc.inc
@@ -1,0 +1,22 @@
+## @file
+# UnitTestFrameworkPkg DSC include file for host and target based test DSC
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[LibraryClasses]
+  BaseMemoryLib|MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf
+  PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
+  UnitTestPersistenceLib|UnitTestFrameworkPkg/Library/UnitTestPersistenceLibNull/UnitTestPersistenceLibNull.inf
+  UnitTestResultReportLib|UnitTestFrameworkPkg/Library/UnitTestResultReportLib/UnitTestResultReportLibDebugLib.inf
+  PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
+
+[PcdsFixedAtBuild]
+  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x17
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS  = -D DISABLE_NEW_DEPRECATED_INTERFACES -D EDKII_UNIT_TEST_FRAMEWORK_ENABLED
+  GCC:*_*_*_CC_FLAGS   = -D DISABLE_NEW_DEPRECATED_INTERFACES -D EDKII_UNIT_TEST_FRAMEWORK_ENABLED
+  XCODE:*_*_*_CC_FLAGS = -D DISABLE_NEW_DEPRECATED_INTERFACES -D EDKII_UNIT_TEST_FRAMEWORK_ENABLED

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
@@ -6,7 +6,7 @@
 #
 ##
 
-!include UnitTestFrameworkPkg/UnitTestFrameworkPkgTarget.dsc.inc
+!include UnitTestFrameworkPkg/UnitTestFrameworkPkgCommon.dsc.inc
 
 [LibraryClasses.common.HOST_APPLICATION]
   BaseLib|MdePkg/Library/BaseLib/UnitTestHostBaseLib.inf

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
@@ -25,7 +25,11 @@
   NULL|UnitTestFrameworkPkg/Library/UnitTestDebugAssertLib/UnitTestDebugAssertLibHost.inf
 
 [BuildOptions]
-  MSFT:*_*_*_CC_FLAGS = /MT
+# MU_CHANGE [BEGIN] - Add build flag to detect when building host-based unit tests
+  MSFT:*_*_*_CC_FLAGS  = /MT -D HOST_UNIT_TEST_BUILD=1 /GS- # Disable Stack Protection for Host-Based Unit Tests
+  GCC:*_*_*_CC_FLAGS   = -D HOST_UNIT_TEST_BUILD=1 -fno-stack-protector # Disable Stack Protection for Host-Based Unit Tests
+  XCODE:*_*_*_CC_FLAGS = -D HOST_UNIT_TEST_BUILD=1
+# MU_CHANGE [END] - Add build flag to detect when building host-based unit tests
   GCC:*_*_*_CC_FLAGS = -fno-pie
 !ifdef $(UNIT_TESTING_DEBUG)
   MSFT:*_*_*_CC_FLAGS  = /MTd -D UNIT_TESTING_DEBUG=1

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkgTarget.dsc.inc
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkgTarget.dsc.inc
@@ -28,6 +28,7 @@
   UnitTestLib|UnitTestFrameworkPkg/Library/UnitTestLib/UnitTestLib.inf
   UnitTestPersistenceLib|UnitTestFrameworkPkg/Library/UnitTestPersistenceLibNull/UnitTestPersistenceLibNull.inf
   UnitTestResultReportLib|UnitTestFrameworkPkg/Library/UnitTestResultReportLib/UnitTestResultReportLibDebugLib.inf
+  NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf # MU_CHANGE: /GS and -fstack-protector support
 
 [LibraryClasses.common.SEC, LibraryClasses.common.PEI_CORE, LibraryClasses.common.PEIM]
   NULL|UnitTestFrameworkPkg/Library/UnitTestDebugAssertLib/UnitTestDebugAssertLib.inf
@@ -59,7 +60,7 @@
   # Since software stack checking may be heuristically enabled by the compiler
   # include BaseStackCheckLib unconditionally.
   #
-  NULL|MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf
+  # NULL|MdePkg/Library/BaseStackCheckLib/BaseStackCheckLib.inf # MU_CHANGE: Use Project Mu StackCheckLib
 
 [LibraryClasses.common.PEIM]
   HobLib|MdePkg/Library/PeiHobLib/PeiHobLib.inf

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkgTarget.dsc.inc
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkgTarget.dsc.inc
@@ -6,6 +6,8 @@
 #
 ##
 
+!include UnitTestFrameworkPkg/UnitTestFrameworkPkgCommon.dsc.inc
+
 [LibraryClasses]
   #
   # Entry point
@@ -15,15 +17,12 @@
   UefiApplicationEntryPoint|MdePkg/Library/UefiApplicationEntryPoint/UefiApplicationEntryPoint.inf
 
   BaseLib|MdePkg/Library/BaseLib/BaseLib.inf
-  BaseMemoryLib|MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf
   DebugLib|MdeModulePkg/Library/PeiDxeDebugLibReportStatusCode/PeiDxeDebugLibReportStatusCode.inf
   ReportStatusCodeLib|MdePkg/Library/BaseReportStatusCodeLibNull/BaseReportStatusCodeLibNull.inf
   DebugPrintErrorLevelLib|MdePkg/Library/BaseDebugPrintErrorLevelLib/BaseDebugPrintErrorLevelLib.inf
   MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
-  PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
   PeiServicesLib|MdePkg/Library/PeiServicesLib/PeiServicesLib.inf
   PerformanceLib|MdePkg/Library/BasePerformanceLibNull/BasePerformanceLibNull.inf
-  PrintLib|MdePkg/Library/BasePrintLib/BasePrintLib.inf
   UefiBootServicesTableLib|MdePkg/Library/UefiBootServicesTableLib/UefiBootServicesTableLib.inf
 
   UnitTestLib|UnitTestFrameworkPkg/Library/UnitTestLib/UnitTestLib.inf
@@ -69,11 +68,3 @@
 
 [LibraryClasses.common.UEFI_APPLICATION]
   UnitTestResultReportLib|UnitTestFrameworkPkg/Library/UnitTestResultReportLib/UnitTestResultReportLibConOut.inf
-
-[PcdsFixedAtBuild]
-  gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x17
-
-[BuildOptions]
-  MSFT:*_*_*_CC_FLAGS  = -D DISABLE_NEW_DEPRECATED_INTERFACES -D EDKII_UNIT_TEST_FRAMEWORK_ENABLED
-  GCC:*_*_*_CC_FLAGS   = -D DISABLE_NEW_DEPRECATED_INTERFACES -D EDKII_UNIT_TEST_FRAMEWORK_ENABLED
-  XCODE:*_*_*_CC_FLAGS = -D DISABLE_NEW_DEPRECATED_INTERFACES -D EDKII_UNIT_TEST_FRAMEWORK_ENABLED


### PR DESCRIPTION
## Description

This PR adds broader stack cookie support to the firmware across toolchains
and architectures. Closes #865.

This also pulls in a Unit Test Infrastructure commit that splits some common dependencies out from the Target and Host dsc.inc files so that Host does not depend on Target any longer. This is required for stack cookies because Target builds have stack cookies enabled and Host builds do not, without this commit we will have linkage failures.

This contains the meaningful parts of the release/202311 commits below:

9dd0624e63
d175925e30
c3d12d3cf7
291b637f97
e8a14cbee1
888b27ce79
e6c62ff194
78961a544b
34c382a2ce
9b0970c2e6
2ffdb64437
92224143d3
9e554f4a3e
44de5d3079
19cafa7527
4a115d401d
b1b0f05d1b
9b3e9a3bcf
2d5ad632ad
6c48e1dcec
c14706b886
a1da29ee21
1c14129314
ec7e76f5d0
92f2656f62

Major Pieces:

Add StackCheckLibNull, StackCheckLibStaticInit, and StackCheckLibDynamicInit
--
These libs provide the functions to link against that clang, gcc, and MSVC generate when stack cookies are enabled. For more information on what each lib does, see the README included in this PR. Each DSC then gets this linked against it.

Add NO_STACK_COOKIE Macro
--
This macro allows functions to opt out of having the compiler add stack cookies to calls of it. This gets used in this PR to avoid this on module entry points.

Enable Stack Cookies
--
Finally, stack cookies are enabled for IA32, X64, ARM, and AARCH64 for gcc and MSVC.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [x] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [x] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Pulled from 2311.

## Integration Instructions

Follow the ReadMe in this PR. A summary is:

Project Mu updated the tools_def to add `/GS` to VS2022 and VS2019 IA32/X64 builds and
`-fstack-protector` to GCC builds. This will cause stack cookie references to be inserted
throughout the code. Every module should have a `StackCheckLib` instances linked to satisfy
these references. So every module doesn't need to add `StackCheckLib` to the LibraryClasses
section of the INF file, `StackCheckLib` instances should be linked as NULL in the platform
DSC fies. The only exception to this is host-based unit tests as they will be compiled with
the runtime libraries which already contain the stack cookie definitions and will collide
with `StackCheckLib`.

SEC and PEI_CORE modules should always use `StackCheckLibNull` and pre-memory modules
should use `StackCheckLibStaticInit`. All other modules should use `StackCheckLibDynamicInit`.
Below is an **example** of how to link the `StackCheckLib` instances in the platform DSC file
but it may need customization based on the platform's requirements:

```text
[LibraryClasses.common.SEC, LibraryClasses.common.PEI_CORE]
  NULL|MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
[LibraryClasses.common.PEIM]
  NULL|MdePkg/Library/StackCheckLib/StackCheckLibStaticInit.inf
[LibraryClasses.common.MM_CORE_STANDALONE, LibraryClasses.common.MM_STANDALONE, LibraryClasses.common.DXE_CORE, LibraryClasses.common.SMM_CORE, LibraryClasses.common.DXE_SMM_DRIVER, LibraryClasses.common.DXE_DRIVER, LibraryClasses.common.DXE_RUNTIME_DRIVER, LibraryClasses.common.DXE_SAL_DRIVER, LibraryClasses.common.UEFI_DRIVER, LibraryClasses.common.UEFI_APPLICATION]
  NULL|MdePkg/Library/StackCheckLib/StackCheckLibDynamicInit.inf
```
