### PR TITLE
[Rebase & FF] 202405: MdePkg: Added definition of AMD specific public MSRs

### DIFF
--- a/MdePkg/Include/Register/Amd/ArchitecturalMsr.h
+++ b/MdePkg/Include/Register/Amd/ArchitecturalMsr.h
@@ -1,0 +1,57 @@
+/** @file ArchitecturalMsr.h
+  MU_CHANGE: Addition of this whole file
+
+  AMD Architectural MSR Definitions.
+
+  Provides defines for Machine Specific Registers(MSR) indexes.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  @par Specification Reference:
+  AMD64 Architecture Programmer’s Manual, Volumes 2
+  Rev. 3.37, Volume 2: System Programming
+
+**/
+
+#ifndef AMD_ARCHITECTURAL_MSR_H_
+#define AMD_ARCHITECTURAL_MSR_H_
+
+/*
+  See Appendix A.8, "System Management Mode MSR Cross-Reference".
+
+  SMBASE MSR that contains the SMRAM base address.
+  Reset value: 0000_0000_0003_0000h
+
+*/
+#define AMD_64_SMM_BASE  0xC0010111
+
+/*
+  See Appendix A.8, "System Management Mode MSR Cross-Reference".
+
+  SMM_ADDR Contains the base address of protected
+  memory for the SMM Handler.
+
+  Specific usage, see AMD64 Architecture Programmer’s Manual,
+  Volumes 2 (Rev. 3.37), Section 10.2.5
+
+  Reset value: 0000_0000_0000_0000h
+
+*/
+#define AMD_64_SMM_ADDR  0xC0010112
+
+/*
+  See Appendix A.8, "System Management Mode MSR Cross-Reference".
+
+  SMM_MASK Contains a mask which determines the size of
+  the protected area for the SMM handler.
+
+  Specific usage, see AMD64 Architecture Programmer’s Manual,
+  Volumes 2 (Rev. 3.37), Section 10.2.5
+
+  Reset value: 0000_0000_0000_0000h
+
+*/
+#define AMD_64_SMM_MASK  0xC0010113
+
+#endif // AMD_ARCHITECTURAL_MSR_H_

--- a/MdePkg/Include/Register/Amd/Msr.h
+++ b/MdePkg/Include/Register/Amd/Msr.h
@@ -18,6 +18,7 @@
 #define __AMD_MSR_H__
 
 #include <Register/Intel/ArchitecturalMsr.h>
+#include <Register/Amd/ArchitecturalMsr.h> // MU_CHANGE: Added Amd/ArchitecturalMsr.h file
 #include <Register/Amd/Fam17Msr.h>
 #include <Register/Amd/SvsmMsr.h>
 


### PR DESCRIPTION
## Description

Added definition of AMD specific public MSRs:
1. SMBASE
2. SMM_ADDR
3. SMM_MASK

---
Cherry-picked from 

2e2958c6d4

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

2311

## Integration Instructions

N/A
