### PR TITLE
Revert Downgrading Page.c Error Prints

### DIFF
--- a/MdeModulePkg/Core/Dxe/Mem/Page.c
+++ b/MdeModulePkg/Core/Dxe/Mem/Page.c
@@ -889,7 +889,7 @@ CoreConvertPagesEx (
     }
 
     if (Link == &gMemoryMap) {
-      DEBUG ((DEBUG_PAGE, "ConvertPages: failed to find range %lx - %lx\n", Start, End));  // MU_CHANGE
+      DEBUG ((DEBUG_ERROR | DEBUG_PAGE, "ConvertPages: failed to find range %lx - %lx\n", Start, End));
       return EFI_NOT_FOUND;
     }
 
@@ -900,8 +900,7 @@ CoreConvertPagesEx (
     //
     if (ChangingType && (NewType != EfiConventionalMemory)) {
       if (Entry->End < End) {
-        // MU_CHANGE: remove this debug print since within debug print there is another allocate pages call
-        // DEBUG ((DEBUG_ERROR | DEBUG_PAGE, "ConvertPages: range %lx - %lx covers multiple entries\n", Start, End));
+        DEBUG ((DEBUG_ERROR | DEBUG_PAGE, "ConvertPages: range %lx - %lx covers multiple entries\n", Start, End));
         return EFI_NOT_FOUND;
       }
     }
@@ -930,11 +929,11 @@ CoreConvertPagesEx (
       // Debug code - verify conversion is allowed
       //
       if (!((NewType == EfiConventionalMemory) ? 1 : 0) ^ ((Entry->Type == EfiConventionalMemory) ? 1 : 0)) {
-        DEBUG ((DEBUG_PAGE, "ConvertPages: Incompatible memory types, "));       // MU_CHANGE
+        DEBUG ((DEBUG_ERROR | DEBUG_PAGE, "ConvertPages: Incompatible memory types, "));
         if (Entry->Type == EfiConventionalMemory) {
-          DEBUG ((DEBUG_PAGE, "the pages to free have been freed\n"));           // MU_CHANGE
+          DEBUG ((DEBUG_ERROR | DEBUG_PAGE, "the pages to free have been freed\n"));
         } else {
-          DEBUG ((DEBUG_PAGE, "the pages to allocate have been allocated\n"));   // MU_CHANGE
+          DEBUG ((DEBUG_ERROR | DEBUG_PAGE, "the pages to allocate have been allocated\n"));
         }
 
         return EFI_NOT_FOUND;
@@ -2248,7 +2247,7 @@ CoreAllocatePoolPages (
   // Convert it to boot services data
   //
   if (Start == 0) {
-    DEBUG ((DEBUG_PAGE, "AllocatePoolPages: failed to allocate %d pages\n", (UINT32)NumberOfPages));      // MU_CHANGE
+    DEBUG ((DEBUG_ERROR | DEBUG_PAGE, "AllocatePoolPages: failed to allocate %d pages\n", (UINT32)NumberOfPages));
   } else {
     if (NeedGuard) {
       CoreConvertPagesWithGuard (Start, NumberOfPages, PoolType);
@@ -2314,12 +2313,14 @@ CoreTerminateMemoryMap (
           ASSERT (Entry->Type != EfiACPIReclaimMemory);
           ASSERT (Entry->Type != EfiACPIMemoryNVS);
           if ((Entry->Start & (RUNTIME_PAGE_ALLOCATION_GRANULARITY - 1)) != 0) {
-            DEBUG ((DEBUG_PAGE, "ExitBootServices: A RUNTIME memory entry is not on a proper alignment.\n"));    // MU_CHANGE
+            DEBUG ((DEBUG_ERROR | DEBUG_PAGE, "ExitBootServices: A RUNTIME memory entry is not on a proper alignment.\n"));
+            Status =  EFI_INVALID_PARAMETER;
             goto Done;
           }
 
           if (((Entry->End + 1) & (RUNTIME_PAGE_ALLOCATION_GRANULARITY - 1)) != 0) {
-            DEBUG ((DEBUG_PAGE, "ExitBootServices: A RUNTIME memory entry is not on a proper alignment.\n"));    // MU_CHANGE
+            DEBUG ((DEBUG_ERROR | DEBUG_PAGE, "ExitBootServices: A RUNTIME memory entry is not on a proper alignment.\n"));
+            Status =  EFI_INVALID_PARAMETER;
             goto Done;
           }
         }


### PR DESCRIPTION
## Description

This reverts commit 76f8060e3a61b52b5f874953a90d1cfaae5d9979.

This commit was from an earlier era of Project Mu where we were not as strict with memory protections. Now that we are more strict, these are important prints (and failures if alignment of a RUNTIME entry is wrong). This was confirmed by booting on Q35 and analyzing the few prints that showed up.

The first was that Rust code was not being linked as we expected, that is fixed here for pure Rust repos: https://github.com/microsoft/mu_devops/pull/356 and here for mu_basecore based repos: https://github.com/microsoft/mu_basecore/pull/1098. This may get fixed in a different way that is more broad. The in-depth issue was that /BASE:0 was not getting set for the Rust linker. It is failing to allocate pages when loading the image. The reason is that the ImageBase field in the PE/COFF optional header is set, so we try to load at that address: https://github.com/microsoft/mu_basecore/blob/45e4430db9d4a27a25201f51f91705fd7c4a0374/MdeModulePkg/Core/Dxe/Image/Image.c#L730-L748 (ImageAddress gets populated from ImageBase: https://github.com/microsoft/mu_basecore/blob/45e4430db9d4a27a25201f51f91705fd7c4a0374/MdePkg/Library/BasePeCoffLib/BasePeCoff.c#L619-L629).
 
Per the PE/COFF spec, this is only intended for use by Windows and I don't think we should really be honoring it, but probably things are relying on it: 
 
![image](https://github.com/user-attachments/assets/3122e5a8-74da-4c38-86ca-b8c8f0948ffc)
 
UefiHidDxe and HelloWorldRustDxe are the only EFI binaries in the mu_tiano_platforms build that set ImageBase. For everything else it is 0, so we don't enter that codepath (what happens in that codepath is the ImageBase provided, 0x140000000 for both modules, is where we attempt to load the modules to, which isn't in our memory tree (or one of those two is already loaded there) and so we fail).Setting /BASE:0 causes MSVC to set the ImageBase to 0 (in ElfConvert we always set the ImageBase to 0: https://github.com/microsoft/mu_basecore/blob/45e4430db9d4a27a25201f51f91705fd7c4a0374/BaseTools/Source/C/GenFw/Elf64Convert.c#L1180).

The other set of failures was from gDS->SetMemorySpaceCapabilities() trying to set attributes in gMemoryMap on GCD memory types that don't exist there and an edk2 PR has been put up to fix that: https://github.com/tianocore/edk2/pull/6062.

There are no other failures seen and when these failures do occur, we want to debug them. Closes #1091.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

Tested on Q35.

## Integration Instructions

N/A.
