### PR TITLE
2405: BaseTools/MuCodeQlQueries.qls: Removed unused static function query

### DIFF
--- a/BaseTools/Plugin/CodeQL/MuCodeQlQueries.qls
+++ b/BaseTools/Plugin/CodeQL/MuCodeQlQueries.qls
@@ -87,8 +87,6 @@
 - include:
     id: cpp/unused-local-variable
 - include:
-    id: cpp/unused-static-function
-- include:
     id: cpp/unused-static-variable
 
 # Note: Some queries above are not active by default with the below filter.


### PR DESCRIPTION
## Description

This is the Project Mu equivalent of the following edk2 commit:

`1bb9f47`

This commit can be squashed with the commit that adds `MuCodeQlQueries.qls` in the future.

---

This query seems to produce a rate of false positives with some common patterns in edk2 like passing function pointers for callback.

Due to the usage of `STATIC` instead of `static` particularly for functions, this query was rarely used in the past. It is removed here to prevent future false positives.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- CodeQL with a `static` function present in the code

## Integration Instructions

- N/A