### PR TITLE
MdeModulePkg NonDiscoverablePciDeviceIo: Mark NonDiscoverablePciDeviceIo Memory XP by default. [Rebase & FF]

### DIFF
--- a/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceIo.c
+++ b/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceIo.c
@@ -1175,7 +1175,7 @@ NonCoherentPciIoAllocateBuffer (
   Status = gDS->SetMemorySpaceAttributes (
                   (EFI_PHYSICAL_ADDRESS)(UINTN)AllocAddress,
                   EFI_PAGES_TO_SIZE (Pages),
-                  MemType
+                  MemType | EFI_MEMORY_XP // MU_CHANGE: Alloc MMIO memory XP by default
                   );
   if (EFI_ERROR (Status)) {
     goto RemoveList;


### PR DESCRIPTION
## Description

When allocating memory for a non-discoverable PCI device's IO, the current core code removes the XP attribute, allowing code to execute from that region. This is a security vulnerability and unneeded. This change updates to mark the region as XP when allocating memory for the non-discoverable PCI device.

These allocations in this function are limited to `EfiBootServicesData` and `EfiRuntimeServicesData`, which we expect to be XP.

## Cherry-Pick the following commits:
[dabc5022d0](https://github.com/microsoft/mu_basecore/commit/dabc5022d0)

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on QEMU and a physical platform.

## Integration Instructions

N/A.