### PR TITLE
[REBASE & FF] Add GetVariable Interface for AdvLogger and Support AdvLogger in PEI

### DIFF
--- a/MdeModulePkg/Core/Pei/PeiMain.h
+++ b/MdeModulePkg/Core/Pei/PeiMain.h
@@ -307,6 +307,8 @@ struct _PEI_CORE_INSTANCE {
   // Those Memory Range will be migrated into physical memory.
   //
   HOLE_MEMORY_DATA                  HoleData[HOLE_MAX_NUMBER];
+
+  EFI_PHYSICAL_ADDRESS              PlatformBlob;             // MU_CHANGE  Used by AdvancedLogger
 };
 
 ///

--- a/MdeModulePkg/Include/Library/AdvLoggerAccessLib.h
+++ b/MdeModulePkg/Include/Library/AdvLoggerAccessLib.h
@@ -1,0 +1,79 @@
+/** @file
+  SMM GetVariable Implementation to retrieve the AdvLogger memory.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef ADV_LOGGER_ACCESS_LIB_H_
+#define ADV_LOGGER_ACCESS_LIB_H_
+
+/**
+
+  This code accesses the AdvLogger private storage.
+
+  Caution: This function may receive untrusted input.
+  This function may be invoked in SMM mode, and datasize is external input.
+  This function will do basic validation, before parse the data.
+
+  @param VariableName               Name of Variable to be found.
+  @param VendorGuid                 Variable vendor GUID.
+  @param Attributes                 Attribute value of the variable found.
+  @param DataSize                   Size of Data found. If size is less than the
+                                    data, this value contains the required size.
+  @param Data                       The buffer to return the contents of the variable. May be NULL
+                                    with a zero DataSize in order to determine the size buffer needed.
+
+  @return EFI_INVALID_PARAMETER     Invalid parameter.
+  @return EFI_SUCCESS               Found the specified data.
+  @return EFI_NOT_FOUND             Not found.
+  @return EFI_BUFFER_TO_SMALL       DataSize is too small for the result.
+
+**/
+EFI_STATUS
+AdvLoggerAccessGetVariable (
+  IN      CHAR16    *VariableName,
+  IN      EFI_GUID  *VendorGuid,
+  OUT     UINT32    *Attributes OPTIONAL,
+  IN OUT  UINTN     *DataSize,
+  OUT     VOID      *Data OPTIONAL
+  );
+
+/**
+    AdvLoggerInit - Obtain the address of the logger info block.
+
+    @param          NONE
+
+    @return         NONE
+**/
+VOID
+AdvLoggerAccessInit (
+  VOID
+  );
+
+/**
+    AdvLoggerAccessAtRuntime - Exit Boot Services.
+
+    @param          NONE
+
+    @return         NONE
+**/
+VOID
+AdvLoggerAccessAtRuntime (
+  VOID
+  );
+
+/**
+    AdvLoggerAccessGonevirtual - Virtual Address Change.
+
+    @param          NONE
+
+    @return         NONE
+**/
+VOID
+AdvLoggerAccessGoneVirtual (
+  VOID
+  );
+
+#endif // ADV_LOGGER_ACCESS_LIB_H_

--- a/MdeModulePkg/Library/AdvLoggerAccessLibNull/AdvLoggerAccessLib.c
+++ b/MdeModulePkg/Library/AdvLoggerAccessLibNull/AdvLoggerAccessLib.c
@@ -1,0 +1,88 @@
+/** @file
+  SMM GetVariable NULL Implementation to retrieve the AdvLogger memory using
+  GetVariable.
+
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi/UefiBaseType.h>
+
+#include <Library/AdvLoggerAccessLib.h>
+
+/**
+
+  This code accesses the AdvLogger private storage.
+
+  Caution: This function may receive untrusted input.
+  This function may be invoked in SMM mode, and datasize is external input.
+  This function will do basic validation, before parsing the data.
+
+  @param VariableName               Name of Variable to be found.
+  @param VendorGuid                 Variable vendor GUID.
+  @param Attributes                 Attribute value of the variable found.
+  @param DataSize                   Size of Data found. If size is less than the
+                                    data, this value contains the required size.
+  @param Data                       The buffer to return the contents of the variable. May be NULL
+                                    with a zero DataSize in order to determine the size buffer needed.
+
+  @return EFI_INVALID_PARAMETER     Invalid parameter.
+  @return EFI_SUCCESS               Found the specified data.
+  @return EFI_NOT_FOUND             Not found.
+  @return EFI_BUFFER_TOO_SMALL      DataSize is too small for the result.
+
+**/
+EFI_STATUS
+AdvLoggerAccessGetVariable (
+  IN      CHAR16    *VariableName,
+  IN      EFI_GUID  *VendorGuid,
+  OUT     UINT32    *Attributes OPTIONAL,
+  IN OUT  UINTN     *DataSize,
+  OUT     VOID      *Data OPTIONAL
+  )
+{
+  return EFI_NOT_FOUND;
+}
+
+/**
+    AdvLoggerAccessAtRuntime - Exit Boot Services.
+
+    @param          NONE
+
+    @return         NONE
+**/
+VOID
+AdvLoggerAccessAtRuntime (
+  VOID
+  )
+{
+}
+
+/**
+    AdvLoggerAccessGonevirtual - Virtual Address Change.
+
+    @param          NONE
+
+    @return         NONE
+**/
+VOID
+AdvLoggerAccessGoneVirtual (
+  VOID
+  )
+{
+}
+
+/**
+  Advanced Logger Library Initialization.
+
+  @return           EFI_SUCCESS
+  @return           other = AdvLoggerAccessInit failed for some reason
+ **/
+VOID
+AdvLoggerAccessInit (
+  VOID
+  )
+{
+}

--- a/MdeModulePkg/Library/AdvLoggerAccessLibNull/AdvLoggerAccessLib.inf
+++ b/MdeModulePkg/Library/AdvLoggerAccessLibNull/AdvLoggerAccessLib.inf
@@ -1,0 +1,31 @@
+## @file
+#  NULL implementation of the Advanced Logger Access library.
+#
+#  Copyright (c) Microsoft Corporation.
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 1.26
+  BASE_NAME                      = AdvLoggerAccessLib
+  MODULE_UNI_FILE                = AdvLoggerAccessLib.uni
+  FILE_GUID                      = f2b61dfb-84d1-4de9-99f0-0bbcc48d1ddc
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = AdvLoggerAccessLib
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64 AARCH64
+#
+
+[Sources]
+  AdvLoggerAccessLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[Guids]
+  gAdvLoggerAccessGuid

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -174,6 +174,11 @@
   #
   SpiHcPlatformLib|Include/Library/SpiHcPlatformLib.h
 
+  ## MU_CHANGE - Add AdvLoggerAccessLib to MdeModulePkg
+  ## @libraryclass Provides an interface for AdvLogger through GetVariable
+  #
+  AdvLoggerAccessLib|Include/Library/AdvLoggerAccessLib.h
+
 [Guids]
   ## MdeModule package token space guid
   # Include/Guid/MdeModulePkgTokenSpace.h
@@ -408,6 +413,14 @@
 
   ## Include/Guid/EndofS3Resume.h
   gEdkiiEndOfS3ResumeGuid = { 0x96f5296d, 0x05f7, 0x4f3c, {0x84, 0x67, 0xe4, 0x56, 0x89, 0x0e, 0x0c, 0xb5 } }
+  
+## MU_CHANGE BEGIN
+  ## Advanced Logger Variable Guid. This variable guid is used to access the log data via GetVariable.
+  #
+  gAdvLoggerAccessGuid = { 0xa021bf2b, 0x34ed, 0x4a98, {0x85, 0x9c, 0x42, 0x0e, 0xf9, 0x4f, 0x3e, 0x94 }}
+
+## MU_CHANGE END
+
 
   ## Used (similar to Variable Services) to communicate policies to the enforcement engine.
   # {DA1B0D11-D1A7-46C4-9DC9-F3714875C6EB}

--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -109,6 +109,8 @@
   IpmiCommandLib|MdeModulePkg/Library/BaseIpmiCommandLibNull/BaseIpmiCommandLibNull.inf
   SpiHcPlatformLib|MdeModulePkg/Library/BaseSpiHcPlatformLibNull/BaseSpiHcPlatformLibNull.inf
 
+  AdvLoggerAccessLib|MdeModulePkg/Library/AdvLoggerAccessLibNull/AdvLoggerAccessLib.inf       ## MU_CHANGE
+
 [LibraryClasses.EBC.PEIM]
   IoLib|MdePkg/Library/PeiIoLibCpuIo/PeiIoLibCpuIo.inf
 
@@ -356,6 +358,7 @@
   MdeModulePkg/Library/DisplayUpdateProgressLibGraphics/DisplayUpdateProgressLibGraphics.inf
   MdeModulePkg/Library/DisplayUpdateProgressLibText/DisplayUpdateProgressLibText.inf
   MdeModulePkg/Library/BaseRngLibTimerLib/BaseRngLibTimerLib.inf
+  MdeModulePkg/Library/AdvLoggerAccessLibNull/AdvLoggerAccessLib.inf              # MU_CHANGE
 
   MdeModulePkg/Universal/BdsDxe/BdsDxe.inf
   MdeModulePkg/Application/BootManagerMenuApp/BootManagerMenuApp.inf

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.c
@@ -16,6 +16,8 @@
 
 Copyright (c) 2010 - 2019, Intel Corporation. All rights reserved.<BR>
 Copyright (c) 2018, Linaro, Ltd. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation.         // MU_CHANGE
+
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -26,6 +28,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Protocol/MmEndOfDxe.h>
 #include <Protocol/SmmVarCheck.h>
 
+#include <Library/AdvLoggerAccessLib.h>             // MU_CHANGE
 #include <Library/MmServicesTableLib.h>
 #include <Library/VariablePolicyLib.h>
 
@@ -551,13 +554,31 @@ SmmVariableHandler (
         goto EXIT;
       }
 
-      Status = VariableServiceGetVariable (
-                 SmmVariableHeader->Name,
-                 &SmmVariableHeader->Guid,
-                 &SmmVariableHeader->Attributes,
-                 &SmmVariableHeader->DataSize,
-                 (UINT8 *)SmmVariableHeader->Name + SmmVariableHeader->NameSize
-                 );
+      // MU_CHANGE Begin -----------------------------------
+      //
+      // AdvLoggerAccess Hook
+      //
+      if (CompareGuid (&SmmVariableHeader->Guid, &gAdvLoggerAccessGuid)) {
+        Status = AdvLoggerAccessGetVariable (
+                   SmmVariableHeader->Name,
+                   &SmmVariableHeader->Guid,
+                   &SmmVariableHeader->Attributes,
+                   &SmmVariableHeader->DataSize,
+                   (UINT8 *)SmmVariableHeader->Name + SmmVariableHeader->NameSize
+                   );
+      } else {
+        Status = VariableServiceGetVariable (
+                   SmmVariableHeader->Name,
+                   &SmmVariableHeader->Guid,
+                   &SmmVariableHeader->Attributes,
+                   &SmmVariableHeader->DataSize,
+                   (UINT8 *)SmmVariableHeader->Name + SmmVariableHeader->NameSize
+                   );
+      }
+
+      //
+      // MU_CHANGE End ----------------------------------
+
       CopyMem (SmmVariableFunctionHeader->Data, mVariableBufferPayload, CommBufferPayloadSize);
       break;
 
@@ -656,13 +677,24 @@ SmmVariableHandler (
         goto EXIT;
       }
 
-      Status = VariableServiceSetVariable (
-                 SmmVariableHeader->Name,
-                 &SmmVariableHeader->Guid,
-                 SmmVariableHeader->Attributes,
-                 SmmVariableHeader->DataSize,
-                 (UINT8 *)SmmVariableHeader->Name + SmmVariableHeader->NameSize
-                 );
+      // MU_CHANGE Begin -----------------------------------
+      //
+      // AdvLoggerAccess Hook
+      //
+      if (CompareGuid (&SmmVariableHeader->Guid, &gAdvLoggerAccessGuid)) {
+        Status = EFI_ACCESS_DENIED;
+      } else {
+        Status = VariableServiceSetVariable (
+                   SmmVariableHeader->Name,
+                   &SmmVariableHeader->Guid,
+                   SmmVariableHeader->Attributes,
+                   SmmVariableHeader->DataSize,
+                   (UINT8 *)SmmVariableHeader->Name + SmmVariableHeader->NameSize
+                   );
+      }
+
+      //
+      // MU_CHANGE End -------------------------------------
       break;
 
     case SMM_VARIABLE_FUNCTION_QUERY_VARIABLE_INFO:
@@ -716,7 +748,8 @@ SmmVariableHandler (
 
     case SMM_VARIABLE_FUNCTION_EXIT_BOOT_SERVICE:
       mAtRuntime = TRUE;
-      Status     = EFI_SUCCESS;
+      AdvLoggerAccessAtRuntime ();                         // MU_CHANGE
+      Status = EFI_SUCCESS;
       break;
 
     case SMM_VARIABLE_FUNCTION_GET_STATISTICS:
@@ -1234,6 +1267,8 @@ MmVariableServiceInitialize (
     //
     VariableWriteServiceInitializeSmm ();
   }
+
+  AdvLoggerAccessInit ();           // MU_CHANGE
 
   return EFI_SUCCESS;
 }

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmm.inf
@@ -84,6 +84,7 @@
   VariablePolicyLib
   VariablePolicyHelperLib
   SafeIntLib
+  AdvLoggerAccessLib                            ## MU_CHANGE
 
 [Protocols]
   gEfiSmmFirmwareVolumeBlockProtocolGuid        ## CONSUMES
@@ -127,6 +128,7 @@
   ## SOMETIMES_CONSUMES   ## Variable:L"VarErrorFlag"
   ## SOMETIMES_PRODUCES   ## Variable:L"VarErrorFlag"
   gEdkiiVarErrorFlagGuid
+  gAdvLoggerAccessGuid                                               ## CONSUMES   MU_CHANGE
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdMaxVariableSize                  ## CONSUMES

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
@@ -867,7 +867,8 @@ RuntimeServiceGetVariable (
   }
 
   AcquireLockOnlyAtBootTime (&mVariableServicesLock);
-  if (FeaturePcdGet (PcdEnableVariableRuntimeCache)) {
+  if (FeaturePcdGet (PcdEnableVariableRuntimeCache) && !CompareGuid (VendorGuid, &gAdvLoggerAccessGuid)) {
+    // MU_CHANGE
     Status = FindVariableInRuntimeCache (VariableName, VendorGuid, Attributes, DataSize, Data);
   } else {
     Status = FindVariableInSmm (VariableName, VendorGuid, Attributes, DataSize, Data);

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf
@@ -104,6 +104,7 @@
   ## SOMETIMES_CONSUMES   ## Variable:L"KEK"
   ## SOMETIMES_CONSUMES   ## Variable:L"SecureBoot"
   gEfiGlobalVariableGuid
+  gAdvLoggerAccessGuid    ## CONSUMES      // MU_CHANGE
 
   ## SOMETIMES_CONSUMES   ## Variable:L"db"
   ## SOMETIMES_CONSUMES   ## Variable:L"dbx"

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.inf
@@ -66,6 +66,7 @@
   StandaloneMmPkg/StandaloneMmPkg.dec
 
 [LibraryClasses]
+  AdvLoggerAccessLib                            ## MU_CHANGE
   AuthVariableLib
   BaseLib
   BaseMemoryLib
@@ -120,6 +121,8 @@
   ## SOMETIMES_CONSUMES   ## Variable:L"VarErrorFlag"
   ## SOMETIMES_PRODUCES   ## Variable:L"VarErrorFlag"
   gEdkiiVarErrorFlagGuid
+
+  gAdvLoggerAccessGuid                                               ## CONSUMES   MU_CHANGE
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdMaxVariableSize                  ## CONSUMES


### PR DESCRIPTION
## Description

Add the GetVariable hook used by AdvancedLogger and the PlatformBlob used in PEI. Cherry-picked from 26e6699b15
c18444f829 in release/202311.

GetVariableHook
--
One of the ways to fetch the AdvLogger log from an external source (general the host OS) is through a GetVariable call. These are not real variables and instead there is a hook that sees the AdvLogger variable names and gets the relevant log data from the in-memory log. This requires a change in basecore to add the hook to the GetVariable call.

PlatformBlob
--
The other change required in basecore for AdvLogger is adding the pointer to the log to the PEI Core instance structure so that in a pre-memory environment, the AdvLogger info structure (and log) can be used. This requires adding a new field to the structure defined in basecore.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

From 2311

## Integration Instructions

N/A.