### PR TITLE
Revert Adding ArmCompilerIntrinsicsLib to UefiCpuPkg

### DIFF
--- a/UefiCpuPkg/UefiCpuPkg.dsc
+++ b/UefiCpuPkg/UefiCpuPkg.dsc
@@ -23,17 +23,6 @@
 #
 
 !include MdePkg/MdeLibs.dsc.inc
-## MU_CHANGE Begin
-[LibraryClasses.ARM, LibraryClasses.AARCH64]
-  #
-  # It is not possible to prevent the ARM compiler for generic intrinsic functions.
-  # This library provides the instrinsic functions generate by a given compiler.
-  # [LibraryClasses.ARM, LibraryClasses.AARCH64] and NULL mean link this library
-  # into all ARM and AARCH64 images.
-  #
-  #NULL|ArmPkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
-  NULL|MdePkg/Library/CompilerIntrinsicsLib/ArmCompilerIntrinsicsLib.inf
-## MU_CHANGE End
 
 [LibraryClasses]
   BaseLib|MdePkg/Library/BaseLib/BaseLib.inf


### PR DESCRIPTION
## Description

When PR #934 was cleaned up to remove ARM/AARCH64 building of UefiCpuPkg, this commit was missed to be dropped. It is no longer necessary because we don't build the package for ARM/AARCH64, so we can drop it.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Building.

## Integration Instructions

N/A.