### PR TITLE
pip: Update all pip-requirements to latest.

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -12,10 +12,10 @@
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 ##
 
-edk2-pytool-library~=0.21.8 # MU_CHANGE
-edk2-pytool-extensions~=0.27.10 # MU_CHANGE
-antlr4-python3-runtime==4.13.1
+edk2-pytool-library~=0.21.10 # MU_CHANGE
+edk2-pytool-extensions~=0.27.11 # MU_CHANGE
+antlr4-python3-runtime==4.13.2
 lcov-cobertura==2.0.2
 pygount==1.8.0 # MU_CHANGE
 toml==0.10.2 # MU_CHANGE
-regex==2023.12.25
+regex==2024.7.24


### PR DESCRIPTION
## Description

edk2-pytool-library from 0.21.8 to 0.21.10
edk2-pytool-extensions from 0.27.10 to 0.27.11
antlr4-python3-runtime from 4.13.1 to 4.13.2
regex from 2023.12.25 to 2024.7.24

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
CI.

## Integration Instructions
N/A