### PR TITLE
Add mock functions under MockPciIoProtocol and Create Mock for Smbio, UsbIo and NvmExpressPassthru protocol

### DIFF
--- a/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockNvmExpressPassthru.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockNvmExpressPassthru.h
@@ -1,0 +1,67 @@
+/** @file MockNvmExpressPassthru.h
+  This file declares a mock of NvmExpress Pass Thru Protocol.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_NVM_EXPRESS_PASS_THRU_H
+#define MOCK_NVM_EXPRESS_PASS_THRU_H
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Protocol/NvmExpressPassthru.h>
+}
+
+struct MockNvmePassThruProtocol {
+  MOCK_INTERFACE_DECLARATION (MockNvmePassThruProtocol);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    PassThru,
+    (
+     IN     EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL          *This,
+     IN     UINT32                                      NamespaceId,
+     IN OUT EFI_NVM_EXPRESS_PASS_THRU_COMMAND_PACKET    *Packet,
+     IN     EFI_EVENT                                   Event OPTIONAL
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    GetNextNamespace,
+    (
+     IN     EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL          *This,
+     IN OUT UINT32                                      *NamespaceId
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    BuildDevicePath,
+    (
+     IN     EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL          *This,
+     IN     UINT32                                      NamespaceId,
+     OUT    EFI_DEVICE_PATH_PROTOCOL                    **DevicePath
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    GetNamespace,
+    (
+     IN     EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL          *This,
+     IN     EFI_DEVICE_PATH_PROTOCOL                    *DevicePath,
+     OUT    UINT32                                      *NamespaceId
+    )
+    );
+};
+
+extern "C" {
+  extern EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL  *gNvmePassThruProtocol;
+}
+
+#endif // NVM_EXPRESS_PASS_THRU_H

--- a/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockPciIoProtocol.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockPciIoProtocol.h
@@ -47,6 +47,17 @@ struct MockPciIoProtocol {
      OUT UINTN                       *FunctionNumber
     )
     );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    Attributes,
+    (
+     IN EFI_PCI_IO_PROTOCOL                       *This,
+     IN  EFI_PCI_IO_PROTOCOL_ATTRIBUTE_OPERATION  Operation,
+     IN  UINT64                                   Attributes,
+     OUT UINT64                                   *Result OPTIONAL
+    )
+    );
 };
 
 extern "C" {

--- a/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockSmbios.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockSmbios.h
@@ -1,0 +1,70 @@
+/** @file MockSmbios.h
+  This file declares a mock of SMBIOS Protocol.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_SMBIOS_PROTOCOL_H
+#define MOCK_SMBIOS_PROTOCOL_H
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Protocol/Smbios.h>
+}
+
+struct MockSmbiosProtocol {
+  MOCK_INTERFACE_DECLARATION (MockSmbiosProtocol);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    Add,
+    (
+     IN CONST      EFI_SMBIOS_PROTOCOL     *This,
+     IN            EFI_HANDLE              ProducerHandle OPTIONAL,
+     IN OUT        EFI_SMBIOS_HANDLE       *SmbiosHandle,
+     IN            EFI_SMBIOS_TABLE_HEADER *Record
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    UpdateString,
+    (
+     IN CONST EFI_SMBIOS_PROTOCOL *This,
+     IN       EFI_SMBIOS_HANDLE   *SmbiosHandle,
+     IN       UINTN               *StringNumber,
+     IN       CHAR8               *String
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    Remove,
+    (
+     IN CONST EFI_SMBIOS_PROTOCOL *This,
+     IN       EFI_SMBIOS_HANDLE   SmbiosHandle
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    GetNext,
+    (
+     IN CONST EFI_SMBIOS_PROTOCOL     *This,
+     IN OUT EFI_SMBIOS_HANDLE       *SmbiosHandle,
+     IN EFI_SMBIOS_TYPE         *Type OPTIONAL,
+     OUT EFI_SMBIOS_TABLE_HEADER **Record,
+     OUT EFI_HANDLE              *ProducerHandle OPTIONAL
+    )
+    );
+};
+
+extern "C" {
+  extern EFI_SMBIOS_PROTOCOL  *gSmbiosProtocol;
+}
+
+#endif // MOCK_SMBIOS_PROTOCOL_H

--- a/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockUsbIo.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockUsbIo.h
@@ -1,0 +1,172 @@
+/** @file MockUsbIo.h
+  This file declares a mock of Usb Io Protocol.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_USB_IO_H
+#define MOCK_USB_IO_H
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Protocol/UsbIo.h>
+}
+
+struct MockUsbIoProtocol {
+  MOCK_INTERFACE_DECLARATION (MockUsbIoProtocol);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    UsbControlTransfer,
+    (
+     IN EFI_USB_IO_PROTOCOL                        *This,
+     IN EFI_USB_DEVICE_REQUEST                     *Request,
+     IN EFI_USB_DATA_DIRECTION                     Direction,
+     IN UINT32                                     Timeout,
+     IN OUT VOID                                   *Data OPTIONAL,
+     IN UINTN                                      DataLength  OPTIONAL,
+     OUT UINT32                                    *Status
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    UsbBulkTransfer,
+    (
+     IN EFI_USB_IO_PROTOCOL            *This,
+     IN UINT8                          DeviceEndpoint,
+     IN OUT VOID                       *Data,
+     IN OUT UINTN                      *DataLength,
+     IN UINTN                          Timeout,
+     OUT UINT32                        *Status
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    UsbAsyncInterruptTransfer,
+    (
+     IN EFI_USB_IO_PROTOCOL                                 *This,
+     IN UINT8                                               DeviceEndpoint,
+     IN BOOLEAN                                             IsNewTransfer,
+     IN UINTN                                               PollingInterval    OPTIONAL,
+     IN UINTN                                               DataLength         OPTIONAL,
+     IN EFI_ASYNC_USB_TRANSFER_CALLBACK                     InterruptCallBack  OPTIONAL,
+     IN VOID                                                *Context OPTIONAL
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    UsbSyncInterruptTransfer,
+    (
+     IN EFI_USB_IO_PROTOCOL            *This,
+     IN     UINT8                      DeviceEndpoint,
+     IN OUT VOID                       *Data,
+     IN OUT UINTN                      *DataLength,
+     IN     UINTN                      Timeout,
+     OUT    UINT32                     *Status
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    UsbIsochronousTransfer,
+    (
+     IN EFI_USB_IO_PROTOCOL            *This,
+     IN     UINT8                      DeviceEndpoint,
+     IN OUT VOID                       *Data,
+     IN     UINTN                      DataLength,
+     OUT    UINT32                     *Status
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    UsbAsyncIsochronousTransfer,
+    (
+     IN EFI_USB_IO_PROTOCOL              *This,
+     IN UINT8                            DeviceEndpoint,
+     IN OUT VOID                         *Data,
+     IN     UINTN                        DataLength,
+     IN EFI_ASYNC_USB_TRANSFER_CALLBACK  IsochronousCallBack,
+     IN VOID                             *Context OPTIONAL
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    UsbGetDeviceDescriptor,
+    (
+     IN EFI_USB_IO_PROTOCOL            *This,
+     OUT EFI_USB_DEVICE_DESCRIPTOR     *DeviceDescriptor
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    UsbGetConfigDescriptor,
+    (
+     IN EFI_USB_IO_PROTOCOL            *This,
+     OUT EFI_USB_CONFIG_DESCRIPTOR     *ConfigurationDescriptor
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    UsbGetInterfaceDescriptor,
+    (
+     IN EFI_USB_IO_PROTOCOL            *This,
+     OUT EFI_USB_INTERFACE_DESCRIPTOR  *InterfaceDescriptor
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    UsbGetEndpointDescriptor,
+    (
+     IN EFI_USB_IO_PROTOCOL            *This,
+     IN  UINT8                         EndpointIndex,
+     OUT EFI_USB_ENDPOINT_DESCRIPTOR   *EndpointDescriptor
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    UsbGetStringDescriptor,
+    (
+     IN EFI_USB_IO_PROTOCOL            *This,
+     IN  UINT16                        LangID,
+     IN  UINT8                         StringID,
+     OUT CHAR16                        **String
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    UsbGetSupportedLanguages,
+    (
+     IN EFI_USB_IO_PROTOCOL            *This,
+     OUT UINT16                        **LangIDTable,
+     OUT UINT16                        *TableSize
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    UsbPortReset,
+    (
+     IN EFI_USB_IO_PROTOCOL    *This
+    )
+    );
+};
+
+extern "C" {
+  extern EFI_USB_IO_PROTOCOL  *gUsbIoProtocol;
+}
+
+#endif // MOCK_USB_IO_H

--- a/MdePkg/Test/Mock/Library/GoogleTest/Protocol/MockNvmExpressPassthru.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/Protocol/MockNvmExpressPassthru.cpp
@@ -1,0 +1,26 @@
+/** @file MockNvmExpressPassthru.cpp
+  Google Test mock for NvmExpress Pass Thru Protocol.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <GoogleTest/Protocol/MockNvmExpressPassthru.h>
+
+MOCK_INTERFACE_DEFINITION (MockNvmePassThruProtocol);
+MOCK_FUNCTION_DEFINITION (MockNvmePassThruProtocol, PassThru, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockNvmePassThruProtocol, GetNextNamespace, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockNvmePassThruProtocol, BuildDevicePath, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockNvmePassThruProtocol, GetNamespace, 3, EFIAPI);
+
+EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL  NVME_PASSTHRU_PROTOCOL_INSTANCE = {
+  { 0 },              // EFI_NVM_EXPRESS_PASS_THRU_MODE                  *Mode;
+  PassThru,           // EFI_NVM_EXPRESS_PASS_THRU_PASSTHRU              PassThru;
+  GetNextNamespace,   // EFI_NVM_EXPRESS_PASS_THRU_GET_NEXT_NAMESPACE    GetNextNamespace;
+  BuildDevicePath,    // EFI_NVM_EXPRESS_PASS_THRU_BUILD_DEVICE_PATH     BuildDevicePath;
+  GetNamespace        // EFI_NVM_EXPRESS_PASS_THRU_GET_NAMESPACE         GetNamespace;
+};
+
+extern "C" {
+  EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL  *gNvmePassThruProtocol = &NVME_PASSTHRU_PROTOCOL_INSTANCE;
+}

--- a/MdePkg/Test/Mock/Library/GoogleTest/Protocol/MockPciIoProtocol.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/Protocol/MockPciIoProtocol.cpp
@@ -12,6 +12,7 @@ MOCK_FUNCTION_DEFINITION (MockPciIoConfigAccess, MockPciIoRead, 5, EFIAPI);
 
 MOCK_INTERFACE_DEFINITION (MockPciIoProtocol);
 MOCK_FUNCTION_DEFINITION (MockPciIoProtocol, GetLocation, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciIoProtocol, Attributes, 4, EFIAPI);
 
 EFI_PCI_IO_PROTOCOL  PCI_IO_PROTOCOL_MOCK = {
   NULL,                    // EFI_PCI_IO_PROTOCOL_POLL_IO_MEM           PollMem;
@@ -26,7 +27,7 @@ EFI_PCI_IO_PROTOCOL  PCI_IO_PROTOCOL_MOCK = {
   NULL,                    // EFI_PCI_IO_PROTOCOL_FREE_BUFFER           FreeBuffer;
   NULL,                    // EFI_PCI_IO_PROTOCOL_FLUSH                 Flush;
   GetLocation,             // EFI_PCI_IO_PROTOCOL_GET_LOCATION          GetLocation;
-  NULL,                    // EFI_PCI_IO_PROTOCOL_ATTRIBUTES            Attributes;
+  Attributes,              // EFI_PCI_IO_PROTOCOL_ATTRIBUTES            Attributes;
   NULL,                    // EFI_PCI_IO_PROTOCOL_GET_BAR_ATTRIBUTES    GetBarAttributes;
   NULL,                    // EFI_PCI_IO_PROTOCOL_SET_BAR_ATTRIBUTES    SetBarAttributes;
   0,                       // UINT64                                    RomSize;

--- a/MdePkg/Test/Mock/Library/GoogleTest/Protocol/MockSmbios.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/Protocol/MockSmbios.cpp
@@ -1,0 +1,27 @@
+/** @file MockSmbios.cpp
+  Google Test mock for Service Binding Protocol.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <GoogleTest/Protocol/MockSmbios.h>
+
+MOCK_INTERFACE_DEFINITION (MockSmbiosProtocol);
+MOCK_FUNCTION_DEFINITION (MockSmbiosProtocol, Add, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockSmbiosProtocol, UpdateString, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockSmbiosProtocol, Remove, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockSmbiosProtocol, GetNext, 5, EFIAPI);
+
+EFI_SMBIOS_PROTOCOL  SMBIOS_PROTOCOL_INSTANCE = {
+  Add,          // EFI_SMBIOS_ADD              Add;
+  UpdateString, // EFI_SMBIOS_UPDATE_STRING    UpdateString;
+  Remove,       // EFI_SMBIOS_REMOVE           Remove;
+  GetNext,      // EFI_SMBIOS_GET_NEXT         GetNext;
+  0,            // UINT8                       MajorVersion;
+  0             // UINT8                       MinorVersion;
+};//
+
+extern "C" {
+  EFI_SMBIOS_PROTOCOL  *gSmbiosProtocol = &SMBIOS_PROTOCOL_INSTANCE;
+}

--- a/MdePkg/Test/Mock/Library/GoogleTest/Protocol/MockUsbIo.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/Protocol/MockUsbIo.cpp
@@ -1,0 +1,43 @@
+/** @file MockUsbIo.cpp
+  Google Test mock for Service Binding Protocol.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <GoogleTest/Protocol/MockUsbIo.h>
+
+MOCK_INTERFACE_DEFINITION (MockUsbIoProtocol);
+MOCK_FUNCTION_DEFINITION (MockUsbIoProtocol, UsbControlTransfer, 7, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUsbIoProtocol, UsbBulkTransfer, 6, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUsbIoProtocol, UsbAsyncInterruptTransfer, 7, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUsbIoProtocol, UsbSyncInterruptTransfer, 6, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUsbIoProtocol, UsbIsochronousTransfer, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUsbIoProtocol, UsbAsyncIsochronousTransfer, 6, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUsbIoProtocol, UsbGetDeviceDescriptor, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUsbIoProtocol, UsbGetConfigDescriptor, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUsbIoProtocol, UsbGetInterfaceDescriptor, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUsbIoProtocol, UsbGetEndpointDescriptor, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUsbIoProtocol, UsbGetStringDescriptor, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUsbIoProtocol, UsbGetSupportedLanguages, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUsbIoProtocol, UsbPortReset, 1, EFIAPI);
+
+EFI_USB_IO_PROTOCOL  USB_IO_PROTOCOL_MOCK = {
+  UsbControlTransfer,             // EFI_USB_IO_CONTROL_TRANSFER              UsbControlTransfer;
+  UsbBulkTransfer,                // EFI_USB_IO_BULK_TRANSFER                 UsbBulkTransfer;
+  UsbAsyncInterruptTransfer,      // EFI_USB_IO_ASYNC_INTERRUPT_TRANSFER      UsbAsyncInterruptTransfer;
+  UsbSyncInterruptTransfer,       // EFI_USB_IO_SYNC_INTERRUPT_TRANSFER       UsbSyncInterruptTransfer;
+  UsbIsochronousTransfer,         // EFI_USB_IO_ISOCHRONOUS_TRANSFER          UsbIsochronousTransfer;
+  UsbAsyncIsochronousTransfer,    // EFI_USB_IO_ASYNC_ISOCHRONOUS_TRANSFER    UsbAsyncIsochronousTransfer;
+  UsbGetDeviceDescriptor,         // EFI_USB_IO_GET_DEVICE_DESCRIPTOR         UsbGetDeviceDescriptor;
+  UsbGetConfigDescriptor,         // EFI_USB_IO_GET_CONFIG_DESCRIPTOR         UsbGetConfigDescriptor;
+  UsbGetInterfaceDescriptor,      // EFI_USB_IO_GET_INTERFACE_DESCRIPTOR      UsbGetInterfaceDescriptor;
+  UsbGetEndpointDescriptor,       // EFI_USB_IO_GET_ENDPOINT_DESCRIPTOR       UsbGetEndpointDescriptor;
+  UsbGetStringDescriptor,         // EFI_USB_IO_GET_STRING_DESCRIPTOR         UsbGetStringDescriptor;
+  UsbGetSupportedLanguages,       // EFI_USB_IO_GET_SUPPORTED_LANGUAGE        UsbGetSupportedLanguages;
+  UsbPortReset                    // EFI_USB_IO_PORT_RESET                    UsbPortReset;
+};
+
+extern "C" {
+  EFI_USB_IO_PROTOCOL  *gUsbIoProtocol = &USB_IO_PROTOCOL_MOCK;
+}


### PR DESCRIPTION
## Description

Add mock functions under MockPciIoProtocol and Create Mock for Smbio, UsbIo and NvmExpressPassthru protocol.

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [x] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Unit tests component can call these mock functions success

## Integration Instructions

N/A
