### PR TITLE
MdePkg: Create Google mock for ReadOnlyVariable2

### DIFF
--- a/MdePkg/Test/Mock/Include/GoogleTest/Ppi/MockReadOnlyVariable2.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Ppi/MockReadOnlyVariable2.h
@@ -1,0 +1,49 @@
+/** @file MockReadOnlyVariable2.h
+  This file declares a mock of Read-only Variable Service2 PPI.
+
+  This PPI permits read-only access to the UEFI variable store during the PEI phase.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_PEI_READ_ONLY_VARIABLE2_PPI_H_
+#define MOCK_PEI_READ_ONLY_VARIABLE2_PPI_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+extern "C" {
+  #include <Uefi.h>
+  #include <Pi/PiPeiCis.h>
+  #include <Ppi/ReadOnlyVariable2.h>
+}
+
+struct MockReadOnlyVariable2 {
+  MOCK_INTERFACE_DECLARATION (MockReadOnlyVariable2);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    GetVariable,
+    (IN CONST  EFI_PEI_READ_ONLY_VARIABLE2_PPI  *This,
+     IN CONST  CHAR16                           *VariableName,
+     IN CONST  EFI_GUID                         *VariableGuid,
+     OUT       UINT32                           *Attributes,
+     IN OUT    UINTN                            *DataSize,
+     OUT       VOID                             *Data OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    NextVariableName,
+    (IN CONST  EFI_PEI_READ_ONLY_VARIABLE2_PPI *This,
+     IN OUT    UINTN                           *VariableNameSize,
+     IN OUT    CHAR16                          *VariableName,
+     IN OUT    EFI_GUID                        *VariableGuid)
+    );
+};
+
+extern "C" {
+  extern EFI_PEI_READ_ONLY_VARIABLE2_PPI  *PpiReadOnlyVariableServices;
+}
+
+#endif

--- a/MdePkg/Test/Mock/Library/GoogleTest/Ppi/MockReadOnlyVariable2.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/Ppi/MockReadOnlyVariable2.cpp
@@ -1,0 +1,23 @@
+/** @file MockReadOnlyVariable2.cpp
+  Google Test mock for ReadOnlyVariable2
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <GoogleTest/Ppi/MockReadOnlyVariable2.h>
+
+MOCK_INTERFACE_DEFINITION (MockReadOnlyVariable2);
+MOCK_FUNCTION_DEFINITION (MockReadOnlyVariable2, GetVariable, 6, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockReadOnlyVariable2, NextVariableName, 4, EFIAPI);
+
+// Normally PpiVariableServices is "found"
+// This will be defined INSIDE the test, with its definition pointing to the mock function GetVariable
+EFI_PEI_READ_ONLY_VARIABLE2_PPI  PeiReadOnlyVariablePpi = {
+  GetVariable,      // EFI_PEI_GET_VARIABLE2
+  NextVariableName  // EFI_PEI_GET_NEXT_VARIABLE_NAME2
+};
+
+extern "C" {
+  EFI_PEI_READ_ONLY_VARIABLE2_PPI  *PpiReadOnlyVariableServices = &PeiReadOnlyVariablePpi;
+}


### PR DESCRIPTION
## Description

This patch creates a gmock for the ReadOnlyVariable2 function, which is used by CI testing. Cherry-picked from https://github.com/microsoft/mu_basecore/commit/7bb3e85a3669fb8f104bb83052ed5c2eb2391131 and with the uncrustify fixup from https://github.com/microsoft/mu_basecore/commit/15506a28146d2dc9b363b945f01878940bec8cb3.

Missed in original cp'ing.

For each item, place an "x" in between `[` and `]` if true. Example: `[x]`.
_(you can also check items in the GitHub UI)_

- [ ] Impacts functionality?
  - **Functionality** - Does the change ultimately impact how firmware functions?
  - Examples: Add a new library, publish a new PPI, update an algorithm, ...
- [ ] Impacts security?
  - **Security** - Does the change have a direct security impact on an application,
    flow, or firmware?
  - Examples: Crypto algorithm change, buffer overflow fix, parameter
    validation improvement, ...
- [ ] Breaking change?
  - **Breaking change** - Will anyone consuming this change experience a break
    in build or boot behavior?
  - Examples: Add a new library class, move a module to a different repo, call
    a function in a new library class in a pre-existing module, ...
- [x] Includes tests?
  - **Tests** - Does the change include any explicit test code?
  - Examples: Unit tests, integration tests, robot tests, ...
- [ ] Includes documentation?
  - **Documentation** - Does the change contain explicit documentation additions
    outside direct code modifications (and comments)?
  - Examples: Update readme file, add feature readme file, link to documentation
    on an a separate Web page, ...

## How This Was Tested

From 2311.

## Integration Instructions

N/A.
