### PR TITLE
[REBASE && FF][202405][SPLIT]NetworkPkg/UefiPxeBcDxe: Mark the device as removed when it is unplugged

### DIFF
--- a/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp4.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp4.c
@@ -1749,14 +1749,19 @@ PxeBcDhcp4Dora (
   AsciiPrint ("\n");
 
 ON_EXIT:
-  if (EFI_ERROR (Status)) {
-    Dhcp4->Stop (Dhcp4);
-    Dhcp4->Configure (Dhcp4, NULL);
-  } else {
-    ZeroMem (&Config, sizeof (EFI_DHCP4_CONFIG_DATA));
-    Dhcp4->Configure (Dhcp4, &Config);
-    Private->IsAddressOk = TRUE;
+  // MU_CHANGE [BEGIN] - 162958
+  if (!Private->DeviceDisconnected) {
+    if (EFI_ERROR (Status)) {
+      Dhcp4->Stop (Dhcp4);
+      Dhcp4->Configure (Dhcp4, NULL);
+    } else {
+      ZeroMem (&Config, sizeof (EFI_DHCP4_CONFIG_DATA));
+      Dhcp4->Configure (Dhcp4, &Config);
+      Private->IsAddressOk = TRUE;
+    }
   }
+
+  // MU_CHANGE [END] - 162958
 
   return Status;
 }

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcDriver.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcDriver.c
@@ -1515,7 +1515,8 @@ ON_ERROR:
   }
 
   if (FirstStart && (Private != NULL)) {
-    FreePool (Private);
+    // FreePool (Private);               // MU_CHANGE - 162958
+    Private->DeviceDisconnected = TRUE;  // MU_CHANGE - 162958
   }
 
   return Status;
@@ -1641,7 +1642,8 @@ PxeBcStop (
            &gEfiCallerIdGuid,
            &Private->Id
            );
-    FreePool (Private);
+    // FreePool (Private);                       // MU_CHANGE - 162958
+    Private->DeviceDisconnected = TRUE;          // MU_CHANGE - 162958
   }
 
   return EFI_SUCCESS;

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcImpl.h
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcImpl.h
@@ -219,6 +219,17 @@ struct _PXEBC_PRIVATE_DATA {
   UINT32                     OfferNum;
   UINT32                     OfferCount[PxeOfferTypeMax];
   UINT32                     OfferIndex[PxeOfferTypeMax][PXEBC_OFFER_MAX_NUM];
+
+  // MU_CHANGE [BEGIN] -  162958
+  //
+  // The Network stack fails when a USB nic is removed
+  // after initialization. This change marks it removed
+  // but doesn't clean up memory allocations so that
+  // other code holding onto and using that memory
+  // doesn't cause an exception.
+  //
+  BOOLEAN    DeviceDisconnected;
+  // MU_CHANGE [END] -  162958
 };
 
 extern EFI_PXE_BASE_CODE_PROTOCOL           gPxeBcProtocolTemplate;

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcMtftp.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcMtftp.c
@@ -48,7 +48,13 @@ PxeBcMtftp6CheckPacket (
   EFI_PXE_BASE_CODE_CALLBACK_PROTOCOL  *Callback;
   EFI_STATUS                           Status;
 
-  Private  = (PXEBC_PRIVATE_DATA *)Token->Context;
+  // MU_CHANGE [BEGIN] - 162958
+  Private = (PXEBC_PRIVATE_DATA *)Token->Context;
+  if (Private->DeviceDisconnected) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  // MU_CHANGE [END] - 162958
   Callback = Private->PxeBcCallback;
   Status   = EFI_SUCCESS;
 
@@ -140,6 +146,12 @@ PxeBcMtftp6GetFileSize (
   OptCnt                    = 1;
   Config->InitialServerPort = PXEBC_BS_DOWNLOAD_PORT;
 
+  // MU_CHANGE [BEGIN] - 162958
+  if (Private->DeviceDisconnected) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  // MU_CHANGE [END] - 162958
   Status = Mtftp6->Configure (Mtftp6, Config);
   if (EFI_ERROR (Status)) {
     return Status;
@@ -274,6 +286,12 @@ PxeBcMtftp6ReadFile (
   UINT8                WindowsizeBuf[10];
   EFI_STATUS           Status;
 
+  // MU_CHANGE [BEGIN] - 162958
+  if (Private->DeviceDisconnected) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  // MU_CHANGE [END] - 162958
   Status                    = EFI_DEVICE_ERROR;
   Mtftp6                    = Private->Mtftp6;
   OptCnt                    = 0;
@@ -324,8 +342,12 @@ PxeBcMtftp6ReadFile (
   //
   *BufferSize = Token.BufferSize;
 
-  Mtftp6->Configure (Mtftp6, NULL);
+  // MU_CHANGE [BEGIN] - 162958 -- don't trust Mtftp6 after a surprise removal
+  if (!Private->DeviceDisconnected) {
+    Mtftp6->Configure (Mtftp6, NULL);
+  }
 
+  // MU_CHANGE [END] - 162958
   return Status;
 }
 
@@ -363,6 +385,12 @@ PxeBcMtftp6WriteFile (
   UINT8                OptBuf[128];
   EFI_STATUS           Status;
 
+  // MU_CHANGE [BEGIN] - 162958
+  if (Private->DeviceDisconnected) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  // MU_CHANGE [END] - 162958
   Status                    = EFI_DEVICE_ERROR;
   Mtftp6                    = Private->Mtftp6;
   OptCnt                    = 0;
@@ -398,7 +426,12 @@ PxeBcMtftp6WriteFile (
   //
   *BufferSize = Token.BufferSize;
 
-  Mtftp6->Configure (Mtftp6, NULL);
+  // MU_CHANGE [BEGIN] - 162958 -- don't trust Mtftp6 after a surprise removal
+  if (!Private->DeviceDisconnected) {
+    Mtftp6->Configure (Mtftp6, NULL);
+  }
+
+  // MU_CHANGE [END] - 162958
 
   return Status;
 }
@@ -489,8 +522,12 @@ PxeBcMtftp6ReadDirectory (
   // Get the real size of received buffer.
   //
   *BufferSize = Token.BufferSize;
+  // MU_CHANGE [BEGIN] - 162958
+  if (!Private->DeviceDisconnected) {
+    Mtftp6->Configure (Mtftp6, NULL);
+  }
 
-  Mtftp6->Configure (Mtftp6, NULL);
+  // MU_CHANGE [END] - 162958
 
   return Status;
 }
@@ -526,7 +563,14 @@ PxeBcMtftp4CheckPacket (
   EFI_PXE_BASE_CODE_CALLBACK_PROTOCOL  *Callback;
   EFI_STATUS                           Status;
 
-  Private  = (PXEBC_PRIVATE_DATA *)Token->Context;
+  Private = (PXEBC_PRIVATE_DATA *)Token->Context;
+
+  // MU_CHANGE [BEGIN] - 162958
+  if (Private->DeviceDisconnected) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  // MU_CHANGE [END] - 162958
   Callback = Private->PxeBcCallback;
   Status   = EFI_SUCCESS;
 
@@ -607,6 +651,13 @@ PxeBcMtftp4GetFileSize (
   UINTN                OptBufSize;
   UINT32               OptCnt;
   EFI_STATUS           Status;
+
+  // MU_CHANGE [BEGIN] - 162958
+  if (Private->DeviceDisconnected) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  // MU_CHANGE [END] - 162958
 
   *BufferSize               = 0;
   Status                    = EFI_DEVICE_ERROR;
@@ -752,6 +803,12 @@ PxeBcMtftp4ReadFile (
   UINT8                WindowsizeBuf[10];
   EFI_STATUS           Status;
 
+  // MU_CHANGE [BEGIN] - 162958
+  if (Private->DeviceDisconnected) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  // MU_CHANGE [END] - 162958
   Status                    = EFI_DEVICE_ERROR;
   Mtftp4                    = Private->Mtftp4;
   OptCnt                    = 0;
@@ -802,8 +859,12 @@ PxeBcMtftp4ReadFile (
   //
   *BufferSize = Token.BufferSize;
 
-  Mtftp4->Configure (Mtftp4, NULL);
+  // MU_CHANGE [BEGIN] - 162958 -- don't trust Mtftp6 after a surprise removal
+  if (!Private->DeviceDisconnected) {
+    Mtftp4->Configure (Mtftp4, NULL);
+  }
 
+  // MU_CHANGE [END] - 162958
   return Status;
 }
 
@@ -841,6 +902,12 @@ PxeBcMtftp4WriteFile (
   UINT8                OptBuf[128];
   EFI_STATUS           Status;
 
+  // MU_CHANGE [BEGIN] - 162958
+  if (Private->DeviceDisconnected) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  // MU_CHANGE [END] - 162958
   Status                    = EFI_DEVICE_ERROR;
   Mtftp4                    = Private->Mtftp4;
   OptCnt                    = 0;
@@ -876,7 +943,12 @@ PxeBcMtftp4WriteFile (
   //
   *BufferSize = Token.BufferSize;
 
-  Mtftp4->Configure (Mtftp4, NULL);
+  // MU_CHANGE [BEGIN] - 162958 -- don't trust Mtftp6 after a surprise removal
+  if (!Private->DeviceDisconnected) {
+    Mtftp4->Configure (Mtftp4, NULL);
+  }
+
+  // MU_CHANGE [END] - 162958
 
   return Status;
 }
@@ -918,6 +990,12 @@ PxeBcMtftp4ReadDirectory (
   UINT8                WindowsizeBuf[10];
   EFI_STATUS           Status;
 
+  // MU_CHANGE [BEGIN] - 162958
+  if (Private->DeviceDisconnected) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  // MU_CHANGE [END] - 162958
   Status                    = EFI_DEVICE_ERROR;
   Mtftp4                    = Private->Mtftp4;
   OptCnt                    = 0;
@@ -968,7 +1046,12 @@ PxeBcMtftp4ReadDirectory (
   //
   *BufferSize = Token.BufferSize;
 
-  Mtftp4->Configure (Mtftp4, NULL);
+  // MU_CHANGE [END] - 162958
+  if (!Private->DeviceDisconnected) {
+    Mtftp4->Configure (Mtftp4, NULL);
+  }
+
+  // MU_CHANGE [BEGIN] - 162958
 
   return Status;
 }


### PR DESCRIPTION
## Description

Network stack fails when USB nic is removed after
initialization. This change marks it removed but
doesn't clean up memory allocations so that other
code holding onto and using that memory doesn't
cause an exception.

This change was split off the commit:
https://github.com/microsoft/mu_basecore/commit/7a38833

- [X] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Release/202405

## Integration Instructions

N/A

## Upstream

- [ ] Done