### PR TITLE
[Rebase & FF] 202405: Add IntrinsicLib class and strcmp

### DIFF
--- a/MdePkg/Library/CompilerIntrinsicsLib/ArmCompilerIntrinsicsLib.inf
+++ b/MdePkg/Library/CompilerIntrinsicsLib/ArmCompilerIntrinsicsLib.inf
@@ -16,9 +16,11 @@
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
   LIBRARY_CLASS                  = CompilerIntrinsicsLib
+  LIBRARY_CLASS                  = IntrinsicLib           # MU_CHANGE: Support IntrinsicLib linking
 
 [Sources]
 
+  strcmp.c             # MU_CHANGE: Add strcmp implementation
   memcpy.c             | GCC
   memset.c             | GCC
 

--- a/MdePkg/Library/CompilerIntrinsicsLib/strcmp.c
+++ b/MdePkg/Library/CompilerIntrinsicsLib/strcmp.c
@@ -1,0 +1,34 @@
+// ------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// MU_CHANGE: WHOLE FILE - Add strcmp
+//
+// ------------------------------------------------------------------------------
+
+int
+strcmp (
+  const char  *,
+  const char  *
+  );
+
+#if defined (_MSC_VER)
+  #pragma intrinsic(strcmp)
+  #pragma function(strcmp)
+#endif
+
+int
+strcmp (
+  const char  *s1,
+  const char  *s2
+  )
+{
+  while ((*s1 != '\0') && (*s1 == *s2)) {
+    s1++;
+    s2++;
+  }
+
+  return *s1 - *s2;
+}


### PR DESCRIPTION
cherry-picked from dea7433b0e

Adds the IntrinsicLib library class to allow the library to satisfy dependencies on that class where needed.

Adds a strcmp implementation which is needed when building OpenSSL for AARCH64 (with Visual Studio or GCC).

- [x] Impacts functionality?
- **Functionality** - Does the change ultimately impact how firmware functions?
- Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
- **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter validation improvement, ...
- [ ] Breaking change?
- **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
- Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
- **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
- Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...
