### PR TITLE
[REBASE&FF][202405] Restore TPL requirements for WaitForEvent()

### DIFF
--- a/MdeModulePkg/Core/Dxe/DxeMain.h
+++ b/MdeModulePkg/Core/Dxe/DxeMain.h
@@ -14,6 +14,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include <Protocol/LoadedImage.h>
 #include <Protocol/GuidedSectionExtraction.h>
+#include <Protocol/InternalEventServices.h> // MU_CHANGE: Support all TPLs
 #include <Protocol/DevicePath.h>
 #include <Protocol/Runtime.h>
 #include <Protocol/LoadFile.h>
@@ -1581,11 +1582,46 @@ CoreWaitForEvent (
 // MU_CHANGE begin
 
 /**
+  Stops execution until an event is signaled.
+
+  @param  NumberOfEvents[in]     The number of events in the UserEvents array
+  @param  UserEvents[in]         An array of EFI_EVENT
+  @param  UserIndex[out]         Pointer to the index of the event which
+                                 satisfied the wait condition
+
+  @retval EFI_SUCCESS            The event indicated by Index was signaled.
+  @retval EFI_INVALID_PARAMETER  The event indicated by Index has a notification
+                                 function or Event was not a valid type
+
+**/
+EFI_STATUS
+EFIAPI
+CoreWaitForEventInternal (
+  IN UINTN      NumberOfEvents,
+  IN EFI_EVENT  *UserEvents,
+  OUT UINTN     *UserIndex
+  );
+
+/**
   Initialize the memory protection special region reporting.
 **/
 VOID
 EFIAPI
 CoreInitializeMemoryProtectionSpecialRegions (
+  VOID
+  );
+
+/**
+  Installs the internal version of Event Services that does not require
+  TPL_APPLICATION to execute.
+
+  @retval EFI_SUCCESS           Driver initialized successfully
+  @retval EFI_OUT_OF_RESOURCES  Could not allocate needed resources
+
+**/
+EFI_STATUS
+EFIAPI
+InternalEventServicesInit (
   VOID
   );
 

--- a/MdeModulePkg/Core/Dxe/DxeMain.inf
+++ b/MdeModulePkg/Core/Dxe/DxeMain.inf
@@ -162,6 +162,7 @@
   gEfiHiiPackageListProtocolGuid                ## SOMETIMES_PRODUCES
   gEfiSmmBase2ProtocolGuid                      ## SOMETIMES_CONSUMES
   gEdkiiPeCoffImageEmulatorProtocolGuid         ## SOMETIMES_CONSUMES
+  gInternalEventServicesProtocolGuid            ## CONSUMES            ## MU_CHANGE
 
   # Arch Protocols
   gEfiBdsArchProtocolGuid                       ## CONSUMES
@@ -203,6 +204,9 @@
   # MU_CHANGE END
   gEfiMdeModulePkgTokenSpaceGuid.PcdFwVolDxeMaxEncapsulationDepth           ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdImageLargeAddressLoad                   ## CONSUMES
+
+[FeaturePcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdInternalEventServicesEnabled ## CONSUMES ## MU_CHANGE
 
 # [Hob]
 # RESOURCE_DESCRIPTOR   ## CONSUMES

--- a/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
+++ b/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
@@ -554,6 +554,17 @@ DxeMain (
   Status = InitializeSectionExtraction (gDxeCoreImageHandle, gDxeCoreST);
   ASSERT_EFI_ERROR (Status);
 
+  // MU_CHANGE [BEGIN] - Support all TPLs
+  //
+  // Produce Internal Event Services
+  //
+  if (FeaturePcdGet (PcdInternalEventServicesEnabled)) {
+    Status = InternalEventServicesInit ();
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  // MU_CHANGE [END] - Support all TPLs
+
   //
   // Initialize the DXE Dispatcher
   //

--- a/MdeModulePkg/Core/Dxe/Event/Event.c
+++ b/MdeModulePkg/Core/Dxe/Event/Event.c
@@ -628,12 +628,14 @@ CoreCheckEvent (
   return Status;
 }
 
+// MU_CHANGE [BEGIN] - Support all TPLs
+
 /**
   Stops execution until an event is signaled.
 
-  @param  NumberOfEvents         The number of events in the UserEvents array
-  @param  UserEvents             An array of EFI_EVENT
-  @param  UserIndex              Pointer to the index of the event which
+  @param  NumberOfEvents[in]     The number of events in the UserEvents array
+  @param  UserEvents[in]         An array of EFI_EVENT
+  @param  UserIndex[out]         Pointer to the index of the event which
                                  satisfied the wait condition
 
   @retval EFI_SUCCESS            The event indicated by Index was signaled.
@@ -650,17 +652,36 @@ CoreWaitForEvent (
   OUT UINTN     *UserIndex
   )
 {
+  if (gEfiCurrentTpl != TPL_APPLICATION) {
+    return EFI_UNSUPPORTED;
+  }
+
+  return CoreWaitForEventInternal (NumberOfEvents, UserEvents, UserIndex);
+}
+
+/**
+  Stops execution until an event is signaled.
+
+  @param  NumberOfEvents[in]     The number of events in the UserEvents array
+  @param  UserEvents[in]         An array of EFI_EVENT
+  @param  UserIndex[out]         Pointer to the index of the event which
+                                 satisfied the wait condition
+
+  @retval EFI_SUCCESS            The event indicated by Index was signaled.
+  @retval EFI_INVALID_PARAMETER  The event indicated by Index has a notification
+                                 function or Event was not a valid type
+
+**/
+EFI_STATUS
+EFIAPI
+CoreWaitForEventInternal (
+  IN UINTN      NumberOfEvents,
+  IN EFI_EVENT  *UserEvents,
+  OUT UINTN     *UserIndex
+  )
+{
   EFI_STATUS  Status;
   UINTN       Index;
-
-  //
-  // Can only WaitForEvent at TPL_APPLICATION
-  //
-  // MU_CHANGE - START
-  // if (gEfiCurrentTpl != TPL_APPLICATION) {
-  //  return EFI_UNSUPPORTED;                    // MU_CHANGE: Supporting all TPLs
-  // }
-  // MU_CHANGE - END
 
   if (NumberOfEvents == 0) {
     return EFI_INVALID_PARAMETER;
@@ -704,6 +725,47 @@ CoreWaitForEvent (
     // MU_CHANGE End: Add Cpu2 Protocol
   }
 }
+
+// MU_CHANGE [END] - Support all TPLs
+
+// MU_CHANGE [BEGIN] - Support all TPLs
+//
+// Provides access to the event.c internal event functions that do not require TPL_APPLICATION
+// The event.c core event functions are provided via gBS and require TPL_APPLICATION however
+// the internal functions can optionally be produced via the Feature PCD PcdInternalEventServicesEnabled
+//
+INTERNAL_EVENT_SERVICES_PROTOCOL  mInternalEventServicesProtocol = {
+  CoreWaitForEventInternal
+};
+
+EFI_HANDLE  mInternalEventServicesProtocolHandle = NULL;
+
+/**
+  Installs the internal version of Event Services that does not require
+  TPL_APPLICATION to execute.
+
+  @param  ImageHandle   A handle for the image that is initializing this protocol
+  @param  SystemTable   A pointer to the EFI system table
+
+  @retval EFI_SUCCESS           Driver initialized successfully
+  @retval EFI_OUT_OF_RESOURCES  Could not allocate needed resources
+
+**/
+EFI_STATUS
+EFIAPI
+InternalEventServicesInit (
+  VOID
+  )
+{
+  return CoreInstallProtocolInterface (
+           &mInternalEventServicesProtocolHandle,
+           &gInternalEventServicesProtocolGuid,
+           EFI_NATIVE_INTERFACE,
+           &mInternalEventServicesProtocol
+           );
+}
+
+// MU_CHANGE [END] - Support all TPLs
 
 /**
   Closes an event and frees the event structure.

--- a/MdeModulePkg/Include/Protocol/InternalEventServices.h
+++ b/MdeModulePkg/Include/Protocol/InternalEventServices.h
@@ -1,0 +1,52 @@
+/** @file
+  This protocol provides WaitForEvent functionality without
+  requiring TPL_APPLICATION level.
+
+Copyright (c) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+// MU_CHANGE entire file
+
+#ifndef INTERNAL_EVENT_SERVICES_
+#define INTERNAL_EVENT_SERVICES_
+
+//
+// Internal Event Services Guid Value
+//
+// *NOTE: Should the interface of INTERNAL_EVENT_SERVICES_PROTOCOL change to
+//   include additional event services functions, a new value for
+//   INTERNAL_EVENT_SERVICES_PROTOCOL_GUID will be generated.
+//
+#define INTERNAL_EVENT_SERVICES_PROTOCOL_GUID  {0x7ecd162a, 0xc664, 0x11ec, { 0x9d, 0x64, 0x02, 0x42, 0xac, 0x12, 0x00, 0x02 } \}
+
+typedef struct _INTERNAL_EVENT_SERVICES_PROTOCOL INTERNAL_EVENT_SERVICES_PROTOCOL;
+
+/**
+  Stops execution until an event is signaled, with no TPL restrictions.
+
+  @param  NumberOfEvents         The number of events in the UserEvents array
+  @param  UserEvents             An array of EFI_EVENT
+  @param  UserIndex              Pointer to the index of the event which
+                                 satisfied the wait condition
+
+  @retval EFI_SUCCESS            The event indicated by Index was signaled.
+  @retval EFI_INVALID_PARAMETER  The event indicated by Index has a notification
+                                 function or Event was not a valid type
+
+**/
+typedef
+EFI_STATUS
+(EFIAPI *WAIT_FOR_EVENT_INTERNAL)(
+  IN UINTN      NumberOfEvents,
+  IN EFI_EVENT  *UserEvents,
+  OUT UINTN     *UserIndex
+  );
+
+struct _INTERNAL_EVENT_SERVICES_PROTOCOL {
+  WAIT_FOR_EVENT_INTERNAL    WaitForEventInternal;
+};
+
+extern EFI_GUID  gInternalEventServicesProtocolGuid;
+
+#endif

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -676,6 +676,10 @@
   # Include/Guid/MemoryProtectionSpecialRegionProtocol.h
   gMemoryProtectionSpecialRegionProtocolGuid = { 0x47BF7F78, 0x0B53, 0x487B, {0xA2, 0xFE, 0x42, 0xE7, 0x09, 0x87, 0x54, 0x5C } }
 
+  # MU_CHANGE
+  # This protocol provides access to Internal Event services that do not need TPL_APPLICATION
+  gInternalEventServicesProtocolGuid = {0x7ecd162a, 0xc664, 0x11ec, { 0x9d, 0x64, 0x02, 0x42, 0xac, 0x12, 0x00, 0x02 } }
+  
   ## This protocol defines the generic memory test interfaces in Dxe phase.
   # Include/Protocol/GenericMemoryTest.h
   gEfiGenericMemTestProtocolGuid = { 0x309DE7F1, 0x7F5E, 0x4ACE, { 0xB4, 0x9C, 0x53, 0x1B, 0xE5, 0xAA, 0x95, 0xEF }}
@@ -1090,6 +1094,14 @@
   #   FALSE - DMA Access can happen before IOMMU protocol install.<BR>
   # @Prompt Enable DMA before IOMMU protocol.
   gEfiMdeModulePkgTokenSpaceGuid.PcdRequireIommu|TRUE|BOOLEAN|0x30001090
+
+  ## MU_CHANGE
+  ## Indicates if the InternalEventServices protocol is published to gBS. This protocol provides access to the
+  #  internal event functions that do not require TPL_APPLICATION.
+  #    TRUE  - Publish the InternalEventServices protocol
+  #    FALSE - Do not publish the InternalEventServices protocol
+  # @Prompt Install Internal Event Services Protocol
+  gEfiMdeModulePkgTokenSpaceGuid.PcdInternalEventServicesEnabled|FALSE|BOOLEAN|0x30003003
 
 [PcdsFeatureFlag.IA32, PcdsFeatureFlag.ARM, PcdsFeatureFlag.AARCH64]
   gEfiMdeModulePkgTokenSpaceGuid.PcdPciDegradeResourceForOptionRom|FALSE|BOOLEAN|0x0001003a


### PR DESCRIPTION
## Description

Restores TPL requirements for WaitForEvent as removed in c3acc1ff370b9f93c811a32025789611a7809c36 to ensure the Event based Self Certification Tests (SCT)s pass, but allow a platform to produce a wait for event protocol that does not have the TPL_APPLICATION requirements.

Includes:
- https://github.com/microsoft/mu_basecore/commit/47273abc00

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

202311

## Integration Instructions

202311
