### PR TITLE
Add a PCD to allow the AP wakeup buffer to be reserved

### DIFF
--- a/UefiCpuPkg/Library/MpInitLib/DxeMpInitLib.inf
+++ b/UefiCpuPkg/Library/MpInitLib/DxeMpInitLib.inf
@@ -100,3 +100,4 @@
   gUefiCpuPkgTokenSpaceGuid.PcdGhcbHypervisorFeatures                  ## CONSUMES
   gUefiCpuPkgTokenSpaceGuid.PcdSevEsWorkAreaBase                       ## SOMETIMES_CONSUMES
   gUefiCpuPkgTokenSpaceGuid.PcdFirstTimeWakeUpAPsBySipi                ## CONSUMES
+  gUefiCpuPkgTokenSpaceGuid.PcdCpuApWakeupBufferReserved               ## CONSUMES MU_CHANGE

--- a/UefiCpuPkg/Library/MpInitLib/DxeMpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/DxeMpLib.c
@@ -166,8 +166,12 @@ GetWakeupBuffer (
   EFI_PHYSICAL_ADDRESS  StartAddress;
   EFI_MEMORY_TYPE       MemoryType;
 
-  if (ConfidentialComputingGuestHas (CCAttrAmdSevEs) &&
-      !ConfidentialComputingGuestHas (CCAttrAmdSevSnp))
+  // MU_CHANGE START Add PCD to make wakeup buffer reserved
+  if (PcdGetBool (PcdCpuApWakeupBufferReserved)) {
+    MemoryType = EfiReservedMemoryType;
+    // MU_CHANGE END
+  } else if (ConfidentialComputingGuestHas (CCAttrAmdSevEs) &&
+             !ConfidentialComputingGuestHas (CCAttrAmdSevSnp))
   {
     //
     // An SEV-ES-only guest requires the memory to be reserved. SEV-SNP, which

--- a/UefiCpuPkg/UefiCpuPkg.dec
+++ b/UefiCpuPkg/UefiCpuPkg.dec
@@ -418,6 +418,13 @@
   #  FASLE - Performance collecting will be disabled in processor trace.<BR>
   # @Prompt Enable performance collecting when processor trace is enabled.
   gUefiCpuPkgTokenSpaceGuid.PcdCpuProcTracePerformanceCollecting|FALSE|BOOLEAN|0x60000020
+  
+  # MU_CHANGE START Add PCD to make wakeup buffer reserved
+  ## Specifies that the wake-up buffer for AP startup should be permanently
+  # allocated as reserved.
+  # @Prompt Allocates CPU wake-up buffer as reserved.
+  gUefiCpuPkgTokenSpaceGuid.PcdCpuApWakeupBufferReserved|FALSE|BOOLEAN|0x0000001F
+  # MU_CHANGE END
 
 [PcdsFixedAtBuild.X64, PcdsPatchableInModule.X64, PcdsDynamic.X64, PcdsDynamicEx.X64]
   ## Indicate access to non-SMRAM memory is restricted to reserved, runtime and ACPI NVS type after SmmReadyToLock.


### PR DESCRIPTION
## Description

Creates a new PCD which when set will cause the AP wakeup buffer to be allocated as a reserved type.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on custom Q35 image

## Integration Instructions

N/A
