### PR TITLE
[REBASE&FF][CHERRY-PICK] ImageValidation: Add default configuration

### DIFF
--- a/.pytool/Plugin/ImageValidation/image_validation.cfg
+++ b/.pytool/Plugin/ImageValidation/image_validation.cfg
@@ -1,0 +1,70 @@
+TARGET_ARCH:
+    X64: IMAGE_FILE_MACHINE_AMD64
+    IA32: IMAGE_FILE_MACHINE_I386
+    AARCH64: IMAGE_FILE_MACHINE_ARM64
+    ARM: IMAGE_FILE_MACHINE_ARM
+
+IGNORE_LIST: []
+
+IMAGE_FILE_MACHINE_AMD64:
+    DEFAULT:
+        IMAGE_BASE: 0
+        DATA_CODE_SEPARATION: true
+        ALIGNMENT:
+            - COMPARISON: "=="
+              VALUE: 0x1000
+    APPLICATION: {}
+    DXE_CORE: {}
+    DXE_DRIVER: {}
+    DXE_RUNTIME_DRIVER: {}
+    DXE_SMM_DRIVER: {}
+    MM_CORE_STANDALONE: {}
+    MM_STANDALONE: {}
+    PEI_CORE:
+        ALIGNMENT: []
+    PEIM:
+        ALIGNMENT: []
+    SEC:
+        ALIGNMENT: []
+    UEFI_APPLICATION: {}
+    UEFI_DRIVER: {}
+    USER_DEFINED: {}
+
+IMAGE_FILE_MACHINE_ARM64:
+    DEFAULT:
+        DATA_CODE_SEPARATION: true
+        ALIGNMENT:
+            - COMPARISON: ==
+              VALUE: 0x1000
+    APPLICATION: {}
+    DXE_CORE: {}
+    DXE_DRIVER: {}
+    DXE_RUNTIME_DRIVER:
+        ALIGNMENT:
+            - COMPARISON: ==
+              VALUE: 0x10000
+    DXE_SMM_DRIVER: {}
+    MM_CORE_STANDALONE: {}
+    MM_STANDALONE: {}
+    PEI_CORE:
+        ALIGNMENT: []
+    PEIM:
+        ALIGNMENT: []
+    SEC:
+        ALIGNMENT: []
+    UEFI_APPLICATION: {}
+    UEFI_DRIVER: {}
+    USER_DEFINED: {}
+
+IMAGE_FILE_MACHINE_I386:
+    DEFAULT:
+        DATA_CODE_SEPARATION: false
+    PEIM: {}
+    PEI_CORE: {}
+    SEC: {}
+    USER_DEFINED: {}
+
+IMAGE_FILE_MACHINE_ARM:
+    DEFAULT:
+        DATA_CODE_SEPARATION: false
+    USER_DEFINED: {}


### PR DESCRIPTION
Previously, ImageValidation was an "opt-in" plugin by setting a build variable `PE_VALIDATION_PATH`, however with this pull request, Image Validation will be on by default, with some default configuration that can be changed with a custom configuration yaml file.

The default requirements are:
1. All efi binaries must not be both write and execute
2. All efi binaries must have an image base of 0x0
3. All dxe phase binaries must be 4k section aligned, with the one exception of AARCH64 DXE_RUNTIME_DRIVERS, which must be 64k aligned.

compiled binaries that need to be opted out of, can do so by adding an `IGNORE_LIST` in the configuration file

```json
{
  "IGNORE_LIST": ["Shell.efi", "etc"]
}
```

A cherry-pick of #1100 into release/202311

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

Confirmed successful execution of the plugin on Windows with QemuQ35 and Ubuntu with QemuSbsa

## Integration Instructions

Platforms that begin to fail this test will need to generate a configuration yaml file, and set a stuart build variable, `PE_VALIDATION_PATH` to it. It is suggested to do this in the Platform's `PlatformBuild.py`.

**The Correct Integration** is to evaluate the binary and why it is not meeting the requirements. The platform can elect to update the compilation of the binary to meet the requirements, add or override validation rules for certain MODULE_TYPEs, or simply add the binary to the ignore list. Please review the Plugin's readme.md file for more details on doing any of these things.
