### PR TITLE
CryptoPkg: Updating Shared Crypto Bin to version 2023.12.2.

### DIFF
--- a/CryptoPkg/Binaries/BaseCryptoDriver_ext_dep.json
+++ b/CryptoPkg/Binaries/BaseCryptoDriver_ext_dep.json
@@ -3,7 +3,7 @@
   "type": "nuget",
   "name": "edk2-basecrypto-driver-bin",
   "source": "https://pkgs.dev.azure.com/projectmu/mu/_packaging/Mu-Public/nuget/v3/index.json",
-  "version": "2023.11.3",
+  "version": "2023.12.2",
   "flags": ["set_build_var"],
   "var_name": "BLD_*_SHARED_CRYPTO_PATH"
 }


### PR DESCRIPTION
## Description

Previous version v2023.11.3 did not contain PDB information, which was causing some problems in a platform which needed PDB information.

v2023.12.1 includes PDB information.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [x] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Ran mu_tiano_platforms with changes and verified boot.

## Integration Instructions

After this update, platforms are required to supply gEfiRngPpiGuid in the Pei phase, and gEfiRngProtocolGuid in the Dxe phase.
Common implementations are available:

SecurityPkg\RandomNumberGenerator\RngPei\RngPei.inf
SecurityPkg\RandomNumberGenerator\RngDxe\RngDxe.inf