### PR TITLE
[Cherry-Pick][Rebase & FF] UefiCpuPkg: Consume PcdCpuSmmApSyncTimeout2.

### DIFF
--- a/UefiCpuPkg/PiSmmCpuDxeSmm/MpService.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/MpService.c
@@ -1,7 +1,7 @@
 /** @file
 SMM MP service implementation
 
-Copyright (c) 2009 - 2023, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2009 - 2024, Intel Corporation. All rights reserved.<BR>
 Copyright (c) 2017, AMD Incorporated. All rights reserved.<BR>
 
 SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -270,7 +270,7 @@ SmmWaitForApArrival (
   // Sync with APs 1st timeout
   //
   for (Timer = StartSyncTimer ();
-       !IsSyncTimerTimeout (Timer) && !(LmceEn && LmceSignal);
+       !IsSyncTimerTimeout (Timer, mTimeoutTicker) && !(LmceEn && LmceSignal);
        )
   {
     mSmmMpSyncData->AllApArrivedWithException = AllCpusInSmmExceptBlockedDisabled ();
@@ -311,7 +311,7 @@ SmmWaitForApArrival (
     // Sync with APs 2nd timeout.
     //
     for (Timer = StartSyncTimer ();
-         !IsSyncTimerTimeout (Timer);
+         !IsSyncTimerTimeout (Timer, mTimeoutTicker2);
          )
     {
       mSmmMpSyncData->AllApArrivedWithException = AllCpusInSmmExceptBlockedDisabled ();
@@ -732,7 +732,7 @@ APHandler (
   // Timeout BSP
   //
   for (Timer = StartSyncTimer ();
-       !IsSyncTimerTimeout (Timer) &&
+       !IsSyncTimerTimeout (Timer, mTimeoutTicker) &&
        !(*mSmmMpSyncData->InsideSmm);
        )
   {
@@ -760,7 +760,7 @@ APHandler (
       // Now clock BSP for the 2nd time
       //
       for (Timer = StartSyncTimer ();
-           !IsSyncTimerTimeout (Timer) &&
+           !IsSyncTimerTimeout (Timer, mTimeoutTicker2) &&
            !(*mSmmMpSyncData->InsideSmm);
            )
       {

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.h
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.h
@@ -498,6 +498,9 @@ extern UINT8                         mPhysicalAddressBits;
 //
 extern UINT64  mAddressEncMask;
 
+extern UINT64  mTimeoutTicker;
+extern UINT64  mTimeoutTicker2;
+
 /**
   Create 4G PageTable in SMRAM.
 
@@ -560,15 +563,17 @@ StartSyncTimer (
   );
 
 /**
-  Check if the SMM AP Sync timer is timeout.
+  Check if the SMM AP Sync Timer is timeout specified by Timeout.
 
-  @param Timer  The start timer from the begin.
+  @param Timer    The start timer from the begin.
+  @param Timeout  The timeout ticker to wait.
 
 **/
 BOOLEAN
 EFIAPI
 IsSyncTimerTimeout (
-  IN      UINT64  Timer
+  IN      UINT64  Timer,
+  IN      UINT64  Timeout
   );
 
 /**

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/PiSmmCpuDxeSmm.inf
@@ -140,6 +140,7 @@
   gUefiCpuPkgTokenSpaceGuid.PcdSmmApPerfLogEnable
 
 [Pcd]
+  gUefiCpuPkgTokenSpaceGuid.PcdCpuSmmApSyncTimeout2                ## CONSUMES
   gUefiCpuPkgTokenSpaceGuid.PcdCpuMaxLogicalProcessorNumber        ## SOMETIMES_CONSUMES
   gUefiCpuPkgTokenSpaceGuid.PcdCpuSmmProfileSize                   ## SOMETIMES_CONSUMES
   gUefiCpuPkgTokenSpaceGuid.PcdCpuSmmStackSize                     ## CONSUMES

--- a/UefiCpuPkg/PiSmmCpuDxeSmm/SyncTimer.c
+++ b/UefiCpuPkg/PiSmmCpuDxeSmm/SyncTimer.c
@@ -1,7 +1,7 @@
 /** @file
 SMM Timer feature support
 
-Copyright (c) 2009 - 2015, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2009 - 2024, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -9,6 +9,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include "PiSmmCpuDxeSmm.h"
 
 UINT64  mTimeoutTicker = 0;
+
+UINT64  mTimeoutTicker2 = 0;
+
 //
 //  Number of counts in a roll-over cycle of the performance counter.
 //
@@ -36,6 +39,10 @@ InitializeSmmTimer (
                      MultU64x64 (TimerFrequency, PcdGet64 (PcdCpuSmmApSyncTimeout)),
                      1000 * 1000
                      );
+  mTimeoutTicker2 = DivU64x32 (
+                      MultU64x64 (TimerFrequency, PcdGet64 (PcdCpuSmmApSyncTimeout2)),
+                      1000 * 1000
+                      );
   if (End < Start) {
     mCountDown = TRUE;
     mCycle     = Start - End;
@@ -59,15 +66,17 @@ StartSyncTimer (
 }
 
 /**
-  Check if the SMM AP Sync timer is timeout.
+  Check if the SMM AP Sync Timer is timeout specified by Timeout.
 
-  @param Timer  The start timer from the begin.
+  @param Timer    The start timer from the begin.
+  @param Timeout  The timeout ticker to wait.
 
 **/
 BOOLEAN
 EFIAPI
 IsSyncTimerTimeout (
-  IN      UINT64  Timer
+  IN      UINT64  Timer,
+  IN      UINT64  Timeout
   )
 {
   UINT64  CurrentTimer;
@@ -105,5 +114,5 @@ IsSyncTimerTimeout (
     }
   }
 
-  return (BOOLEAN)(Delta >= mTimeoutTicker);
+  return (BOOLEAN)(Delta >= Timeout);
 }

--- a/UefiCpuPkg/UefiCpuPkg.dec
+++ b/UefiCpuPkg/UefiCpuPkg.dec
@@ -362,8 +362,8 @@
   # @Prompt The specified AP target C-state for Mwait.
   gUefiCpuPkgTokenSpaceGuid.PcdCpuApTargetCstate|0|UINT8|0x00000007
 
-  ## Specifies timeout value in microseconds for the BSP in SMM to wait for all APs to come into SMM.
-  # @Prompt AP synchronization timeout value in SMM.
+  ## Specifies the 1st timeout value in microseconds for the BSP/AP in SMM to wait for one another to enter SMM.
+  # @Prompt The 1st BSP/AP synchronization timeout value in SMM.
   gUefiCpuPkgTokenSpaceGuid.PcdCpuSmmApSyncTimeout|1000000|UINT64|0x32132104
 
   ## Specifies the 2nd timeout value in microseconds for the BSP/AP in SMM to wait for one another to enter SMM.

--- a/UefiCpuPkg/UefiCpuPkg.uni
+++ b/UefiCpuPkg/UefiCpuPkg.uni
@@ -128,9 +128,9 @@
 
 #string STR_gUefiCpuPkgTokenSpaceGuid_PcdCpuSmmShadowStackSize_HELP   #language en-US "Specifies shadow stack size in bytes for each processor in SMM."
 
-#string STR_gUefiCpuPkgTokenSpaceGuid_PcdCpuSmmApSyncTimeout_PROMPT  #language en-US "AP synchronization timeout value in SMM"
+#string STR_gUefiCpuPkgTokenSpaceGuid_PcdCpuSmmApSyncTimeout_PROMPT  #language en-US "The 1st BSP/AP synchronization timeout value in SMM."
 
-#string STR_gUefiCpuPkgTokenSpaceGuid_PcdCpuSmmApSyncTimeout_HELP  #language en-US "Specifies timeout value in microseconds for the BSP in SMM to wait for all APs to come into SMM."
+#string STR_gUefiCpuPkgTokenSpaceGuid_PcdCpuSmmApSyncTimeout_HELP  #language en-US "Specifies the 1st timeout value in microseconds for the BSP/AP in SMM to wait for one another to enter SMM."
 
 #string STR_gUefiCpuPkgTokenSpaceGuid_PcdCpuSmmApSyncTimeout2_PROMPT  #language en-US "The 2nd BSP/AP synchronization timeout value in SMM"
 


### PR DESCRIPTION
## Description

In addition to what was said in the Cherry-Pick in #1096.

It looks like Edk2 picked up these changes, reverted them, and then added them back because Ovmf packages had already started consuming them.

The changes should not impact existing platforms, because the changes only modify PiSmmCpuDxeSmm.

- [x] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [ ] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested
Local CI.

## Integration Instructions
N/A