### PR TITLE
[Cherry-Pick] MdePkg: Add Ipmi Net Sensor Thresholds command defines.

### DIFF
--- a/MdePkg/Include/IndustryStandard/IpmiNetFnSensorEvent.h
+++ b/MdePkg/Include/IndustryStandard/IpmiNetFnSensorEvent.h
@@ -10,6 +10,7 @@
   and Appendix H, Sub-function Assignments.
 
   Copyright (c) 1999 - 2015, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) Microsoft Corporation.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -41,6 +42,51 @@ typedef struct {
   UINT8    OEMEvData2;
   UINT8    OEMEvData3;
 } IPMI_PLATFORM_EVENT_MESSAGE_DATA_REQUEST;
+
+//
+// Definitions for Set Sensor Thresholds command
+//
+#define IPMI_SENSOR_SET_SENSOR_THRESHOLDS  0x26
+
+typedef union {
+  struct _SENSOR_BITS {
+    UINT8    LowerNonCriticalThreshold    : 1;
+    UINT8    LowerCriticalThreshold       : 1;
+    UINT8    LowerNonRecoverableThreshold : 1;
+    UINT8    UpperNonCriticalThreshold    : 1;
+    UINT8    UpperCriticalThreshold       : 1;
+    UINT8    UpperNonRecoverableThreshold : 1;
+    UINT8    Reserved                     : 2;
+  } Bits;
+  UINT8    Uint8;
+} SENSOR_BITS;
+
+typedef struct _IPMI_SENSOR_SET_SENSOR_THRESHOLD_REQUEST_DATA {
+  UINT8          SensorNumber;
+  SENSOR_BITS    SetBitEnable;
+  UINT8          LowerNonCriticalThreshold;
+  UINT8          LowerCriticalThreshold;
+  UINT8          LowerNonRecoverableThreshold;
+  UINT8          UpperNonCriticalThreshold;
+  UINT8          UpperCriticalThreshold;
+  UINT8          UpperNonRecoverableThreshold;
+} IPMI_SENSOR_SET_SENSOR_THRESHOLD_REQUEST_DATA;
+
+//
+// Definitions for Get Sensor Thresholds command
+//
+#define IPMI_SENSOR_GET_SENSOR_THRESHOLDS  0x27
+
+typedef struct _IPMI_SENSOR_GET_SENSOR_THRESHOLD_RESPONSE_DATA {
+  UINT8          CompletionCode;
+  SENSOR_BITS    GetBitEnable;
+  UINT8          LowerNonCriticalThreshold;
+  UINT8          LowerCriticalThreshold;
+  UINT8          LowerNonRecoverableThreshold;
+  UINT8          UpperNonCriticalThreshold;
+  UINT8          UpperCriticalThreshold;
+  UINT8          UpperNonRecoverableThreshold;
+} IPMI_SENSOR_GET_SENSOR_THRESHOLD_RESPONSE_DATA;
 
 #pragma pack()
 #endif


### PR DESCRIPTION
MdePkg: Add Ipmi Net Sensor Thresholds command defines.

Adding definitions for Ipmi Net Sensor Get/Set Thresholds commands and
structures as found in Ipmi specification v2.0

Signed-off-by: Aaron Pop <aaronpop@microsoft.com>