### PR TITLE
2405: [CHERRY-PICK] BaseTools/CodeQL: Removed unused static function query

### DIFF
--- a/BaseTools/Plugin/CodeQL/CodeQlQueries.qls
+++ b/BaseTools/Plugin/CodeQL/CodeQlQueries.qls
@@ -70,8 +70,6 @@
 - include:
     id: cpp/unused-local-variable
 - include:
-    id: cpp/unused-static-function
-- include:
     id: cpp/unused-static-variable
 
 # Note: Some queries above are not active by default with the below filter.


### PR DESCRIPTION
## Description

This query seems to produce a rate of false positives with some common patterns in edk2 like passing function pointers for callback.

Due to the usage of `STATIC` instead of `static` particularly for functions, this query was rarely used in the past. It is removed here to prevent future false positives.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Run CodeQL with a `static` function and confirm there is no error

## Integration Instructions

- N/A