### PR TITLE
NetworkPkg/SnpDxe: Shutdown SnpDxe on BeforeExitBootServices Event. [Rebase & FF]

### DIFF
--- a/NetworkPkg/SnpDxe/Snp.c
+++ b/NetworkPkg/SnpDxe/Snp.c
@@ -32,6 +32,12 @@ SnpNotifyExitBootServices (
   //
   PxeShutdown (Snp);
   PxeStop (Snp);
+
+  // MU_CHANGE [BEGIN] - Shutdown SnpDxe in BeforeExitBootServices
+  // Since BeforeExitBootServices is run on each call, close event
+  // to prevent reentry.
+  gBS->CloseEvent (Event);
+  // MU_CHANGE [END]
 }
 
 /**
@@ -655,7 +661,7 @@ SimpleNetworkDriverStart (
                     TPL_CALLBACK,
                     SnpNotifyExitBootServices,
                     Snp,
-                    &gEfiEventExitBootServicesGuid,
+                    &gEfiEventBeforeExitBootServicesGuid,   // MU_CHANGE - Shutdown SnpDxe in BeforeExitBootServices
                     &Snp->ExitBootServicesEvent
                     );
     if (EFI_ERROR (Status)) {

--- a/NetworkPkg/SnpDxe/SnpDxe.inf
+++ b/NetworkPkg/SnpDxe/SnpDxe.inf
@@ -65,7 +65,10 @@
   NetLib
 
 [Guids]
-  gEfiEventExitBootServicesGuid                 ## SOMETIMES_CONSUMES ## Event
+# MU_CHANGE [BEGIN] - Shutdown SnpDxe in BeforeExitBootServices
+#  gEfiEventExitBootServicesGuid                 ## SOMETIMES_CONSUMES ## Event
+  gEfiEventBeforeExitBootServicesGuid           ## SOMETIMES_CONSUMES ## Event
+# MU_CHANGE [END]
 
 [Protocols]
   gEfiSimpleNetworkProtocolGuid                 ## BY_START


### PR DESCRIPTION
## Description

SnpDxe registers for an ExitBootServices callback and runs the
PXE_OPCODE_SHUTDOWN and PXE_OPCODE_STOP commands for any network
controllers that the driver is attached to. If the Bus Master Enable bit
is cleared by PciBusDxe before this point, then completions returned by
the network cards will be unreadable to their drivers during the
shutdown sequence.

Register the SnpDxe callback for gEfiEventBeforeExitBootServicesGuid instead
of gEfiEventExitBootServicesGuid to ensure the correct ordering:

1. ExitBootServices event
2. Network card shutdown sequence is completed
3. BME is disabled on PCI bridges (if configured)

Also, close the event to prevent rerunning the shutdown if multiple
ExitBootServices events need to be called by the OS.

Fixes https://github.com/microsoft/mu_basecore/issues/520

## Cherry-Pick the following commits:
[810c64776c](https://github.com/microsoft/mu_basecore/commit/810c64776c)


- [ X] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested
Tested on AARCH64 platform with dual network cards.

## Integration Instructions
N/A