### PR TITLE
UefiCpuPkg: Ensure Valid PeiServicesTablePointerLibIdt [Rebase & FF]

### DIFF
--- a/UefiCpuPkg/Library/MpInitLib/MpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/MpLib.c
@@ -2112,6 +2112,8 @@ MpInitLibInitialize (
   BufferSize += MonitorFilterSize * MaxLogicalProcessorNumber;
   BufferSize += ApResetVectorSizeBelow1Mb;
   BufferSize  = ALIGN_VALUE (BufferSize, 8);
+  BufferSize += 8;  // MU_CHANGE allow a UINT32 to be at Idtr.Base - sizeof (32 bit pointer) and
+                    //           maintain 8 byte alignment.
   BufferSize += VolatileRegisters.Idtr.Limit + 1;
   BufferSize += sizeof (CPU_MP_DATA);
   BufferSize += (sizeof (CPU_AP_DATA) + sizeof (CPU_INFO_IN_HOB))* MaxLogicalProcessorNumber;
@@ -2130,7 +2132,7 @@ MpInitLibInitialize (
   //    +--------------------+ <-- BackupBufferAddr (CpuMpData->BackupBuffer)
   //         Backup Buffer
   //    +--------------------+
-  //           Padding
+  //           Padding              MU_CHANGE Add 8 bytes for PeiServicesTablePointerLibIdt compatibility
   //    +--------------------+ <-- ApIdtBase (8-byte boundary)
   //           AP IDT          All APs share one separate IDT.
   //    +--------------------+ <-- CpuMpData
@@ -2143,7 +2145,7 @@ MpInitLibInitialize (
   //
   MonitorBuffer               = (UINT8 *)(Buffer + ApStackSize * MaxLogicalProcessorNumber);
   BackupBufferAddr            = (UINTN)MonitorBuffer + MonitorFilterSize * MaxLogicalProcessorNumber;
-  ApIdtBase                   = ALIGN_VALUE (BackupBufferAddr + ApResetVectorSizeBelow1Mb, 8);
+  ApIdtBase                   = ALIGN_VALUE (BackupBufferAddr + ApResetVectorSizeBelow1Mb, 8) + 8; // MU_CHANGE;
   CpuMpData                   = (CPU_MP_DATA *)(ApIdtBase + VolatileRegisters.Idtr.Limit + 1);
   CpuMpData->Buffer           = Buffer;
   CpuMpData->CpuApStackSize   = ApStackSize;
@@ -2180,7 +2182,14 @@ MpInitLibInitialize (
   // Duplicate BSP's IDT to APs.
   // All APs share one separate IDT. So AP can get the address of CpuMpData by using IDTR.BASE + IDTR.LIMIT + 1
   //
-  CopyMem ((VOID *)ApIdtBase, (VOID *)VolatileRegisters.Idtr.Base, VolatileRegisters.Idtr.Limit + 1);
+  // MU_CHANGE - maintain compatibility with PeiServicesTablePointerLibIdt until Silicon code and PeiCore
+  //             deprecate its use. PeiServicesTablePointerLibIdt stores the *PeiServices at Idt.Base - sizeof(32 bit pointer);
+  CopyMem (
+    (VOID *)(ApIdtBase - sizeof (UINT32)),
+    (VOID *)(VolatileRegisters.Idtr.Base - sizeof (UINT32)),
+    VolatileRegisters.Idtr.Limit + 1 + sizeof (UINT32)
+    );
+  // MU_CHANGE
   VolatileRegisters.Idtr.Base = ApIdtBase;
   //
   // Don't pass BSP's TR to APs to avoid AP init failure.


### PR DESCRIPTION
## Description

Fix to allow compatibility with PeiServicesTablePointerLibIdt

APs all hitting exceptions because silicon specific code expected a valid PeiServicesTablePointer before the IDT address.

Silicon code needs to be updated to not leverage PeiServices but for compatibility with older silicon code support this behavior

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

2311 change.

## Integration Instructions

N/A.