### PR TITLE
MdePkg/Test: Create a host-based implementation of RngLib [Rebase & FF]

### DIFF
--- a/MdePkg/Test/Library/RngLibHostTestLfsr/RngLibHostTestLfsr.c
+++ b/MdePkg/Test/Library/RngLibHostTestLfsr/RngLibHostTestLfsr.c
@@ -1,0 +1,116 @@
+/** @file -- RngLibHostTestLfsr.c
+A minimal implementation of RngLib that supports host based testing
+with a simple LFSR:
+https://en.wikipedia.org/wiki/Linear-feedback_shift_register
+
+Copyright (c) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+#include <Library/RngLib.h>
+
+STATIC
+UINT16
+LfsrXorshift16 (
+  VOID
+  )
+{
+  static UINT16  Lfsr = 0xACE1;         /* Any nonzero start state will work. */
+
+  // 7,9,13 triplet from http://www.retroprogramming.com/2017/07/xorshift-pseudorandom-numbers-in-z80.html
+  Lfsr ^= Lfsr >> 7;
+  Lfsr ^= Lfsr << 9;
+  Lfsr ^= Lfsr >> 13;
+
+  return Lfsr;
+}
+
+/**
+  Generates a 16-bit random number.
+
+  @param[out] Rand     Buffer pointer to store the 16-bit random value.
+
+  @retval TRUE         Random number generated successfully.
+  @retval FALSE        Failed to generate the random number.
+
+**/
+BOOLEAN
+EFIAPI
+GetRandomNumber16 (
+  OUT     UINT16  *Rand
+  )
+{
+  *Rand = LfsrXorshift16 ();
+  return TRUE;
+}
+
+/**
+  Generates a 32-bit random number.
+
+  @param[out] Rand     Buffer pointer to store the 32-bit random value.
+
+  @retval TRUE         Random number generated successfully.
+  @retval FALSE        Failed to generate the random number.
+
+**/
+BOOLEAN
+EFIAPI
+GetRandomNumber32 (
+  OUT     UINT32  *Rand
+  )
+{
+  UINT16  *Marker;
+
+  Marker = (UINT16 *)Rand;
+  GetRandomNumber16 (&Marker[0]);
+  GetRandomNumber16 (&Marker[1]);
+  return TRUE;
+}
+
+/**
+  Generates a 64-bit random number.
+
+  @param[out] Rand     Buffer pointer to store the 64-bit random value.
+
+  @retval TRUE         Random number generated successfully.
+  @retval FALSE        Failed to generate the random number.
+
+**/
+BOOLEAN
+EFIAPI
+GetRandomNumber64 (
+  OUT     UINT64  *Rand
+  )
+{
+  UINT32  *Marker;
+
+  Marker = (UINT32 *)Rand;
+  GetRandomNumber32 (&Marker[0]);
+  GetRandomNumber32 (&Marker[1]);
+  return TRUE;
+}
+
+/**
+  Generates a 128-bit random number.
+
+  @param[out] Rand     Buffer pointer to store the 128-bit random value.
+
+  @retval TRUE         Random number generated successfully.
+  @retval FALSE        Failed to generate the random number.
+
+**/
+BOOLEAN
+EFIAPI
+GetRandomNumber128 (
+  OUT     UINT64  *Rand
+  )
+{
+  UINT64  *Marker;
+
+  Marker = (UINT64 *)Rand;
+  GetRandomNumber64 (&Marker[0]);
+  GetRandomNumber64 (&Marker[1]);
+  return TRUE;
+}

--- a/MdePkg/Test/Library/RngLibHostTestLfsr/RngLibHostTestLfsr.inf
+++ b/MdePkg/Test/Library/RngLibHostTestLfsr/RngLibHostTestLfsr.inf
@@ -1,0 +1,25 @@
+## @file
+# A minimal implementation of RngLib that supports host based testing
+# with a simple LFSR:
+# https://en.wikipedia.org/wiki/Linear-feedback_shift_register
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+
+[Defines]
+  INF_VERSION         = 0x00010017
+  BASE_NAME           = RngLibHostTestLfsr
+  FILE_GUID           = E96C1E06-1052-4967-9FF2-F3E07EE02D8B
+  VERSION_STRING      = 1.0
+  MODULE_TYPE         = HOST_APPLICATION
+  LIBRARY_CLASS       = RngLib|HOST_APPLICATION
+
+
+[Sources]
+  RngLibHostTestLfsr.c
+
+
+[Packages]
+  MdePkg/MdePkg.dec

--- a/MdePkg/Test/MdePkgHostTest.dsc
+++ b/MdePkg/Test/MdePkgHostTest.dsc
@@ -38,6 +38,7 @@
   MdePkg/Test/GoogleTest/Library/BaseLib/GoogleTestBaseLib.inf
   # MU_CHANGE [BEGIN]
   MdePkg/Test/Library/SynchronizationLibHostUnitTest/SynchronizationLibHostUnitTest.inf
+  MdePkg/Test/Library/RngLibHostTestLfsr/RngLibHostTestLfsr.inf
   # MU_CHANGE [END]
 
   #


### PR DESCRIPTION
## Description

A minimal implementation of RngLib that support host-based testing
with a simple Linear Feedback Shift Register (LFSR).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `release/202311` branch

## Integration Instructions

N/A