### PR TITLE
[202405][Rebase&&FF] Update USB's Descriptor Information

### DIFF
--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBus.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbBus.c
@@ -979,6 +979,13 @@ UsbIoPortReset (
 
   DEBUG ((DEBUG_INFO, "UsbIoPortReset: device is now ADDRESSED at %d\n", Dev->Address));
 
+  // MU_CHANGE [BEGIN] 291137
+  //
+  // Endpoint descriptor state needs to be updated following a reset.
+  //
+  UsbUpdateDescriptors (Dev);
+  // MU_CHANGE [END]
+
   //
   // Reset the current active configure, after this device
   // is in CONFIGURED state.

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.c
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.c
@@ -1009,3 +1009,29 @@ UsbIoClearFeature (
 
   return Status;
 }
+
+// MU_CHANGE [BEGIN] - 291137
+
+/**
+  Update the device's descriptor information.
+  @param  UsbDev                The Usb device.
+**/
+VOID
+UsbUpdateDescriptors (
+  IN USB_DEVICE  *UsbDev
+  )
+{
+  EFI_USB_CONFIG_DESCRIPTOR  *ConfDesc;
+  EFI_USB_DEVICE_DESCRIPTOR  DevDesc;
+  UINT8                      Index;
+
+  UsbCtrlGetDesc (UsbDev, USB_DESC_TYPE_DEVICE, 0, 0, &DevDesc, sizeof (EFI_USB_DEVICE_DESCRIPTOR));
+  for (Index = 0; Index < DevDesc.NumConfigurations; Index++) {
+    ConfDesc = UsbGetOneConfig (UsbDev, Index);
+    FreePool (ConfDesc);
+  }
+
+  return;
+}
+
+// MU_CHANGE [END]

--- a/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.h
+++ b/MdeModulePkg/Bus/Usb/UsbBusDxe/UsbDesc.h
@@ -224,4 +224,17 @@ UsbIoClearFeature (
   IN  UINT16               Index
   );
 
+// MU_CHANGE [BEGIN] 291137
+
+/**
+  Usb UsbIo interface to update descriptor information.
+  @param  UsbDev                The Usb device.
+**/
+VOID
+UsbUpdateDescriptors (
+  IN USB_DEVICE  *UsbDev
+  );
+
+// MU_CHANGE END
+
 #endif


### PR DESCRIPTION
Following a reset the descriptor information needs to be updated. This change adds an interface to
update the descriptor information and calls it after a reset.

This was dropped from https://github.com/microsoft/mu_basecore/pull/1017 and was meant to be added to USB feature. However, USB changes remained here and this change was never re-added.  This commit re-adds this change.

Attach to https://github.com/microsoft/mu_basecore/pull/1017

## How This Was Tested

Release/202311

## Integration Instructions

N/A