### PR TITLE
[2405] [SQUASH ON REBASE] Fix pip-requirement double listing

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -15,7 +15,6 @@
 edk2-pytool-library~=0.21.8 # MU_CHANGE
 edk2-pytool-extensions~=0.27.10 # MU_CHANGE
 antlr4-python3-runtime==4.13.1
-regex
 lcov-cobertura==2.0.2
 pygount==1.8.0 # MU_CHANGE
 toml==0.10.2 # MU_CHANGE


### PR DESCRIPTION
## Description

regex is listed twice, once without a version, which causes Linux pip to fail to install. This should be squashed with the CI commit on next rebase: https://github.com/microsoft/mu_basecore/commit/92a21e356267186c84731a5e71baf7cb937915c3.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Installing on Linux.

## Integration Instructions

N/A.