### PR TITLE
BaseTools: GenC: Fixing an edge case where BUILDMODULE might fail

### DIFF
--- a/BaseTools/Source/Python/AutoGen/GenC.py
+++ b/BaseTools/Source/Python/AutoGen/GenC.py
@@ -2076,7 +2076,7 @@ def CreateCode(Info, AutoGenC, AutoGenH, StringH, UniGenCFlag, UniGenBinBuffer, 
             else:
                 CookieValue = int(GlobalData.gStackCookieValues64[hash(Info.Guid) % len(GlobalData.gStackCookieValues64)])
         except:
-            EdkLogger.error("build", AUTOGEN_ERROR, "Failed to get Stack Cookie Value List! Generating random value.", ExtraData="[%s]" % str(Info))
+            EdkLogger.warn("build", "Failed to get Stack Cookie Value List! Generating random value.", ExtraData="[%s]" % str(Info))
             if Bitwidth == 32:
                 CookieValue = secrets.randbelow (0xFFFFFFFF)
             else:


### PR DESCRIPTION
## Description

This change fixed an edge case when invoking the build process with "BUILDMODULE" and no stack cookie is involved (i.e. pure assembly code), the build might fail.

The existing code path is written to handle such case, but the error method is actually breaking the build. This change demotes the message to warning.

Signed-off-by: Kun Qin <kun.qin@microsoft.com>

(cherry picked from commit ca0ae3c4a56c1eb0cd2c0c84c34bd5a09f58c3c3)

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

This was tested on QEMU Q35 build process.

## Integration Instructions

N/A