### PR TITLE
[Cherry-Pick] Support Report Status Code in the UefiPxe driver.

### DIFF
--- a/NetworkPkg/UefiPxeBcDxe/PxeBcBoot.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcBoot.c
@@ -1276,5 +1276,12 @@ ON_EXIT:
     AsciiPrint ("\n  PXE-E99: Unexpected network error.\n");
   }
 
+  REPORT_STATUS_CODE_WITH_EXTENDED_DATA (
+    EFI_ERROR_CODE,
+    (EFI_STATUS_CODE_VALUE)(EFI_IO_BUS_IP_NETWORK | EFI_OEM_SPECIFIC | ((EFI_STATUS_CODE_VALUE)(Status & 0x1F))),
+    (VOID *)&(PxeBcMode->UsingIpv6),
+    sizeof (PxeBcMode->UsingIpv6)
+    );
+
   return Status;
 }

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcImpl.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcImpl.c
@@ -72,6 +72,13 @@ EfiPxeBcStart (
     return EFI_UNSUPPORTED;
   }
 
+  REPORT_STATUS_CODE_WITH_EXTENDED_DATA (
+    EFI_PROGRESS_CODE,
+    EFI_IO_BUS_IP_NETWORK | EFI_IOB_PC_RECONFIG,
+    (VOID *)&(Mode->UsingIpv6),
+    sizeof (Mode->UsingIpv6)
+    );
+
   if (Mode->UsingIpv6) {
     AsciiPrint ("\n>>Start PXE over IPv6");
     //

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcImpl.h
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcImpl.h
@@ -48,6 +48,7 @@
 #include <Library/DpcLib.h>
 #include <Library/DevicePathLib.h>
 #include <Library/PcdLib.h>
+#include <Library/ReportStatusCodeLib.h>
 
 typedef struct _PXEBC_PRIVATE_DATA      PXEBC_PRIVATE_DATA;
 typedef struct _PXEBC_PRIVATE_PROTOCOL  PXEBC_PRIVATE_PROTOCOL;

--- a/NetworkPkg/UefiPxeBcDxe/UefiPxeBcDxe.inf
+++ b/NetworkPkg/UefiPxeBcDxe/UefiPxeBcDxe.inf
@@ -62,6 +62,7 @@
   DpcLib
   DevicePathLib
   PcdLib
+  ReportStatusCodeLib
 
 [Protocols]
   ## TO_START


### PR DESCRIPTION
## Description

Report PXE error status via Status Code, with this design, it will be flexible to register a status code handler via gEfiRscHandlerProtocolGuid to output the customized error code to other telemetry service.

The subclass code is `EFI_IO_BUS_IP_NETWORK`

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
N/A

## Integration Instructions
N/A