### PR TITLE
Add MuCodeQlQueries.qls and pin to the 0.9.12 codeq/cpp-queries pack

### DIFF
--- a/BaseTools/Plugin/CodeQL/CodeQlAnalyzePlugin.py
+++ b/BaseTools/Plugin/CodeQL/CodeQlAnalyzePlugin.py
@@ -113,7 +113,7 @@ class CodeQlAnalyzePlugin(IUefiBuildPlugin):
         # Use this plugins query set file as the default fallback if it is
         # not overridden. It is possible the file is not present if modified
         # locally. In that case, skip the plugin.
-        plugin_query_set = Path(Path(__file__).parent, "CodeQlQueries.qls")
+        plugin_query_set = Path(Path(__file__).parent, "MuCodeQlQueries.qls")
 
         if not query_specifiers and plugin_query_set.is_file():
             query_specifiers = str(plugin_query_set.resolve())

--- a/BaseTools/Plugin/CodeQL/MuCodeQlQueries.qls
+++ b/BaseTools/Plugin/CodeQL/MuCodeQlQueries.qls
@@ -1,0 +1,135 @@
+---
+- description: Project Mu UEFI (C++) queries
+
+- queries: '.'
+  from: codeql/cpp-queries@0.9.12
+
+##########################################################################################
+# "Core" Queries - Part of Core SDL
+##########################################################################################
+
+## Errors
+- include:
+    id: cpp/badoverflowguard
+- include:
+    id: cpp/likely-bugs/memory-management/v2/conditionally-uninitialized-variable
+- include:
+    id: cpp/pointer-overflow-check
+- include:
+    id: cpp/unguardednullreturndereference
+
+## Warnings
+- include:
+    id: cpp/comparison-with-wider-type
+- include:
+    id: cpp/conditionallyuninitializedvariable
+- include:
+    id: cpp/paddingbyteinformationdisclosure
+- include:
+    id: cpp/uselesstest
+
+## Recommendations
+- include:
+    id: cpp/redundant-null-check-param
+
+##########################################################################################
+# Extra Queries - Outside Core SDL
+##########################################################################################
+
+## Enable When Time is Available to Fix Issues
+# Hundreds of issues. Most appear valid. Type: Recommendation.
+#- include:
+#    id: cpp/missing-null-test
+
+## Errors
+- include:
+    id: cpp/infiniteloop
+- include:
+    id: cpp/missing-return
+- include:
+    id: cpp/no-space-for-terminator
+- include:
+    id: cpp/pointer-overflow-check
+- include:
+    id: cpp/redundant-null-check-simple
+- include:
+    id: cpp/sizeof/const-int-argument
+- include:
+    id: cpp/sizeof/sizeof-or-operation-as-argument
+- include:
+    id: cpp/very-likely-overrunning-write
+
+## Warnings
+- include:
+    id: cpp/comparison-precedence
+- include:
+    id: cpp/implicit-bitfield-downcast
+- include:
+    id: cpp/infinite-loop-with-unsatisfiable-exit-condition
+- include:
+    id: cpp/offset-use-before-range-check
+- include:
+    id: cpp/overflow-buffer
+- include:
+    id: cpp/overflow-calculated
+- include:
+    id: cpp/overflow-destination
+- include:
+    id: cpp/return-stack-allocated-memory
+- include:
+    id: cpp/static-buffer-overflow
+- include:
+    id: cpp/unsigned-comparison-zero
+
+## Recommendations
+- include:
+    id: cpp/missing-header-guard
+- include:
+    id: cpp/unused-local-variable
+- include:
+    id: cpp/unused-static-function
+- include:
+    id: cpp/unused-static-variable
+
+# Note: Some queries above are not active by default with the below filter.
+#       Update the filter and run the queries again to get all results.
+- include:
+    tags:
+      - "security"
+      - "correctness"
+    severity:
+      - "error"
+      - "warning"
+      - "recommendation"
+
+# Specifically hide the results of these.
+#
+# The following rules have been evaluated and explicitly not included for the following reasons:
+#   - `cpp/allocation-too-small` - Appears to be hardcoded for C standard library functions `malloc`, `calloc`,
+#     `realloc`, so it consumes time without much value with custom allocation functions in the codebase.
+#   - `cpp/commented-out-code` - Triggers (way) too often on MU_CHANGE tags.
+#   - `cpp/duplicate-include-guard` - The <Phase>EntryPoint.h files includes a common include guard value
+#     `__MODULE_ENTRY_POINT_H__`. This was the only occurrence found. So not very useful.
+#   - `cpp/invalid-pointer-deref` - Very limited results with what appear to be false positives.
+#   - `cpp/use-of-goto` - Goto is valid and allowed in the codebase.
+#   - `cpp/useless-expression` - Triggers too often on cases where a NULL lib implementation is provided for a function.
+#     Because the implementation simply returns, the check considers it useless.
+#   - `cpp/weak-crypto/*` - Crypto algorithms are tracked outside CodeQL.
+- exclude:
+    id: cpp/allocation-too-small
+- exclude:
+    id: cpp/commented-out-code
+- exclude:
+    id: cpp/duplicate-include-guard
+- exclude:
+    id: cpp/invalid-pointer-deref
+- exclude:
+    id: cpp/use-of-goto
+- exclude:
+    id: cpp/useless-expression
+- exclude:
+    id: cpp/weak-crypto/banned-hash-algorithms
+- exclude:
+    id: cpp/weak-crypto/capi/banned-modes
+- exclude:
+    id: cpp/weak-crypto/openssl/banned-hash-algorithms

--- a/BaseTools/Plugin/CodeQL/Readme.md
+++ b/BaseTools/Plugin/CodeQL/Readme.md
@@ -332,7 +332,7 @@ operation behind the plugin and can be skipped by anyone not interested in those
 6. Determine the CodeQL query specifiers to use for the given package and target
    - First choice, the package CI YAML file value
    - Second choice, the `STUART_CODEQL_QUERY_SPECIFIERS`
-   - Third choice, use `CodeQlQueries.qls` (in the plugin directory)
+   - Third choice, use `MuCodeQlQueries.qls` (in the plugin directory)
 7. Run CodeQL CLI to perform database analysis
 8. Parse the analysis SARIF file to determine the number of CodeQL failures
 9. Return the number of failures (or zero if `AuditOnly` is enabled)

--- a/BaseTools/Plugin/CodeQL/codeqlcli_ext_dep.yaml
+++ b/BaseTools/Plugin/CodeQL/codeqlcli_ext_dep.yaml
@@ -8,6 +8,13 @@
 # In an environment where a platform might build in different operating systems, it is recommended to set
 # the scope for the appropriate CodeQL external dependency based on the host operating system being used.
 #
+# ****VERSION UPDATE INSTRUCTIONS****
+#
+# When updating the CodeQL CLI used here, update the corresponding codeql/cpp-queries version in MuCodeQlQueries.qls.
+# Visit the `qlpack.yml` in the release branch for the CodeQL CLI to get the version to use there. For example, the
+# CodeQL CLI 2.17.3 file is https://github.com/github/codeql/blob/codeql-cli-2.17.3/cpp/ql/src/qlpack.yml and the
+# pack version there is 0.9.12.
+#
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##

--- a/BaseTools/Plugin/CodeQL/codeqlcli_linux_ext_dep.yaml
+++ b/BaseTools/Plugin/CodeQL/codeqlcli_linux_ext_dep.yaml
@@ -6,6 +6,13 @@
 # systems, it is recommended to set the scope for the appropriate CodeQL external dependency based on the
 # host operating system being used.
 #
+# ****VERSION UPDATE INSTRUCTIONS****
+#
+# When updating the CodeQL CLI used here, update the corresponding codeql/cpp-queries version in MuCodeQlQueries.qls.
+# Visit the `qlpack.yml` in the release branch for the CodeQL CLI to get the version to use there. For example, the
+# CodeQL CLI 2.17.3 file is https://github.com/github/codeql/blob/codeql-cli-2.17.3/cpp/ql/src/qlpack.yml and the
+# pack version there is 0.9.12.
+#
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##

--- a/BaseTools/Plugin/CodeQL/codeqlcli_windows_ext_dep.yaml
+++ b/BaseTools/Plugin/CodeQL/codeqlcli_windows_ext_dep.yaml
@@ -6,6 +6,13 @@
 # systems, it is recommended to set the scope for the appropriate CodeQL external dependency based on the
 # host operating system being used.
 #
+# ****VERSION UPDATE INSTRUCTIONS****
+#
+# When updating the CodeQL CLI used here, update the corresponding codeql/cpp-queries version in MuCodeQlQueries.qls.
+# Visit the `qlpack.yml` in the release branch for the CodeQL CLI to get the version to use there. For example, the
+# CodeQL CLI 2.17.3 file is https://github.com/github/codeql/blob/codeql-cli-2.17.3/cpp/ql/src/qlpack.yml and the
+# pack version there is 0.9.12.
+#
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##


### PR DESCRIPTION
## Description

Adds the MuCodeQlQueries.qls file and changes the CodeQlAnalyzePlugin to use MuCodeQlQueries instead of the edk2 CodeQlQueries file. This runs the CodeQL queries that project mu cares about instead of the edk2 CodeQL queries that don't all apply.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- 2311 transfer

## Integration Instructions

- MuCodeQlQueries.qls should be used by Project Mu based platforms