### PR TITLE
TCBZ2596: Added FltUsedLib to MdePkg

### DIFF
--- a/MdePkg/Library/FltUsedLib/FltUsedLib.c
+++ b/MdePkg/Library/FltUsedLib/FltUsedLib.c
@@ -1,0 +1,10 @@
+/** @file
+  Lib to include if using floats
+
+Copyright (C) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+// You need to include this to let the compiler know we are going to use floating point
+int  _fltused = 0x9875;

--- a/MdePkg/Library/FltUsedLib/FltUsedLib.inf
+++ b/MdePkg/Library/FltUsedLib/FltUsedLib.inf
@@ -1,0 +1,31 @@
+## @file
+#  Lib to include if using floats
+#
+# Copyright (C) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = FltUsedLib
+  FILE_GUID                      = C004F180-9FE2-4D2B-8318-BADC2A231774
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = FltUsedLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 AARCH64
+#
+
+[Sources]
+  FltUsedLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[BuildOptions]
+  # Disable GL due to linker error LNK1237
+  # https://docs.microsoft.com/en-us/cpp/error-messages/tool-errors/linker-tools-error-lnk1237?view=vs-2017
+  MSFT:*_*_*_CC_FLAGS = /GL-

--- a/MdePkg/Library/FltUsedLib/Readme.md
+++ b/MdePkg/Library/FltUsedLib/Readme.md
@@ -1,0 +1,15 @@
+# FltUsedLib
+
+This library provides a global (fltused) that needs to be defined anywhere floating point operations are used.
+The C compiler produces the _fltused symbol by default, this is just to satisfy the linker.
+
+## Using
+
+To use FltUsedLib, just include it in the INF of the module that uses floating point.
+
+```inf
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  FltUsedLib
+```

--- a/MdePkg/MdePkg.ci.yaml
+++ b/MdePkg/MdePkg.ci.yaml
@@ -119,6 +119,7 @@
     "DscCompleteCheck": {
         "IgnoreInf": [
             "MdePkg/Library/VsIntrinsicLib/VsIntrinsicLib.inf",   # MU_CHANGE - Ignore intrinsics for toolchains that don't support it.
+            "MdePkg/Library/FltUsedLib/FltUsedLib.inf" # MU_CHANGE this isn't compilable since it has no code
         ],
         "DscPath": "MdePkg.dsc"
     },


### PR DESCRIPTION
## Description

This library provides a global (fltused) that needs to be defined anywhere floating point operations are used.
The C compiler produces the _fltused symbol by default, this is just to satisfy the linker.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested in Qemu.

## Integration Instructions

This information is included in the Readme.md file.
To use FltUsedLib, just include it in the INF of the module that uses floating point.

```inf
[LibraryClasses]
  BaseLib
  BaseMemoryLib
  FltUsedLib
```