### PR TITLE
MdeModulePkg: Localize the mInternalRT global var in RuntimeResetSystemLib

### DIFF
--- a/MdeModulePkg/Library/RuntimeResetSystemLib/RuntimeResetSystemLib.c
+++ b/MdeModulePkg/Library/RuntimeResetSystemLib/RuntimeResetSystemLib.c
@@ -12,8 +12,9 @@
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/DebugLib.h>
 
-EFI_EVENT             mRuntimeResetSystemLibVirtualAddressChangeEvent;
-EFI_RUNTIME_SERVICES  *mInternalRT;
+EFI_EVENT  mRuntimeResetSystemLibVirtualAddressChangeEvent;
+// MU_CHANGE: localizing the global to avoid name collision with UefiRuntimeLib:
+STATIC EFI_RUNTIME_SERVICES  *mInternalRT;
 
 /**
   This function causes a system-wide reset (cold reset), in which


### PR DESCRIPTION
## Description

This avoids a name collision with UefiRuntimeLib which causes a linker error if a platform includes both libraries.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

2311 commit.

## Integration Instructions

N/A.