### PR TITLE
[202405][Rebase&&FF] Firmware Performance

### DIFF
--- a/MdeModulePkg/Core/Dxe/Dispatcher/Dispatcher.c
+++ b/MdeModulePkg/Core/Dxe/Dispatcher/Dispatcher.c
@@ -27,6 +27,7 @@
   SOR   - Schedule On Request - Don't schedule if this bit is set.
 
 Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -414,6 +415,7 @@ CoreDispatcher (
     //
     // If the dispatcher is running don't let it be restarted.
     //
+    PERF_FUNCTION_END (); // MU_CHANGE
     return EFI_ALREADY_STARTED;
   }
 
@@ -428,6 +430,7 @@ CoreDispatcher (
              &DxeDispatchEvent
              );
   if (EFI_ERROR (Status)) {
+    PERF_FUNCTION_END (); // MU_CHANGE
     return Status;
   }
 

--- a/MdeModulePkg/Core/Dxe/Image/Image.c
+++ b/MdeModulePkg/Core/Dxe/Image/Image.c
@@ -2,6 +2,7 @@
   Core image handling services to load and unload PeImage.
 
 Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -1783,6 +1784,8 @@ CoreStartImage (
   // Save the Status because Image will get destroyed if it is unloaded.
   //
   Status = Image->Status;
+
+  // PERF_ENTRYPOINT_END (Handle); // MU_CHANGE
 
   //
   // If the image returned an error, or if the image is an application

--- a/MdeModulePkg/Core/Pei/PeiMain.h
+++ b/MdeModulePkg/Core/Pei/PeiMain.h
@@ -2,6 +2,7 @@
   Definition of Pei Core Structures and Services
 
 Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/

--- a/MdeModulePkg/Core/Pei/PeiMain.inf
+++ b/MdeModulePkg/Core/Pei/PeiMain.inf
@@ -7,6 +7,7 @@
 # 3) Handoff control to DxeIpl to load DXE core and enter DXE phase.
 #
 # Copyright (c) 2006 - 2019, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) Microsoft Corporation<BR>
 #
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -80,8 +81,8 @@
   gStatusCodeCallbackGuid
   gEdkiiMigratedFvInfoGuid                      ## SOMETIMES_PRODUCES     ## HOB
   gEdkiiMigrationInfoGuid                       ## SOMETIMES_CONSUMES     ## HOB
+  gEfiFirmwarePerformanceGuid    # MU_CHANGE_161871 - needed to build SEC perf HOB
   gEfiDelayedDispatchTableGuid   # MU_CHANGE
-  gPerfDelayedDispatchEndOfPei   # MU_CHANGE
 
 [Ppis]
   gEfiPeiStatusCodePpiGuid                      ## SOMETIMES_CONSUMES # PeiReportStatusService is not ready if this PPI doesn't exist
@@ -104,6 +105,7 @@
   gEfiPeiReset2PpiGuid                          ## SOMETIMES_CONSUMES
   gEfiSecHobDataPpiGuid                         ## SOMETIMES_CONSUMES
   gEfiPeiCoreFvLocationPpiGuid                  ## SOMETIMES_CONSUMES
+  gPeiSecPerformancePpiGuid  # MU_CHANGE_161871 - needed to build SEC perf HOB
   gEfiDelayedDispatchPpiGuid # MU_CHANGE
   gEfiEndOfPeiSignalPpiGuid  # MU_CHANGE
 

--- a/MdeModulePkg/Core/PiSmmCore/Dispatcher.c
+++ b/MdeModulePkg/Core/PiSmmCore/Dispatcher.c
@@ -29,6 +29,7 @@
 
   Copyright (c) 2014, Hewlett-Packard Development Company, L.P.
   Copyright (c) 2009 - 2023, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) Microsoft Corporation<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -664,18 +665,27 @@ SmmLoadImage (
   // Print the load address and the PDB file name if it is available
   //
 
-  DEBUG_CODE_BEGIN ();
+  // MU_CHANGE [BEGIN] - 304324
+  // DEBUG_CODE_BEGIN ();
+  // MU_CHANGE [END] - 304324
 
   UINTN  Index;
   UINTN  StartIndex;
   CHAR8  EfiFileName[256];
 
-  DEBUG ((
-    DEBUG_INFO | DEBUG_LOAD,
-    "Loading SMM driver at 0x%11p EntryPoint=0x%11p ",
-    (VOID *)(UINTN)ImageContext.ImageAddress,
-    FUNCTION_ENTRY_POINT (ImageContext.EntryPoint)
-    ));
+  // MU_CHANGE [BEGIN]
+  if (DebugCodeEnabled ()) {
+    DEBUG ((
+      DEBUG_INFO | DEBUG_LOAD,
+      "Loading SMM driver at 0x%11p EntryPoint=0x%11p ",
+      (VOID *)(UINTN)ImageContext.ImageAddress,
+      FUNCTION_ENTRY_POINT (ImageContext.EntryPoint)
+      ));
+  } else {
+    DEBUG ((DEBUG_ERROR | DEBUG_LOAD, "Loading SMM driver "));
+  }
+
+  // MU_CHANGE [END]
 
   //
   // Print Module Name by Pdb file path.
@@ -713,12 +723,14 @@ SmmLoadImage (
       EfiFileName[Index] = 0;
     }
 
-    DEBUG ((DEBUG_INFO | DEBUG_LOAD, "%a", EfiFileName));   // &Image->ImageContext.PdbPointer[StartIndex]));
+    DEBUG ((DEBUG_ERROR | DEBUG_LOAD, "%a", EfiFileName));  // &Image->ImageContext.PdbPointer[StartIndex]));  // MU_CHANGE
   }
 
-  DEBUG ((DEBUG_INFO | DEBUG_LOAD, "\n"));
+  DEBUG ((DEBUG_ERROR | DEBUG_LOAD, "\n"));                                                                    // MU_CHANGE
 
-  DEBUG_CODE_END ();
+  // MU_CHANGE [BEGIN]
+  // DEBUG_CODE_END ();
+  // MU_CHANGE [END]
 
   //
   // Free buffer allocated by Fv->ReadSection.

--- a/MdeModulePkg/Core/PiSmmCore/PiSmmIpl.c
+++ b/MdeModulePkg/Core/PiSmmCore/PiSmmIpl.c
@@ -2,7 +2,7 @@
   SMM IPL that produces SMM related runtime protocols and load the SMM Core into SMRAM
 
   Copyright (c) 2009 - 2018, Intel Corporation. All rights reserved.<BR>
-  Copyright (c) Microsoft Corporation.<BR>
+  Copyright (c) Microsoft Corporation<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -1142,7 +1142,14 @@ ExecuteSmmCoreFromSmram (
   //
   // Print debug message showing SMM Core load address.
   //
-  DEBUG ((DEBUG_INFO, "SMM IPL loading SMM Core at SMRAM address %p\n", (VOID *)(UINTN)ImageContext.ImageAddress));
+  // MU_CHANGE [BEGIN]
+  if (DebugCodeEnabled ()) {
+    DEBUG ((DEBUG_INFO, "SMM IPL loading SMM Core at SMRAM address %p\n", (VOID *)(UINTN)ImageContext.ImageAddress));
+  } else {
+    DEBUG ((DEBUG_ERROR, "SMM IPL loading SMM Core (PiSmmCore.efi)\n"));
+  }
+
+  // MU_CHANGE [END]
 
   //
   // Load the image to our new buffer

--- a/MdeModulePkg/Include/Ppi/DelayedDispatch.h
+++ b/MdeModulePkg/Include/Ppi/DelayedDispatch.h
@@ -3,7 +3,7 @@
   PPI that allows a Pei module to request a callback after a minumum
   delay.
 
-  Copyright (c) Microsoft Corporation.
+  Copyright (c) Microsoft Corporation. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/

--- a/MdeModulePkg/Library/DxeCorePerformanceLib/DxeCorePerformanceLib.c
+++ b/MdeModulePkg/Library/DxeCorePerformanceLib/DxeCorePerformanceLib.c
@@ -12,6 +12,7 @@
 
 Copyright (c) 2006 - 2023, Intel Corporation. All rights reserved.<BR>
 (C) Copyright 2016 Hewlett Packard Enterprise Development LP<BR>
+Copyright (c) Microsoft Corporation<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -1519,7 +1520,7 @@ DxeCorePerformanceLibConstructor (
   //
   Status = gBS->CreateEventEx (
                   EVT_NOTIFY_SIGNAL,
-                  TPL_NOTIFY,
+                  TPL_CALLBACK, // MU_CHANGE - Change to TPL_CALLBACK from TPL_NOTIFY
                   ReportFpdtRecordBuffer,
                   NULL,
                   &gEfiEndOfDxeEventGroupGuid,

--- a/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
@@ -1926,7 +1926,16 @@ EfiBootManagerBoot (
     DEBUG ((DEBUG_INFO, "[Bds] Booting Boot Manager Menu.\n"));
     BmStopHotkeyService (NULL, NULL);
   } else {
+    PERF_EVENT_SIGNAL_BEGIN (&gEfiEventPreReadyToBootGuid); // MU_CHANGE
+    EfiEventGroupSignal (&gEfiEventPreReadyToBootGuid);     // MU_CHANGE
+    PERF_EVENT_SIGNAL_END (&gEfiEventPreReadyToBootGuid);   // MU_CHANGE
+    PERF_EVENT_SIGNAL_BEGIN (&gEfiEventReadyToBootGuid);    // MU_CHANGE
     EfiSignalEventReadyToBoot ();
+    PERF_EVENT_SIGNAL_END (&gEfiEventReadyToBootGuid);       // MU_CHANGE
+    PERF_EVENT_SIGNAL_BEGIN (&gEfiEventPostReadyToBootGuid); // MU_CHANGE
+    EfiEventGroupSignal (&gEfiEventPostReadyToBootGuid);     // MU_CHANGE
+    PERF_EVENT_SIGNAL_END (&gEfiEventPostReadyToBootGuid);   // MU_CHANGE
+
     //
     // Report Status Code to indicate ReadyToBoot was signalled
     //

--- a/MdeModulePkg/Library/UefiBootManagerLib/InternalBm.h
+++ b/MdeModulePkg/Library/UefiBootManagerLib/InternalBm.h
@@ -4,6 +4,7 @@
 Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 Copyright (c) 2004 - 2018, Intel Corporation. All rights reserved.<BR>
 (C) Copyright 2015 Hewlett Packard Enterprise Development LP<BR>
+Copyright (c) Microsoft Corporation<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -68,7 +69,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/DxeServicesLib.h>
 #include <Library/ReportStatusCodeLib.h>
 #include <Library/CapsuleLib.h>
-#include <Library/PerformanceLib.h>
+// #include <Library/PerformanceLib.h> // MU_CHANGE
 #include <Library/HiiLib.h>
 
 #if !defined (EFI_REMOVABLE_MEDIA_FILE_NAME)

--- a/MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
+++ b/MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
@@ -8,6 +8,7 @@
 #  Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 #  Copyright (c) 2007 - 2018, Intel Corporation. All rights reserved.<BR>
 #  (C) Copyright 2016 Hewlett Packard Enterprise Development LP<BR>
+#  Copyright (c) Microsoft Corporation<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
@@ -59,7 +60,7 @@
   MemoryAllocationLib
   DxeServicesLib
   ReportStatusCodeLib
-  PerformanceLib
+  # PerformanceLib ## MU_CHANGE
   HiiLib
   SortLib
   VariablePolicyHelperLib
@@ -72,6 +73,7 @@
   ## SOMETIMES_PRODUCES ## Variable:L"MemoryTypeInformation."
   gEfiMemoryTypeInformationGuid
   gEfiMemoryTypeMinimumAllocationGuid ## SOMETIMES_CONSUMES ## HOB # MU_CHANGE
+  gEfiGlobalVariableGuid
 
   ## SOMETIMES_PRODUCES ## Variable:L"BootCurrent" (The boot option of current boot)
   ## SOMETIMES_CONSUMES ## Variable:L"BootXX" (Boot option variable)
@@ -80,7 +82,6 @@
   ## SOMETIMES_CONSUMES ## Variable:L"ConIn" (The device path of console in device)
   ## SOMETIMES_CONSUMES ## Variable:L"ConOut" (The device path of console out device)
   ## SOMETIMES_CONSUMES ## Variable:L"ErrOut" (The device path of error out device)
-  gEfiGlobalVariableGuid
 
   gEdkiiStatusCodeDataTypeVariableGuid          ## SOMETIMES_CONSUMES ## GUID
   gEfiDiskInfoAhciInterfaceGuid                 ## SOMETIMES_CONSUMES ## GUID

--- a/MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
+++ b/MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
@@ -89,6 +89,9 @@
   gEfiDiskInfoScsiInterfaceGuid                 ## SOMETIMES_CONSUMES ## GUID
   gEfiDiskInfoSdMmcInterfaceGuid                ## SOMETIMES_CONSUMES ## GUID
   gEfiDiskInfoUfsInterfaceGuid                  ## SOMETIMES_CONSUMES ## GUID
+  gEfiEventPreReadyToBootGuid                   ## PRODUCES   ##MSCHANGE
+  gEfiEventPostReadyToBootGuid                  ## PRODUCES   ##MSCHANGE
+  gEfiEventReadyToBootGuid                      # MU_CHANGE
 
 [Protocols]
   gEfiPciRootBridgeIoProtocolGuid               ## CONSUMES

--- a/MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTableDxe/FirmwarePerformanceDxe.c
+++ b/MdeModulePkg/Universal/Acpi/FirmwarePerformanceDataTableDxe/FirmwarePerformanceDxe.c
@@ -6,6 +6,7 @@
   and install FPDT to ACPI table.
 
   Copyright (c) 2011 - 2021, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) Microsoft Corporation<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -686,7 +687,7 @@ FirmwarePerformanceDxeEntryPoint (
   //
   Status = gBS->CreateEventEx (
                   EVT_NOTIFY_SIGNAL,
-                  TPL_NOTIFY,
+                  TPL_CALLBACK,             // MU_CHANGE - Change to TPL_CALLBACK from TPL_NOTIFY
                   FpdtEndOfDxeEventNotify,
                   NULL,
                   &gEfiEndOfDxeEventGroupGuid,

--- a/MdeModulePkg/Universal/EsrtFmpDxe/EsrtFmp.c
+++ b/MdeModulePkg/Universal/EsrtFmpDxe/EsrtFmp.c
@@ -17,6 +17,7 @@
 #include <Library/DebugLib.h>
 #include <Library/PcdLib.h>
 #include <Library/UefiLib.h>
+#include <Library/PerformanceLib.h> // MU_CHANGE
 #include <Protocol/FirmwareManagement.h>
 #include <Guid/EventGroup.h>
 #include <Guid/SystemResourceTable.h>
@@ -504,6 +505,8 @@ EsrtReadyToBootEventNotify (
   EFI_STATUS                 Status;
   EFI_SYSTEM_RESOURCE_TABLE  *Table;
 
+  PERF_CALLBACK_BEGIN (&gEfiEventReadyToBootGuid); // MU_CHANGE
+
   Table = CreateFmpBasedEsrt ();
   if (Table != NULL) {
     //
@@ -525,6 +528,8 @@ EsrtReadyToBootEventNotify (
   // Close the event to prevent it be signalled again.
   //
   gBS->CloseEvent (Event);
+
+  PERF_CALLBACK_END (&gEfiEventReadyToBootGuid); // MU_CHANGE
 }
 
 /**

--- a/MdeModulePkg/Universal/EsrtFmpDxe/EsrtFmpDxe.inf
+++ b/MdeModulePkg/Universal/EsrtFmpDxe/EsrtFmpDxe.inf
@@ -40,6 +40,7 @@
   UefiBootServicesTableLib
   DebugLib
   PcdLib
+  PerformanceLib # MU_CHANGE
 
 [Protocols]
   gEfiFirmwareManagementProtocolGuid  ## CONSUMES

--- a/MdeModulePkg/Universal/HiiDatabaseDxe/HiiDatabase.h
+++ b/MdeModulePkg/Universal/HiiDatabaseDxe/HiiDatabase.h
@@ -2,6 +2,7 @@
 Private structures definitions in HiiDatabase.
 
 Copyright (c) 2007 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -40,6 +41,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/PcdLib.h>
 #include <Library/UefiRuntimeServicesTableLib.h>
 #include <Library/PrintLib.h>
+#include <Library/PerformanceLib.h> // MU_CHANGE
 
 #define MAX_STRING_LENGTH      1024
 #define MAX_FONT_NAME_LEN      256

--- a/MdeModulePkg/Universal/HiiDatabaseDxe/HiiDatabaseDxe.inf
+++ b/MdeModulePkg/Universal/HiiDatabaseDxe/HiiDatabaseDxe.inf
@@ -5,7 +5,7 @@
 # HiiFont, HiiConfigRouting. To support UEFI HII, this driver is required.
 #
 # Copyright (c) 2007 - 2018, Intel Corporation. All rights reserved.<BR>
-#
+# Copyright (c) Microsoft Corporation<BR>
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 #
@@ -54,6 +54,7 @@
   PcdLib
   UefiRuntimeServicesTableLib
   PrintLib
+  PerformanceLib # MU_CHANGE
 
 [Protocols]
   gEfiDevicePathProtocolGuid                                            ## SOMETIMES_CONSUMES
@@ -86,6 +87,7 @@
   gEfiHiiImageDecoderNameJpegGuid |gEfiMdeModulePkgTokenSpaceGuid.PcdSupportHiiImageProtocol  ## SOMETIMES_CONSUMES ## GUID
   gEfiHiiImageDecoderNamePngGuid  |gEfiMdeModulePkgTokenSpaceGuid.PcdSupportHiiImageProtocol  ## SOMETIMES_CONSUMES ## GUID
   gEdkiiIfrBitVarstoreGuid                                                                    ## SOMETIMES_CONSUMES ## GUID
+  gEfiEventReadyToBootGuid
 
 [Depex]
   TRUE

--- a/MdeModulePkg/Universal/HiiDatabaseDxe/HiiDatabaseEntry.c
+++ b/MdeModulePkg/Universal/HiiDatabaseDxe/HiiDatabaseEntry.c
@@ -3,6 +3,7 @@ This file contains the entry code to the HII database, which is defined by
 UEFI 2.1 specification.
 
 Copyright (c) 2007 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -133,6 +134,8 @@ OnReadyToBoot (
   IN      VOID       *Context
   )
 {
+  PERF_CALLBACK_BEGIN (&gEfiEventReadyToBootGuid); // MU_CHANGE
+
   //
   // When ready to boot, we begin to export the HiiDatabase date.
   // And hook all the possible HiiDatabase change actions to export data.
@@ -142,6 +145,8 @@ OnReadyToBoot (
   gExportAfterReadyToBoot = TRUE;
 
   gBS->CloseEvent (Event);
+
+  PERF_CALLBACK_END (&gEfiEventReadyToBootGuid); // MU_CHANGE
 }
 
 /**

--- a/MdePkg/Include/Guid/EventGroup.h
+++ b/MdePkg/Include/Guid/EventGroup.h
@@ -2,6 +2,7 @@
   GUIDs for gBS->CreateEventEx Event Groups. Defined in UEFI spec 2.0 and PI 1.2.1.
 
 Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+Copyright (c) Microsoft Corporation<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -49,4 +50,15 @@ extern EFI_GUID  gEfiEventDxeDispatchGuid;
 
 extern EFI_GUID  gEfiEndOfDxeEventGroupGuid;
 
+// MU_CHANGE [BEGIN]
+#define EFI_PRE_READY_TO_BOOT_GUID \
+  { 0x10c41e8f, 0xc52a, 0x4ea4, {0xa2, 0x69, 0x0b, 0x45, 0x09, 0x31, 0xab, 0xf6}}
+
+extern EFI_GUID  gEfiEventPreReadyToBootGuid;
+
+#define EFI_POST_READY_TO_BOOT_GUID  \
+  { 0xa5b489b4, 0x18fd, 0x4425, { 0x91, 0xa4, 0x61, 0x3a, 0xdd, 0xd2, 0x74, 0x5 }}
+
+extern EFI_GUID  gEfiEventPostReadyToBootGuid;
+// MU_CHANGE [END]
 #endif

--- a/MdePkg/MdePkg.dec
+++ b/MdePkg/MdePkg.dec
@@ -11,6 +11,7 @@
 # Copyright (c) 2021 - 2022, Arm Limited. All rights reserved.<BR>
 # Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.<BR>
 # Copyright (c) 2023, Ampere Computing LLC. All rights reserved.<BR>
+# Copyright (c) Microsoft Corporation<BR>
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
@@ -452,8 +453,14 @@
   ## Include/Protocol/Hash.h
   gEfiHashAlgorithmSha1Guid      = { 0x2AE9D80F, 0x3FB2, 0x4095, { 0xB7, 0xB1, 0xE9, 0x31, 0x57, 0xB9, 0x46, 0xB6 }}
 
+  ## Include/Guid/EventGroup.h                                                                                       ##MU_CHANGE
+  gEfiEventPreReadyToBootGuid    = { 0x7b94c75c, 0x36a4, 0x4aa4, {0xa1, 0xdf, 0x14, 0xbc, 0x9a, 0x04, 0x9a, 0xe4}}   ##MU_CHANGE
+
   ## Include/Guid/EventGroup.h
   gEfiEventReadyToBootGuid       = { 0x7CE88FB3, 0x4BD7, 0x4679, { 0x87, 0xA8, 0xA8, 0xD8, 0xDE, 0xE5, 0x0D, 0x2B }}
+
+  ## Include/Guid/EventGroup.h                                                                                        ##MU_CHANGE
+  gEfiEventPostReadyToBootGuid   =  { 0xa5b489b4, 0x18fd, 0x4425, { 0x91, 0xa4, 0x61, 0x3a, 0xdd, 0xd2, 0x74, 0x5 }}  ##MU_CHANGE
 
   ## Include/Guid/EventGroup.h
   gEfiEventAfterReadyToBootGuid  = { 0x3a2a00ad, 0x98b9, 0x4cdf, { 0xa4, 0x78, 0x70, 0x27, 0x77, 0xf1, 0xc1, 0x0b }}


### PR DESCRIPTION
This PR adds a series of commits intended to add firmware performance measurements to a platform.

### Overview of commits:

1. MdePkg: Add EFI_PRE_READY_TO_BOOT_GUID and EFI_POST_READY_TO_BOOT_GUID
   1. This commit adds two new GUIDS required for Delay Dispatch
2. REBASE: Revert "MdePkg: Added header file for Delayed Dispatch PPI"
   1. This commit reverts a commit brought in from upstream that modifies the DelayDispatch.h file in MdePkg that was moved to MdeModulePkg
 3. MdeModulePkg/MdeModulePkg.dec: Adds Delay Dispatch
    1. This commit adds Delay Dispatch
 4. MdeModulePkg: Adds Performance Measurement V2
    1. This commit adds the initial performance measurements
 5. Perf-instrument PreReadyToBoot, ReadyToBoot, PostReadyToBoot signals …
    1. This commit adds the signals required for performance measurements
 6. Merged PR 5181: Change FirmwarePerformanceDxe.c EndofDxeEvent tpl to …
    1. This commit changes the TPL_NOTIFYs to TPL_CALLBACKS
 7. MdeModulePkg: PeiMain: Adds performance measurement for PeiMain
    1. Adds peformance measurements for PEI


- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

----
### How This Was Tested
From 2311.

