### PR TITLE
[Rebase & FF] 202405: MdePkg/UefiDebugLibDebugPortProtocol: Make ExitBootServicesCallback() static (TCBZ3083)

### DIFF
--- a/MdePkg/Library/UefiDebugLibDebugPortProtocol/DebugLibConstructor.c
+++ b/MdePkg/Library/UefiDebugLibDebugPortProtocol/DebugLibConstructor.c
@@ -34,6 +34,7 @@ EFI_BOOT_SERVICES  *mDebugBS;
   @param  Context      Pointer to the notification function's context.
 
 **/
+STATIC // MU_CHANGE TCBZ3083 - changed to static to avoid conflicts
 VOID
 EFIAPI
 ExitBootServicesCallback (


### PR DESCRIPTION
Abandoned for https://github.com/microsoft/mu_basecore/pull/1043

## Description
Make ExitBootServicesCallback() static. Bug fix for TCBZ3083
Contains MU_CHANGE to upstream

---
Cherry-picked the following commit:
8fb5224d93

---


- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
 
## How This Was Tested

Changes from release/202311

## Integration Instructions

N/A
