### PR TITLE
BaseTools/build_rule.template: Add FILE_GUID to the environment for Rust modules

### DIFF
--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -294,7 +294,7 @@
         $(OUTPUT_DIR)(+)$(MODULE_NAME).efi
 
     <Command>
-        $(CARGO) make $(CARGOMAKE_FLAGS) -e FEATURES=$(CARGO_FEATURES) -e RUSTFLAGS="-C link-arg=/MAP:$(DEBUG_DIR)(+)$(MODULE_NAME).map -C link-arg=/base:0x0 -C link-arg=/subsystem:efi_boot_service_driver $(RUST_FLAGS)" build $(MODULE_NAME)
+        $(CARGO) make $(CARGOMAKE_FLAGS) -e FILE_GUID=$(MODULE_GUID) -e FEATURES=$(CARGO_FEATURES) -e RUSTFLAGS="-C link-arg=/MAP:$(DEBUG_DIR)(+)$(MODULE_NAME).map -C link-arg=/base:0x0 -C link-arg=/subsystem:efi_boot_service_driver $(RUST_FLAGS)" build $(MODULE_NAME)
         "$(GENFW)" -e $(MODULE_TYPE) -o $(DEBUG_DIR)(+)$(MODULE_NAME).efi $(DEBUG_DIR)(+)$(TARGET_TRIPLE)(+)$(RUST_TARGET)(+)$(MODULE_NAME).efi $(GENFW_FLAGS)
         $(CP) $(DEBUG_DIR)(+)$(MODULE_NAME).map  $(OUTPUT_DIR)(+)$(MODULE_NAME).map
         $(CP) $(DEBUG_DIR)(+)$(MODULE_NAME).efi $(OUTPUT_DIR)(+)$(MODULE_NAME).efi


### PR DESCRIPTION
## Description

This change allows Rust modules to know their own FILE_GUID using the `env!("FILE_GUID")` macro, providing a self-identification mechanism equivalent to gEfiCallerIdGuid in legacy EDK2 code.

For details on how to complete to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Inserted prints containing `env!("FILE_GUID")` in multiple modules as well as a shared library crate and verified that the GUID which was printed corresponded to the correct parent module.

## Integration Instructions

Can be retrieved directly in string form with `env!("FILE_GUID")` or converted to useful data with `uuid!(env!("FILE_GUID"))`
