### PR TITLE
Changed gEfiMdeModulePkgTokenSpaceGuid.PcdHiiOsRuntimeSupport default value to FALSE

### DIFF
--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -993,7 +993,9 @@
   #   TRUE  - Export HII data and configuration data.<BR>
   #   FALSE - Does not export HII data and configuration.<BR>
   # @Prompt Enable export HII data and configuration to be used in OS runtime.
-  gEfiMdeModulePkgTokenSpaceGuid.PcdHiiOsRuntimeSupport|TRUE|BOOLEAN|0x00010074
+  # MU_CHANGE: Default PcdHiiOsRuntimeSupport to FALSE
+  # gEfiMdeModulePkgTokenSpaceGuid.PcdHiiOsRuntimeSupport|TRUE|BOOLEAN|0x00010074
+  gEfiMdeModulePkgTokenSpaceGuid.PcdHiiOsRuntimeSupport|FALSE|BOOLEAN|0x00010074
 
   ## Indicates if PS2 mouse does a extended verification during start.
   #  Extended verification will take some performance. It can be set to FALSE for boot performance.<BR><BR>


### PR DESCRIPTION
## Description

Changed gEfiMdeModulePkgTokenSpaceGuid.PcdHiiOsRuntimeSupport default value to FALSE. This will prevent potential runtime type memory bucket size fluctuation in release builds.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [x] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

N/A

## Integration Instructions

If a platform was depending on PcdHiiOsRuntimeSupport being TRUE they'll need to update the value in their platform dsc file.
