### PR TITLE
MdeModulePkg: Compatibility Mode: Only Remap System Memory Regions

### DIFF
--- a/MdeModulePkg/Core/Dxe/DxeMain.inf
+++ b/MdeModulePkg/Core/Dxe/DxeMain.inf
@@ -99,6 +99,7 @@
   ImagePropertiesRecordLib
   DxeMemoryProtectionHobLib        ## MU_CHANGE
   MemoryBinOverrideLib      ## MU_CHANGE
+  SafeIntLib                ## MU_CHANGE
 
 [Guids]
   gEfiEventMemoryMapChangeGuid                  ## PRODUCES             ## Event


### PR DESCRIPTION
## Description

When we enter memory protections compatibility mode, we attempt to disable null protection and remap 0 - 0xA0000 as RWX. This was done for x86 systems with broken shim/grubs on Linux that would attempt to use those regions. This resolved that issue and we could boot non-memory protection safe Linux images on x86 HW. However, this approach did not take into account systems that do not have that range marked as system memory, for example ARM64 systems do not have this requirement. As such, this would inappropriately map these regions as RWX when they were not system memory.

This patch updates the remapping to only remap and disable null protection if these ranges are marked as system memory, otherwise it will leave them alone.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [x] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on an ARM64 platform that does not have 0 - 0xA0000 as system memory, as well as an X86 system that does have that range as system memory, booting a Linux image on both that forces us to enter compatibility mode.

## Integration Instructions

N/A.
