### PR TITLE
Change CpuDeadLoops to panic calls in PiSmmCpuDxeSmm.c

### DIFF
--- a/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.c
@@ -584,7 +584,7 @@ GetSmBase (
 
   ASSERT (NumberOfProcessors == MaxNumberOfCpus);
   if (NumberOfProcessors != MaxNumberOfCpus) {
-    CpuDeadLoop ();
+    PANIC ("Incorrect number of processors!");  // MU_CHANGE
   }
 
   SmBaseHobs = AllocatePool (sizeof (SMM_BASE_HOB_DATA *) * HobCount);
@@ -1111,7 +1111,7 @@ PiCpuSmmEntry (
   if (TileSize > SIZE_8KB) {
     DEBUG ((DEBUG_ERROR, "The Range of Smbase in SMRAM is not enough -- Required TileSize = 0x%08x, Actual TileSize = 0x%08x\n", TileSize, SIZE_8KB));
     FreePool (gSmmCpuPrivate->ProcessorInfo);
-    CpuDeadLoop ();
+    PANIC ("TileSize larger than 8KB");  // MU_CHANGE
     return RETURN_BUFFER_TOO_SMALL;
   }
 
@@ -1123,7 +1123,7 @@ PiCpuSmmEntry (
   Status                 = GetSmBase (mMaxNumberOfCpus, &mCpuHotPlugData.SmBase);
   ASSERT (!EFI_ERROR (Status));
   if (EFI_ERROR (Status)) {
-    CpuDeadLoop ();
+    PANIC ("mCpuHotPlugData.SmBase is NULL");  // MU_CHANGE
   }
 
   //

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.h
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.h
@@ -56,6 +56,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/CpuPageTableLib.h>
 #include <Library/MmSaveStateLib.h>
 #include <Library/SmmCpuSyncLib.h>
+#include <Library/PanicLib.h> // MU_CHANGE
 
 #include <AcpiCpuData.h>
 #include <CpuHotPlugData.h>

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf
@@ -103,6 +103,7 @@
   MmSaveStateLib
   SmmCpuSyncLib
   MmMemoryProtectionHobLib                   ## MU_CHANGE
+  PanicLib                                   ## MU_CHANGE
 
 [Protocols]
   gEfiSmmAccess2ProtocolGuid               ## CONSUMES


### PR DESCRIPTION
## Description

Changes the newly added CpuDeadLoops in PiSmmCpuDxeSmm.c into PANIC calls to give more information on issues that are hit instead of hanging the system.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

N/A

## Integration Instructions

N/A