### PR TITLE
[SQUASH ON REBASE] MdeModulePkg: UefiBootManagerLib: Move SetVariableCall

### DIFF
--- a/MdeModulePkg/Library/UefiBootManagerLib/BmLoadOption.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmLoadOption.c
@@ -284,19 +284,21 @@ structure.
                  VARIABLE_POLICY_TYPE_LOCK_NOW
                  );
       ASSERT_EFI_ERROR (Status);
+
+      // VariableAttributes = EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS;
     }
 
-    VariableAttributes = EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS;
+    // Status = gRT->SetVariable (
+    //                 OptionName,
+    //                 &gEfiGlobalVariableGuid,
+    //                 VariableAttributes,
+    //                 VariableSize,
+    //                 Variable
+    //                 );
+    // FreePool (Variable);
   }
 
-  Status = gRT->SetVariable (
-                  OptionName,
-                  &gEfiGlobalVariableGuid,
-                  VariableAttributes,
-                  VariableSize,
-                  Variable
-                  );
-  FreePool (Variable);
+  // MU_CHANGE END
 
   return Status;
 }


### PR DESCRIPTION
## Description

BmLoadOption.c: Move Locking OptionName variable after calling SetVariable.

This commit was cherry-picked from 7c17fd9b3457a546dbcb7746a4f9aeebd4f85d1f. It was partially taken in https://github.com/microsoft/mu_basecore/commit/3483ae8dfa4165467f74648a40d74b8d9d63a545, but that commit merely added the SetVariable call in the new place, did not comment out the old location. As a result, we were attempting to call SetVariable after we had done a FreePool on `Variable`, which resulted in an exception.

For future integrations, this should be squashed with the above commit.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Booted SBSA to an OS.

## Integration Instructions

N/A.