### PR TITLE
[Rebase & FF] 202405: Add DeviceStateLib and its dynamic PCD to MdeModulePkg 

### DIFF
--- a/MdeModulePkg/Include/Library/DeviceStateLib.h
+++ b/MdeModulePkg/Include/Library/DeviceStateLib.h
@@ -1,0 +1,58 @@
+/** @file
+Functions used to support Getting and Setting Device States.
+
+Copyright (C) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+MU_CHANGE: new file
+**/
+
+#ifndef DEVICE_STATE_LIB_H__
+#define DEVICE_STATE_LIB_H__
+
+//
+// DEFINE the possible device states here.
+// Current API is defined as a 31bit bitmask  (bit 32 is reserved for MAX)
+//
+#define DEVICE_STATE_SECUREBOOT_OFF             (1 << (0))
+#define DEVICE_STATE_MANUFACTURING_MODE         (1 << (1))
+#define DEVICE_STATE_DEVELOPMENT_BUILD_ENABLED  (1 << (2))
+#define DEVICE_STATE_SOURCE_DEBUG_ENABLED       (1 << (3))
+#define DEVICE_STATE_UNDEFINED                  (1 << (4))
+#define DEVICE_STATE_UNIT_TEST_MODE             (1 << (5))
+
+#define DEVICE_STATE_PLATFORM_MODE_0  (1 << (20))
+#define DEVICE_STATE_PLATFORM_MODE_1  (1 << (21))
+#define DEVICE_STATE_PLATFORM_MODE_2  (1 << (22))
+#define DEVICE_STATE_PLATFORM_MODE_3  (1 << (23))
+#define DEVICE_STATE_PLATFORM_MODE_4  (1 << (24))
+#define DEVICE_STATE_PLATFORM_MODE_5  (1 << (25))
+#define DEVICE_STATE_PLATFORM_MODE_6  (1 << (26))
+#define DEVICE_STATE_PLATFORM_MODE_7  (1 << (27))
+
+#define DEVICE_STATE_MAX  (1 << (31))
+
+typedef UINT32 DEVICE_STATE;
+
+/**
+Function to Get current device state
+@retval the current DEVICE_STATE
+**/
+DEVICE_STATE
+EFIAPI
+GetDeviceState (
+  );
+
+/**
+Function to Add additional bits to the device state
+
+@param AdditionalState - additional state to set active
+@retval Status of operation.  EFI_SUCCESS on successful update.
+**/
+RETURN_STATUS
+EFIAPI
+AddDeviceState (
+  DEVICE_STATE  AdditionalState
+  );
+
+#endif

--- a/MdeModulePkg/Library/DeviceStateLib/DeviceStateLib.c
+++ b/MdeModulePkg/Library/DeviceStateLib/DeviceStateLib.c
@@ -1,0 +1,60 @@
+/** @file
+Functions used to support Getting and Setting Device States.
+This library uses the PcdDeviceStateBitmask dynamic PCD to store the device state
+
+Copyright (C) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+MU_CHANGE: new file
+**/
+
+#include <PiPei.h>
+#include <Library/PcdLib.h>
+#include <Library/DeviceStateLib.h>
+#include <Library/DebugLib.h>
+
+/**
+Function to Get current device state
+@retval the current DEVICE_STATE
+**/
+DEVICE_STATE
+EFIAPI
+GetDeviceState (
+  )
+{
+  DEVICE_STATE  DevState = PcdGet32 (PcdDeviceStateBitmask);
+
+  return DevState;
+}
+
+/**
+Function to Add additional bits to the device state
+
+@param AdditionalState - additional state to set active
+@retval Status of operation.  EFI_SUCCESS on successful update.
+**/
+RETURN_STATUS
+EFIAPI
+AddDeviceState (
+  DEVICE_STATE  AdditionalState
+  )
+{
+  DEVICE_STATE  DevState;
+  DEVICE_STATE  SetValue;
+  EFI_STATUS    Status;
+
+  DevState = PcdGet32 (PcdDeviceStateBitmask);
+
+  DEBUG ((DEBUG_INFO, "Adding Device State.  0x%X\n", AdditionalState));
+
+  DevState |= AdditionalState;
+  Status    = PcdSet32S (PcdDeviceStateBitmask, DevState);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - Error setting device state - %r\n", __FUNCTION__, Status));
+    return RETURN_DEVICE_ERROR;
+  }
+
+  SetValue = PcdGet32 (PcdDeviceStateBitmask);
+
+  return ((SetValue == DevState) ? RETURN_SUCCESS : RETURN_OUT_OF_RESOURCES);
+}

--- a/MdeModulePkg/Library/DeviceStateLib/DeviceStateLib.inf
+++ b/MdeModulePkg/Library/DeviceStateLib/DeviceStateLib.inf
@@ -1,0 +1,33 @@
+## @file
+# Library to get and set the device state
+#
+# Copyright (C) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+# MU_CHANGE: new file
+##
+
+
+[Defines]
+INF_VERSION    = 0x00010017
+BASE_NAME      = DeviceStateLib
+FILE_GUID      = 49F18455-FE0D-4DFC-B88B-BEC283BB46DD
+VERSION_STRING = 1.0
+MODULE_TYPE    = BASE
+LIBRARY_CLASS  = DeviceStateLib
+
+[LibraryClasses]
+DebugLib
+MemoryAllocationLib
+BaseMemoryLib
+PcdLib
+
+[Packages]
+MdePkg/MdePkg.dec
+MdeModulePkg/MdeModulePkg.dec
+
+[Sources]
+DeviceStateLib.c
+
+[Pcd]
+gEfiMdeModulePkgTokenSpaceGuid.PcdDeviceStateBitmask

--- a/MdeModulePkg/Library/DeviceStateLib/Readme.md
+++ b/MdeModulePkg/Library/DeviceStateLib/Readme.md
@@ -1,0 +1,32 @@
+# DeviceStateLib
+
+## About
+
+The DeviceStateLib provides the necessary functions to store platform specific device
+states.  These device states can then be queried by any element within the boot
+environment to enable special code paths.  In this library implementation a
+bitmask is stored in a PCD to signify what modes are active.
+
+The default bits in the bitmask are set in DeviceStateLib.h - but each platform
+is expected to implement its own header to define the platform specific device
+states or to define any of the unused bits:
+
+* BIT 0:  DEVICE_STATE_SECUREBOOT_OFF - UEFI Secure Boot disabled
+* BIT 1:  DEVICE_STATE_MANUFACTURING_MODE - Device is in an OEM defined
+  manufacturing mode
+* BIT 2:  DEVICE_STATE_DEVELOPMENT_BUILD_ENABLED - Device is a development
+  build.  Non-production features might be enabled
+* BIT 3:  DEVICE_STATE_SOURCE_DEBUG_ENABLED - Source debug mode is enabled
+  allowing a user to connect and control the device
+* BIT 4:  DEVICE_STATE_UNDEFINED - Set by the platform
+* BIT 5:  DEVICE_STATE_UNIT_TEST_MODE - Device has a unit test build. Some
+  features are disabled to allow for unit tests in UEFI Shell
+* BIT 24: DEVICE_STATE_PLATFORM_MODE_0
+* BIT 25: DEVICE_STATE_PLATFORM_MODE_1
+* BIT 26: DEVICE_STATE_PLATFORM_MODE_2
+* BIT 27: DEVICE_STATE_PLATFORM_MODE_3
+
+## Copyright
+
+Copyright (C) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -184,6 +184,11 @@
   ##                across a reboot.
   MemoryTypeInformationChangeLib|Include/Library/MemoryTypeInformationChangeLib.h
 
+  ## MU_CHANGE - Add DeviceStateLib to MdeModulePkg
+  ## @libraryclass Provides a way to store and update the current device state
+  #
+  DeviceStateLib|Include/Library/DeviceStateLib.h
+
 [Guids]
   ## MdeModule package token space guid
   # Include/Guid/MdeModulePkgTokenSpace.h
@@ -2330,6 +2335,11 @@
   # @Prompt GHCB Pool Size
   gEfiMdeModulePkgTokenSpaceGuid.PcdGhcbSize|0|UINT64|0x00030008
 
+  ## MU_CHANGE - Add DeviceStateLib to MdeModulePkg
+  ## This dynamic PCD holds the device state bitmap as described in Include/Library/DeviceStateLib.h
+  # @Prompt Describes device state
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDeviceStateBitmask|0x00000000|UINT32|0x00030009
+  
 [PcdsDynamicEx]
   ## This dynamic PCD enables the default variable setting.
   #  Its value is the default store ID value. The default value is zero as Standard default.

--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -471,6 +471,8 @@
   MdeModulePkg/Library/FmpAuthenticationLibNull/FmpAuthenticationLibNull.inf
   MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.inf
   MdeModulePkg/Library/DxeCapsuleLibFmp/DxeRuntimeCapsuleLib.inf
+  # MU_CHANGE - Add DeviceStateLib to MdeModulePkg:
+  MdeModulePkg/Library/DeviceStateLib/DeviceStateLib.inf
   MdeModulePkg/Library/BaseVariableFlashInfoLib/BaseVariableFlashInfoLib.inf
 
 # MU_CHANGE START


### PR DESCRIPTION
## Description

This lib is being moved from MsCorePkg because code in MdeModulePkg's variable services will need to check for the unit test bit in the device state to see whether to lock Variable Policy or not.

cherry-pick from 3f7403d3c1


- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...


