### PR TITLE
[202405][Rebase&&FF] Missing Variable Policy commit:  [WHEA-HwErr]

### DIFF
--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableNonVolatile.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableNonVolatile.c
@@ -332,10 +332,19 @@ InitNonVolatileVariableStore (
   while (IsValidVariableHeader (Variable, GetEndPointer (mNvVariableCache))) {
     NextVariable = GetNextVariablePtr (Variable, mVariableModuleGlobal->VariableGlobal.AuthFormat);
     VariableSize = (UINTN)NextVariable - (UINTN)Variable;
-    if ((Variable->Attributes & (EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_HARDWARE_ERROR_RECORD)) == (EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_HARDWARE_ERROR_RECORD)) {
-      mVariableModuleGlobal->HwErrVariableTotalSize += VariableSize;
-    } else {
+    // MU_CHANGE Starts: Deleted hw error records should not count towards the hw error record space quota
+    // When computing total variable size, HwErrRec marked as Deleted should be treated as a common variable
+    if (((Variable->Attributes & (EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_HARDWARE_ERROR_RECORD)) == (EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_HARDWARE_ERROR_RECORD)) &&
+        ((Variable->State | VAR_DELETED) == VAR_DELETED))
+    {
       mVariableModuleGlobal->CommonVariableTotalSize += VariableSize;
+    } else {
+      // MU_CHANGE Ends
+      if ((Variable->Attributes & (EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_HARDWARE_ERROR_RECORD)) == (EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_HARDWARE_ERROR_RECORD)) {
+        mVariableModuleGlobal->HwErrVariableTotalSize += VariableSize;
+      } else {
+        mVariableModuleGlobal->CommonVariableTotalSize += VariableSize;
+      }
     }
 
     Variable = NextVariable;


### PR DESCRIPTION

This commit was missed during the rebasing of variable policy. This PR addresses this.

Missed 0a38ef7041c7a8d19620e61ad3926a9bf41d715f

During upstreaming attach to #978

## How This Was Tested

Release/202311

## Integration Instructions

N/A