### PR TITLE
Create memory bin override library to allow for more extensive platform customization

### DIFF
--- a/MdeModulePkg/Core/Dxe/DxeMain.inf
+++ b/MdeModulePkg/Core/Dxe/DxeMain.inf
@@ -95,6 +95,7 @@
   CpuExceptionHandlerLib
   PcdLib
   ImagePropertiesRecordLib
+  MemoryBinOverrideLib      ## MU_CHANGE
 
 [Guids]
   gEfiEventMemoryMapChangeGuid                  ## PRODUCES             ## Event

--- a/MdeModulePkg/Core/Dxe/Mem/Page.c
+++ b/MdeModulePkg/Core/Dxe/Mem/Page.c
@@ -10,6 +10,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include "Imem.h"
 #include "HeapGuard.h"
 #include <Pi/PiDxeCis.h>
+#include <Library/MemoryBinOverrideLib.h> // MU_CHANGE
 
 //
 // Entry for tracking the memory regions for each memory type to coalesce similar memory types
@@ -661,6 +662,7 @@ CoreAddMemoryDescriptor (
   EFI_STATUS            Status;
   UINTN                 Index;
   UINTN                 FreeIndex;
+  EFI_ALLOCATE_TYPE     AllocationType; // MU_CHANGE
 
   if ((Start & EFI_PAGE_MASK) != 0) {
     return;
@@ -710,16 +712,28 @@ CoreAddMemoryDescriptor (
     }
 
     if (gMemoryTypeInformation[Index].NumberOfPages != 0) {
+      // MU_CHANGE START Allow overriding of bin locations.
+      AllocationType = AllocateAnyPages;
+      GetMemoryBinOverride (
+        Type,
+        &mMemoryTypeStatistics[Type].BaseAddress,
+        &gMemoryTypeInformation[Index].NumberOfPages,
+        &AllocationType
+        );
+      // MU_CHANGE END
+
       //
       // Allocate pages for the current memory type from the top of available memory
       //
       Status = CoreAllocatePages (
-                 AllocateAnyPages,
+                 AllocationType, // MU_CHANGE
                  Type,
                  gMemoryTypeInformation[Index].NumberOfPages,
                  &mMemoryTypeStatistics[Type].BaseAddress
                  );
       if (EFI_ERROR (Status)) {
+        mMemoryTypeStatistics[Type].BaseAddress = 0; // MU_CHANGE
+
         //
         // If an error occurs allocating the pages for the current memory type, then
         // free all the pages allocates for the previous memory types and return.  This
@@ -786,6 +800,15 @@ CoreAddMemoryDescriptor (
       mMemoryTypeStatistics[Type].NumberOfPages   = gMemoryTypeInformation[Index].NumberOfPages;
       gMemoryTypeInformation[Index].NumberOfPages = 0;
     }
+
+    // MU_CHANGE START
+    ReportMemoryBinLocation (
+      Type,
+      mMemoryTypeStatistics[Type].BaseAddress,
+      mMemoryTypeStatistics[Type].NumberOfPages
+      );
+
+    // MU_CHANGE END
   }
 
   //

--- a/MdeModulePkg/Include/Library/MemoryBinOverrideLib.h
+++ b/MdeModulePkg/Include/Library/MemoryBinOverrideLib.h
@@ -1,0 +1,48 @@
+/** @file
+  Header definitions for the memory bin override library. This library allows
+  a platform to override the location or size of the memory type bins.
+
+  Copyright (c) Microsoft Corporation
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef MEMORY_BIN_OVERRIDE_LIB_H__
+#define MEMORY_BIN_OVERRIDE_LIB_H__
+
+/**
+  Reports a runtime memory bin location to the override library.
+
+  @param[in]  Type            The memory type for the reported bin.
+  @param[in]  BaseAddress     The base physical address of the reported bin.
+  @param[in]  NumberOfPages   The number of pages in the reported bin.
+**/
+VOID
+EFIAPI
+ReportMemoryBinLocation (
+  IN EFI_MEMORY_TYPE       Type,
+  IN EFI_PHYSICAL_ADDRESS  BaseAddress,
+  IN UINT64                NumberOfPages
+  );
+
+/**
+  Checks if the library needs to override the given memory bin allocation type,
+  location, and size. If this function encounters internal errors, the
+  parameters should remain unchanged.
+
+  @param[in]    Type            The memory type of the bin.
+  @param[out]   BaseAddress     The base address of the bin override on return.
+  @param[out]   NumberOfPages   The number of pages of the bin override on return.
+  @param[out]   AllocationType  The allocation type for the bin, AllocateAddress
+                                if an override was provided.
+**/
+VOID
+EFIAPI
+GetMemoryBinOverride (
+  IN EFI_MEMORY_TYPE        Type,
+  OUT EFI_PHYSICAL_ADDRESS  *BaseAddress,
+  OUT UINT32                *NumberOfPages,
+  OUT EFI_ALLOCATE_TYPE     *AllocationType
+  );
+
+#endif

--- a/MdeModulePkg/Library/MemoryBinOverrideLibNull/MemoryBinOverrideLibNull.c
+++ b/MdeModulePkg/Library/MemoryBinOverrideLibNull/MemoryBinOverrideLibNull.c
@@ -1,0 +1,52 @@
+/**
+  NULL implementation of the memory bin override lib.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+#include <Library/BaseLib.h>
+#include <Library/MemoryBinOverrideLib.h>
+
+/**
+  Reports a runtime memory bin location to the override library.
+
+  @param[in]  Type            The memory type for the reported bin.
+  @param[in]  BaseAddress     The base physical address of the reported bin.
+  @param[in]  NumberOfPages   The number of pages in the reported bin.
+**/
+VOID
+EFIAPI
+ReportMemoryBinLocation (
+  IN EFI_MEMORY_TYPE       Type,
+  IN EFI_PHYSICAL_ADDRESS  BaseAddress,
+  IN UINT64                NumberOfPages
+  )
+{
+  return;
+}
+
+/**
+  Checks if the library needs to override the given memory bin allocation type,
+  location, and size. If this function encounters internal errors, the
+  parameters should remain unchanged.
+
+  @param[in]    Type            The memory type of the bin.
+  @param[out]   BaseAddress     The base address of the bin override on return.
+  @param[out]   NumberOfPages   The number of pages of the bin override on return.
+  @param[out]   AllocationType  The allocation type for the bin, AllocateAddress
+                                if an override was provided.
+**/
+VOID
+EFIAPI
+GetMemoryBinOverride (
+  IN EFI_MEMORY_TYPE        Type,
+  OUT EFI_PHYSICAL_ADDRESS  *BaseAddress,
+  OUT UINT32                *NumberOfPages,
+  OUT EFI_ALLOCATE_TYPE     *AllocationType
+  )
+{
+  return;
+}

--- a/MdeModulePkg/Library/MemoryBinOverrideLibNull/MemoryBinOverrideLibNull.inf
+++ b/MdeModulePkg/Library/MemoryBinOverrideLibNull/MemoryBinOverrideLibNull.inf
@@ -1,0 +1,31 @@
+## @file
+# NULL implementation of the memory bin override lib.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 1.27
+  BASE_NAME                      = MemoryOverrideLibNull
+  FILE_GUID                      = 368687CE-3189-4C26-A6EB-615B64CAA911
+  MODULE_TYPE                    = DXE_CORE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = MemoryBinOverrideLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 AARCH64
+#
+
+[Sources]
+  MemoryBinOverrideLibNull.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[LibraryClasses]
+  BaseLib

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -184,6 +184,12 @@
   ##                across a reboot.
   MemoryTypeInformationChangeLib|Include/Library/MemoryTypeInformationChangeLib.h
 
+  # MU_CHANGE - Add MemoryBinOverrideLib to MdeModulePkg
+  ## @libraryclass Provides a way to override memory bin locations and sizes
+  #                dynamically.
+  #
+  MemoryBinOverrideLib|Include/Library/MemoryBinOverrideLib.h
+
 [Guids]
   ## MdeModule package token space guid
   # Include/Guid/MdeModulePkgTokenSpace.h
@@ -431,7 +437,7 @@
 
   ## Include/Guid/EndofS3Resume.h
   gEdkiiEndOfS3ResumeGuid = { 0x96f5296d, 0x05f7, 0x4f3c, {0x84, 0x67, 0xe4, 0x56, 0x89, 0x0e, 0x0c, 0xb5 } }
-  
+
 ## MU_CHANGE BEGIN
   ## Advanced Logger Variable Guid. This variable guid is used to access the log data via GetVariable.
   #

--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -134,6 +134,7 @@
   HobLib|MdePkg/Library/DxeCoreHobLib/DxeCoreHobLib.inf
   MemoryAllocationLib|MdeModulePkg/Library/DxeCoreMemoryAllocationLib/DxeCoreMemoryAllocationLib.inf
   ExtractGuidedSectionLib|MdePkg/Library/DxeExtractGuidedSectionLib/DxeExtractGuidedSectionLib.inf
+  MemoryBinOverrideLib|MdeModulePkg/Library/MemoryBinOverrideLibNull/MemoryBinOverrideLibNull.inf  # MU_CHANGE
 
 [LibraryClasses.common.DXE_DRIVER]
   HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
@@ -472,6 +473,7 @@
   MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.inf
   MdeModulePkg/Library/DxeCapsuleLibFmp/DxeRuntimeCapsuleLib.inf
   MdeModulePkg/Library/BaseVariableFlashInfoLib/BaseVariableFlashInfoLib.inf
+  MdeModulePkg/Library/MemoryBinOverrideLibNull/MemoryBinOverrideLibNull.inf  # MU_CHANGE
 
 # MU_CHANGE START
 !if $(TOOLCHAIN) != VS2017 and $(TOOLCHAIN) != VS2019


### PR DESCRIPTION
## Description

Adds a memory bin override library that allows a platform to customize logic around memory bin locations in DXE.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [x] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on the Q35 platform with a custom memory bin override library

## Integration Instructions

Add the new NULL version of the library to the platform DSC file
```
MemoryBinOverrideLib|MdeModulePkg/Library/MemoryBinOverrideLibNull/MemoryBinOverrideLibNull.inf
```