### PR TITLE
MdeModulePkg: Removed PeiAllocatePool Assert

### DIFF
--- a/MdeModulePkg/Core/Pei/Memory/MemoryServices.c
+++ b/MdeModulePkg/Core/Pei/Memory/MemoryServices.c
@@ -862,7 +862,10 @@ PeiAllocatePool (
              (UINT16)(sizeof (EFI_HOB_MEMORY_POOL) + Size),
              (VOID **)&Hob
              );
-  ASSERT_EFI_ERROR (Status);
+
+  // MU_CHANGE
+  // Allocator should be resilient, leave error handling for callers.
+  // ASSERT_EFI_ERROR (Status);
 
   if (EFI_ERROR (Status)) {
     *Buffer = NULL;


### PR DESCRIPTION
## Description

This patch removes an assert if PeiAllocatePool fails to allocate memory. This defers the error handling to the caller, where it can be either gracefully handled or asserted in the caller, which is the more interesting place to debug from.

Cherry-picked from c1cd041889.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

2311.

## Integration Instructions

N/A.