### PR TITLE
Improve log messages for DependencyCheck, UncrustifyCheck, and SpellCheck

### DIFF
--- a/.pytool/Plugin/DependencyCheck/DependencyCheck.py
+++ b/.pytool/Plugin/DependencyCheck/DependencyCheck.py
@@ -108,11 +108,9 @@ class DependencyCheck(ICiBuildPlugin):
                     if mod_specific_key in pkgconfig and p in pkgconfig[mod_specific_key]:
                         continue
 
-                    # MU_CHANGE [BEGIN] - Provide more DependencyCheck error info
                     logging.error(f"Dependency Check: {file} depends on pkg {p} but pkg is not listed in AcceptableDependencies")
                     tc.LogStdError(f"Dependency Check: {file} depends on pkg {p} but pkg is not listed in AcceptableDependencies")
                     overall_status += 1
-                    # MU_CHANGE [END] - Provide more DependencyCheck error info
 
         # If XML object exists, add results
         if overall_status != 0:


### PR DESCRIPTION
## Description

Improve CI log output with more actionable messages, and downgraded some errors/warnings that should not be treated as such.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Checked CI plugin results.

## Integration Instructions

N/A
