### PR TITLE
MdeModulePkg/Core/Dxe/DxeMain/DxeMain: Add late initialization for Debug Agent. [Rebase & FF]

### DIFF
--- a/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
+++ b/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
@@ -456,6 +456,13 @@ DxeMain (
   Status = CoreInitializeEventServices ();
   ASSERT_EFI_ERROR (Status);
 
+  // MU_CHANGE [BEGIN]
+  // Give the debug agent a chance to initialize with events.
+
+  InitializeDebugAgent (DEBUG_AGENT_INIT_DXE_CORE_LATE, HobStart, NULL);
+
+  // MU_CHANGE [END]
+
   MemoryProfileInstallProtocol ();
 
   CoreInitializeMemoryAttributesTable ();

--- a/MdeModulePkg/Include/Library/DebugAgentLib.h
+++ b/MdeModulePkg/Include/Library/DebugAgentLib.h
@@ -21,6 +21,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define DEBUG_AGENT_INIT_DXE_LOAD             10
 #define DEBUG_AGENT_INIT_DXE_UNLOAD           11
 #define DEBUG_AGENT_INIT_THUNK_PEI_IA32TOX64  12
+#define DEBUG_AGENT_INIT_REINITIALIZE         13      // MU_CHANGE
+#define DEBUG_AGENT_INIT_DXE_CORE_LATE        14      // MU_CHANGE
 
 //
 // Context for DEBUG_AGENT_INIT_POSTMEM_SEC


### PR DESCRIPTION
## Description

Adds a late initialize in DxeMain for the debug agent. This is required for the debug agent to be able to setup events to handle image loads, exit boot services, and other important callbacks.

## Cherry-Pick the following commits:
[66197bc9af](https://github.com/microsoft/mu_basecore/commit/66197bc9af)

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested
Tested on Qemu

## Integration Instructions
N/A