### PR TITLE
Added missing function definition in SecPeiCpuExceptionMu

### DIFF
--- a/MdeModulePkg/Include/Library/ExceptionPersistenceLib.h
+++ b/MdeModulePkg/Include/Library/ExceptionPersistenceLib.h
@@ -1,0 +1,130 @@
+/**@file ExceptionPersistenceLib.h
+
+Library enables passing exception information between boots via the platform-specific early store.
+
+Copyright (c) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef EX_PERSIST_LIB_H_
+#define EX_PERSIST_LIB_H_
+
+typedef enum {
+  ExceptionPersistNone,
+  ExceptionPersistPageFault,
+  ExceptionPersistStackCookie,
+  ExceptionPersistOther,
+  ExceptionPersistMax
+} EXCEPTION_TYPE;
+
+/**
+  Check if an exception was hit on a previous boot.
+
+  @param[out]  Exception          EXCEPTION_TYPE in persistent storage
+                                  NOTE: Exception IS NOT updated if the function returns an error
+
+  @retval EFI_SUCCESS             Exception contains the result of the check
+  @retval EFI_INVALID_PARAMETER   Unable to validate persistent storage contents or Exception is NULL
+  @retval EFI_UNSUPPORTED         Platform-specific persistent storage is unresponsive or NULL implementation called
+  @retval EFI_DEVICE_ERROR        Can't write/read platform-specific persistent storage
+**/
+EFI_STATUS
+EFIAPI
+ExPersistGetException (
+  OUT   EXCEPTION_TYPE  *Exception
+  );
+
+/**
+  Write input EXCEPTION_TYPE to platform-specific persistent storage.
+
+  @param[in]  Exception   EXCEPTION_TYPE to set in persistent storage
+                          NOTE: ExceptionPersistNone has the same effect as ExPersistClearExceptions()
+
+  @retval EFI_SUCCESS             Value set
+  @retval EFI_UNSUPPORTED         NULL implementation called
+  @retval EFI_INVALID_PARAMETER   Platform-specific persistent storage contents are invalid or
+                                  input EXCEPTION_TYPE is invalid
+  @retval EFI_DEVICE_ERROR        Can't write/read platform-specific persistent storage
+**/
+EFI_STATUS
+EFIAPI
+ExPersistSetException (
+  IN  EXCEPTION_TYPE  Exception
+  );
+
+/**
+  Clears from the platform-specific persistent storage of all exception info.
+
+  @retval EFI_SUCCESS       Value cleared
+  @retval EFI_UNSUPPORTED   Platform-specific persistent storage contents are invalid or NULL implementation called
+  @retval EFI_DEVICE_ERROR  Can't write/read platform-specific persistent storage
+**/
+EFI_STATUS
+EFIAPI
+ExPersistClearExceptions (
+  VOID
+  );
+
+/**
+  Checks if the next page fault should be ignored and cleared. Using platform-specific persistent storage
+  is a means for communicating to the exception handler that the page fault was intentional. Resuming execution
+  requires faulting pages to have their attributes cleared so execution can continue.
+
+  @param[out]  IgnoreNextPageFault  Boolean TRUE if next page fault should be ignored, FALSE otherwise.
+                                    Persistent storage IS NOT updated if the function returns an error.
+
+  @retval EFI_SUCCESS             IgnoreNextPageFault contains the result of the check
+  @retval EFI_INVALID_PARAMETER   Unable to validate persistent storage contents
+  @retval EFI_UNSUPPORTED         Platform-specific persistent storage is unresponsive or NULL implementation called
+  @retval EFI_DEVICE_ERROR        Can't write/read platform-specific persistent storage
+**/
+EFI_STATUS
+EFIAPI
+ExPersistGetIgnoreNextPageFault (
+  OUT BOOLEAN  *IgnoreNextPageFault
+  );
+
+/**
+  Updates the platform-specific persistent storage to indicate that the next page fault should be ignored and cleared.
+  Using platform-specific persistent storage is a means for communicating to the exception handler that the
+  page fault was intentional. Resuming execution requires faulting pages to have their attributes cleared so
+  execution can continue.
+
+  @retval EFI_SUCCESS       Value set
+  @retval EFI_UNSUPPORTED   Platform-specific persistent storage is unresponsive or NULL implementation called
+  @retval EFI_DEVICE_ERROR  Can't write/read platform-specific persistent storage
+**/
+EFI_STATUS
+EFIAPI
+ExPersistSetIgnoreNextPageFault (
+  VOID
+  );
+
+/**
+  Clears from the platform-specific persistent storage the value indicating that the
+  next page fault should be ignored.
+
+  @retval EFI_SUCCESS       Value cleared
+  @retval EFI_UNSUPPORTED   Platform-specific persistent storage is unresponsive or NULL implementation called
+  @retval EFI_DEVICE_ERROR  Can't write/read platform-specific persistent storage
+**/
+EFI_STATUS
+EFIAPI
+ExPersistClearIgnoreNextPageFault (
+  VOID
+  );
+
+/**
+  Clears all values from the platform-specific persistent storage.
+
+  @retval EFI_SUCCESS       Successfully cleared the exception bytes
+  @retval EFI_UNSUPPORTED   Platform-specific persistent storage is unresponsive or NULL implementation called
+  @retval EFI_DEVICE_ERROR  Can't write/read platform-specific persistent storage
+**/
+EFI_STATUS
+EFIAPI
+ExPersistClearAll (
+  VOID
+  );
+
+#endif

--- a/MdeModulePkg/Library/BaseExceptionPersistenceLibNull/BaseExceptionPersistenceLibNull.c
+++ b/MdeModulePkg/Library/BaseExceptionPersistenceLibNull/BaseExceptionPersistenceLibNull.c
@@ -1,0 +1,142 @@
+/**@file BaseExceptionPersistenceLibNull.c
+
+NULL Implementation of ExceptionPersistenceLib
+
+Copyright (c) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Uefi.h>
+
+#include <Library/ExceptionPersistenceLib.h>
+
+/**
+  Check if an exception was hit on a previous boot.
+
+  @param[out]  Exception          EXCEPTION_TYPE in persistent storage
+                                  NOTE: Exception IS NOT updated if the function returns an error.
+
+  @retval EFI_SUCCESS             Exception contains the result of the check
+  @retval EFI_INVALID_PARAMETER   Unable to validate persistent storage contents or Exception is NULL
+  @retval EFI_UNSUPPORTED         Platform-specific persistent storage is unresponsive or NULL implementation called
+  @retval EFI_DEVICE_ERROR        Can't write/read platform-specific persistent storage
+**/
+EFI_STATUS
+EFIAPI
+ExPersistGetException (
+  OUT   EXCEPTION_TYPE  *Exception
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Write input EXCEPTION_TYPE to platform-specific persistent storage.
+
+  @param[in]  Exception   EXCEPTION_TYPE to set in persistent storage
+                          NOTE: ExceptionPersistNone has the same effect as ExPersistClearExceptions()
+
+  @retval EFI_SUCCESS             Value set
+  @retval EFI_UNSUPPORTED         NULL implementation called
+  @retval EFI_INVALID_PARAMETER   Platform-specific persistent storage contents are invalid or
+                                  input EXCEPTION_TYPE is invalid
+  @retval EFI_DEVICE_ERROR        Can't write/read platform-specific persistent storage
+**/
+EFI_STATUS
+EFIAPI
+ExPersistSetException (
+  IN  EXCEPTION_TYPE  Exception
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Clears from the platform-specific persistent storage of all exception info.
+
+  @retval EFI_SUCCESS       Value cleared
+  @retval EFI_UNSUPPORTED   Platform-specific persistent storage contents are invalid or NULL implementation called
+  @retval EFI_DEVICE_ERROR  Can't write/read platform-specific persistent storage
+**/
+EFI_STATUS
+EFIAPI
+ExPersistClearExceptions (
+  VOID
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Checks if the next page fault should be ignored and cleared. Using platform-specific persistent storage
+  is a means for communicating to the exception handler that the page fault was intentional. Resuming execution
+  requires faulting pages to have their attributes cleared so execution can continue.
+
+  @param[out]  IgnoreNextPageFault  Boolean TRUE if next page fault should be ignored, FALSE otherwise.
+                                    Persistent storage IS NOT updated if the function returns an error.
+
+  @retval EFI_SUCCESS             IgnoreNextPageFault contains the result of the check
+  @retval EFI_INVALID_PARAMETER   Unable to validate persistent storage contents
+  @retval EFI_UNSUPPORTED         Platform-specific persistent storage is unresponsive or NULL implementation called
+  @retval EFI_DEVICE_ERROR        Can't write/read platform-specific persistent storage
+**/
+EFI_STATUS
+EFIAPI
+ExPersistGetIgnoreNextPageFault (
+  OUT BOOLEAN  *IgnoreNextPageFault
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Updates the platform-specific persistent storage to indicate that the next page fault should be ignored and cleared.
+  Using platform-specific persistent storage is a means for communicating to the exception handler that the
+  page fault was intentional. Resuming execution requires faulting pages to have their attributes cleared
+  so execution can continue.
+
+  @retval EFI_SUCCESS       Value set
+  @retval EFI_UNSUPPORTED   Platform-specific persistent storage is unresponsive or NULL implementation called
+  @retval EFI_DEVICE_ERROR  Can't write/read platform-specific persistent storage
+**/
+EFI_STATUS
+EFIAPI
+ExPersistSetIgnoreNextPageFault (
+  VOID
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Clears from the platform-specific persistent storage the value indicating that the
+  next page fault should be ignored.
+
+  @retval EFI_SUCCESS       Value cleared
+  @retval EFI_UNSUPPORTED   Platform-specific persistent storage is unresponsive or NULL implementation called
+  @retval EFI_DEVICE_ERROR  Can't write/read platform-specific persistent storage
+**/
+EFI_STATUS
+EFIAPI
+ExPersistClearIgnoreNextPageFault (
+  VOID
+  )
+{
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Clears all values from the platform-specific persistent storage.
+
+  @retval EFI_SUCCESS       Successfully cleared the exception bytes
+  @retval EFI_UNSUPPORTED   Platform-specific persistent storage is unresponsive or NULL implementation called
+  @retval EFI_DEVICE_ERROR  Can't write/read platform-specific persistent storage
+**/
+EFI_STATUS
+EFIAPI
+ExPersistClearAll (
+  VOID
+  )
+{
+  return EFI_UNSUPPORTED;
+}

--- a/MdeModulePkg/Library/BaseExceptionPersistenceLibNull/BaseExceptionPersistenceLibNull.inf
+++ b/MdeModulePkg/Library/BaseExceptionPersistenceLibNull/BaseExceptionPersistenceLibNull.inf
@@ -1,0 +1,26 @@
+## @file BaseExceptionPersistenceLibNull.inf
+#
+# NULL implementation of ExceptionPersistenceLib
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = BaseExceptionPersistenceLibNull
+  FILE_GUID                      = adefa38d-ea8c-4418-beb5-ff9e13ea2260
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = ExceptionPersistenceLib
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  BaseExceptionPersistenceLibNull.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -205,6 +205,12 @@
   #
   PcdDatabaseLoaderLib|Include/Library/PcdDatabaseLoaderLib.h
 
+  # MU_CHANGE - Add ExceptionPersistenceLib to MdeModulePkg
+  ## @libraryclass Provides a way to turn off exceptions if an exception related to memory
+  ##               protection is tripped
+  #
+  ExceptionPersistenceLib|Include/Library/ExceptionPersistenceLib.h
+
 [Guids]
   ## MdeModule package token space guid
   # Include/Guid/MdeModulePkgTokenSpace.h

--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -114,6 +114,7 @@
   IpmiCommandLib|MdeModulePkg/Library/BaseIpmiCommandLibNull/BaseIpmiCommandLibNull.inf
   SpiHcPlatformLib|MdeModulePkg/Library/BaseSpiHcPlatformLibNull/BaseSpiHcPlatformLibNull.inf
    MemoryTypeInfoSecVarCheckLib|MdeModulePkg/Library/MemoryTypeInfoSecVarCheckLib/MemoryTypeInfoSecVarCheckLib.inf     # MU_CHANGE TCBZ1086
+  ExceptionPersistenceLib|MdeModulePkg/Library/BaseExceptionPersistenceLibNull/BaseExceptionPersistenceLibNull.inf # MU_CHANGE
 
   AdvLoggerAccessLib|MdeModulePkg/Library/AdvLoggerAccessLibNull/AdvLoggerAccessLib.inf       ## MU_CHANGE
   PanicLib|MdePkg/Library/BasePanicLibNull/BasePanicLibNull.inf  # MU_CHANGE
@@ -238,6 +239,7 @@
   MdeModulePkg/Library/MemoryTypeInformationChangeLibNull/MemoryTypeInformationChangeLibNull.inf ## MU_CHANGE
   MdeModulePkg/Library/CapsulePersistLibNull/CapsulePersistLibNull.inf                           ## MU_CHANGE
   MdeModulePkg/Library/SecurityLockAuditDebugMessageLib/SecurityLockAuditDebugMessageLib.inf     ## MU_CHANGE
+  MdeModulePkg/Library/BaseExceptionPersistenceLibNull/BaseExceptionPersistenceLibNull.inf       ## MU_CHANGE
   MdeModulePkg/Library/SecurityLockAuditLibNull/SecurityLockAuditLibNull.inf                     ## MU_CHANGE
   MdeModulePkg/Library/UefiSortLib/UefiSortLib.inf
   MdeModulePkg/Logo/Logo.inf

--- a/UefiCpuPkg/Library/CpuExceptionHandlerLib/SecPeiCpuExceptionHandlerLib.inf
+++ b/UefiCpuPkg/Library/CpuExceptionHandlerLib/SecPeiCpuExceptionHandlerLib.inf
@@ -57,6 +57,8 @@
   PeCoffGetEntryPointLib
   PrintLib
   SerialPortLib
+  ExceptionPersistenceLib  # MU_CHANGE
+  ResetSystemLib           # MU_CHANGE
 
 [LibraryClasses.Ia32, LibraryClasses.X64]
   CcExitLib

--- a/UefiCpuPkg/UefiCpuPkg.dsc
+++ b/UefiCpuPkg/UefiCpuPkg.dsc
@@ -69,6 +69,8 @@
   UnitTestPersistenceLib|UnitTestFrameworkPkg/Library/UnitTestPersistenceLibNull/UnitTestPersistenceLibNull.inf
   UnitTestResultReportLib|UnitTestFrameworkPkg/Library/UnitTestResultReportLib/UnitTestResultReportLibDebugLib.inf
   PanicLib|MdePkg/Library/BasePanicLibNull/BasePanicLibNull.inf   # MU_CHANGE
+  ExceptionPersistenceLib|MdeModulePkg/Library/BaseExceptionPersistenceLibNull/BaseExceptionPersistenceLibNull.inf   # MU_CHANGE
+  ResetSystemLib|MdeModulePkg/Library/BaseResetSystemLibNull/BaseResetSystemLibNull.inf   # MU_CHANGE
 
 # MU_CHANGE [BEGIN] - Add HwResetSystemLib
 [LibraryClasses.X64, LibraryClasses.IA32]


### PR DESCRIPTION
## Description
Added ExceptionPersistanceLib and SecPeiCpuExceptionMu.  The following commits are included here:

98c1649
f54f81f3
b7ad337

The following are descriptions around these commits:

Added ExceptionPersistenceLib for early boot exceptions.

---

Added SecPeiCpuExceptionMu as a new CpuException library implementation.

---

Added missing function definition in SecPeiCpuExceptionMu that was added upstream but not included in our SecPeiCpuException implementation.

---

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Was able to successfully use the new SecPeiCpuExceptionMu library to record early exceptions.

## Integration Instructions

N/A.