### PR TITLE
[Rebase & FF] 202405: MdeModulePkg: VariableStandaloneMm.c - TCG MOR workaround for Standalone MM

### DIFF
--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableStandaloneMm.c
@@ -85,5 +85,5 @@ VariableHaveTcgProtocols (
   VOID
   )
 {
-  return FALSE;
+  return TRUE;  // MU_CHANGE TCBZ3513 - workaround MOR bit heuristic that is incompatible with Standalone MM
 }


### PR DESCRIPTION
## Description

TCG MOR workaround for VariableStandaloneMm
Pretend TCG protocol(s) are present to work around antiquated heuristic in common code TcgMorLockSmm.c.

https://bugzilla.tianocore.org/show_bug.cgi?id=3513

---
Chery-picked from 

2187bfeb7b

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
 
## How This Was Tested

Tested in 2311

## Integration Instructions

N/A