### PR TITLE
UefiBootManagerLib: Update assert condition in BmFindBootOptionInVariable

### DIFF
--- a/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
@@ -147,6 +147,14 @@ BmFindBootOptionInVariable (
   if (OptionNumber == LoadOptionNumberUnassigned) {
     BootOptions = EfiBootManagerGetLoadOptions (&BootOptionCount, LoadOptionTypeBoot);
 
+    // MU_CHANGE [BEGIN] - Only assert if BootOptionCount is non-zero
+    if ((BootOptions == NULL) && (BootOptionCount > 0)) {
+      ASSERT (BootOptions != NULL);
+      return LoadOptionNumberUnassigned;
+    }
+
+    // MU_CHANGE [END] - Only assert if BootOptionCount is non-zero
+
     Index = EfiBootManagerFindLoadOption (OptionToFind, BootOptions, BootOptionCount);
     if (Index != -1) {
       OptionNumber = BootOptions[Index].OptionNumber;


### PR DESCRIPTION
## Description

Currently the following assertion is made in
`BmFindBootOptionInVariable()`:

```c
  if (OptionNumber == LoadOptionNumberUnassigned) {
    BootOptions = EfiBootManagerGetLoadOptions (&BootOptionCount, LoadOptionTypeBoot);

    if (BootOptions == NULL) {
      ASSERT (BootOptions != NULL);
      return LoadOptionNumberUnassigned;
    }

    Index = EfiBootManagerFindLoadOption (OptionToFind, BootOptions, BootOptionCount);
```

The reason behind this is to prevent passing a null pointer to `EfiBootManagerFindLoadOption()`.

However, `EfiBootManagerFindLoadOption()` accepts a null pointer argument to be passed as the second argument ('Array') as long as the `Count` argument is `0`.

In that case `LoadOptionNumberUnassigned` will still be returned from the function but an assert is not necessary.

This change updates the condition to only assert if the pointer is null and the boot option count is non-zero.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Verified build and boot on Qemu35Pkg.

## Integration Instructions

N/A
