### PR TITLE
Enable Data Terminal Ready and Request to Send at the end of a Serial

### DIFF
--- a/MdeModulePkg/Universal/Console/TerminalDxe/TerminalConIn.c
+++ b/MdeModulePkg/Universal/Console/TerminalDxe/TerminalConIn.c
@@ -95,6 +95,14 @@ TerminalConInReset (
       );
   }
 
+  // MU_CHANGE [BEGIN] - Ensure serial device is ready to receive data
+  // by setting data terminal ready and request to send
+  if (!EFI_ERROR (Status)) {
+    Status = TerminalDevice->SerialIo->SetControl (TerminalDevice->SerialIo, EFI_SERIAL_DATA_TERMINAL_READY|EFI_SERIAL_REQUEST_TO_SEND);
+  }
+
+  // MU_CHANGE [END]
+
   return Status;
 }
 


### PR DESCRIPTION
## Description

When a Serial device reset, the Modem Control Register Data Terminal Ready and Request to Send need to be cleared also. Otherwise the registers will be left in their previous state, and the connected device will not be able to transmit data.

A particular device was not able to receive data after a SerialReset call because the Dtrc and Rts bits were left in their previous states.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested using a 16550 "compatible" pci serial device and verified that remote keys over serial work correctly

## Integration Instructions

N/A