### PR TITLE
[REBASE & FF] TCMORPH Remove Dangling References

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "CryptoPkg/Library/OpensslLib/openssl"]
 	path = CryptoPkg/Library/OpensslLib/openssl
 	url = https://github.com/openssl/openssl
-[submodule "SoftFloat"]
-	path = ArmPkg/Library/ArmSoftFloatLib/berkeley-softfloat-3
-	url = https://github.com/ucb-bar/berkeley-softfloat-3.git
 [submodule "UnitTestFrameworkPkg/Library/CmockaLib/cmocka"]
 	path = UnitTestFrameworkPkg/Library/CmockaLib/cmocka
 	url = https://github.com/tianocore/edk2-cmocka.git
@@ -17,9 +14,6 @@
 	path = BaseTools/Source/C/BrotliCompress/brotli
 	url = https://github.com/google/brotli
 	ignore = untracked
-[submodule "RedfishPkg/Library/JsonLib/jansson"]
-	path = RedfishPkg/Library/JsonLib/jansson
-	url = https://github.com/akheron/jansson
 [submodule "UnitTestFrameworkPkg/Library/GoogleTestLib/googletest"]
 	path = UnitTestFrameworkPkg/Library/GoogleTestLib/googletest
 	url = https://github.com/google/googletest.git

--- a/.pytool/CISettings.py
+++ b/.pytool/CISettings.py
@@ -74,32 +74,15 @@ class Settings(CiBuildSettingsManager, UpdateSettingsManager, SetupSettingsManag
         ''' return iterable of edk2 packages supported by this build.
         These should be edk2 workspace relative paths '''
 
-        return ("ArmPkg",
-                "ArmPlatformPkg",
-                "ArmVirtPkg",
-                "DynamicTablesPkg",
-                "EmbeddedPkg",
-                "EmulatorPkg",
-                "IntelFsp2Pkg",
-                "IntelFsp2WrapperPkg",
+        return ("CryptoPkg",
                 "MdePkg",
                 "MdeModulePkg",
                 "NetworkPkg",
                 "PcAtChipsetPkg",
-                "SecurityPkg",
-                "UefiCpuPkg",
-                "FmpDevicePkg",
                 "ShellPkg",
-                "SignedCapsulePkg",
+                "UefiCpuPkg",
                 "StandaloneMmPkg",
-                "FatPkg",
-                "CryptoPkg",
-                "PrmPkg",
-                "UnitTestFrameworkPkg",
-                "OvmfPkg",
-                "RedfishPkg",
-                "SourceLevelDebugPkg",
-                "UefiPayloadPkg"
+                "UnitTestFrameworkPkg"
                 )
 
     def GetArchitecturesSupported(self):
@@ -108,9 +91,7 @@ class Settings(CiBuildSettingsManager, UpdateSettingsManager, SetupSettingsManag
                 "IA32",
                 "X64",
                 "ARM",
-                "AARCH64",
-                "RISCV64",
-                "LOONGARCH64")
+                "AARCH64")
 
     def GetTargetsSupported(self):
         ''' return iterable of edk2 target tags supported by this build '''
@@ -194,6 +175,13 @@ class Settings(CiBuildSettingsManager, UpdateSettingsManager, SetupSettingsManag
             else:
                 logging.warning("Falling back to using in-tree BaseTools")
 
+            if is_linux and self.ActualToolChainTag.upper().startswith("GCC"):
+                if "AARCH64" in self.ActualArchitectures:
+                    scopes += ("gcc_aarch64_linux",)
+                if "ARM" in self.ActualArchitectures:
+                    scopes += ("gcc_arm_linux",)
+                if "RISCV64" in self.ActualArchitectures:
+                    scopes += ("gcc_riscv64_unknown",)
             try:
                 scopes += codeql_helpers.get_scopes(self.codeql)
 
@@ -214,8 +202,6 @@ class Settings(CiBuildSettingsManager, UpdateSettingsManager, SetupSettingsManag
         '''
         rs = []
         rs.append(RequiredSubmodule(
-            "ArmPkg/Library/ArmSoftFloatLib/berkeley-softfloat-3", False))
-        rs.append(RequiredSubmodule(
             "CryptoPkg/Library/OpensslLib/openssl", False))
         rs.append(RequiredSubmodule(
             "UnitTestFrameworkPkg/Library/CmockaLib/cmocka", False))
@@ -227,8 +213,6 @@ class Settings(CiBuildSettingsManager, UpdateSettingsManager, SetupSettingsManag
             "MdeModulePkg/Library/BrotliCustomDecompressLib/brotli", False))
         rs.append(RequiredSubmodule(
             "BaseTools/Source/C/BrotliCompress/brotli", False))
-        rs.append(RequiredSubmodule(
-            "RedfishPkg/Library/JsonLib/jansson", False))
         rs.append(RequiredSubmodule(
             "UnitTestFrameworkPkg/Library/SubhookLib/subhook", False))
         rs.append(RequiredSubmodule(

--- a/.pytool/Readme.md
+++ b/.pytool/Readme.md
@@ -11,29 +11,13 @@ on the TianoCore wiki.
 
 | Package              | Windows VS2019 (IA32/X64)| Ubuntu GCC (IA32/X64/ARM/AARCH64) | Known Issues |
 | :----                | :-----                   | :----                             | :---         |
-| ArmPkg               |                    | :heavy_check_mark: |
-| ArmPlatformPkg       |                    | :heavy_check_mark: |
-| ArmVirtPkg           | SEE PACKAGE README | SEE PACKAGE README |
-| CryptoPkg            | :heavy_check_mark: | :heavy_check_mark: | Spell checking in audit mode
-| DynamicTablesPkg     | :heavy_check_mark: | :heavy_check_mark: |
-| EmbeddedPkg          |
-| EmulatorPkg          | SEE PACKAGE README | SEE PACKAGE README | Spell checking in audit mode
-| FatPkg               | :heavy_check_mark: | :heavy_check_mark: |
-| FmpDevicePkg         | :heavy_check_mark: | :heavy_check_mark: |
-| IntelFsp2Pkg         |
-| IntelFsp2WrapperPkg  |
 | MdeModulePkg         | :heavy_check_mark: | :heavy_check_mark: | DxeIpl dependency on ArmPkg, Depends on StandaloneMmPkg, Spell checking in audit mode
 | MdePkg               | :heavy_check_mark: | :heavy_check_mark: | Spell checking in audit mode
 | NetworkPkg           | :heavy_check_mark: | :heavy_check_mark: | Spell checking in audit mode
-| OvmfPkg              | SEE PACKAGE README | SEE PACKAGE README | Spell checking in audit mode
 | PcAtChipsetPkg       | :heavy_check_mark: | :heavy_check_mark: |
 | SecurityPkg          | :heavy_check_mark: | :heavy_check_mark: | Spell checking in audit mode
-| ShellPkg             | :heavy_check_mark: | :heavy_check_mark: | Spell checking in audit mode, 3 modules are not being built by DSC
-| SignedCapsulePkg     |
-| SourceLevelDebugPkg  |
 | StandaloneMmPkg      | :heavy_check_mark: | :heavy_check_mark: |
 | UefiCpuPkg           | :heavy_check_mark: | :heavy_check_mark: | Spell checking in audit mode, 2 binary modules not being built by DSC
-| UefiPayloadPkg       |
 | UnitTestFrameworkPkg | :heavy_check_mark: | :heavy_check_mark: |
 
 For more detailed status look at the test results of the latest CI run on the


### PR DESCRIPTION
## Description

This PR contains the set of commits to remove the dangling references from the initial TCMORPH commit.

It is the release/202311 commit: aa476b268e

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

From 202311.

## Integration Instructions

N/A.
