### PR TITLE
MdeModulePkg: Extend PciBusDxe to allow for ignoring option ROMs

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumerator.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumerator.c
@@ -300,10 +300,16 @@ ProcessOptionRom (
     }
 
     if ((Temp->RomSize != 0) && (Temp->RomSize <= MaxLength)) {
-      //
-      // Load and process the option rom
-      //
-      LoadOpRomImage (Temp, RomBase);
+      // MU_CHANGE Start
+      if (!Temp->IgnoreROM) {
+        DEBUG ((DEBUG_INFO, "Loading option rom from device at BDF=%u/%u/%u\n", Temp->BusNumber, Temp->DeviceNumber, Temp->FunctionNumber));
+        //
+        // Load and process the option rom
+        //
+        LoadOpRomImage (Temp, RomBase);
+      }
+
+      // MU_CHANGE End
     }
 
     CurrentLink = CurrentLink->ForwardLink;

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciEnumeratorSupport.c
@@ -1587,6 +1587,15 @@ UpdatePciInfo (
       continue;
     }
 
+    // MU_CHANGE begin
+    if (Ptr->ResType == INCOMPATIBLE_ACPI_ADDRESS_SPACE_TYPE_ROM) {
+      PciIoDevice->IgnoreROM = TRUE;
+      Ptr++;
+      continue;
+    }
+
+    // MU_CHANGE end
+
     for (BarIndex = 0; BarIndex < PCI_MAX_BAR; BarIndex++) {
       if ((Ptr->AddrTranslationOffset != MAX_UINT64) &&
           (Ptr->AddrTranslationOffset != MAX_UINT8) &&

--- a/MdePkg/Include/Protocol/IncompatiblePciDeviceSupport.h
+++ b/MdePkg/Include/Protocol/IncompatiblePciDeviceSupport.h
@@ -78,6 +78,17 @@
     0xeb23f55a, 0x7863, 0x4ac2, {0x8d, 0x3d, 0x95, 0x65, 0x35, 0xde, 0x03, 0x75} \
   }
 
+// MU_CHANGE begin
+///
+/// Extension to Acpi10.h for describing the ROM BAR as the incompatible BAR.
+///
+/// Specifying the ROM bar as incompatible indicates to the PciBusDxe driver to
+/// ignore the ROM BAR altogether.  Currently, ACPI only defines 0x01-0x03 for
+/// MEM, IO, BUS.
+///
+#define INCOMPATIBLE_ACPI_ADDRESS_SPACE_TYPE_ROM  0x0F
+// MU_CHANGE end
+
 ///
 /// Forward declaration for EFI_INCOMPATIBLE_PCI_DEVICE_SUPPORT_PROTOCOL
 ///


### PR DESCRIPTION
## Description

The ROM bar is incompatible as ACPI only defines MEM, IO, and BUS bars. This patch allows PciBusDxe to ignore incompatible option ROMs from the ROM bar.

Cherry-picked from 396589d834.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

From 2311.

## Integration Instructions

N/A.