### PR TITLE
.github/workflows: Add label-issues config files

### DIFF
--- a/.github/workflows/label-issues/file-paths.yml
+++ b/.github/workflows/label-issues/file-paths.yml
@@ -1,0 +1,18 @@
+# Specifies labels to apply to issues and pull requests based on file path patterns in Project Mu repositories.
+#
+# NOTE: This file is automatically synchronized from Mu DevOps. Update the original file there
+#       instead of the file in this repo.
+#
+# - Mu DevOps Repo: https://github.com/microsoft/mu_devops
+# - File Sync Settings: https://github.com/microsoft/mu_devops/blob/main/.sync/Files.yml
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# For more information, see:
+# https://github.com/actions/labeler
+
+# Maintenance: Keep labels organized in ascending alphabetical order - easier to scan, identify duplicates, etc.
+
+language:python:
+  - '**/*.py'

--- a/.github/workflows/label-issues/regex-pull-requests.yml
+++ b/.github/workflows/label-issues/regex-pull-requests.yml
@@ -1,0 +1,30 @@
+# Specifies labels to apply to pull requests in Project Mu repositories based on regular expressions.
+#
+# NOTE: This file is automatically synchronized from Mu DevOps. Update the original file there
+#       instead of the file in this repo.
+#
+# - Mu DevOps Repo: https://github.com/microsoft/mu_devops
+# - File Sync Settings: https://github.com/microsoft/mu_devops/blob/main/.sync/Files.yml
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# For more information, see:
+# https://github.com/github/issue-labeler
+
+# Maintenance: Keep labels organized in ascending alphabetical order - easier to scan, identify duplicates, etc.
+
+impact:breaking-change:
+  - '\s*-\s*\[\s*[x|X]\s*\] Breaking change\?'
+
+impact:non-functional:
+  - '\s*-\s*\[\s*(?![x|X])\s*\] Impacts functionality\?'
+
+impact:security:
+  - '\s*-\s*\[\s*[x|X]\s*\] Impacts security\?'
+
+impact:testing:
+  - '\s*-\s*\[\s*[x|X]\s*\] Includes tests\?'
+
+type:documentation:
+  - '\s*-\s*\[\s*[x|X]\s*\] Includes documentation\?'


### PR DESCRIPTION
## Description

Files used to label issues in pull requests. Will be auto synced
from Mu DevOps in the future.

Missed in earlier CI changes because the `pull_request_target` type
of the action does not run the action on changes not in the target
(not PR) branch.

---

Note: This PR will fail for the same reason. It needs to be merged
for future PRs to pick up the files.

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Run the label issues GitHub action

## Integration Instructions

- N/A