### PR TITLE
Add extra RestoreTpl() call in DiskIo and StartImage() to maintain TPL raise/restore symmetry [Rebase & FF]

### DIFF
--- a/MdeModulePkg/Core/Dxe/Image/Image.c
+++ b/MdeModulePkg/Core/Dxe/Image/Image.c
@@ -1725,7 +1725,10 @@ CoreStartImage (
   // Image has completed.  Verify the tpl is the same
   //
   ASSERT (Image->Tpl == gEfiCurrentTpl);
-  CoreRestoreTpl (Image->Tpl);
+  // MU_CHANGE - reduce TPL restore
+  if (Image->Tpl != gEfiCurrentTpl) {
+    CoreRestoreTpl (Image->Tpl);
+  } // MU_CHANGE - reduce TPL restore
 
   CoreFreePool (Image->JumpBuffer);
 

--- a/MdeModulePkg/Universal/Disk/DiskIoDxe/DiskIo.c
+++ b/MdeModulePkg/Universal/Disk/DiskIoDxe/DiskIo.c
@@ -847,6 +847,7 @@ DiskIo2ReadWriteDisk (
   DISK_IO_SUBTASK         *Subtask;
   DISK_IO2_TASK           *Task;
   EFI_TPL                 OldTpl;
+  EFI_TPL                 OldTpl1; // MU_CHANGE - TPL Symmetry
   BOOLEAN                 Blocking;
   BOOLEAN                 SubtaskBlocking;
   LIST_ENTRY              *SubtasksPtr;
@@ -977,7 +978,7 @@ DiskIo2ReadWriteDisk (
     }
   }
 
-  gBS->RaiseTPL (TPL_NOTIFY);
+  OldTpl1 = gBS->RaiseTPL (TPL_NOTIFY); // MU_CHANGE - TPL symmetry
 
   //
   // Remove all the remaining subtasks when failure.
@@ -1012,6 +1013,7 @@ DiskIo2ReadWriteDisk (
     FreePool (Task);
   }
 
+  gBS->RestoreTPL (OldTpl1); // MU_CHANGE TPL Symmetry
   gBS->RestoreTPL (OldTpl);
 
   return Status;


### PR DESCRIPTION
## Description

Adds a call to RestoreTpl() in DiskIo2ReadWriteDisk(). While the current implementation does not technically violate spec on raise/restore TPL, this extra call ensures symmetry between RaiseTpl and RestoreTpl calls, which makes analysis of TPL correctness simpler and permits certain non-standard TPL usages that some platforms require.

Comments out a redundant call to RestoreTpl(). While this does not technically violate spec on raise/restore TPL, TPL should already be at the specified level. This extra call introduces an asymmetry between RaiseTpl and RestoreTpl calls, which makes analysis of TPL correctness more difficult and hampers certain non-standard TPL usages that some platforms require.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Booted and observed no un-intended side effects w.r.t. TPL with this modification. Added test instrumentation to verify that TPL is always already at the desired state prior to this call being executed.

## Integration Instructions

N/A