### PR TITLE
 IndustryStandard\IpmiNetFnSensorEvent.h: Added SetSensorThreshold and GetSensorThreshold commands [Rebase & FF]

### DIFF
--- a/MdePkg/Include/IndustryStandard/IpmiNetFnSensorEvent.h
+++ b/MdePkg/Include/IndustryStandard/IpmiNetFnSensorEvent.h
@@ -10,6 +10,7 @@
   and Appendix H, Sub-function Assignments.
 
   Copyright (c) 1999 - 2015, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) Microsoft Corporation.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -41,6 +42,51 @@ typedef struct {
   UINT8    OEMEvData2;
   UINT8    OEMEvData3;
 } IPMI_PLATFORM_EVENT_MESSAGE_DATA_REQUEST;
+
+//
+// Definitions for Set Sensor Thresholds command
+//
+#define IPMI_SENSOR_SET_SENSOR_THRESHOLDS  0x26
+
+typedef union {
+  struct _SENSOR_BITS {
+    UINT8    LowerNonCriticalThreshold    : 1;
+    UINT8    LowerCriticalThreshold       : 1;
+    UINT8    LowerNonRecoverableThreshold : 1;
+    UINT8    UpperNonCriticalThreshold    : 1;
+    UINT8    UpperCriticalThreshold       : 1;
+    UINT8    UpperNonRecoverableThreshold : 1;
+    UINT8    Reserved                     : 2;
+  } Bits;
+  UINT8    Uint8;
+} SENSOR_BITS;
+
+typedef struct _IPMI_SENSOR_SET_SENSOR_THRESHOLD_REQUEST_DATA {
+  UINT8          SensorNumber;
+  SENSOR_BITS    SetBitEnable;
+  UINT8          LowerNonCriticalThreshold;
+  UINT8          LowerCriticalThreshold;
+  UINT8          LowerNonRecoverableThreshold;
+  UINT8          UpperNonCriticalThreshold;
+  UINT8          UpperCriticalThreshold;
+  UINT8          UpperNonRecoverableThreshold;
+} IPMI_SENSOR_SET_SENSOR_THRESHOLD_REQUEST_DATA;
+
+//
+// Definitions for Get Sensor Thresholds command
+//
+#define IPMI_SENSOR_GET_SENSOR_THRESHOLDS  0x27
+
+typedef struct _IPMI_SENSOR_GET_SENSOR_THRESHOLD_RESPONSE_DATA {
+  UINT8          CompletionCode;
+  SENSOR_BITS    GetBitEnable;
+  UINT8          LowerNonCriticalThreshold;
+  UINT8          LowerCriticalThreshold;
+  UINT8          LowerNonRecoverableThreshold;
+  UINT8          UpperNonCriticalThreshold;
+  UINT8          UpperCriticalThreshold;
+  UINT8          UpperNonRecoverableThreshold;
+} IPMI_SENSOR_GET_SENSOR_THRESHOLD_RESPONSE_DATA;
 
 #pragma pack()
 #endif


### PR DESCRIPTION
## Description

Cherry-picked from edk2: https://github.com/tianocore/edk2/commit/e2e09d8512898709a3d076fdd36c8abee2734027

[The Ipmi Specification](https://www.intel.com/content/www/us/en/products/docs/servers/ipmi/ipmi-second-gen-interface-spec-v2-rev1-1.html) contains a lot of commands and structures that are not widely used in firmware.

PR to add the Set Sensor Thresholds and Get Sensor Thresholds commands, and their associated structure definitions.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

These are just command and structure definitions. 

## Integration Instructions

N/A