### PR TITLE
[CHERRY-PICK] MdeModulePkg/FaultTolerantWriteDxe: Fix buffer overrun issue

### DIFF
--- a/MdeModulePkg/Universal/FaultTolerantWriteDxe/FtwMisc.c
+++ b/MdeModulePkg/Universal/FaultTolerantWriteDxe/FtwMisc.c
@@ -810,12 +810,18 @@ FtwGetLastWriteHeader (
   FtwHeader       = (EFI_FAULT_TOLERANT_WRITE_HEADER *)(FtwWorkSpaceHeader + 1);
   Offset          = sizeof (EFI_FAULT_TOLERANT_WORKING_BLOCK_HEADER);
 
+  if (!CompareGuid (&FtwWorkSpaceHeader->Signature, &gEdkiiWorkingBlockSignatureGuid)) {
+    *FtwWriteHeader = FtwHeader;
+    return EFI_ABORTED;
+  }
+
   while (FtwHeader->Complete == FTW_VALID_STATE) {
     Offset += FTW_WRITE_TOTAL_SIZE (FtwHeader->NumberOfWrites, FtwHeader->PrivateDataSize);
     //
     // If Offset exceed the FTW work space boudary, return error.
     //
-    if (Offset >= FtwWorkSpaceSize) {
+
+    if ((Offset + sizeof (EFI_FAULT_TOLERANT_WRITE_HEADER)) >= FtwWorkSpaceSize) {
       *FtwWriteHeader = FtwHeader;
       return EFI_ABORTED;
     }


### PR DESCRIPTION
## Description

- This PR aims to  prevent a buffer overrun issue found in FtwGetLastWriteHeader function.As per the current code, when there is a malformed blocks (with all bytes as 0s) then `Offset += FTW_WRITE_TOTAL_SIZE (FtwHeader->NumberOfWrites, FtwHeader->PrivateDataSize)` would access beyond FtwWorkSpaceSize.

- Also added the signature check to validate work space

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on failing platform.

## Integration Instructions

N/A.
