### PR TITLE
Added MockServiceBinding and Add mock functions under MockUefiBootServicesTableLib, MockUefiLib and MockUefiDevicePathLib

### DIFF
--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiBootServicesTableLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiBootServicesTableLib.h
@@ -169,6 +169,16 @@ struct MockUefiBootServicesTableLib {
      IN  UINTN                        Size,
      OUT VOID                         **Buffer)
     );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_LocateHandle,
+    (IN     EFI_LOCATE_SEARCH_TYPE   SearchType,
+     IN     EFI_GUID                 *Protocol     OPTIONAL,
+     IN     VOID                     *SearchKey    OPTIONAL,
+     IN OUT UINTN                    *BufferSize,
+     OUT    EFI_HANDLE               *Buffer)
+    );
 };
 
 #endif // MOCK_UEFI_BOOT_SERVICES_TABLE_LIB_H_

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiDevicePathLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiDevicePathLib.h
@@ -26,6 +26,134 @@ struct MockUefiDevicePathLib {
      IN CONST EFI_DEVICE_PATH_PROTOCOL  *DevicePath
     )
     );
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    IsDevicePathValid,
+    (IN CONST EFI_DEVICE_PATH_PROTOCOL  *DevicePath,
+     IN       UINTN                     MaxSize)
+    );
+  MOCK_FUNCTION_DECLARATION (
+    UINT8,
+    DevicePathType,
+    (IN CONST VOID  *Node)
+    );
+  MOCK_FUNCTION_DECLARATION (
+    UINT8,
+    DevicePathSubType,
+    (IN CONST VOID  *Node)
+    );
+  MOCK_FUNCTION_DECLARATION (
+    UINTN,
+    DevicePathNodeLength,
+    (IN CONST VOID  *Node)
+    );
+  MOCK_FUNCTION_DECLARATION (
+    EFI_DEVICE_PATH_PROTOCOL *,
+    NextDevicePathNode,
+    (IN CONST VOID  *Node)
+    );
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    IsDevicePathEndType,
+    (IN CONST VOID  *Node)
+    );
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    IsDevicePathEnd,
+    (IN CONST VOID  *Node)
+    );
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    IsDevicePathEndInstance,
+    (IN CONST VOID  *Node)
+    );
+  MOCK_FUNCTION_DECLARATION (
+    UINT16,
+    SetDevicePathNodeLength,
+    (IN OUT VOID  *Node,
+     IN UINTN     Length)
+    );
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    SetDevicePathEndNode,
+    (OUT VOID  *Node)
+    );
+  MOCK_FUNCTION_DECLARATION (
+    UINTN,
+    GetDevicePathSize,
+    (IN CONST EFI_DEVICE_PATH_PROTOCOL  *DevicePath)
+    );
+  MOCK_FUNCTION_DECLARATION (
+    EFI_DEVICE_PATH_PROTOCOL *,
+    AppendDevicePath,
+    (IN CONST EFI_DEVICE_PATH_PROTOCOL  *FirstDevicePath   OPTIONAL,
+     IN CONST EFI_DEVICE_PATH_PROTOCOL  *SecondDevicePath  OPTIONAL)
+    );
+  MOCK_FUNCTION_DECLARATION (
+    EFI_DEVICE_PATH_PROTOCOL *,
+    AppendDevicePathNode,
+    (IN CONST EFI_DEVICE_PATH_PROTOCOL  *DevicePath      OPTIONAL,
+     IN CONST EFI_DEVICE_PATH_PROTOCOL  *DevicePathNode  OPTIONAL)
+    );
+  MOCK_FUNCTION_DECLARATION (
+    EFI_DEVICE_PATH_PROTOCOL *,
+    AppendDevicePathInstance,
+    (IN CONST EFI_DEVICE_PATH_PROTOCOL  *DevicePath         OPTIONAL,
+     IN CONST EFI_DEVICE_PATH_PROTOCOL  *DevicePathInstance OPTIONAL)
+    );
+  MOCK_FUNCTION_DECLARATION (
+    EFI_DEVICE_PATH_PROTOCOL *,
+    GetNextDevicePathInstance,
+    (IN OUT EFI_DEVICE_PATH_PROTOCOL  **DevicePath,
+     OUT UINTN                        *Size)
+    );
+  MOCK_FUNCTION_DECLARATION (
+    EFI_DEVICE_PATH_PROTOCOL *,
+    CreateDeviceNode,
+    (IN UINT8   NodeType,
+     IN UINT8   NodeSubType,
+     IN UINT16  NodeLength)
+    );
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    IsDevicePathMultiInstance,
+    (IN CONST EFI_DEVICE_PATH_PROTOCOL  *DevicePath)
+    );
+  MOCK_FUNCTION_DECLARATION (
+    EFI_DEVICE_PATH_PROTOCOL *,
+    DevicePathFromHandle,
+    (IN EFI_HANDLE  Handle)
+    );
+  MOCK_FUNCTION_DECLARATION (
+    EFI_DEVICE_PATH_PROTOCOL *,
+    FileDevicePath,
+    (IN EFI_HANDLE    Device      OPTIONAL,
+     IN CONST CHAR16  *FileName)
+    );
+  MOCK_FUNCTION_DECLARATION (
+    CHAR16 *,
+    ConvertDevicePathToText,
+    (IN CONST EFI_DEVICE_PATH_PROTOCOL  *DevicePath,
+     IN BOOLEAN                         DisplayOnly,
+     IN BOOLEAN                         AllowShortcuts)
+    );
+  MOCK_FUNCTION_DECLARATION (
+    CHAR16 *,
+    ConvertDeviceNodeToText,
+    (IN CONST EFI_DEVICE_PATH_PROTOCOL  *DeviceNode,
+     IN BOOLEAN                         DisplayOnly,
+     IN BOOLEAN                         AllowShortcuts)
+    );
+  MOCK_FUNCTION_DECLARATION (
+    EFI_DEVICE_PATH_PROTOCOL *,
+    ConvertTextToDeviceNode,
+    (IN CONST CHAR16  *TextDeviceNode)
+    );
+  MOCK_FUNCTION_DECLARATION (
+    EFI_DEVICE_PATH_PROTOCOL *,
+    ConvertTextToDevicePath,
+    (IN CONST CHAR16  *TextDevicePath)
+    );
 };
 
 #endif

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiLib.h
@@ -44,6 +44,51 @@ struct MockUefiLib {
      IN VOID              *NotifyContext OPTIONAL,
      OUT VOID             **Registration)
     );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiTestManagedDevice,
+    (IN CONST EFI_HANDLE ControllerHandle,
+     IN CONST EFI_HANDLE DriverBindingHandle,
+     IN CONST EFI_GUID    *ProtocolGuid)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    LookupUnicodeString2,
+    (IN CONST CHAR8                     *Language,
+     IN CONST CHAR8                     *SupportedLanguages,
+     IN CONST EFI_UNICODE_STRING_TABLE  *UnicodeStringTable,
+     OUT CHAR16                         **UnicodeString,
+     IN BOOLEAN Iso639Language)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    AddUnicodeString2,
+    (IN CONST CHAR8               *Language,
+     IN CONST CHAR8               *SupportedLanguages,
+     IN OUT EFI_UNICODE_STRING_TABLE  **UnicodeStringTable,
+     IN CONST CHAR16              *UnicodeString,
+     IN BOOLEAN Iso639Language)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    FreeUnicodeStringTable,
+    (IN EFI_UNICODE_STRING_TABLE  *UnicodeStringTable)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiLibInstallDriverBindingComponentName2,
+    (IN CONST EFI_HANDLE                    ImageHandle,
+     IN CONST EFI_SYSTEM_TABLE              *SystemTable,
+     IN EFI_DRIVER_BINDING_PROTOCOL         *DriverBinding,
+     IN EFI_HANDLE                          DriverBindingHandle,
+     IN CONST EFI_COMPONENT_NAME_PROTOCOL   *ComponentName        OPTIONAL,
+     IN CONST EFI_COMPONENT_NAME2_PROTOCOL  *ComponentName2       OPTIONAL)
+    );
 };
 
 #endif

--- a/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockServiceBinding.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockServiceBinding.h
@@ -1,0 +1,45 @@
+/** @file MockServiceBinding.h
+  This file declares a mock of Service Binding Protocol.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_SERVICE_BINDING_H
+#define MOCK_SERVICE_BINDING_H
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Protocol/ServiceBinding.h>
+}
+
+struct MockServiceBinding {
+  MOCK_INTERFACE_DECLARATION (MockServiceBinding);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    CreateChild,
+    (
+     IN     EFI_SERVICE_BINDING_PROTOCOL  *This,
+     IN OUT EFI_HANDLE                    *ChildHandle
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    DestroyChild,
+    (
+     IN EFI_SERVICE_BINDING_PROTOCOL          *This,
+     IN EFI_HANDLE                            ChildHandle
+    )
+    );
+};
+
+extern "C" {
+  extern EFI_SERVICE_BINDING_PROTOCOL  *gServiceBindingProtocol;
+}
+
+#endif // MOCK_SERVICE_BINDING_H

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockUefiBootServicesTableLib/MockUefiBootServicesTableLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockUefiBootServicesTableLib/MockUefiBootServicesTableLib.cpp
@@ -24,6 +24,7 @@ MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_FreePool, 1, EFIAPI)
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_LocateDevicePath, 3, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_ReinstallProtocolInterface, 4, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_AllocatePool, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_LocateHandle, 5, EFIAPI);
 
 extern "C" {
   EFI_STATUS
@@ -118,7 +119,7 @@ static EFI_BOOT_SERVICES  LocalBs = {
   gBS_HandleProtocol,                                                                  // EFI_HANDLE_PROTOCOL
   NULL,                                                                                // VOID
   NULL,                                                                                // EFI_REGISTER_PROTOCOL_NOTIFY
-  NULL,                                                                                // EFI_LOCATE_HANDLE
+  gBS_LocateHandle,                                                                    // EFI_LOCATE_HANDLE
   gBS_LocateDevicePath,                                                                // EFI_LOCATE_DEVICE_PATH
   NULL,                                                                                // EFI_INSTALL_CONFIGURATION_TABLE
   NULL,                                                                                // EFI_IMAGE_LOAD

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockUefiDevicePathLib/MockUefiDevicePathLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockUefiDevicePathLib/MockUefiDevicePathLib.cpp
@@ -9,3 +9,26 @@
 
 MOCK_INTERFACE_DEFINITION (MockUefiDevicePathLib);
 MOCK_FUNCTION_DEFINITION (MockUefiDevicePathLib, DuplicateDevicePath, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiDevicePathLib, IsDevicePathValid, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiDevicePathLib, DevicePathType, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiDevicePathLib, DevicePathSubType, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiDevicePathLib, DevicePathNodeLength, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiDevicePathLib, NextDevicePathNode, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiDevicePathLib, IsDevicePathEndType, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiDevicePathLib, IsDevicePathEnd, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiDevicePathLib, IsDevicePathEndInstance, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiDevicePathLib, SetDevicePathNodeLength, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiDevicePathLib, SetDevicePathEndNode, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiDevicePathLib, GetDevicePathSize, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiDevicePathLib, AppendDevicePath, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiDevicePathLib, AppendDevicePathNode, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiDevicePathLib, AppendDevicePathInstance, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiDevicePathLib, GetNextDevicePathInstance, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiDevicePathLib, CreateDeviceNode, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiDevicePathLib, IsDevicePathMultiInstance, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiDevicePathLib, DevicePathFromHandle, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiDevicePathLib, FileDevicePath, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiDevicePathLib, ConvertDevicePathToText, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiDevicePathLib, ConvertDeviceNodeToText, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiDevicePathLib, ConvertTextToDeviceNode, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiDevicePathLib, ConvertTextToDevicePath, 1, EFIAPI);

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockUefiLib/MockUefiLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockUefiLib/MockUefiLib.cpp
@@ -11,3 +11,8 @@ MOCK_INTERFACE_DEFINITION (MockUefiLib);
 MOCK_FUNCTION_DEFINITION (MockUefiLib, GetVariable2, 4, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiLib, GetEfiGlobalVariable2, 3, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiLib, EfiCreateProtocolNotifyEvent, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiLib, EfiTestManagedDevice, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiLib, LookupUnicodeString2, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiLib, AddUnicodeString2, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiLib, FreeUnicodeStringTable, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiLib, EfiLibInstallDriverBindingComponentName2, 6, EFIAPI);

--- a/MdePkg/Test/Mock/Library/GoogleTest/Protocol/MockServiceBinding.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/Protocol/MockServiceBinding.cpp
@@ -1,0 +1,21 @@
+/** @file MockServiceBinding.cpp
+  Google Test mock for Service Binding Protocol.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <GoogleTest/Protocol/MockServiceBinding.h>
+
+MOCK_INTERFACE_DEFINITION (MockServiceBinding);
+MOCK_FUNCTION_DEFINITION (MockServiceBinding, CreateChild, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockServiceBinding, DestroyChild, 2, EFIAPI);
+
+EFI_SERVICE_BINDING_PROTOCOL  SERVICE_BINDING_PROTOCOL_INSTANCE = {
+  CreateChild,    // EFI_SERVICE_BINDING_CREATE_CHILD
+  DestroyChild,   // EFI_SERVICE_BINDING_DESTROY_CHILD
+};
+
+extern "C" {
+  EFI_SERVICE_BINDING_PROTOCOL  *gServiceBindingProtocol = &SERVICE_BINDING_PROTOCOL_INSTANCE;
+}


### PR DESCRIPTION
## Description

Added MockServiceBinding and Add mock functions under MockUefiBootServicesTableLib, MockUefiLib and MockUefiDevicePathLib for Unit Test.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [x] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Unit tests component can call this mock function success

## Integration Instructions

N/A