### PR TITLE
PcAtChipsetPkg/PcatRealTimeClockRuntimeDxe/PcRtc: Default year based on build time. [Rebase & FF]

### DIFF
--- a/PcAtChipsetPkg/PcatRealTimeClockRuntimeDxe/PcRtc.c
+++ b/PcAtChipsetPkg/PcatRealTimeClockRuntimeDxe/PcRtc.c
@@ -319,8 +319,7 @@ PcRtcInit (
     Time.Hour       = RTC_INIT_HOUR;
     Time.Day        = RTC_INIT_DAY;
     Time.Month      = RTC_INIT_MONTH;
-    Time.Year       = MAX (mRtcDefaultYear, mMinimalValidYear);
-    Time.Year       = MIN (Time.Year, mMaximalValidYear);
+    Time.Year       = RTC_INIT_YEAR;   // MU_CHANGE
     Time.Nanosecond = 0;
     Time.TimeZone   = EFI_UNSPECIFIED_TIMEZONE;
     Time.Daylight   = 0;

--- a/PcAtChipsetPkg/PcatRealTimeClockRuntimeDxe/PcRtc.h
+++ b/PcAtChipsetPkg/PcatRealTimeClockRuntimeDxe/PcRtc.h
@@ -63,8 +63,24 @@ extern PC_RTC_MODULE_GLOBALS  mModuleGlobal;
 #define RTC_INIT_SECOND  0
 #define RTC_INIT_MINUTE  0
 #define RTC_INIT_HOUR    0
-#define RTC_INIT_DAY     1
-#define RTC_INIT_MONTH   1
+// MU_CHANGE [BEGIN] - Default date on the build date midnight.
+// Since we are in PST/PDT, if anyone between here and the international date line
+#define RTC_INIT_DAY    ( ((__DATE__)[5] - '0') +  ( (((__DATE__)[4] >= '0') && ((__DATE__)[4] <= '3') ) ? (((__DATE__)[4] - '0') * 10) : 0 ) )
+#define RTC_INIT_MONTH  ( (__DATE__[0] == 'F') ? 2  : (\
+                          (__DATE__[0] == 'S') ? 9  : (\
+                          (__DATE__[0] == 'O') ? 10 : (\
+                          (__DATE__[0] == 'N') ? 11 : (\
+                          (__DATE__[0] == 'D') ? 12 : (\
+                          (__DATE__[2] == 'l') ? 7  : (\
+                          (__DATE__[2] == 'g') ? 8  : (\
+                          (__DATE__[2] == 'y') ? 5  : (\
+                          (__DATE__[1] == 'p') ? 4  : (\
+                          (__DATE__[1] == 'u') ? 6  : (\
+                          (__DATE__[0] == 'J') ? 1  : (\
+                          3))))))))))))
+
+#define RTC_INIT_YEAR  (((__DATE__)[7] - '0')*1000 + ((__DATE__)[8] - '0')*100 + ((__DATE__)[9] - '0')*10 + ((__DATE__)[10] - '0'))
+// MU_CHANGE [END]
 
 #pragma pack(1)
 //


### PR DESCRIPTION
## Description

The default year and day when RTC is invalid would originally be set based on PCDs. Change the implementation to set default day, month, year to be based on the build time.

## Cherry-Pick the following commits:
[028aee5140](https://github.com/microsoft/mu_basecore/commit/028aee5140)

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Booted system, manually set invalid time and verified it was reset to build time. 

## Integration Instructions

N/A