### PR TITLE
BaseTools: Add ProductDataFormatter [Rebase & FF]

### DIFF
--- a/BaseTools/BinWrappers/PosixLike/ProductDataFormatter
+++ b/BaseTools/BinWrappers/PosixLike/ProductDataFormatter
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#python `dirname $0`/RunToolFromSource.py `basename $0` $*
+
+# If a ${PYTHON_COMMAND} command is available, use it in preference to python
+if command -v ${PYTHON_COMMAND} >/dev/null 2>&1; then
+    python_exe=${PYTHON_COMMAND}
+fi
+
+full_cmd=${BASH_SOURCE:-$0} # see http://mywiki.wooledge.org/BashFAQ/028 for a discussion of why $0 is not a good choice here
+dir=$(dirname "$full_cmd")
+exe=$(basename "$full_cmd")
+
+export PYTHONPATH="$dir/../../Source/Python${PYTHONPATH:+:"$PYTHONPATH"}"
+exec "${python_exe:-python}" "$dir/../../Source/Python/$exe/$exe.py" "$@"

--- a/BaseTools/BinWrappers/WindowsLike/ProductDataFormatter.bat
+++ b/BaseTools/BinWrappers/WindowsLike/ProductDataFormatter.bat
@@ -1,0 +1,3 @@
+@setlocal
+@set ToolName=%~n0%
+@%PYTHON_COMMAND% %BASE_TOOLS_PATH%\Source\Python\%ToolName%\%ToolName%.py %*

--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -2,6 +2,7 @@
 #  Copyright (c) 2007 - 2018, Intel Corporation. All rights reserved.<BR>
 #  Portions copyright (c) 2008 - 2010, Apple Inc. All rights reserved.<BR>
 #  Copyright (c) 2020, ARM Ltd. All rights reserved.<BR>
+#  Copyright (c) Microsoft Corporation
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 
@@ -108,6 +109,13 @@
 ## Build Rule Version Number
 #  build_rule_version=0.1
 #
+#
+# 1.00 - Increase this version tag any time you want user to get warning about updating this file in the Conf dir.  By default it does not do update existing conf dirs.
+# 1.01 - Add MASM for Microsoft ARM assembly files. "MS-ARMx-Assembly-Code-File.COMMON.COMMON"
+# 2.00 - Add .slib and .efi support in the sources file
+# 2.01 - Add support for DEPS_FLAGS as well as
+
+#!VERSION=2.01
 
 [C-Code-File]
     <InputFile>
@@ -170,8 +178,9 @@
         # The C pre-processor is used to insert code snippets in assembly from preprocessor macros.  Unfortunately
         # the preprocessor doesn't also insert CR/LF and Microsoft's assembler expects each instruction to be on its own
         # line.  We search and replace a special string (__CR__) with CR.
-        type ${d_path}(+)${s_base}.i | python -c "import sys; print sys.stdin.read().replace('__CR__','\n')" > ${d_path}(+)${s_base}.ii
+        type ${d_path}(+)${s_base}.i | python -c "import sys; print (sys.stdin.read().replace('__CR__','\n'))" > ${d_path}(+)${s_base}.ii
         Trim --trim-long --source-code -o ${d_path}(+)${s_base}.iii ${d_path}(+)${s_base}.ii
+        # NOTE- need to review why the command is different.  Missing /Fo and /I options
         "$(ASM)" $(ASM_FLAGS) -o ${dst} $(INC) ${d_path}(+)${s_base}.iii
 
 [Assembly-Code-File.COMMON.COMMON]
@@ -363,7 +372,7 @@
     <Command.XCODE>
         "$(DLINK)" $(DLINK_FLAGS) -o ${dst} $(DLINK_SPATH) -filelist $(STATIC_LIBRARY_FILES_LIST)  $(DLINK2_FLAGS)
 
-
+    
 [Static-Library-File.SEC.AARCH64, Static-Library-File.PEI_CORE.AARCH64, Static-Library-File.PEIM.AARCH64,Static-Library-File.SEC.ARM, Static-Library-File.PEI_CORE.ARM, Static-Library-File.PEIM.ARM]
     <InputFile>
         *.lib
@@ -398,7 +407,7 @@
     <Command.XCODE>
         "$(DLINK)" -o ${dst} $(DLINK_FLAGS)  $(DLINK_SPATH) -filelist $(STATIC_LIBRARY_FILES_LIST)  $(DLINK2_FLAGS)
 
-
+      
 [Dynamic-Library-File]
     <InputFile>
         ?.dll
@@ -539,7 +548,7 @@
         "$(MTOC)" -subsystem $(MODULE_TYPE)  $(MTOC_FLAGS) $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.dll $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.pecoff
         "$(GENFW)" -o ${dst} -c $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.pecoff $(GENFW_FLAGS)
 
-
+      
 [Masm16-Code-File]
     <InputFile>
         ?.asm16, ?.Asm16, ?.ASM16, ?.s16, ?.S16
@@ -573,6 +582,39 @@
       "$(SLINK)" $(SLINK_FLAGS) $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.slib $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.obj
       otool -t $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.slib | hex2bin.py ${dst}
 
+#MU_CHANGE
+# Build Rule to support using precompiled
+# LIB files.  Just copies the LIB from src to output
+# so the rest of the build system works.
+#
+[Precompiled-Lib-File]
+    <InputFile>
+        *.slib
+
+    <ExtraDependency>
+
+    <OutputFile>
+        $(OUTPUT_DIR)(+)$(MODULE_NAME).lib
+
+    <Command>
+        -$(CP) ${src} ${dst}
+
+#MU_CHANGE
+# Build Rule to support using precompiled
+# EFI files.  Just copies the EFI from src to output
+# so the rest of the build system works.
+#
+[Precompiled-Efi-File]
+    <InputFile>
+        ?.preefi
+
+    <ExtraDependency>
+
+    <OutputFile>
+        $(OUTPUT_DIR)(+)${s_base}.efi
+
+    <Command>
+        -$(CP) ${src} ${dst}
 
 [Nasm-to-Binary-Code-File]
     <InputFile>

--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -114,8 +114,10 @@
 # 1.01 - Add MASM for Microsoft ARM assembly files. "MS-ARMx-Assembly-Code-File.COMMON.COMMON"
 # 2.00 - Add .slib and .efi support in the sources file
 # 2.01 - Add support for DEPS_FLAGS as well as
+# 2.23 - Add OemData Definitions
+# 2.24 - Rename OemData to ProductData.
 
-#!VERSION=2.01
+#!VERSION=2.24
 
 [C-Code-File]
     <InputFile>
@@ -372,7 +374,7 @@
     <Command.XCODE>
         "$(DLINK)" $(DLINK_FLAGS) -o ${dst} $(DLINK_SPATH) -filelist $(STATIC_LIBRARY_FILES_LIST)  $(DLINK2_FLAGS)
 
-    
+
 [Static-Library-File.SEC.AARCH64, Static-Library-File.PEI_CORE.AARCH64, Static-Library-File.PEIM.AARCH64,Static-Library-File.SEC.ARM, Static-Library-File.PEI_CORE.ARM, Static-Library-File.PEIM.ARM]
     <InputFile>
         *.lib
@@ -407,7 +409,7 @@
     <Command.XCODE>
         "$(DLINK)" -o ${dst} $(DLINK_FLAGS)  $(DLINK_SPATH) -filelist $(STATIC_LIBRARY_FILES_LIST)  $(DLINK2_FLAGS)
 
-      
+
 [Dynamic-Library-File]
     <InputFile>
         ?.dll
@@ -548,7 +550,44 @@
         "$(MTOC)" -subsystem $(MODULE_TYPE)  $(MTOC_FLAGS) $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.dll $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.pecoff
         "$(GENFW)" -o ${dst} -c $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.pecoff $(GENFW_FLAGS)
 
-      
+# MU_CHANGE BEGIN
+[C-Code-File-ProductDataIntermediate]
+    <InputFile>
+        ?.productdatac
+
+    <OutputFile>
+        $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.productdatabin.i
+
+    <ExtraDependency>
+        $(MAKE_FILE)
+
+    <Command.MSFT>
+        "$(CC)" /Fo$(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.obj $(DEPS_FLAGS) /nologo /c /FIAutoGen.h /TC /Dmain=main $(INC) ${src}
+        "$(DLINK)" /OUT:$(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.dll /NODEFAULTLIB /ENTRY:main /SUBSYSTEM:CONSOLE $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.obj
+        "$(GENFW)" -o $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.productdatabin.i -b $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.dll $(GENFW_FLAGS)
+
+    <Command.GCC>
+        "$(CC)" $(DEPS_FLAGS) -c -o $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.obj $(CC_FLAGS) -fno-toplevel-reorder -x c $(DEPS_FLAGS) $(INC) ${src}
+        "$(DLINK)" -o $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.dll $(DLINK_COMMON) -u $(IMAGE_ENTRY_POINT) $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.obj $(CC_FLAGS)
+        "$(GENFW)" -o $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.productdatabin.i -b $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.dll $(GENFW_FLAGS)
+
+    <Command.CLANGPDB>
+        "$(CC)" $(DEPS_FLAGS) -c -o $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.obj -O0 -fkeep-static-consts --language=c $(DEPS_FLAGS) $(INC) ${src}
+        "$(DLINK)" /OUT:$(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.dll /NODEFAULTLIB /ENTRY:main /SUBSYSTEM:CONSOLE $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.obj
+        "$(GENFW)" -o $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.productdatabin.i -b $(OUTPUT_DIR)(+)${s_dir}(+)${s_base}.dll $(GENFW_FLAGS)
+
+[ProductDataIntermediate-to-ProductDataBin]
+    <InputFile>
+        ?.productdatabin.i
+
+    <OutputFile>
+        $(OUTPUT_DIR)(+)${s_dir}(+)$(MODULE_NAME).productdatabin
+
+    <Command>
+        ProductDataFormatter $(OUTPUT_DIR)(+)${s_dir} $(OUTPUT_DIR)(+)${s_dir}(+)$(MODULE_NAME).productdatabin
+
+# MU_CHANGE END
+
 [Masm16-Code-File]
     <InputFile>
         ?.asm16, ?.Asm16, ?.ASM16, ?.s16, ?.S16

--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -22,6 +22,7 @@
 #      - Deprecate GCC48, GCC49 and GCC5.
 # 3.01 - Update toolchain for VS2022
 # 3.02 - Enable stack cookies for IA32, ARM, and AARCH64 builds for GCC and MSVC
+# 3.03 - Remove WHOLEARCHIVE as this breaks the build for VS2017/VS2019 (MU_CHANGE)
 #
 #!VERSION=3.02
 
@@ -467,7 +468,7 @@ NOOPT_VS2015x86_X64_DLINK_FLAGS    = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /OPT:REF
 *_VS2017_*_APP_FLAGS       = /nologo /E /TC
 *_VS2017_*_PP_FLAGS        = /nologo /E /TC /FIAutoGen.h
 *_VS2017_*_VFRPP_FLAGS     = /nologo /E /TC /DVFRCOMPILE /FI$(MODULE_NAME)StrDefs.h
-*_VS2017_*_DLINK2_FLAGS    = /WHOLEARCHIVE
+# *_VS2017_*_DLINK2_FLAGS    = /WHOLEARCHIVE # MU_CHANGE
 *_VS2017_*_ASM16_PATH      = DEF(VS2017_BIN_IA32)\ml.exe
 *_VS2017_*_DEPS_FLAGS      = DEF(MSFT_DEPS_FLAGS)
 ##################
@@ -608,7 +609,7 @@ NOOPT_VS2017_AARCH64_DLINK_FLAGS   = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /OPT:REF
 *_VS2019_*_APP_FLAGS       = /nologo /E /TC
 *_VS2019_*_PP_FLAGS        = /nologo /E /TC /FIAutoGen.h
 *_VS2019_*_VFRPP_FLAGS     = /nologo /E /TC /DVFRCOMPILE /FI$(MODULE_NAME)StrDefs.h
-*_VS2019_*_DLINK2_FLAGS    = /WHOLEARCHIVE
+# *_VS2019_*_DLINK2_FLAGS    = /WHOLEARCHIVE # MU_CHANGE
 *_VS2019_*_ASM16_PATH      = DEF(VS2019_BIN_IA32)\ml.exe
 *_VS2019_*_DEPS_FLAGS      = DEF(MSFT_DEPS_FLAGS)
 ##################
@@ -2314,7 +2315,7 @@ RELEASE_XCODE5_X64_CC_FLAGS   = -target x86_64-pc-win32-macho -c    -Os       -W
 #################
 # ASM 16 linker definitions
 #################
-*_*_*_ASMLINK_PATH                 = DEF(WINDDK_BIN16)\link16.exe
+*_*_*_ASMLINK_PATH                 = ENV(LINK_16_PREFIX)link16.exe # MU_CHANGE - change to prefix
 *_*_*_ASMLINK_FLAGS                = /nologo /tiny
 
 ##################

--- a/BaseTools/Source/Python/ProductDataFormatter/ProductDataFormatter.py
+++ b/BaseTools/Source/Python/ProductDataFormatter/ProductDataFormatter.py
@@ -1,0 +1,120 @@
+# @file
+#
+# Formats a collection of intermediate product data binary files
+# in a given directory into a single product binary file
+#
+# Copyright (C) Microsoft Corporation.
+#
+##
+
+import glob
+import io
+import os
+import struct
+from collections import namedtuple
+
+
+class ProductDataFormatter:
+    STRUCT_SIGNATURE = b"__SDSH__"
+    ITEM_SIGNATURE = b"_SDDATA_"
+    PRODUCT_ID = b"__MSFT__"
+
+    def __init__(self, directory_path):
+        if not os.path.isdir(directory_path):
+            raise NotADirectoryError(
+                f"{directory_path} is an invalid directory!")
+
+        self._directory_path = directory_path
+
+    def _get_bins(self):
+        return glob.glob(os.path.join(
+            self._directory_path, '*.productdatabin.i'))
+
+    def _get_signed_item(self, file_path):
+        with open(file_path, 'rb') as bin_file:
+            bin_data = bytearray(bin_file.read())
+
+        signed_item_pos = 0
+        while True:
+            signed_item_pos = bin_data.find(
+                self.ITEM_SIGNATURE, signed_item_pos)
+
+            if signed_item_pos == -1:
+                return
+
+            ItemHeader = namedtuple('ItemHeader', 'sig header_len id len')
+
+            item_header = ItemHeader._make(struct.unpack_from(
+                '<QHHI', bin_data, signed_item_pos))
+
+            print(f"Signed data item found")
+            print(f"  Item ID: {item_header.id}")
+            print(f"  Item Length: {item_header.len} bytes")
+
+            signed_item = bin_data[signed_item_pos:signed_item_pos +
+                                   item_header.header_len + item_header.len]
+
+            yield signed_item
+            signed_item_pos += (item_header.header_len + item_header.len)
+
+    def _get_signed_structure(self):
+        signed_items = [i for b in self._get_bins() for i in
+                        self._get_signed_item(b)]
+
+        StructureHeader = namedtuple('StructureHeader',
+                                     'sig rev header_len product_id desc_count')
+
+        struct_header = StructureHeader(
+                        self.STRUCT_SIGNATURE,
+                        1,
+                        26,
+                        self.PRODUCT_ID,
+                        len(signed_items))
+
+        struct_header_data = struct.pack('<8sHI8sI', *struct_header)
+
+        with io.BytesIO() as out_buffer:
+            out_buffer.write(struct_header_data)
+            for item in signed_items:
+                # Note: Just keep things packed tight for now
+                # aligned_boundary = (((~out_buffer.tell()) + 1) &
+                #                     self.ITEM_ALIGNMENT - 1)
+                # out_buffer.seek(out_buffer.tell() + aligned_boundary)
+                out_buffer.write(item)
+            return out_buffer.getvalue()
+
+    def get_file_data(self):
+        return {f: list(self._get_signed_item(f)) for f in self._get_bins()}
+
+    def write_data(self, out_file_path):
+        with open(out_file_path, 'wb') as out_bin_file:
+            out_bin_file.write(self._get_signed_structure())
+
+    def remove_intermediate_files(self):
+        for binary in self._get_bins():
+            try:
+                os.remove(binary)
+            except OSError as e:
+                print(e)
+                print(f"File path could not be removed.")
+
+
+# Todo: Clean up arg parsing, documentation, logger, etc.
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description=(
+            'Formats intermediate product data files into '
+            'a single consolidated binary.'))
+    parser.add_argument(
+        'input_directory',
+        help='Directory of .productdatabin.i files')
+    parser.add_argument(
+        'output_file_path',
+        help='Name of of the final .productdatabin file.')
+    args = parser.parse_args()
+
+    product_data = ProductDataFormatter(args.input_directory)
+    product_data.write_data(args.output_file_path)
+    product_data.remove_intermediate_files()


### PR DESCRIPTION
## Description
The following commits from 202311 are linked here:
d188c8d
7a6a30a6
86dfe9b6

The changes are listed below:

---

Added versioning to the buildrule_template.

---

Added the OemDataFormatter to basetools.  This includes the name change to ProductDataFormatter.


- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

CI

## Integration Instructions

N/A