### PR TITLE
[Cherry-Pick] StandaloneMmPkg/Include/Library/FvLib: Fix section data length larger. [Rebase & FF]

### DIFF
--- a/StandaloneMmPkg/Include/Library/FvLib.h
+++ b/StandaloneMmPkg/Include/Library/FvLib.h
@@ -87,7 +87,7 @@ FindFfsSectionInSections (
   @param  FfsFileHeader   Pointer to the current file to search.
   @param  SectionData     Pointer to the Section matching SectionType in FfsFileHeader.
                           NULL if section not found
-  @param  SectionDataSize The size of SectionData
+  @param  SectionDataSize The size of SectionData, excluding the section header.
 
   @retval  EFI_NOT_FOUND  No files matching the search criteria were found
   @retval  EFI_SUCCESS

--- a/StandaloneMmPkg/Library/FvLib/FvLib.c
+++ b/StandaloneMmPkg/Library/FvLib/FvLib.c
@@ -338,11 +338,11 @@ FfsFindSection (
   Given the input file pointer, search for the next matching section in the
   FFS volume.
 
-  @param  SearchType      Filter to find only sections of this type.
-  @param  FfsFileHeader   Pointer to the current file to search.
-  @param  SectionData     Pointer to the Section matching SectionType in FfsFileHeader.
-                          NULL if section not found
-  @param  SectionDataSize The size of SectionData
+  @param[in]      SectionType     Filter to find only sections of this type.
+  @param[in]      FfsFileHeader   Pointer to the current file to search.
+  @param[in,out]  SectionData     Pointer to the Section matching SectionType in FfsFileHeader.
+                                  NULL if section not found
+  @param[in,out]  SectionDataSize The size of SectionData, excluding the section header.
 
   @retval  EFI_NOT_FOUND  No files matching the search criteria were found
   @retval  EFI_SUCCESS
@@ -380,10 +380,10 @@ FfsFindSectionData (
     if (Section->Type == SectionType) {
       if (IS_SECTION2 (Section)) {
         *SectionData     = (VOID *)((EFI_COMMON_SECTION_HEADER2 *)Section + 1);
-        *SectionDataSize = SECTION2_SIZE (Section);
+        *SectionDataSize = SECTION2_SIZE (Section) - sizeof (EFI_COMMON_SECTION_HEADER2);
       } else {
         *SectionData     = (VOID *)(Section + 1);
-        *SectionDataSize = SECTION_SIZE (Section);
+        *SectionDataSize = SECTION_SIZE (Section) - sizeof (EFI_COMMON_SECTION_HEADER);
       }
 
       return EFI_SUCCESS;


### PR DESCRIPTION
## Description

This change fixed an issue where the returned section data length is always 4 bytes larger than the real section. This would cause an issue where the caller could read into the final 4 bytes which is invalid data region.


## Cherry-Pick the following commits:
Replaces the original [b778f1e462](https://github.com/microsoft/mu_basecore/commit/b778f1e462)
with the cherry-pick from edk2 [051c7bb4](https://github.com/tianocore/edk2/commit/051c7bb4)

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This is verified on QEMU Q35 platform and booted to UEFI shell.

## Integration Instructions

N/A