### PR TITLE
Add code to block on AP execution if a task is in progress.

### DIFF
--- a/UefiCpuPkg/CpuMpPei/CpuMpPei.c
+++ b/UefiCpuPkg/CpuMpPei/CpuMpPei.c
@@ -290,10 +290,14 @@ PeiStartupThisAP (
   The execution is in non-blocking mode. The BSP continues executing immediately
   after starting the AP.
 
-  Caller is responsible for ensuring that the scheduled AP task is complete (via
-  caller-specific logic) before dispatching further tasks on the AP using this
-  or other routines in the API.
+  If an attempt is made to dispatch a blocking or non-blocking task on the AP
+  while it is running a non-blocking task, that dispatch will block until the
+  AP completes the current task.
 
+  No timeout is specified - failure of the AP to complete the task is fatal. If
+  the AP crashes or fails to return from Procedure, then the next attempt to
+  dispatch blocking or non-blocking tasks on the AP will hang waiting on the AP.
+  No attempt is made to reset or recover the AP in this state.
 
   @param[in] PeiServices          An indirect pointer to the PEI Services Table
                                   published by the PEI Foundation.

--- a/UefiCpuPkg/Library/MpInitLib/PeiMpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/PeiMpLib.c
@@ -409,11 +409,18 @@ CheckAndUpdateApsStatus (
       continue;
     }
 
-    Status = CheckThisAP (ProcessorNumber);
+    //
+    // Block until all CPUs are ready. This ensures that we don't attempt to dispatch
+    // tasks on CPUs that are executing a non-blocking task. NOTE: this implies
+    // that only one non-blocking AP dispatch may be outstanding at a time.
+    //
+    do {
+      Status = CheckThisAP (ProcessorNumber);
 
-    if (Status != EFI_NOT_READY) {
-      CpuMpData->CpuData[ProcessorNumber].WaitEvent = NULL;
-    }
+      if (Status != EFI_NOT_READY) {
+        CpuMpData->CpuData[ProcessorNumber].WaitEvent = NULL;
+      }
+    } while (Status == EFI_NOT_READY);
   }
 
   // MU_CHANGE - End Add basic support for non-blocking AP dispatch in PEI.


### PR DESCRIPTION
## Description

This adds a blocking loop to AP status check to ensure all APs are completed with any non-blocking tasks before allowing dispatch of new tasks.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested by dispatching a long-running non-blocking task, and then attempting to dispatch a second task. Prior to this change, second task would proceed with dispatch, interfering with the first task. With this change, the second task waits in CheckAndUpdateApsStatus() until the first task completes.

## Integration Instructions

N/A