### PR TITLE
Require IOMMU protocol install before DMA access.

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciIo.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciIo.c
@@ -1007,6 +1007,17 @@ PciIoMap (
       );
   }
 
+  // MU_CHANGE [BEGIN] - Re-attempt to locate IoMmu protocol, if missing.
+  if (mIoMmuProtocol == NULL) {
+    gBS->LocateProtocol (
+           &gEdkiiIoMmuProtocolGuid,
+           NULL,
+           (VOID **)&mIoMmuProtocol
+           );
+  }
+
+  // MU_CHANGE [END]
+
   if (mIoMmuProtocol != NULL) {
     if (!EFI_ERROR (Status)) {
       switch (Operation) {
@@ -1057,6 +1068,17 @@ PciIoUnmap (
   PCI_IO_DEVICE  *PciIoDevice;
 
   PciIoDevice = PCI_IO_DEVICE_FROM_PCI_IO_THIS (This);
+
+  // MU_CHANGE [BEGIN] - Re-attempt to locate IoMmu protocol, if missing.
+  if (mIoMmuProtocol == NULL) {
+    gBS->LocateProtocol (
+           &gEdkiiIoMmuProtocolGuid,
+           NULL,
+           (VOID **)&mIoMmuProtocol
+           );
+  }
+
+  // MU_CHANGE [END]
 
   if (mIoMmuProtocol != NULL) {
     mIoMmuProtocol->SetAttribute (

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridgeDxe.inf
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridgeDxe.inf
@@ -39,6 +39,11 @@
   UefiLib
   PciHostBridgeLib
   TimerLib
+  PcdLib                                          ## MU_CHANGE
+  ReportStatusCodeLib                             ## MU_CHANGE
+
+[FeaturePcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdRequireIommu  ## MU_CHANGE
 
 [Protocols]
   gEfiCpuIo2ProtocolGuid                          ## CONSUMES

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
@@ -11,9 +11,16 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include "PciRootBridge.h"
 #include "PciHostResource.h"
 
+// MU_CHANGE - Allow platform to disallow unprotected DMA access when done before IOMMU install.
+#include <Library/ReportStatusCodeLib.h>
+
 #define NO_MAPPING  (VOID *) (UINTN) -1
 
 #define RESOURCE_VALID(Resource)  ((Resource)->Base <= (Resource)->Limit)
+
+// MU_CHANGE - Allow platform to disallow unprotected DMA access when done before IOMMU install.
+#define PCI_DMA_ORDERING_ERROR_STATUS_TYPE  (EFI_ERROR_MAJOR | EFI_ERROR_CODE)
+#define PCI_DMA_ORDERING_ERROR_CODE         (EFI_IO_BUS_PCI | EFI_IOB_EC_NOT_CONFIGURED)
 
 //
 // Lookup table for increment values based on transfer widths
@@ -1315,6 +1322,7 @@ RootBridgeIoPciWrite (
   @retval EFI_UNSUPPORTED        The HostAddress cannot be mapped as a common buffer.
   @retval EFI_DEVICE_ERROR       The System hardware could not map the requested address.
   @retval EFI_OUT_OF_RESOURCES   The request could not be completed due to lack of resources.
+  @retval EFI_NOT_READY          Require IOMMU PCD has been set and request happens before IOMMU protocol install.    MU_CHANGE
 **/
 EFI_STATUS
 EFIAPI
@@ -1346,6 +1354,16 @@ RootBridgeIoMap (
   }
 
   RootBridge = ROOT_BRIDGE_FROM_THIS (This);
+
+  // MU_CHANGE [BEGIN] - Allow platform to disallow unprotected DMA access when done before IOMMU install.
+  if (FeaturePcdGet (PcdRequireIommu) && (mIoMmu == NULL)) {
+    DEBUG ((DEBUG_ERROR, "%a - mIoMmuProtocol is NULL!\n", __func__));
+    ASSERT (mIoMmu != NULL);
+    ReportStatusCode (PCI_DMA_ORDERING_ERROR_STATUS_TYPE, PCI_DMA_ORDERING_ERROR_CODE);
+    return EFI_NOT_READY;
+  }
+
+  // MU_CHANGE [END]
 
   if (mIoMmu != NULL) {
     if (!RootBridge->DmaAbove4G) {
@@ -1481,6 +1499,7 @@ RootBridgeIoMap (
   @retval EFI_SUCCESS            The range was unmapped.
   @retval EFI_INVALID_PARAMETER  Mapping is not a value that was returned by Map().
   @retval EFI_DEVICE_ERROR       The data was not committed to the target system memory.
+  @retval EFI_NOT_READY          Require IOMMU PCD has been set and request happens before IOMMU protocol install.    MU_CHANGE
 **/
 EFI_STATUS
 EFIAPI
@@ -1493,6 +1512,16 @@ RootBridgeIoUnmap (
   LIST_ENTRY                *Link;
   PCI_ROOT_BRIDGE_INSTANCE  *RootBridge;
   EFI_STATUS                Status;
+
+  // MU_CHANGE [BEGIN] - Allow platform to disallow unprotected DMA access when done before IOMMU install.
+  if (FeaturePcdGet (PcdRequireIommu) && (mIoMmu == NULL)) {
+    DEBUG ((DEBUG_ERROR, "%a - mIoMmuProtocol is NULL!\n", __func__));
+    ASSERT (mIoMmu != NULL);
+    ReportStatusCode (PCI_DMA_ORDERING_ERROR_STATUS_TYPE, PCI_DMA_ORDERING_ERROR_CODE);
+    return EFI_NOT_READY;
+  }
+
+  // MU_CHANGE [END]
 
   if (mIoMmu != NULL) {
     Status = mIoMmu->Unmap (
@@ -1582,6 +1611,7 @@ RootBridgeIoUnmap (
                                  attribute bits are MEMORY_WRITE_COMBINE,
                                  MEMORY_CACHED, and DUAL_ADDRESS_CYCLE.
   @retval EFI_OUT_OF_RESOURCES   The memory pages could not be allocated.
+  @retval EFI_NOT_READY          Require IOMMU PCD has been set and request happens before IOMMU protocol install.    MU_CHANGE
 **/
 EFI_STATUS
 EFIAPI
@@ -1624,6 +1654,16 @@ RootBridgeIoAllocateBuffer (
   }
 
   RootBridge = ROOT_BRIDGE_FROM_THIS (This);
+
+  // MU_CHANGE [BEGIN] - Allow platform to disallow unprotected DMA access when done before IOMMU install.
+  if (FeaturePcdGet (PcdRequireIommu) && (mIoMmu == NULL)) {
+    DEBUG ((DEBUG_ERROR, "%a - mIoMmuProtocol is NULL!\n", __func__));
+    ASSERT (mIoMmu != NULL);
+    ReportStatusCode (PCI_DMA_ORDERING_ERROR_STATUS_TYPE, PCI_DMA_ORDERING_ERROR_CODE);
+    return EFI_NOT_READY;
+  }
+
+  // MU_CHANGE [END]
 
   if (mIoMmu != NULL) {
     if (!RootBridge->DmaAbove4G) {
@@ -1681,6 +1721,7 @@ RootBridgeIoAllocateBuffer (
   @retval EFI_SUCCESS            The requested memory pages were freed.
   @retval EFI_INVALID_PARAMETER  The memory range specified by HostAddress and
                                  Pages was not allocated with AllocateBuffer().
+  @retval EFI_NOT_READY          Require IOMMU PCD has been set and request happens before IOMMU protocol install.    MU_CHANGE
 **/
 EFI_STATUS
 EFIAPI
@@ -1691,6 +1732,16 @@ RootBridgeIoFreeBuffer (
   )
 {
   EFI_STATUS  Status;
+
+  // MU_CHANGE [BEGIN] - Allow platform to disallow unprotected DMA access when done before IOMMU install.
+  if (FeaturePcdGet (PcdRequireIommu) && (mIoMmu == NULL)) {
+    DEBUG ((DEBUG_ERROR, "%a - mIoMmuProtocol is NULL!\n", __func__));
+    ASSERT (mIoMmu != NULL);
+    ReportStatusCode (PCI_DMA_ORDERING_ERROR_STATUS_TYPE, PCI_DMA_ORDERING_ERROR_CODE);
+    return EFI_NOT_READY;
+  }
+
+  // MU_CHANGE [END]
 
   if (mIoMmu != NULL) {
     Status = mIoMmu->FreeBuffer (

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -1005,6 +1005,14 @@
   # @Prompt Defer BME enablement
   gEfiMdeModulePkgTokenSpaceGuid.PcdDeferBME|TRUE|BOOLEAN|0x30002050
 
+  ## MU_CHANGE
+  ## Indicates if DMA is allowed before IOMMU protocol install
+  #  If enabled, device wil assert and return EFI_DEVICE_ERROR on any DMA access before IOMMU Protocol Install.<BR><BR>
+  #   TRUE  - IOMMU protocol required for DMA access.<BR>
+  #   FALSE - DMA Access can happen before IOMMU protocol install.<BR>
+  # @Prompt Enable DMA before IOMMU protocol.
+  gEfiMdeModulePkgTokenSpaceGuid.PcdRequireIommu|TRUE|BOOLEAN|0x30001090
+
 [PcdsFeatureFlag.IA32, PcdsFeatureFlag.ARM, PcdsFeatureFlag.AARCH64]
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciDegradeResourceForOptionRom|FALSE|BOOLEAN|0x0001003a
 


### PR DESCRIPTION
## Description

Add a PCD (gEfiMdeModulePkgTokenSpaceGuid.PcdRequireIommu) and support code to enable a platform to require that the IOMMU be present before allowing PCI DMA operations.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Passed CI

## Integration Instructions

N/A