### PR TITLE
TCBZ2442: Change S3 PCD default

### DIFF
--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -2160,7 +2160,8 @@
   #   TRUE  - ACPI S3 will be enabled.<BR>
   #   FALSE - ACPI S3 will be disabled.<BR>
   # @Prompt ACPI S3 Enable.
-  gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiS3Enable|TRUE|BOOLEAN|0x01100000
+  # MU_CHANGE - Default should be FALSE. We don't support S3. TCBZ2442
+  gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiS3Enable|FALSE|BOOLEAN|0x01100000
 
   ## Specify memory size for boot script executor stack usage in S3 phase.
   #  The default size 32K. When changing the value make sure the memory size is large enough


### PR DESCRIPTION
## Description

Change S3 PCD default to FALSE.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Passed CI.

## Integration Instructions

If a platform was depending on PcdAcpiS3Enable being TRUE they'll need to update the value in their platform dsc file.