### PR TITLE
BaseTools/build_rule.template: Set additional Rust module linker flags

### DIFF
--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -282,7 +282,7 @@
         $(OUTPUT_DIR)(+)$(MODULE_NAME)rust.lib
 
     <Command>
-        $(CARGO) make $(CARGOMAKE_FLAGS) -e FEATURES=$(CARGO_FEATURES) -e RUSTFLAGS="-C link-arg=/MAP:$(DEBUG_DIR)(+)$(MODULE_NAME).map $(RUST_FLAGS)" build $(MODULE_NAME)
+        $(CARGO) make $(CARGOMAKE_FLAGS) -e FEATURES=$(CARGO_FEATURES) -e RUSTFLAGS="-C link-arg=/MAP:$(DEBUG_DIR)(+)$(MODULE_NAME).map -C link-arg=/base:0x0 -C link-arg=/subsystem:efi_boot_service_driver $(RUST_FLAGS)" build $(MODULE_NAME)
         $(CP) $(DEBUG_DIR)(+)$(TARGET_TRIPLE)(+)$(RUST_TARGET)(+)*.a $(DEBUG_DIR)(+)$(MODULE_NAME)rust.lib
         $(CP) $(DEBUG_DIR)(+)$(TARGET_TRIPLE)(+)$(RUST_TARGET)(+)*.a $(OUTPUT_DIR)(+)$(MODULE_NAME)rust.lib
 
@@ -294,7 +294,7 @@
         $(OUTPUT_DIR)(+)$(MODULE_NAME).efi
 
     <Command>
-        $(CARGO) make $(CARGOMAKE_FLAGS) -e FEATURES=$(CARGO_FEATURES) -e RUSTFLAGS="-C link-arg=/MAP:$(DEBUG_DIR)(+)$(MODULE_NAME).map $(RUST_FLAGS)" build $(MODULE_NAME)
+        $(CARGO) make $(CARGOMAKE_FLAGS) -e FEATURES=$(CARGO_FEATURES) -e RUSTFLAGS="-C link-arg=/MAP:$(DEBUG_DIR)(+)$(MODULE_NAME).map -C link-arg=/base:0x0 -C link-arg=/subsystem:efi_boot_service_driver $(RUST_FLAGS)" build $(MODULE_NAME)
         "$(GENFW)" -e $(MODULE_TYPE) -o $(DEBUG_DIR)(+)$(MODULE_NAME).efi $(DEBUG_DIR)(+)$(TARGET_TRIPLE)(+)$(RUST_TARGET)(+)$(MODULE_NAME).efi $(GENFW_FLAGS)
         $(CP) $(DEBUG_DIR)(+)$(MODULE_NAME).map  $(OUTPUT_DIR)(+)$(MODULE_NAME).map
         $(CP) $(DEBUG_DIR)(+)$(MODULE_NAME).efi $(OUTPUT_DIR)(+)$(MODULE_NAME).efi


### PR DESCRIPTION
## Description

This change sets the ImageBase in the PE header for Rust modules to `0` so they do not have a preferred base. This is similar to the EFI images produced by the edk2 build system. The subsystem type is also set to `efi_boot_service_driver` instead of the default target specification value of `EFI_APPLICATION`. Details for changing the subsystem type are here:

https://doc.rust-lang.org/nightly/rustc/platform-support/unknown-uefi.html#requirements

Ideally, these values would be set as individual `target.<triple>.rustflags` in `.cargo/config.toml`. However, we override the `/MAP` argument using `-C linker-args` in `build_rule.txt` to the build output directory. This must be set dynamically since the output directory and module name are based on per module values.

Since the cargo configuration file does not support reading environment variables and setting an environment there in a `[env]` section would be too late to impact the commands that run in `build_rules.txt` (cargo is called from cargo make based on those rules), this is the simplest approach to retain the map file path in addition to the new changes.

In the future, this may be moved to a common target specification so the values are available without these changes.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Checked `ImageBase` and `Subsystem` of EFI images in output directory
  to confirm expected values.

## Integration Instructions

This change is marked as breaking in case flows were dependent on the
previous behavior. Otherwise, no changes are nedeed.
