### PR TITLE
MdeModulePkg/MemoryTypeInfoSecVarCheckLib: Elaborate on expected mem. [Rebase & FF]

### DIFF
--- a/MdeModulePkg/Library/MemoryTypeInfoSecVarCheckLib/MemoryTypeInfoSecVarCheckLib.c
+++ b/MdeModulePkg/Library/MemoryTypeInfoSecVarCheckLib/MemoryTypeInfoSecVarCheckLib.c
@@ -19,6 +19,17 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <Guid/MemoryTypeInformation.h>
 
+//
+// The following 6 runtime visible memory types are currently expected in the
+// memory type information variable:
+//
+//   1. EfiACPIMemoryNVS
+//   2. EfiACPIReclaimMemory
+//   3. EfiReservedMemoryType
+//   4. EfiRuntimeServicesCode
+//   5. EfiRuntimeServicesData
+//   6. EfiMaxMemoryType
+//
 #define   EFI_MEMORY_TYPE_INFORMATION_VARIABLE_INFO_COUNT  6
 #define   EFI_MEMORY_TYPE_INFORMATION_VARIABLE_SIZE        (sizeof(EFI_MEMORY_TYPE_INFORMATION) * EFI_MEMORY_TYPE_INFORMATION_VARIABLE_INFO_COUNT)
 
@@ -84,7 +95,7 @@ MemoryTypeInfoVarCheckHandler (
   if (DataSize != EFI_MEMORY_TYPE_INFORMATION_VARIABLE_SIZE) {
     DEBUG ((
       DEBUG_ERROR,
-      "ERROR: %a() - DataSize = 0x%x Expected = 0x%x\n",
+      "ERROR: %a() - DataSize = 0x%x Expected = 0x%x. Check actual memory types against expected memory types.\n",
       __func__,
       DataSize,
       EFI_MEMORY_TYPE_INFORMATION_VARIABLE_SIZE


### PR DESCRIPTION
## Description

This variable check library instance currently checks the size of the
`MemoryTypeInformation` UEFI variable to determine if it contains the
total size expected based on the expected number of entries and the
`EFI_MEMORY_TYPE_INFORMATION` structure size where the structure is
used to represent an individual entry.

This changes adds a comment near entry count to describe what entries
are expected and updates the associated assert message to indicate the
developer should check the actual memory types against the expected
memory types if a size mismatch occurs.

## Cherry-Pick the following commits:
[dcf8be9cb8](https://github.com/microsoft/mu_basecore/commit/dcf8be9cb8)

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested
- MdeModulePkg build and CI
- QemuQ35Pkg and QemuSbsaPkg build and boot with the change

## Integration Instructions
N/A