### PR TITLE
[202311] ImageValidation.py: Don't parse entire image

### DIFF
--- a/.pytool/Plugin/ImageValidation/ImageValidation.py
+++ b/.pytool/Plugin/ImageValidation/ImageValidation.py
@@ -93,7 +93,6 @@ class ImageValidation(IUefiBuildPlugin):
 
         # Load Configuration Data
         config_path = thebuilder.env.GetValue("PE_VALIDATION_PATH", None)
-        tool_chain_tag = thebuilder.env.GetValue("TOOL_CHAIN_TAG")
         if config_path is None:
             logging.info("PE_VALIDATION_PATH not set, Using default configuration")
             logging.info("Review ImageValidation/Readme.md for configuration options.")
@@ -232,7 +231,11 @@ class ImageValidation(IUefiBuildPlugin):
 
     # Executes run_tests() on the efi
     def _validate_image(self, efi_path, profile="DEFAULT"):
-        pe = PE(efi_path)
+        try:
+            pe = PE(efi_path, fast_load=True)
+        except Exception:
+            logging.error(f'Failed to parse {os.path.basename(efi_path)}')
+            return Result.FAIL
 
         target_config = self.config_data[MACHINE_TYPE[pe.FILE_HEADER.Machine]].get(
             profile)


### PR DESCRIPTION
## Description

This commit modifies the PE parsing functionality to only parse the headers of the image, rather than the entire image. This change is made to improve performance and also the probability of failing to parse the entire image. This comes after this commit (https://github.com/erocarrera/pefile/pull/365) in pefile resulted in efi image parsing failures, breaking the build.

This commit also wraps the parsing of the image in a try-except block to catch any exceptions that may be raised during parsing, to cleanly exit.

See: https://github.com/microsoft/mu_tiano_platforms/pull/1025 and https://github.com/erocarrera/pefile/issues/421

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Validated pipelines build on mu_tiano_platforms

## Integration Instructions

N/A