### PR TITLE
MdeModulePkg ConPlatform: Add support for IAD-style USB input devices. [Rebase & FF]

### DIFF
--- a/MdeModulePkg/Universal/Console/ConPlatformDxe/ConPlatform.c
+++ b/MdeModulePkg/Universal/Console/ConPlatformDxe/ConPlatform.c
@@ -808,10 +808,15 @@ MatchUsbClass (
   DeviceClass    = DevDesc.DeviceClass;
   DeviceSubClass = DevDesc.DeviceSubClass;
   DeviceProtocol = DevDesc.DeviceProtocol;
-  if (DeviceClass == 0) {
+
+  // MSCHANGE - BEGIN - Add support for IAD-type multi-function devices.
+  if ((DeviceClass == 0) ||
+      ((DeviceClass == 0xEF) && (DeviceSubClass == 0x02) && (DeviceProtocol == 0x01)))
+  {
     //
-    // If Class in Device Descriptor is set to 0, use the Class, SubClass and
-    // Protocol in Interface Descriptor instead.
+    // If Class in Device Descriptor is set to 0 (Device), or
+    // Class/SubClass/Protocol is 0xEF/0x02/0x01 (IAD), use the Class, SubClass
+    // and Protocol in Interface Descriptor instead.
     //
     Status = UsbIo->UsbGetInterfaceDescriptor (UsbIo, &IfDesc);
     if (EFI_ERROR (Status)) {
@@ -822,6 +827,8 @@ MatchUsbClass (
     DeviceSubClass = IfDesc.InterfaceSubClass;
     DeviceProtocol = IfDesc.InterfaceProtocol;
   }
+
+  // MSCHANGE - END
 
   //
   // Check Class, SubClass and Protocol.


### PR DESCRIPTION
## Description

Some multi-function input devices (e.g. combo keyboard and mouse) present as IAD-style devices (see:
https://learn.microsoft.com/en-us/windows-hardware/drivers/usbcon/usb-interface-association-descriptor). Historically, multi-function devices would report a DeviceClass of 0, indicating that interface matching should be done on the interface descriptor rather than the global device descriptor.

IAD-style devices us DeviceClass of 0xEF, so they don't match MatchUsbClass() for keyboard (DeviceClass=3, SubClass=1, Proto=1). If they are treated as if they had a DeviceClass of zero, which is more traditional for legacy multi-function devices, then the interface descriptors are used instead and these types of devices will "just work" without needing to add a custom USB device path to ConIn.

IAD-style devices will now use interface descriptor matching rather than device descriptor matching when evaluating ConIn contents. Mostly this means that composite input devices that didn't used to work without ConIn customization in UEFI will now work out of the box.

## Cherry-Pick the following commits:
[21f4ba2dc0](https://github.com/microsoft/mu_basecore/commit/21f4ba2dc0)

- [X] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Verified this with an arduino-based test device that exposes an
IAD-style descriptor with keyboard and mouse HID interfaces. Prior to
this change, device keyboard input was not usable in FP or shell because
it didn't match the default ConIn USB input descriptor. After this
change, the keyboard input worked as expected.

## Integration Instructions

N/A