### PR TITLE
[CHERRY-PICK] [Rebase & FF] 202405: MdePkg/UefiDebugLibDebugPortProtocol: make ExitBootServicesCallback() static

### DIFF
--- a/MdePkg/Library/UefiDebugLibDebugPortProtocol/DebugLibConstructor.c
+++ b/MdePkg/Library/UefiDebugLibDebugPortProtocol/DebugLibConstructor.c
@@ -34,9 +34,10 @@ EFI_BOOT_SERVICES  *mDebugBS;
   @param  Context      Pointer to the notification function's context.
 
 **/
+static
 VOID
 EFIAPI
-ExitBootServicesCallback (
+UefiDebugLibDebugPortProtocolExitBootServicesCallback (
   EFI_EVENT  Event,
   VOID       *Context
   )
@@ -67,7 +68,7 @@ DxeDebugLibConstructor (
   mDebugBS->CreateEvent (
               EVT_SIGNAL_EXIT_BOOT_SERVICES,
               TPL_NOTIFY,
-              ExitBootServicesCallback,
+              UefiDebugLibDebugPortProtocolExitBootServicesCallback,
               NULL,
               &mExitBootServicesEvent
               );


### PR DESCRIPTION
## Description

Since this is a library, make the function ExitBootServicesCallback() STATIC to prevent the likelihood that it collides with other symbols.

---
REF:https://bugzilla.tianocore.org/show_bug.cgi?id=3083

Cherry-picked from edk2:
55b0437

Abandoned [PR 1003](https://github.com/microsoft/mu_basecore/pull/1003) in favor of this upstream change

---


- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

CI

## Integration Instructions

N/A