### PR TITLE
Added mock functions on UefiBootServicesTableLib, added mock PciExpressLib and TimerLib [REBASE & FF]

### DIFF
--- a/MdePkg/Test/MdePkgHostTest.dsc
+++ b/MdePkg/Test/MdePkgHostTest.dsc
@@ -55,3 +55,4 @@
   MdePkg/Test/Mock/Library/GoogleTest/MockMmServicesTableLib/MockMmServicesTableLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockUefiRuntimeLib/MockUefiRuntimeLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockMemoryAllocationLib/MockMemoryAllocationLib.inf
+  MdePkg/Test/Mock/Library/GoogleTest/MockPciExpressLib/MockPciExpressLib.inf

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockPciExpressLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockPciExpressLib.h
@@ -1,0 +1,45 @@
+/** @file MockPciExpressLib.h
+  Google Test mocks for PciExpressLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_PCI_EXPRESS_LIB_H_
+#define MOCK_PCI_EXPRESS_LIB_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+extern "C" {
+  #include <Uefi.h>
+  #include <Library/PciExpressLib.h>
+}
+
+struct MockPciExpressLib {
+  MOCK_INTERFACE_DECLARATION (MockPciExpressLib);
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT8,
+    PciExpressRead8,
+    (
+     IN UINTN  Address
+    )
+    );
+  MOCK_FUNCTION_DECLARATION (
+    UINT16,
+    PciExpressRead16,
+    (
+     IN UINTN  Address
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT32,
+    PciExpressRead32,
+    (
+     IN UINTN  Address
+    )
+    );
+};
+
+#endif //MOCK_PCI_EXPRESS_LIB_H_

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiBootServicesTableLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiBootServicesTableLib.h
@@ -58,10 +58,30 @@ struct MockUefiBootServicesTableLib {
 
   MOCK_FUNCTION_DECLARATION (
     EFI_STATUS,
+    gBS_UninstallProtocolInterface,
+    (IN EFI_HANDLE               Handle,
+     IN EFI_GUID                 *Protocol,
+     IN VOID                     *Interface)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
     gBS_HandleProtocol,
     (IN  EFI_HANDLE Handle,
      IN  EFI_GUID   *Protocol,
      OUT VOID       **Interface)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_LocateHandleBuffer,
+    (
+     IN     EFI_LOCATE_SEARCH_TYPE       SearchType,
+     IN     EFI_GUID                     *Protocol       OPTIONAL,
+     IN     VOID                         *SearchKey      OPTIONAL,
+     OUT    UINTN                        *NoHandles,
+     OUT    EFI_HANDLE                   **Buffer
+    )
     );
 
   MOCK_FUNCTION_DECLARATION (
@@ -81,6 +101,65 @@ struct MockUefiBootServicesTableLib {
      IN CONST VOID        *NotifyContext OPTIONAL,
      IN CONST EFI_GUID    *EventGroup OPTIONAL,
      OUT EFI_EVENT        *Event)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    gBS_SetMem,
+    (IN VOID     *Buffer,
+     IN UINTN    Size,
+     IN UINT8    Value)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    gBS_CopyMem,
+    (IN VOID     *Destination,
+     IN VOID     *Source,
+     IN UINTN    Length)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_OpenProtocol,
+    (IN  EFI_HANDLE                Handle,
+     IN  EFI_GUID                  *Protocol,
+     OUT VOID                      **Interface  OPTIONAL,
+     IN  EFI_HANDLE                AgentHandle,
+     IN  EFI_HANDLE                ControllerHandle,
+     IN  UINT32                    Attributes)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_CloseProtocol,
+    (IN EFI_HANDLE               Handle,
+     IN EFI_GUID                 *Protocol,
+     IN EFI_HANDLE               AgentHandle,
+     IN EFI_HANDLE               ControllerHandle)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_FreePool,
+    (IN  VOID                         *Buffer)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_LocateDevicePath,
+    (IN     EFI_GUID                         *Protocol,
+     IN OUT EFI_DEVICE_PATH_PROTOCOL         **DevicePath,
+     OUT    EFI_HANDLE                       *Device)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_ReinstallProtocolInterface,
+    (IN EFI_HANDLE               Handle,
+     IN EFI_GUID                 *Protocol,
+     IN VOID                     *OldInterface,
+     IN VOID                     *NewInterface)
     );
 };
 

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockPciExpressLib/MockPciExpressLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockPciExpressLib/MockPciExpressLib.cpp
@@ -1,0 +1,13 @@
+/** @file MockPciExpressLib.cpp
+  Google Test mocks for PciExpressLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <GoogleTest/Library/MockPciExpressLib.h>
+
+MOCK_INTERFACE_DEFINITION (MockPciExpressLib);
+MOCK_FUNCTION_DEFINITION (MockPciExpressLib, PciExpressRead8, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciExpressLib, PciExpressRead16, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciExpressLib, PciExpressRead32, 1, EFIAPI);

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockPciExpressLib/MockPciExpressLib.inf
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockPciExpressLib/MockPciExpressLib.inf
@@ -1,0 +1,33 @@
+## @file MockPciExpressLib.inf
+# Google Test mocks for PciExpressLib
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MockPciExpressLib
+  FILE_GUID                      = EB17BE3C-2B3E-4B40-8C71-0EA4EF294EFA
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = PciExpressLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  MockPciExpressLib.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHsc

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockUefiBootServicesTableLib/MockUefiBootServicesTableLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockUefiBootServicesTableLib/MockUefiBootServicesTableLib.cpp
@@ -11,9 +11,18 @@ MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_GetMemoryMap, 5, EFI
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_CreateEvent, 5, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_CloseEvent, 1, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_InstallProtocolInterface, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_UninstallProtocolInterface, 3, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_HandleProtocol, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_LocateHandleBuffer, 5, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_LocateProtocol, 3, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_CreateEventEx, 6, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_SetMem, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_CopyMem, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_OpenProtocol, 6, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_CloseProtocol, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_FreePool, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_LocateDevicePath, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_ReinstallProtocolInterface, 4, EFIAPI);
 
 extern "C" {
   EFI_STATUS
@@ -50,54 +59,89 @@ extern "C" {
     VA_END (Args);
     return Status;
   }
+
+  EFI_STATUS
+  EFIAPI
+  gBS_UninstallMultipleProtocolInterfaces (
+    IN EFI_HANDLE  *Handle,
+    ...
+    )
+  {
+    VA_LIST     Args;
+    EFI_STATUS  Status;
+    EFI_GUID    *Protocol;
+    VOID        *Interface;
+    UINTN       Index;
+
+    VA_START (Args, Handle);
+    for (Index = 0, Status = EFI_SUCCESS; !EFI_ERROR (Status); Index++) {
+      //
+      // If protocol is NULL, then it's the end of the list
+      //
+      Protocol = VA_ARG (Args, EFI_GUID *);
+      if (Protocol == NULL) {
+        break;
+      }
+
+      Interface = VA_ARG (Args, VOID *);
+
+      //
+      // Uninstall it
+      //
+      Status = gBS_UninstallProtocolInterface (Handle, Protocol, Interface);
+    }
+
+    VA_END (Args);
+    return Status;
+  }
 }
 
 static EFI_BOOT_SERVICES  LocalBs = {
-  { 0, 0, 0, 0, 0 },                     // EFI_TABLE_HEADER
-  NULL,                                  // EFI_RAISE_TPL
-  NULL,                                  // EFI_RESTORE_TPL
-  NULL,                                  // EFI_ALLOCATE_PAGES
-  NULL,                                  // EFI_FREE_PAGES
-  gBS_GetMemoryMap,                      // EFI_GET_MEMORY_MAP
-  NULL,                                  // EFI_ALLOCATE_POOL
-  NULL,                                  // EFI_FREE_POOL
-  gBS_CreateEvent,                       // EFI_CREATE_EVENT
-  NULL,                                  // EFI_SET_TIMER
-  NULL,                                  // EFI_WAIT_FOR_EVENT
-  NULL,                                  // EFI_SIGNAL_EVENT
-  gBS_CloseEvent,                        // EFI_CLOSE_EVENT
-  NULL,                                  // EFI_CHECK_EVENT
-  gBS_InstallProtocolInterface,          // EFI_INSTALL_PROTOCOL_INTERFACE
-  NULL,                                  // EFI_REINSTALL_PROTOCOL_INTERFACE
-  NULL,                                  // EFI_UNINSTALL_PROTOCOL_INTERFACE
-  gBS_HandleProtocol,                    // EFI_HANDLE_PROTOCOL
-  NULL,                                  // VOID
-  NULL,                                  // EFI_REGISTER_PROTOCOL_NOTIFY
-  NULL,                                  // EFI_LOCATE_HANDLE
-  NULL,                                  // EFI_LOCATE_DEVICE_PATH
-  NULL,                                  // EFI_INSTALL_CONFIGURATION_TABLE
-  NULL,                                  // EFI_IMAGE_LOAD
-  NULL,                                  // EFI_IMAGE_START
-  NULL,                                  // EFI_EXIT
-  NULL,                                  // EFI_IMAGE_UNLOAD
-  NULL,                                  // EFI_EXIT_BOOT_SERVICES
-  NULL,                                  // EFI_GET_NEXT_MONOTONIC_COUNT
-  NULL,                                  // EFI_STALL
-  NULL,                                  // EFI_SET_WATCHDOG_TIMER
-  NULL,                                  // EFI_CONNECT_CONTROLLER
-  NULL,                                  // EFI_DISCONNECT_CONTROLLER
-  NULL,                                  // EFI_OPEN_PROTOCOL
-  NULL,                                  // EFI_CLOSE_PROTOCOL
-  NULL,                                  // EFI_OPEN_PROTOCOL_INFORMATION
-  NULL,                                  // EFI_PROTOCOLS_PER_HANDLE
-  NULL,                                  // EFI_LOCATE_HANDLE_BUFFER
-  gBS_LocateProtocol,                    // EFI_LOCATE_PROTOCOL
-  gBS_InstallMultipleProtocolInterfaces, // EFI_INSTALL_MULTIPLE_PROTOCOL_INTERFACES
-  NULL,                                  // EFI_UNINSTALL_MULTIPLE_PROTOCOL_INTERFACES
-  NULL,                                  // EFI_CALCULATE_CRC32
-  NULL,                                  // EFI_COPY_MEM
-  NULL,                                  // EFI_SET_MEM
-  gBS_CreateEventEx                      // EFI_CREATE_EVENT_EX
+  { 0, 0, 0, 0, 0 },                                                                   // EFI_TABLE_HEADER
+  NULL,                                                                                // EFI_RAISE_TPL
+  NULL,                                                                                // EFI_RESTORE_TPL
+  NULL,                                                                                // EFI_ALLOCATE_PAGES
+  NULL,                                                                                // EFI_FREE_PAGES
+  gBS_GetMemoryMap,                                                                    // EFI_GET_MEMORY_MAP
+  NULL,                                                                                // EFI_ALLOCATE_POOL
+  gBS_FreePool,                                                                        // EFI_FREE_POOL
+  gBS_CreateEvent,                                                                     // EFI_CREATE_EVENT
+  NULL,                                                                                // EFI_SET_TIMER
+  NULL,                                                                                // EFI_WAIT_FOR_EVENT
+  NULL,                                                                                // EFI_SIGNAL_EVENT
+  gBS_CloseEvent,                                                                      // EFI_CLOSE_EVENT
+  NULL,                                                                                // EFI_CHECK_EVENT
+  gBS_InstallProtocolInterface,                                                        // EFI_INSTALL_PROTOCOL_INTERFACE
+  gBS_ReinstallProtocolInterface,                                                      // EFI_REINSTALL_PROTOCOL_INTERFACE
+  gBS_UninstallProtocolInterface,                                                      // EFI_UNINSTALL_PROTOCOL_INTERFACE
+  gBS_HandleProtocol,                                                                  // EFI_HANDLE_PROTOCOL
+  NULL,                                                                                // VOID
+  NULL,                                                                                // EFI_REGISTER_PROTOCOL_NOTIFY
+  NULL,                                                                                // EFI_LOCATE_HANDLE
+  gBS_LocateDevicePath,                                                                // EFI_LOCATE_DEVICE_PATH
+  NULL,                                                                                // EFI_INSTALL_CONFIGURATION_TABLE
+  NULL,                                                                                // EFI_IMAGE_LOAD
+  NULL,                                                                                // EFI_IMAGE_START
+  NULL,                                                                                // EFI_EXIT
+  NULL,                                                                                // EFI_IMAGE_UNLOAD
+  NULL,                                                                                // EFI_EXIT_BOOT_SERVICES
+  NULL,                                                                                // EFI_GET_NEXT_MONOTONIC_COUNT
+  NULL,                                                                                // EFI_STALL
+  NULL,                                                                                // EFI_SET_WATCHDOG_TIMER
+  NULL,                                                                                // EFI_CONNECT_CONTROLLER
+  NULL,                                                                                // EFI_DISCONNECT_CONTROLLER
+  gBS_OpenProtocol,                                                                    // EFI_OPEN_PROTOCOL
+  gBS_CloseProtocol,                                                                   // EFI_CLOSE_PROTOCOL
+  NULL,                                                                                // EFI_OPEN_PROTOCOL_INFORMATION
+  NULL,                                                                                // EFI_PROTOCOLS_PER_HANDLE
+  gBS_LocateHandleBuffer,                                                              // EFI_LOCATE_HANDLE_BUFFER
+  gBS_LocateProtocol,                                                                  // EFI_LOCATE_PROTOCOL
+  gBS_InstallMultipleProtocolInterfaces,                                               // EFI_INSTALL_MULTIPLE_PROTOCOL_INTERFACES
+  (EFI_UNINSTALL_MULTIPLE_PROTOCOL_INTERFACES)gBS_UninstallMultipleProtocolInterfaces, // EFI_UNINSTALL_MULTIPLE_PROTOCOL_INTERFACES
+  NULL,                                                                                // EFI_CALCULATE_CRC32
+  gBS_CopyMem,                                                                         // EFI_COPY_MEM
+  gBS_SetMem,                                                                          // EFI_SET_MEM
+  gBS_CreateEventEx                                                                    // EFI_CREATE_EVENT_EX
 };
 
 extern "C" {

--- a/UefiCpuPkg/Test/Mock/Include/GoogleTest/Library/MockTimerLib.h
+++ b/UefiCpuPkg/Test/Mock/Include/GoogleTest/Library/MockTimerLib.h
@@ -1,0 +1,29 @@
+/** @file MockTimerLib.h
+  Google Test mocks for TimerLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_TIMER_LIB_H_
+#define MOCK_TIMER_LIB_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+extern "C" {
+  #include <Library/TimerLib.h>
+}
+
+struct MockTimerLib {
+  MOCK_INTERFACE_DECLARATION (MockTimerLib);
+
+  MOCK_FUNCTION_DECLARATION (
+    UINTN,
+    MicroSecondDelay,
+    (
+     IN UINTN  MicroSeconds
+    )
+    );
+};
+
+#endif //MOCK_TIMER_LIB_H_

--- a/UefiCpuPkg/Test/Mock/Library/GoogleTest/MockTimerLib/MockTimerLib.cpp
+++ b/UefiCpuPkg/Test/Mock/Library/GoogleTest/MockTimerLib/MockTimerLib.cpp
@@ -1,0 +1,11 @@
+/** @file MockTimerLib.cpp
+  Google Test mocks for TimerLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <GoogleTest/Library/MockTimerLib.h>
+
+MOCK_INTERFACE_DEFINITION (MockTimerLib);
+MOCK_FUNCTION_DEFINITION (MockTimerLib, MicroSecondDelay, 1, EFIAPI);

--- a/UefiCpuPkg/Test/Mock/Library/GoogleTest/MockTimerLib/MockTimerLib.inf
+++ b/UefiCpuPkg/Test/Mock/Library/GoogleTest/MockTimerLib/MockTimerLib.inf
@@ -1,0 +1,34 @@
+## @file MockTimerLib.inf
+# Google Test mocks for TimerLib
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MockTimerLib
+  FILE_GUID                      = CF06C23E-5B46-4CC9-A5AE-794E0E58A564
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = TimerLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  MockTimerLib.cpp
+
+[Packages]
+  UefiCpuPkg/UefiCpuPkg.dec
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHsc

--- a/UefiCpuPkg/Test/UefiCpuPkgHostTest.dsc
+++ b/UefiCpuPkg/Test/UefiCpuPkgHostTest.dsc
@@ -42,3 +42,4 @@
   # Build HOST_APPLICATION Libraries for GoogleTests
   #
   UefiCpuPkg/Test/Mock/Library/GoogleTest/MockLocalApicLib/MockLocalApicLib.inf
+  UefiCpuPkg/Test/Mock/Library/GoogleTest/MockTimerLib/MockTimerLib.inf


### PR DESCRIPTION
Added mock functions on UefiBootServicesTableLib, added mock PciExpressLib and TimerLib [REBASE & FF]

# Preface

Please ensure you have read the [contribution docs](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md) prior
to submitting the pull request. In particular,
[pull request guidelines](https://github.com/microsoft/mu/blob/master/CONTRIBUTING.md#pull-request-best-practices).

## Description

Added mock functions on UefiBootServicesTableLib, added mock PciExpressLib and TimerLib

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Included the mock functions on GoogleTests for the appropriate libraries under x86 and ensured build successful

## Integration Instructions

N/A
