### PR TITLE
Add markdownlint as a pytool plugin [Rebase & FF]

### DIFF
--- a/.pytool/Plugin/MarkdownLintCheck/MarkdownLintCheck.py
+++ b/.pytool/Plugin/MarkdownLintCheck/MarkdownLintCheck.py
@@ -1,0 +1,177 @@
+# @file MarkdownLintCheck.py
+#
+# An edk2-pytool based plugin wrapper for markdownlint
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+import logging
+import json
+import yaml
+from io import StringIO
+import os
+from typing import List
+from edk2toolext.environment.plugintypes.ci_build_plugin import ICiBuildPlugin
+from edk2toollib.utility_functions import RunCmd
+from edk2toolext.environment.var_dict import VarDict
+from edk2toolext.environment import version_aggregator
+
+
+class MarkdownLintCheck(ICiBuildPlugin):
+    """
+    A CiBuildPlugin that uses the markdownlint-cli node module to scan the files
+    from the package being tested for linter errors.
+
+    The linter config file (.markdownlint.yaml) must be present in one of the defined
+    locations otherwise the test will be skipped.  These locations were picked to also
+    align with how editors and tools will find the config file.
+
+    1st priority location - At the package root
+    2nd Priority location - At the workspace root of the build (suggested location unless override needed)
+
+    Configuration options:
+    "MarkdownLintCheck": {
+        "AuditOnly": False,          # If True, log all errors and then mark as skipped
+        "IgnoreFiles": []            # package root relative file, folder, or glob pattern to ignore
+    }
+    """
+
+    CONFIG_FILE_NAME = ".markdownlint.yaml"
+
+    def GetTestName(self, packagename: str, environment: VarDict) -> tuple:
+        """ Provide the testcase name and classname for use in reporting
+
+            Args:
+              packagename: string containing name of package to build
+              environment: The VarDict for the test to run in
+            Returns:
+                a tuple containing the testcase name and the classname
+                (testcasename, classname)
+                testclassname: a descriptive string for the testcase can include whitespace
+                classname: should be patterned <packagename>.<plugin>.<optionally any unique condition>
+        """
+        return ("Lint Markdown files in " + packagename, packagename + ".markdownlint")
+
+    ##
+    # External function of plugin.  This function is used to perform the task of the CiBuild Plugin
+    #
+    #   - package is the edk2 path to package.  This means workspace/packagepath relative.
+    #   - edk2path object configured with workspace and packages path
+    #   - PkgConfig Object (dict) for the pkg
+    #   - EnvConfig Object
+    #   - Plugin Manager Instance
+    #   - Plugin Helper Obj Instance
+    #   - Junit Logger
+    #   - output_stream the StringIO output stream from this plugin via logging
+
+    def RunBuildPlugin(self, packagename, Edk2pathObj, pkgconfig, environment, PLM, PLMHelper, tc, output_stream=None):
+        Errors = []
+
+        abs_pkg_path = Edk2pathObj.GetAbsolutePathOnThisSystemFromEdk2RelativePath(
+            packagename)
+
+        if abs_pkg_path is None:
+            tc.SetSkipped()
+            tc.LogStdError("No package {0}".format(packagename))
+            return -1
+
+        # check for node
+        return_buffer = StringIO()
+        ret = RunCmd("node", "--version", outstream=return_buffer)
+        if (ret != 0):
+            tc.SetSkipped()
+            tc.LogStdError("NodeJs not installed. Test can't run")
+            logging.warning("NodeJs not installed. Test can't run")
+            return -1
+        node_version = return_buffer.getvalue().strip()  # format vXX.XX.XX
+        tc.LogStdOut(f"Node version: {node_version}")
+
+        # Check for markdownlint-cli
+        return_buffer = StringIO()
+        ret = RunCmd("markdownlint", "--version", outstream=return_buffer)
+        if (ret != 0):
+            tc.SetSkipped()
+            tc.LogStdError("markdownlint not installed.  Test can't run")
+            logging.warning("markdownlint not installed.  Test can't run")
+            return -1
+        mdl_version = return_buffer.getvalue().strip()  # format XX.XX.XX
+        tc.LogStdOut(f"MarkdownLint version: {mdl_version}")
+        version_aggregator.GetVersionAggregator().ReportVersion(
+            "MarkDownLint", mdl_version, version_aggregator.VersionTypes.INFO)
+
+        # Get relative path for the root of package to use with ignore and path parameters
+        relpath = os.path.relpath(abs_pkg_path)
+
+        # Newer versions of markdownlint don't understand backslashes
+        relpath = relpath.replace(os.path.sep, '/')
+
+        #
+        # check for any package specific ignore patterns defined by package config
+        #
+        Ignores = []
+        if("IgnoreFiles" in pkgconfig):
+            for i in pkgconfig["IgnoreFiles"]:
+                Ignores.append(f"{relpath}/{i}")
+
+        #
+        # Make the path string to check
+        #
+        path_to_check = f'{relpath}/**/*.md'
+
+        # get path to config file -
+
+        # Currently there is support for two different config files
+        # If the config file is not found then the test case is skipped
+        #
+        # 1st - At the package root
+        # 2nd - At the workspace root of the build
+        config_file_path = None
+
+        # 1st check to see if the config file is at package root
+        if os.path.isfile(os.path.join(abs_pkg_path, MarkdownLintCheck.CONFIG_FILE_NAME)):
+            config_file_path = os.path.join(abs_pkg_path, MarkdownLintCheck.CONFIG_FILE_NAME)
+
+        # 2nd check to see if at workspace root
+        elif os.path.isfile(os.path.join(Edk2pathObj.WorkspacePath, MarkdownLintCheck.CONFIG_FILE_NAME)):
+            config_file_path = os.path.join(Edk2pathObj.WorkspacePath, MarkdownLintCheck.CONFIG_FILE_NAME)
+
+        # If not found - skip test
+        else:
+            tc.SetSkipped()
+            tc.LogStdError(f"{MarkdownLintCheck.CONFIG_FILE_NAME} not found.  Skipping test")
+            logging.warning(f"{MarkdownLintCheck.CONFIG_FILE_NAME} not found.  Skipping test")
+            return -1
+
+
+        # Run the linter
+        results = self._check_markdown(path_to_check, config_file_path, Ignores)
+        for r in results:
+            tc.LogStdError(r.strip())
+
+        # add result to test case
+        overall_status = len(results)
+        if overall_status != 0:
+            if "AuditOnly" in pkgconfig and pkgconfig["AuditOnly"]:
+                # set as skipped if AuditOnly
+                tc.SetSkipped()
+                return -1
+            else:
+                tc.SetFailed("Markdown Lint Check {0} Failed.  Errors {1}".format(
+                    packagename, overall_status), "CHECK_FAILED")
+        else:
+            tc.SetSuccess()
+        return overall_status
+
+    def _check_markdown(self, rel_file_to_check: os.PathLike, abs_config_file_to_use: os.PathLike, Ignores: List) -> []:
+        output = StringIO()
+        param = f"--config {abs_config_file_to_use}"
+        for a in Ignores:
+            param += f' --ignore "{a}"'
+        param += f' "{rel_file_to_check}"'
+
+        ret = RunCmd(
+            "markdownlint",  param, outstream=output)
+        if ret == 0:
+            return []
+        else:
+            return output.getvalue().strip().splitlines()

--- a/.pytool/Plugin/MarkdownLintCheck/MarkdownLintCheck_plug_in.yaml
+++ b/.pytool/Plugin/MarkdownLintCheck/MarkdownLintCheck_plug_in.yaml
@@ -1,0 +1,11 @@
+## @file
+# CiBuildPlugin used to lint repository documentation in markdown files
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+{
+  "scope": "cibuild",
+  "name": "Markdown Lint Test",
+  "module": "MarkdownLintCheck"
+}

--- a/.pytool/Plugin/MarkdownLintCheck/Readme.md
+++ b/.pytool/Plugin/MarkdownLintCheck/Readme.md
@@ -1,0 +1,68 @@
+# Markdown Lint Plugin
+
+This CiBuildPlugin scans all the markdown files in a given package and
+checks for linter errors.
+
+## Requirements
+
+The test case in this plugin will be skipped if the requirements are not met.
+
+1. NodeJs installed and on your path
+2. `markdownlint-cli` NodeJs package installed
+3. a `.markdownlint.yaml` config file either at your repository root or package root.
+
+* NodeJS: <https://nodejs.org/en/>
+* markdownlint-cli: <https://www.npmjs.com/package/markdownlint-cli>
+  * Src available:  <https://github.com/igorshubovych/markdownlint-cli>
+
+## Configuration
+
+It is desired to use standard configuration methods so that both local editors (vscode, etc)
+and the CI process leverage the same configuration.  This mostly works but for ignoring
+files there is currently a small discrepancy.
+
+First there is/can be a `.markdownlintignore` file at root of the repository.  This
+file much like a `.gitignore` is great for broadly ignoring files with patterns.  This
+works for both editor/ci.
+
+But for package based ignores and to keep the control of which files to ignore within the package
+there is no answer that supports both CI and editors.  Open question here
+<https://github.com/DavidAnson/vscode-markdownlint/issues/130>
+
+For the CI plugin you can use the IgnoreFiles configuration option described in the Plugin Configuration.
+
+## Plugin Configuration
+
+The plugin has only minimal configuration options to support the UEFI codebase.
+
+``` yaml
+  "MarkdownLintCheck": {
+    "AuditOnly": False,          # If True, log all errors and then mark as skipped
+    "IgnoreFiles": []            # package root relative file, folder, or glob pattern to ignore
+  }
+```
+
+### AuditOnly
+
+Boolean - Default is False.
+If True run the test in an Audit only mode which will log all errors but instead
+of failing the build it will set the test as skipped.  This allows visibility
+into the failures without breaking the build.
+
+### IgnoreFiles
+
+This supports package relative files, folders, and glob patterns to ignore.
+These are passed to the markdownlint-cli tool as quoted -i parameters.
+
+## Linter Configuration
+
+All configuration options available to the linter can be set in the  `.markdownlint.yaml`.
+This includes customizing rule options and enforcement.
+See more details here: <https://github.com/DavidAnson/markdownlint#configuration>
+Linter Rules are described here: <https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md>
+
+## Rule Overrides
+
+There are times when a certain rule should not apply to part of a markdown file.
+Markdownlint has numerous ways to configure this.
+See the in file Configuration options described at the links above

--- a/BaseTools/Scripts/PackageDocumentTools/Readme.md
+++ b/BaseTools/Scripts/PackageDocumentTools/Readme.md
@@ -1,19 +1,25 @@
+# Package Document Tool
+
 Prerequisite Tools:
-1. Install Python 2.7.3 from https://www.python.org/download/releases/2.7.3/
-2. Install wxPython 2.8.12.1 from https://sourceforge.net/projects/wxpython/files/wxPython/2.8.12.1/
+
+1. Install Python 2.7.3 from <https://www.python.org/download/releases/2.7.3/>
+2. Install wxPython 2.8.12.1 from <https://sourceforge.net/projects/wxpython/files/wxPython/2.8.12.1/>
    generally the libraries will be installed at python's subfolder, for example in windows: c:\python27\Lib\site-packages\
-3. Install DoxyGen 1.8.6 from https://sourceforge.net/projects/doxygen/files/rel-1.8.6/
-4. (Windows only) Install Htmlhelp tool from https://msdn.microsoft.com/en-us/library/windows/desktop/ms669985(v=vs.85).aspx
+3. Install DoxyGen 1.8.6 from <https://sourceforge.net/projects/doxygen/files/rel-1.8.6/>
+4. (Windows only) Install Htmlhelp tool from <https://msdn.microsoft.com/en-us/library/windows/desktop/ms669985(v=vs.85).aspx>
 
 Limitation:
-1. Current tool doesn't work on latest wxPython and DoxyGen tool. Please use the sepecific version in above.
+
+* Current tool doesn't work on latest wxPython and DoxyGen tool. Please use the sepecific version in above.
 
 Run the Tool:
-a) Run with GUI:
-  1. Enter src folder, double click "packagedocapp.pyw" or run command "python packagedocapp.pyw" to open the GUI.
-  2. Make sure all the information in blank are correct.
-  3. Click "Generate Package Document!"
-b) Run with command line:
-  1. Open command line window
-  2. Enter src folder, for example: "cd C:\PackageDocumentTools\src"
-  3. Run "python packagedoc_cli.py --help" for detail command.
+
+* Run with GUI:
+    1. Enter src folder, double click "packagedocapp.pyw" or run command "python packagedocapp.pyw" to open the GUI.
+    2. Make sure all the information in blank are correct.
+    3. Click "Generate Package Document!"
+
+* Run with command line:
+    1. Open command line window
+    2. Enter src folder, for example: "cd C:\PackageDocumentTools\src"
+    3. Run "python packagedoc_cli.py --help" for detail command.

--- a/BaseTools/Source/Python/FMMT/README.md
+++ b/BaseTools/Source/Python/FMMT/README.md
@@ -1,38 +1,44 @@
 # FMMT
+
 ## Overview
-This FMMT tool is the python implementation of the edk2 FMMT tool which locates at https://github.com/tianocore/edk2-staging/tree/FceFmmt.
+
+This FMMT tool is the python implementation of the edk2 FMMT tool which locates at <https://github.com/tianocore/edk2-staging/tree/FceFmmt>
 This implementation has the same usage as the edk2 FMMT, but it's more readable and relaiable.
 
-# FMMT User Guide
+## FMMT User Guide
 
-#### Last updated April 28, 2022
+### Last updated April 28, 2022
 
 Important Changes and Updates:
 
 - Oct 13, 2021 Initial Draft of FMMT Python Tool
 - Apr 28, 2022 Optimize functions & Command line
 
-#### Note:
+#### Note
 
 - FMMT Python Tool keeps same function with origin FMMT C Tool. It is much easier to maintain and extend other functions.
 
-#### Known issue:
+#### Known issue
 
 - Currently, FMMT Python tool does not support PEIM rebase feature, this feature will be added in future update.
 
-# 1. Introduction
+## 1. Introduction
 
-## 1.1  Overview
+### 1.1  Overview
 
-The Firmware Device is a persistent physical repository that contains firmware code and/or data. The firmware code and/or data stored in Firmware Volumes. Detail layout of Firmware Volumes is described in ?Figure 1. The Firmware Volume Format?.
+The Firmware Device is a persistent physical repository that contains firmware code and/or data. The firmware code
+and/or data stored in Firmware Volumes. Detail layout of Firmware Volumes is described in ?Figure 1. The Firmware
+Volume Format?.
 
-![](Img/FirmwareVolumeFormat.png)
+![ref](Img/FirmwareVolumeFormat.png)
 
 ?                                                   Figure 1. The Firmware Volume Format
 
-In firmware development, binary file has its firmware layout following the Platform-Initialization Specification. Thus, operation on FV file / FFS file (Firmware File) is an efficient and convenient way for firmware function testing and developing. FMMT Python tool is used for firmware files operation.
+In firmware development, binary file has its firmware layout following the Platform-Initialization Specification. Thus,
+operation on FV file / FFS file (Firmware File) is an efficient and convenient way for firmware function testing and
+developing. FMMT Python tool is used for firmware files operation.
 
-## 1.2  Tool Capabilities
+### 1.2  Tool Capabilities
 
 The FMMT tool is capable of:
 
@@ -44,19 +50,19 @@ The FMMT tool is capable of:
 
 - Delete an FFS in a FV file (both included in a FD file or not)
 
--  Extract the FFS from a FV file (both included in a FD file or not)
+- Extract the FFS from a FV file (both included in a FD file or not)
 
-## 1.3  References
+### 1.3  References
 
 | Document                                         |
 | ------------------------------------------------ |
 | UEFI Platform Initialization (PI)  Specification |
 
-# 2. FMMT Python Tool Usage
+## 2. FMMT Python Tool Usage
 
-## 2.1  Required Files
+### 2.1  Required Files
 
-### 2.1.1  Independent use
+#### 2.1.1  Independent use
 
 When independent use the FMMT Python Tool, the following files and settings are required:
 
@@ -64,60 +70,71 @@ When independent use the FMMT Python Tool, the following files and settings are 
 
 - Environment variables path with GuidTool path setting.
 
-### 2.1.2  Use with Build System
+#### 2.1.2  Use with Build System
 
 When use the FMMT Python Tool with Build System:
 
--  If only use Edk2 based GuidTool, do not need other preparation.
+- If only use Edk2 based GuidTool, do not need other preparation.
 
-- If use other customized GuidTool, need prepare the config file with GuidTool info. The syntax for GuidTool definition shown as follow:
+- If use other customized GuidTool, need prepare the config file with GuidTool info. The syntax for GuidTool definition
+shown as follow:
 
   ***ToolsGuid ShortName Command***
 
   -- Example:  ***3d532050-5cda-4fd0-879e-0f7f630d5afb BROTLI BrotliCompress***
 
-## 2.2  Syntax
+### 2.2  Syntax
 
-### 2.2.1  Syntax for Parse file
+#### 2.2.1  Syntax for Parse file
 
   ***-v < Inputfile > < Outputfile > -l < LogFileType > -c < ConfigFilePath >***
 
-- Parse *Inputfile*, show its firmware layout with log file. *Outputfile* is optional, if inputs, the *Inputfile* will be encapsulated into *Outputfile* following the parsed firmware layout. *"-l LogFileType"* is optional, it decides the format of log file which saves Binary layout. Currently supports: json, txt. More formats will be added in the future. *"-c ConfigFilePath "* is optional, target FmmtConf.ini file can be selected with this parameter. If not provided, default FmmtConf.ini file will be used.
+- Parse *Inputfile*, show its firmware layout with log file. *Outputfile* is optional, if inputs, the *Inputfile* will
+be encapsulated into *Outputfile* following the parsed firmware layout. *"-l LogFileType"* is optional, it decides the
+format of log file which saves Binary layout. Currently supports: json, txt. More formats will be added in the future.
+*"-c ConfigFilePath "* is optional, target FmmtConf.ini file can be selected with this parameter. If not provided,
+default FmmtConf.ini file will be used.
 - Ex: py -3 FMMT.py -v test.fd
 
-### 2.2.2  Syntax for Add a new FFS
+#### 2.2.2  Syntax for Add a new FFS
 
   ***-a  < Inputfile > < TargetFvName/TargetFvGuid > < NewFfsFile > < Outputfile >***
 
-- Add the *NewFfsFile* into *Inputfile*. *TargetFvName/TargetFvGuid* (Name or Guid) is the TargetFv which *NewFfsFile* will be added into.
+- Add the *NewFfsFile* into *Inputfile*. *TargetFvName/TargetFvGuid* (Name or Guid) is the TargetFv which *NewFfsFile*
+will be added into.
 - Ex: py -3 FMMT.py -a Ovmf.fd 6938079b-b503-4e3d-9d24-b28337a25806 NewAdd.ffs output.fd
 
-### 2.2.3  Syntax for Delete an FFS
+#### 2.2.3  Syntax for Delete an FFS
 
   ***-d  < Inputfile > < TargetFvName/TargetFvGuid > < TargetFfsName > < Outputfile >***
 
-- Delete the Ffs from *Inputfile*. TargetFfsName (Guid) is the TargetFfs which will be deleted. *TargetFvName/TargetFvGuid* is optional, which is the parent of TargetFfs*.*
+- Delete the Ffs from *Inputfile*. TargetFfsName (Guid) is the TargetFfs which will be deleted. *TargetFvName/TargetFvGuid*
+is optional, which is the parent of TargetFfs*.*
 - Ex: py -3 FMMT.py -d Ovmf.fd 6938079b-b503-4e3d-9d24-b28337a25806 S3Resume2Pei output.fd
 
-### 2.2.4  Syntax for Replace an FFS
+#### 2.2.4  Syntax for Replace an FFS
 
 ?  ***-r  < Inputfile > < TargetFvName/TargetFvGuid > < TargetFfsName > < NewFfsFile > < Outputfile >***
 
-- Replace the Ffs with the NewFfsFile. TargetFfsName (Guid) is the TargetFfs which will be replaced. *TargetFvName/TargetFvGuid* is optional, which is the parent of TargetFfs*.*
+- Replace the Ffs with the NewFfsFile. TargetFfsName (Guid) is the TargetFfs which will be replaced.
+*TargetFvName/TargetFvGuid* is optional, which is the parent of TargetFfs*.*
 - Ex: py -3 FMMT.py -r Ovmf.fd 6938079b-b503-4e3d-9d24-b28337a25806 S3Resume2Pei NewS3Resume2Pei.ffs output.fd
 
-### 2.2.5  Syntax for Extract an FFS
+#### 2.2.5  Syntax for Extract an FFS
 
   ***-e  < Inputfile > < TargetFvName/TargetFvGuid > < TargetFfsName > < Outputfile >***
 
-- Extract the Ffs from the Inputfile. TargetFfsName (Guid) is the TargetFfs which will be extracted. *TargetFvName/TargetFvGuid* is optional, which is the parent of TargetFfs*.*
+- Extract the Ffs from the Inputfile. TargetFfsName (Guid) is the TargetFfs which will be extracted.
+*TargetFvName/TargetFvGuid* is optional, which is the parent of TargetFfs*.*
 - Ex: py -3 FMMT.py -e Ovmf.fd 6938079b-b503-4e3d-9d24-b28337a25806 S3Resume2Pei output.fd
 
-# 3. FMMT Python Tool Design
+## 3. FMMT Python Tool Design
 
-FMMT Python Tool uses the NodeTree saves whole Firmware layout. Each Node have its Data field, which saves the FirmwareClass(FD/FV/FFS/SECTION/BINARY) Data. All the parse/add/delete/replace/extract operations are based on the NodeTree (adjusting the layout and data).
+FMMT Python Tool uses the NodeTree saves whole Firmware layout. Each Node have its Data field, which saves the
+FirmwareClass(FD/FV/FFS/SECTION/BINARY) Data. All the parse/add/delete/replace/extract operations are based on the
+NodeTree (adjusting the layout and data).
 
-## 3.1  NodeTree
+### 3.1  NodeTree
 
 A whole NodeTree saves all the Firmware info.
 
@@ -125,9 +142,10 @@ A whole NodeTree saves all the Firmware info.
 
 - Each Node have several fields. ?Data? field saves an FirmwareClass instance which contains all the data info of the info.
 
-### 3.1.1  NodeTree Format
+#### 3.1.1  NodeTree Format
 
-The NodeTree will be created with parse function. When parse a file, a Root Node will be initialized firstly. The Data split and Tree construction process is described with an FD file shown as ?Figure 2. The NodeTree format?:
+The NodeTree will be created with parse function. When parse a file, a Root Node will be initialized firstly. The Data
+split and Tree construction process is described with an FD file shown as ?Figure 2. The NodeTree format?:
 
 - A Root Node is initialized.
 
@@ -139,19 +157,21 @@ The NodeTree will be created with parse function. When parse a file, a Root Node
 
 - If some of Section includes other Sections, continue use the ?Section Data Size? as Section key to split each Section Data.
 
-- After all Node created, the whole NodeTree saves all the info. (Can be used in other functions or print the whole firmware layout into log file)
+- After all Node created, the whole NodeTree saves all the info. (Can be used in other functions or print the whole
+firmware layout into log file)
 
-![](Img/NodeTreeFormat.png)
+![ref](Img/NodeTreeFormat.png)
 
 ?                                                         Figure 2. The NodeTree format
 
-### 3.1.2  Node Factory and Product
+#### 3.1.2  Node Factory and Product
 
-As 3.1.1, Each Node is created by data split and recognition. To extend the NodeTree usage, Factory pattern is used in Node created process.
+As 3.1.1, Each Node is created by data split and recognition. To extend the NodeTree usage, Factory pattern is used in
+Node created process.
 
 Each Node have its Factory to create Product and use Product ParserData function to deal with the data.
 
-## 3.2  GuidTool
+### 3.2  GuidTool
 
 There are two ways to set the GuidTool. One from Config file, another from environment variables.
 
@@ -161,7 +181,7 @@ Current GuidTool first check if has Config file.
 
 - Else get from environment variables.
 
-### 3.2.1  Get from Config file
+#### 3.2.1  Get from Config file
 
 - Config file should in same folder with FMMT.py or the path in environment variables.
 
@@ -169,11 +189,11 @@ Current GuidTool first check if has Config file.
 
   ***ToolsGuid ShortName Command***
 
-### 3.2.2  Get from Environment Variables
+#### 3.2.2  Get from Environment Variables
 
 - The GuidTool Command used must be set in environment variables.
 
-### 3.2.3  Edk2 Based GuidTool
+#### 3.2.3  Edk2 Based GuidTool
 
 | ***Guid***                                 | ***ShortName*** | ***Command***         |
 | ------------------------------------------ | --------------- | --------------------- |
@@ -181,4 +201,4 @@ Current GuidTool first check if has Config file.
 | ***ee4e5898-3914-4259-9d6e-dc7bd79403cf*** | ***LZMA***      | ***LzmaCompress***    |
 | ***fc1bcdb0-7d31-49aa-936a-a4600d9dd083*** | ***CRC32***     | ***GenCrc32***        |
 | ***d42ae6bd-1352-4bfb-909a-ca72a6eae889*** | ***LZMAF86***   | ***LzmaF86Compress*** |
-| ***3d532050-5cda-4fd0-879e-0f7f630d5afb*** | ***BROTLI***    | ***BrotliCompress***  |
+| ***3d532050-5cda-4fd0-879e-0f7f630d5afb*** | ***BROTLI***    | ***BrotliCompress***  |

--- a/BaseTools/Source/Python/Pkcs7Sign/Readme.md
+++ b/BaseTools/Source/Python/Pkcs7Sign/Readme.md
@@ -1,120 +1,157 @@
 # Step by step to generate sample self-signed X.509 certificate chain and sign data with PKCS7 structure
 
-This readme demonstrates how to generate 3-layer X.509 certificate chain (RootCA -> IntermediateCA -> SigningCert) with OpenSSL commands, and user MUST set a UNIQUE Subject Name ("Common Name") on these three different certificates.
+This readme demonstrates how to generate 3-layer X.509 certificate chain (RootCA
+-> IntermediateCA -> SigningCert) with OpenSSL commands, and user MUST set a
+UNIQUE Subject Name ("Common Name") on these three different certificates.
 
 ## How to generate a self-signed X.509 certificate chain via OPENSSL
-* Set OPENSSL environment.
 
-NOTE: Below steps are required for Windows. Linux may already have the OPENSSL environment correctly.
+### Set OPENSSL environment
 
-    set OPENSSL_HOME=c:\home\openssl\openssl-[version]
-    set OPENSSL_CONF=%OPENSSL_HOME%\apps\openssl.cnf
+NOTE: Below steps are required for Windows. Linux may already have the OPENSSL
+environment correctly.
 
-When a user uses OpenSSL (req or ca command) to generate the certificates, OpenSSL will use the openssl.cnf file as the configuration data (can use "-config path/to/openssl.cnf" to describe the specific config file).
+```cmd
+set OPENSSL_HOME=c:\home\openssl\openssl-[version]
+set OPENSSL_CONF=%OPENSSL_HOME%\apps\openssl.cnf
+```
 
-The user need check the openssl.cnf file, to find your CA path setting, e.g. check if the path exists in [ CA_default ] section.
+When a user uses OpenSSL (req or ca command) to generate the certificates,
+OpenSSL will use the openssl.cnf file as the configuration data (can use
+"-config path/to/openssl.cnf" to describe the specific config file).
 
-    [ CA_default ]
-        dir = ./demoCA              # Where everything is kept
+The user need check the openssl.cnf file, to find your CA path setting, e.g.
+check if the path exists in [ CA_default ] section.
+
+```inf
+[ CA_default ]
+    dir = ./demoCA              # Where everything is kept
+```
 
 You may need the following steps for initialization:
 
-    rd ./demoCA /S/Q
-    mkdir ./demoCA
-    echo.>./demoCA/index.txt
-    echo 01 > ./demoCA/serial
-    mkdir ./demoCA/newcerts
+```cmd
+rd ./demoCA /S/Q
+mkdir ./demoCA
+echo.>./demoCA/index.txt
+echo 01 > ./demoCA/serial
+mkdir ./demoCA/newcerts
+```
 
-OpenSSL will apply the options from the specified sections in openssl.cnf when creating certificates or certificate signing requests. Make sure your configuration in openssl.cnf is correct and rational for certificate constraints.
-The following sample sections were used when generating test certificates in this readme.
-    ...
-    [ req ]
-    default_bits        = 2048
-    default_keyfile     = privkey.pem
-    distinguished_name  = req_distinguished_name
-    attributes          = req_attributes
-    x509_extensions     = v3_ca       # The extensions to add to the self signed cert
-    ...
-    [ v3_ca ]
-    # Extensions for a typical Root CA.
-    subjectKeyIdentifier=hash
-    authorityKeyIdentifier=keyid:always,issuer
-    basicConstraints = critical,CA:true
-    keyUsage = critical, digitalSignature, cRLSign, keyCertSign
-    ...
-    [ v3_intermediate_ca ]
-    # Extensions for a typical intermediate CA.
-    subjectKeyIdentifier = hash
-    authorityKeyIdentifier = keyid:always,issuer
-    basicConstraints = critical, CA:true
-    keyUsage = critical, digitalSignature, cRLSign, keyCertSign
-    ...
-    [ usr_cert ]
-    # Extensions for user end certificates.
-    basicConstraints = CA:FALSE
-    nsCertType = client, email
-    subjectKeyIdentifier = hash
-    authorityKeyIdentifier = keyid,issuer
-    keyUsage = critical, nonRepudiation, digitalSignature, keyEncipherment
-    extendedKeyUsage = clientAuth, emailProtection
-    ...
+OpenSSL will apply the options from the specified sections in openssl.cnf when
+creating certificates or certificate signing requests. Make sure your
+configuration in `openssl.cnf` is correct and rational for certificate
+constraints. The following sample sections were used when generating test
+certificates in this readme.
 
-* Generate the certificate chain:
+``` inf
+[ req ]
+default_bits        = 2048
+default_keyfile     = privkey.pem
+distinguished_name  = req_distinguished_name
+attributes          = req_attributes
+x509_extensions     = v3_ca       # The extensions to add to the self signed cert
+...
+[ v3_ca ]
+# Extensions for a typical Root CA.
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid:always,issuer
+basicConstraints = critical,CA:true
+keyUsage = critical, digitalSignature, cRLSign, keyCertSign
+...
+[ v3_intermediate_ca ]
+# Extensions for a typical intermediate CA.
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+basicConstraints = critical, CA:true
+keyUsage = critical, digitalSignature, cRLSign, keyCertSign
+...
+[ usr_cert ]
+# Extensions for user end certificates.
+basicConstraints = CA:FALSE
+nsCertType = client, email
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer
+keyUsage = critical, nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = clientAuth, emailProtection
+...
+```
+
+### Generate the certificate chain
 
 NOTE: User MUST set a UNIQUE "Common Name" on the different certificate
 
 1) Generate the Root Pair:
 
-Generate a root key:
+    * Generate a root key:
 
-    openssl genrsa -aes256 -out TestRoot.key 2048
+        ```cmd
+        openssl genrsa -aes256 -out TestRoot.key 2048
+        ```
 
-Generate a self-signed root certificate:
+    * Generate a self-signed root certificate:
 
-    openssl req -extensions v3_ca -new -x509 -days 3650 -key TestRoot.key -out TestRoot.crt
-    openssl x509 -in TestRoot.crt -out TestRoot.cer -outform DER
-    openssl x509 -inform DER -in TestRoot.cer -outform PEM -out TestRoot.pub.pem
+        ```cmd
+        openssl req -extensions v3_ca -new -x509 -days 3650 -key TestRoot.key -out TestRoot.crt
+        openssl x509 -in TestRoot.crt -out TestRoot.cer -outform DER
+        openssl x509 -inform DER -in TestRoot.cer -outform PEM -out TestRoot.pub.pem
+        ```
 
 2) Generate the Intermediate Pair:
 
-Generate the intermediate key:
+    * Generate the intermediate key:
 
-    openssl genrsa -aes256 -out TestSub.key 2048
+        ```cmd
+        openssl genrsa -aes256 -out TestSub.key 2048
+        ```
 
-Generate the intermediate certificate:
+    * Generate the intermediate certificate:
 
-    openssl req -new -days 3650 -key TestSub.key -out TestSub.csr
-    openssl ca -extensions v3_intermediate_ca -in TestSub.csr -days 3650 -out TestSub.crt -cert TestRoot.crt -keyfile TestRoot.key
-    openssl x509 -in TestSub.crt -out TestSub.cer -outform DER
-    openssl x509 -inform DER -in TestSub.cer -outform PEM -out TestSub.pub.pem
+        ```cmd
+        openssl req -new -days 3650 -key TestSub.key -out TestSub.csr
+        openssl ca -extensions v3_intermediate_ca -in TestSub.csr -days 3650 -out TestSub.crt -cert TestRoot.crt -keyfile TestRoot.key
+        openssl x509 -in TestSub.crt -out TestSub.cer -outform DER
+        openssl x509 -inform DER -in TestSub.cer -outform PEM -out TestSub.pub.pem
+        ```
 
 3) Generate User Key Pair for Data Signing:
 
-Generate User key:
+    * Generate User key:
 
-    openssl genrsa -aes256 -out TestCert.key 2048
+        ```cmd
+        openssl genrsa -aes256 -out TestCert.key 2048
+        ```
 
-Generate User certificate:
+    * Generate User certificate:
 
-    openssl req -new -days 3650 -key TestCert.key -out TestCert.csr
-    openssl ca -extensions usr_cert -in TestCert.csr -days 3650 -out TestCert.crt -cert TestSub.crt -keyfile TestSub.key
-    openssl x509 -in TestCert.crt -out TestCert.cer -outform DER
-    openssl x509 -inform DER -in TestCert.cer -outform PEM -out TestCert.pub.pem
+        ```cmd
+        openssl req -new -days 3650 -key TestCert.key -out TestCert.csr
+        openssl ca -extensions usr_cert -in TestCert.csr -days 3650 -out TestCert.crt -cert TestSub.crt -keyfile TestSub.key
+        openssl x509 -in TestCert.crt -out TestCert.cer -outform DER
+        openssl x509 -inform DER -in TestCert.cer -outform PEM -out TestCert.pub.pem
+        ```
 
-Convert Key and Certificate for signing. Password is removed with -nodes flag for convenience in this sample.
+    * Convert Key and Certificate for signing  
+        Password is removed with -nodes flag for convenience in this sample.
 
-    openssl pkcs12 -export -out TestCert.pfx -inkey TestCert.key -in TestCert.crt
-    openssl pkcs12 -in TestCert.pfx -nodes -out TestCert.pem
+        ```cmd
+        openssl pkcs12 -export -out TestCert.pfx -inkey TestCert.key -in TestCert.crt
+        openssl pkcs12 -in TestCert.pfx -nodes -out TestCert.pem
+        ```
 
-* Verify Data Signing & Verification with new X.509 Certificate Chain
+## Verify Data Signing & Verification with new X.509 Certificate Chain
 
 1) Sign a Binary File to generate a detached PKCS7 signature:
 
+    ```cmd
     openssl smime -sign -binary -signer TestCert.pem -outform DER -md sha256 -certfile TestSub.pub.pem -out test.bin.p7 -in test.bin
+    ```
 
 2) Verify PKCS7 Signature of a Binary File:
 
+    ```cmd
     openssl smime -verify -inform DER -in test.bin.p7 -content test.bin -CAfile TestRoot.pub.pem -out test.org.bin
+    ```
 
 ## Generate DSC PCD include files for Certificate
 
@@ -125,34 +162,40 @@ Certificate file.
 The following 2 PCDs can be set to the PKCS7 Certificate value.  The first one
 supports a single certificate.  The second one supports multiple certificate
 values using the XDR format.
+
 * `gEfiSecurityPkgTokenSpaceGuid.PcdPkcs7CertBuffer`
 * `gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr`
 
-Generate DSC PCD include files:
-```
+### Generate DSC PCD include files
+
+```cmd
 BinToPcd.py -i TestRoot.cer -p gEfiSecurityPkgTokenSpaceGuid.PcdPkcs7CertBuffer -o TestRoot.cer.gEfiSecurityPkgTokenSpaceGuid.PcdPkcs7CertBuffer.inc
 BinToPcd.py -i TestRoot.cer -p gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr -x -o TestRoot.cer.gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr.inc
 ```
 
-These files can be used in `!include` statements in DSC file PCD sections.  For example:
+These files can be used in `!include` statements in DSC file PCD sections.  For
+example:
 
 * Platform scoped fixed at build PCD section
-```
-[PcdsFixedAtBuild]
-  !include BaseTools/Source/Python/Pkcs7Sign/TestRoot.cer.gEfiSecurityPkgTokenSpaceGuid.PcdPkcs7CertBuffer.inc
-```
+
+    ```edk2_dsc
+    [PcdsFixedAtBuild]
+    !include BaseTools/Source/Python/Pkcs7Sign/TestRoot.cer.gEfiSecurityPkgTokenSpaceGuid.PcdPkcs7CertBuffer.inc
+    ```
 
 * Platform scoped patchable in module PCD section
-```
-[PcdsPatchableInModule]
-  !include BaseTools/Source/Python/Pkcs7Sign/TestRoot.cer.gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr.inc
-```
+
+    ```edk2_dsc
+    [PcdsPatchableInModule]
+    !include BaseTools/Source/Python/Pkcs7Sign/TestRoot.cer.gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr.inc
+    ```
 
 * Module scoped fixed at build PCD section
-```
-[Components]
-  FmpDevicePkg/FmpDxe/FmpDxe.inf {
-    <PcdsFixedAtBuild>
-      !include BaseTools/Source/Python/Pkcs7Sign/TestRoot.cer.gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr.inc
-  }
-```
+
+    ```edk2_dsc
+    [Components]
+    FmpDevicePkg/FmpDxe/FmpDxe.inf {
+        <PcdsFixedAtBuild>
+        !include BaseTools/Source/Python/Pkcs7Sign/TestRoot.cer.gFmpDevicePkgTokenSpaceGuid.PcdFmpDevicePkcs7CertBufferXdr.inc
+    }
+    ```

--- a/BaseTools/Source/Python/README.md
+++ b/BaseTools/Source/Python/README.md
@@ -1,22 +1,22 @@
 # Edk2 Basetools
 
 This folder has traditionally held the source of Python based tools used by EDK2.
-The official repo this source has moved to https://github.com/tianocore/edk2-basetools.
+The official repo this source has moved to <https://github.com/tianocore/edk2-basetools>.
 This folder will remain in the tree until the next stable release (expected 202102).
 There is a new folder under Basetools `BinPipWrappers` that uses the pip module rather than this tree for Basetools.
 By adding the scope `pipbuild-win` or `pipbuild-unix` (depending on your host system), the SDE will use the
 `BinPipWrappers` instead of the regular `BinWrappers`.
 
-## Why Move It?
+## Why Move It
 
-The discussion is on the mailing list. The RFC is here: https://edk2.groups.io/g/rfc/topic/74009714#270
+The discussion is on the mailing list. The RFC is here: <https://edk2.groups.io/g/rfc/topic/74009714#270>
 The benefits allow for the Basetools project to be used separately from EDK2 itself as well as offering it in a
 globally accessible manner.
 This makes it much easier to build a module using Basetools.
 Separating the Basetools into their own repo allows for easier CI and contribution process.
 Additional pros, cons, and process can be found on the mailing list.
 
-## How Do I Install It?
+## How Do I Install It
 
 By default, EDK2 is tied to and tested with a specific version of the Basetools through `pip-requirements.txt`.
 You can simply run:

--- a/MdeModulePkg/Library/TraceHubDebugSysTLib/Readme.md
+++ b/MdeModulePkg/Library/TraceHubDebugSysTLib/Readme.md
@@ -1,26 +1,32 @@
-## Introduction of TrcaceHubDebugSysTLib ##
-TrcaceHubDebugSysTLib library is a top level library for dumping Trace Hub messages.
+# Introduction of TrcaceHubDebugSysTLib #
+
+TraceHubDebugSysTLib library is a top level library for dumping Trace Hub messages.
 It provides Trace Hub related APIs to dump Trace Hub message via MIPI SYS-T submodule.
 User need to properly configure following Trace Hub related PCDs and HOB.
   (See MdeModulePkg.dec to get detailed definition for PCDs below)
-  - PcdTraceHubDebugLevel
-  - PcdEnableTraceHubDebugMsg
-  - PcdTraceHubDebugMmioAddress
-  (See TraceHubDebugInfoHob.h to get detailed definition for HOB below)
-  - gTraceHubDebugInfoHobGuid
+  
+- PcdTraceHubDebugLevel
+- PcdEnableTraceHubDebugMsg
+- PcdTraceHubDebugMmioAddress
+(See TraceHubDebugInfoHob.h to get detailed definition for HOB below)
+- gTraceHubDebugInfoHobGuid
 
 ## BaseTraceHubDebugSysTLib.inf ##
+
 System prints Trace Hub message in SEC/PEI/DXE/SMM based on fixed PCDs.
 Only support single Trace Hub debug instance.
 
 ## PeiTraceHubDebugSysTLib.inf ##
+
 System prints Trace Hub message in PEI based on fixed PCDs and HOB.
 System applies Trace Hub HOB once it detect gTraceHubDebugInfoHobGuid HOB.
 Trace Hub PCDs will be applied if no HOB exist.
 
 ## DxeSmmTraceHubDebugSysTLib.inf ##
+
 System prints Trace Hub message in DXE/SMM based on fixed PCDs and HOB.
 Trace Hub PCDs will be applied if no HOB exist.
 
 ## Note ##
+
 Trace Hub debug library not support DXE_RUNTIME_DRIVER type of module currently.

--- a/MdeModulePkg/Library/VariablePolicyLib/ReadMe.md
+++ b/MdeModulePkg/Library/VariablePolicyLib/ReadMe.md
@@ -4,8 +4,6 @@ version:    1.0
 copyright:  Copyright (c) Microsoft Corporation.
 ---
 
-# UEFI Variable Policy
-
 ## Summary
 
 UEFI Variable Policy spec aims to describe the DXE protocol interface
@@ -17,14 +15,14 @@ The Variable Policy is comprised of a set of policy entries which
 describe, per UEFI variable (identified by namespace GUID and variable
 name) the following rules:
 
--   Required variable attributes
--   Prohibited variable attributes
--   Minimum variable size
--   Maximum variable size
--   Locking:
-    -   Locking "immediately"
-    -   Locking on creation
-    -   Locking based on a state of another variable
+- Required variable attributes
+- Prohibited variable attributes
+- Minimum variable size
+- Maximum variable size
+- Locking:
+  - Locking "immediately"
+  - Locking on creation
+  - Locking based on a state of another variable
 
 The spec assumes that the Variable Policy Engine runs in a trusted
 enclave, potentially off the main CPU that runs UEFI. For that reason,
@@ -34,9 +32,9 @@ enclave is proprietary.
 
 At power-on, the Variable Policy Engine is:
 
--   Enabled -- present policy entries are evaluated on variable access
+- Enabled -- present policy entries are evaluated on variable access
     calls.
--   Unlocked -- new policy entries can be registered.
+- Unlocked -- new policy entries can be registered.
 
 Policy is expected to be clear on power-on. Policy is volatile and not
 preserved across system reset.
@@ -85,7 +83,7 @@ more than once, it will return `EFI_ALREADY_STARTED`. Note, this process
 is irreversible until the next system reset -- there is no
 "EnablePolicy" protocol function.
 
-_IMPORTANT NOTE:_ It is strongly recommended that VariablePolicy *NEVER*
+_IMPORTANT NOTE:_ It is strongly recommended that VariablePolicy _NEVER_
 be disabled in "normal, production boot conditions". It is expected to always
 be enforced. The most likely reasons to disable are for Manufacturing and
 Refurbishing scenarios. If in doubt, leave the `gEfiMdeModulePkgTokenSpaceGuid.PcdAllowVariablePolicyEnforcementDisable`
@@ -214,18 +212,18 @@ are self-explanatory.
 
 `LockPolicyType` can have the following values:
 
--   `VARIABLE_POLICY_TYPE_NO_LOCK` -- means that no variable locking is performed. However,
+- `VARIABLE_POLICY_TYPE_NO_LOCK` -- means that no variable locking is performed. However,
     the attribute and size constraints are still enforced. LockPolicy
     field is size 0.
--   `VARIABLE_POLICY_TYPE_LOCK_NOW` -- means that the variable starts being locked
+- `VARIABLE_POLICY_TYPE_LOCK_NOW` -- means that the variable starts being locked
     immediately after policy entry registration. If the variable doesn't
     exist at this point, being LockedNow means it cannot be created on
     this boot. LockPolicy field is size 0.
--   `VARIABLE_POLICY_TYPE_LOCK_ON_CREATE` -- means that the variable starts being locked
+- `VARIABLE_POLICY_TYPE_LOCK_ON_CREATE` -- means that the variable starts being locked
     after it is created. This allows for variable creation and
     protection after LockVariablePolicy() function has been called. The
     LockPolicy field is size 0.
--   `VARIABLE_POLICY_TYPE_LOCK_ON_VAR_STATE` -- means that the Variable Policy Engine will
+- `VARIABLE_POLICY_TYPE_LOCK_ON_VAR_STATE` -- means that the Variable Policy Engine will
     examine the state/contents of another variable to determine if the
     variable referenced in the policy entry is locked.
 
@@ -254,14 +252,14 @@ considered inactive.
 Two types of wildcards can be used in the UEFI variable name field in a
 policy entry:
 
-1.  If the Name is a zero-length array (easily checked by comparing
-    fields `Size` and `OffsetToName` -- if they're the same, then the
-    `Name` is zero-length), then all variables in the namespace specified
-    by the provided GUID are targeted by the policy entry.
-2.  Character "#" in the `Name` corresponds to one numeric character
-    (0-9, A-F, a-f). For example, string "Boot####" in the `Name`
-    field of the policy entry will make it so that the policy entry will
-    target variables named "Boot0001", "Boot0002", etc.
+1. If the Name is a zero-length array (easily checked by comparing
+   fields `Size` and `OffsetToName` -- if they're the same, then the
+   `Name` is zero-length), then all variables in the namespace specified
+   by the provided GUID are targeted by the policy entry.
+2. Character "#" in the `Name` corresponds to one numeric character
+   (0-9, A-F, a-f). For example, string "Boot####" in the `Name`
+   field of the policy entry will make it so that the policy entry will
+   target variables named "Boot0001", "Boot0002", etc.
 
 Given the above two types of wildcards, one variable can be targeted by
 more than one policy entry, thus there is a need to establish the
@@ -288,15 +286,21 @@ directory).
 
 ### Host-Based Unit Test
 
-There is a test that can be run as part of the Host-Based Unit Testing
-infrastructure provided by EDK2 PyTools (documented elsewhere). It will test
-all internal guarantees and is where you will find test cases for most of the
-policy matching and security of the Variable Policy Engine.
+MU_CHANGE
+
+This test:
+
+`MdeModulePkg\Library\VariablePolicyLib\VariablePolicyUnitTest\VariablePolicyUnitTest.inf`
+
+can be run as part of the Host-Based Unit Testing infrastructure provided by EDK2
+PyTools (documented elsewhere). It will test all internal guarantees and is
+where you will find test cases for most of the policy matching and security of the
+Variable Policy Engine.
 
 ### Shell-Based Functional Test
 
-This test -- [Variable Policy Functional Unit Test](https://github.com/microsoft/mu_plus/tree/release/202005/UefiTestingPkg/FunctionalSystemTests/VarPolicyUnitTestApp) -- can be built as a
-UEFI Shell application and run to validate that the Variable Policy Engine
+This test -- [Variable Policy Functional Unit Test](https://github.com/microsoft/mu_plus/tree/release/202005/UefiTestingPkg/FunctionalSystemTests/VarPolicyUnitTestApp)
+-- can be built as a UEFI Shell application and run to validate that the Variable Policy Engine
 is correctly installed and enforcing policies on the target system.
 
 NOTE: This test _must_ be run prior to calling `DisableVariablePolicy` for all
@@ -321,8 +325,8 @@ the variable, appropriate GUID listed as the namespace, and 1 as
 value. Entry into the trusted UEFI menu app doesn't signal
 ReadyToBoot, but booting to any device does, and the setup variables
 are write-protected. The "ReadyToBoot" variable would need to be
-locked-on-create. *(THIS IS ESSENTIALLY LOCK ON EVENT, BUT SINCE THE
-POLICY ENGINE IS NOT IN THE UEFI ENVIRONMENT VARIABLES ARE USED)*
+locked-on-create. _(THIS IS ESSENTIALLY LOCK ON EVENT, BUT SINCE THE
+POLICY ENGINE IS NOT IN THE UEFI ENVIRONMENT VARIABLES ARE USED)_
 
 For example, "AllowPXEBoot" variable locked by "ReadyToBoot" variable.
 

--- a/MdeModulePkg/MdeModulePkg.ci.yaml
+++ b/MdeModulePkg/MdeModulePkg.ci.yaml
@@ -122,5 +122,12 @@
             "canthave"
         ],
         "AdditionalIncludePaths": [] # Additional paths to spell check relative to package root (wildcards supported)
+    },
+
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "IgnoreFiles": [ "Universal/RegularExpressionDxe/oniguruma",  # submodule outside of control
+                         "Library/BrotliCustomDecompressLib/brotli"   # submodule outside of control
+        ]            # package root relative file, folder, or glob pattern to ignore
     }
 }

--- a/MdePkg/Library/MipiSysTLib/Readme.md
+++ b/MdePkg/Library/MipiSysTLib/Readme.md
@@ -1,24 +1,32 @@
-## Introduction of MipiSysTLib ##
+# Introduction of MipiSysTLib #
+
 MipiSysTLib library is a upper level library consuming MIPI SYS-T submodule.
 It provides MIPI-related APIs in EDK2 format to be consumed.
 
 ## MipiSysTLib Version ##
+
 EDK2 supports building with v1.1+edk2 official version which was fully validated.
 
 ## HOW to Install MipiSysTLib for UEFI Building ##
+
 MIPI SYS-T repository was added as a submodule of EDK2 project. Please
 refer to edk2/Readme.md for how to clone the code.
 
 ## About GenMipiSystH.py ##
+
 "GenMipiSystH.py" is a Python script which is used for customizing the
 mipi_syst.h.in in mipi sys-T repository. The resulting file, mipi_syst.h, will
 be put to same folder level as this script.
-```
+
+```text
+
   mipisyst submodule                        MipiSysTLib library
 |---------------------| GenMipiSystH.py   |---------------------|
 |   mipi_syst.h.in    |-----------------> |   mipi_syst.h       |
 |---------------------|                   |---------------------|
+
 ```
+
 This script needs to be done once by a developer when adding some
 project-related definition or a new version of mipi_syst.h.in was released.
 Normal users do not need to do this, since the resulting file is stored

--- a/MdePkg/MdePkg.ci.yaml
+++ b/MdePkg/MdePkg.ci.yaml
@@ -197,5 +197,11 @@
             "Library/BaseFdtLib/string.h",
             "mipi_syst.h"
         ]
+    },
+
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "IgnoreFiles": [ "Library/MipiSysTLib/mipisyst"  # submodule outside of control
+        ]            # package root relative file, folder, or glob pattern to ignore
     }
 }

--- a/UnitTestFrameworkPkg/ReadMe.md
+++ b/UnitTestFrameworkPkg/ReadMe.md
@@ -124,7 +124,7 @@ you should be good to go.
 
 See this example in `SampleUnitTestUefiShell.inf`...
 
-```
+```inf
 [Packages]
   MdePkg/MdePkg.dec
 
@@ -139,7 +139,7 @@ See this example in `SampleUnitTestUefiShell.inf`...
 Also, if you want your test to automatically be picked up by the Test Runner plugin, you will need
 to make sure that the module `BASE_NAME` contains the word `Test`...
 
-```
+```inf
 [Defines]
   BASE_NAME      = SampleUnitTestUefiShell
 ```
@@ -151,7 +151,7 @@ section so that the unit tests will be built.
 
 See this example in `UnitTestFrameworkPkg.dsc`...
 
-```
+```inf
 [Components]
   UnitTestFrameworkPkg/Test/UnitTest/Sample/SampleUnitTest/SampleUnitTestUefiShell.inf
 ```
@@ -160,7 +160,7 @@ Also, based on the type of tests that are being created, the associated DSC incl
 UnitTestFrameworkPkg for Host or Target based tests should also be included at the top of the DSC
 file.
 
-```
+```inf
 !include UnitTestFrameworkPkg/UnitTestFrameworkPkgTarget.dsc.inc
 ```
 
@@ -170,7 +170,7 @@ they should be added in the \<LibraryClasses\> sub-section for the INF file in t
 
 See this example in `SecurityPkgHostTest.dsc`...
 
-```
+```inf
 [Components]
   SecurityPkg/Library/SecureBootVariableLib/UnitTest/SecureBootVariableLibUnitTest.inf {
     <LibraryClasses>
@@ -326,7 +326,7 @@ Beyond that, if you're writing host-based tests and want to take a dependency on
 leverage the `cmocka.h` interface and write tests with all the features of the Cmocka framework.
 
 Documentation for Cmocka can be found here:
-https://api.cmocka.org/
+<https://api.cmocka.org/>
 
 ## GoogleTest Libraries
 
@@ -354,7 +354,7 @@ the following tables.
 | Matcher Name | Similar gMock Generic Matcher | Usage |
 |:--- |:--- |:--- |
 | `BufferEq()` | `Pointee(Eq())` | Used to compare two buffer pointer types (such as UINT8*, VOID*, a structure pointer, etc.). Can be used in an `EXPECT_CALL()`, `EXPECT_THAT()`, or anywhere else a matcher to compare two buffers is needed. |
-| `Char16StrEq()` | `Pointee(Eq())` | Used to compare two CHAR16* strings. Can be used in an `EXPECT_CALL()`, `EXPECT_THAT()`, or anywhere else a matcher to compare two CHAR16* strings is needed. |
+| `Char16StrEq()` | `Pointee(Eq())` | Used to compare two CHAR16 string pointers. Can be used in an `EXPECT_CALL()`, `EXPECT_THAT()`, or anywhere else a matcher to compare two CHAR16* strings is needed. |
 
 ### FunctionMockLib
 
@@ -370,6 +370,7 @@ the mock functions, and the other two macros are related to creating an interfac
 to contain the mock functions and connect them into the gMock framework.
 
 The macros used to create the interface are...
+
 1. `MOCK_INTERFACE_DECLARATION(MOCK)`
 2. `MOCK_INTERFACE_DEFINITION(MOCK)`
 
@@ -392,6 +393,7 @@ MOCK_INTERFACE_DEFINITION(MockUefiLib);
 ```
 
 The macros used to create the mock functions are...
+
 1. `MOCK_FUNCTION_DECLARATION(RET_TYPE, FUNC, ARGS)`
 2. `MOCK_FUNCTION_DEFINITION(MOCK, FUNC, NUM_ARGS, CALL_TYPE)`
 3. `MOCK_FUNCTION_INTERNAL_DECLARATION(RET_TYPE, FUNC, ARGS)`
@@ -839,7 +841,7 @@ the `GoogleTestLib`, and the `[BuildOptions]` will need to append the `/EHsc`
 compilation flag to all MSFT builds to enable proper use of the C++ exception
 handler. Below is the complete `MockUefiLib.inf` as an example.
 
-```
+```text
 [Defines]
   INF_VERSION                    = 0x00010005
   BASE_NAME                      = MockUefiLib
@@ -874,7 +876,7 @@ if no test uses it yet, this created INF file needs to be added into the
 which this INF file resides. For example, the above `MockUefiLib.inf` would
 need to be added to the `MdePkg/Test/MdePkgHostTest.dsc` file as shown below.
 
-```
+```text
 [Components]
   MdePkg/Test/Mock/Library/GoogleTest/MockUefiLib/MockUefiLib.inf
 ```
@@ -892,7 +894,7 @@ locate the mock function header file. For example, if `MockUefiLib.inf` were
 the first mock added to the `MdePkg`, then the below snippet would need to be
 added to the `MdePkg.dec` file.
 
-```
+```text
 [Includes]
   Test/Mock/Include
 ```
@@ -912,7 +914,7 @@ mock function definitions file be added to the `[Sources]` section, the
 Below is a minimal contrived example for a `MyModuleGoogleTest.inf` that uses a
 `MockMyModuleInternalFunctions.cpp` source file for its internal mock functions.
 
-```
+```text
 [Defines]
   INF_VERSION         = 0x00010017
   BASE_NAME           = MyModuleGoogleTest
@@ -974,7 +976,7 @@ you should be good to go.
 
 See this example in `SampleGoogleTestHost.inf`...
 
-```
+```text
 [Packages]
   MdePkg/MdePkg.dec
   UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
@@ -988,7 +990,7 @@ See this example in `SampleGoogleTestHost.inf`...
 Also, if you want your test to automatically be picked up by the Test Runner plugin, you will need
 to make sure that the module `BASE_NAME` contains the word `Test`...
 
-```
+```text
 [Defines]
   BASE_NAME      = SampleGoogleTestHost
 ```
@@ -1000,7 +1002,7 @@ section so that the unit tests will be built.
 
 See this example in `UnitTestFrameworkPkgHostTest.dsc`...
 
-```
+```text
 [Components]
   UnitTestFrameworkPkg/Test/GoogleTest/Sample/SampleGoogleTest/SampleGoogleTestHost.inf
 ```
@@ -1009,7 +1011,7 @@ Also, based on the type of tests that are being created, the associated DSC incl
 UnitTestFrameworkPkg for Host or Target based tests should also be included at the top of the DSC
 file.
 
-```
+```text
 !include UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
 ```
 
@@ -1022,7 +1024,7 @@ See this example in `SecurityPkgHostTest.dsc` where the `SecureBootVariableLib` 
 being tested using mock versions of `UefiRuntimeServicesTableLib`, `PlatformPKProtectionLib`,
 and `UefiLib`...
 
-```
+```text
 [Components]
   SecurityPkg/Library/SecureBootVariableLib/GoogleTest/SecureBootVariableLibGoogleTest.inf {
     <LibraryClasses>
@@ -1469,7 +1471,7 @@ Unit test applications using Framework are built using Cmocka that requires the
 following environment variables to be set to generate structured XML output
 rather than text:
 
-```
+```inf
 CMOCKA_MESSAGE_OUTPUT=xml
 CMOCKA_XML_FILE=<absolute or relative path to output file>
 ```
@@ -1477,7 +1479,7 @@ CMOCKA_XML_FILE=<absolute or relative path to output file>
 Unit test applications using GoogleTest require the following environment
 variable to be set to generate structured XML output rather than text:
 
-```
+```inf
 GTEST_OUTPUT=xml:<absolute or relative path to output file>
 ```
 
@@ -1647,14 +1649,15 @@ Non-Host-Based (PEI/DXE/SMM/Shell) Tests for a Functionality or Feature   | Simi
 
 ### Future Locations in Consideration
 
-We don't know if these types will exist or be applicable yet, but if you write a support library or module that matches the following, please make sure they live in the correct place.
+We don't know if these types will exist or be applicable yet, but if you write a support library or module that matches
+the following, please make sure they live in the correct place.
 
 Code/Test                                   | Location
 ---------                                   | --------
 Host-Based Library Implementations                 | Host-Based Implementations of common libraries (eg. MemoryAllocationLibHost) should live in the same package that declares the library interface in its .DEC file in the `*Pkg/HostLibrary` directory. Should have 'Host' in the name.
 Host-Based Mocks and Stubs  | Mock and Stub libraries should live in the `UefiTestFrameworkPkg/StubLibrary` with either 'Mock' or 'Stub' in the library name.
 
-### If still in doubt...
+### If still in doubt
 
 Hop on GitHub and ask @corthon, @mdkinney, or @spbrogan. ;)
 

--- a/UnitTestFrameworkPkg/UnitTestFrameworkPkg.ci.yaml
+++ b/UnitTestFrameworkPkg/UnitTestFrameworkPkg.ci.yaml
@@ -127,6 +127,14 @@
             "Library/CmockaLib/cmocka/**",
             "Library/GoogleTestLib/googletest/**",
             "Library/SubhookLib/subhook/**"
-        ]
+        ],
+    },
+    
+    ## options defined .pytool/Plugin/MarkdownLintCheck
+    "MarkdownLintCheck": {
+        "IgnoreFiles": [ 
+            "Library/CmockaLib/cmocka",  # cmocka is submodule outside of control
+            "Library/GoogleTestLib/googletest"  # googletest is submodule outside of control
+        ] # package root relative file, folder, or glob pattern to ignore
     }
 }


### PR DESCRIPTION
## Description

Cherry-pick commits that add markdownlint as a pytool plugin as well as markdown fixes in several MD files.
Commits from 202311 included here:

df8805cf8f
6d509b255e
72f4ac0dfc
40da3f2b31
984dee96cf
c149b3f3e3
aa5ae2af5d
26eb685974
26e38dc194

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

N/A

## Integration Instructions

N/A