### PR TITLE
[Cherry-Pick] BaseTools/HostBasedUnitTestRunner: Promote Unittest error to CI fail.

### DIFF
--- a/BaseTools/Plugin/HostBasedUnitTestRunner/HostBasedUnitTestRunner.py
+++ b/BaseTools/Plugin/HostBasedUnitTestRunner/HostBasedUnitTestRunner.py
@@ -112,6 +112,7 @@ class HostBasedUnitTestRunner(IUefiBuildPlugin):
                 if ret != 0:
                     logging.error("UnitTest Execution Error: " +
                                   os.path.basename(test))
+                    failure_count += 1
                 else:
                     logging.info("UnitTest Completed: " +
                                  os.path.basename(test))


### PR DESCRIPTION
## Description

Some unit tests would fail to execute or execute and not produce any output logs. In these cases, the only output would be in the CI Log as `UnitTest Execution Error`.

A UnitTest Execution Error should be considered the same as a unit tests test failing.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
On repo where hosted based unit test failed execution prior to generating test results, CI would pass and CI Log would show "Execution Error" for the unit test.

After integrating this change, CI will fail with a unit test error.

## Integration Instructions

For unit tests that are failing, each unit test will need to be examined and individually corrected.
