### PR TITLE
[CHERRY-PICK] MdePkg: Bring in mocks from 2311

### DIFF
--- a/MdePkg/Test/MdePkgHostTest.dsc
+++ b/MdePkg/Test/MdePkgHostTest.dsc
@@ -63,5 +63,6 @@
   MdePkg/Test/Mock/Library/Stub/StubUefiLib/StubUefiLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockPciExpressLib/MockPciExpressLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockUefiDevicePathLib/MockUefiDevicePathLib.inf
+  MdePkg/Test/Mock/Library/GoogleTest/MockDxeServicesTableLib/MockDxeServicesTableLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockPciLib/MockPciLib.inf
   # MU_CHANGE [END]

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockDxeServicesTableLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockDxeServicesTableLib.h
@@ -1,0 +1,31 @@
+/** @file MockDxeServicesTableLib.h
+  Google Test mocks for DxeServicesTableLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_DXE_SERVICES_TABLE_LIB_H_
+#define MOCK_DXE_SERVICES_TABLE_LIB_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+extern "C" {
+  #include <Uefi.h>
+  #include <Pi/PiDxeCis.h>
+}
+
+//
+// Declarations to handle usage of the DxeServicesTableLib by creating mock
+//
+struct MockDxeServicesTableLib {
+  MOCK_INTERFACE_DECLARATION (MockDxeServicesTableLib);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gDS_Dispatch,
+    ()
+    );
+};
+
+#endif // MOCK_UEFI_DXE_SERVICES_TABLE_LIB_H_

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiBootServicesTableLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiBootServicesTableLib.h
@@ -74,6 +74,14 @@ struct MockUefiBootServicesTableLib {
 
   MOCK_FUNCTION_DECLARATION (
     EFI_STATUS,
+    gBS_RegisterProtocolNotify,
+    (IN  EFI_GUID                 *Protocol,
+     IN  EFI_EVENT                Event,
+     OUT VOID                     **Registration)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
     gBS_LocateHandleBuffer,
     (
      IN     EFI_LOCATE_SEARCH_TYPE       SearchType,
@@ -178,6 +186,23 @@ struct MockUefiBootServicesTableLib {
      IN     VOID                     *SearchKey    OPTIONAL,
      IN OUT UINTN                    *BufferSize,
      OUT    EFI_HANDLE               *Buffer)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_ConnectController,
+    (IN  EFI_HANDLE                    ControllerHandle,
+     IN  EFI_HANDLE                    *DriverImageHandle    OPTIONAL,
+     IN  EFI_DEVICE_PATH_PROTOCOL      *RemainingDevicePath  OPTIONAL,
+     IN  BOOLEAN                       Recursive)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_DisconnectController,
+    (IN  EFI_HANDLE                     ControllerHandle,
+     IN  EFI_HANDLE                     DriverImageHandle  OPTIONAL,
+     IN  EFI_HANDLE                     ChildHandle        OPTIONAL)
     );
 };
 

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiRuntimeServicesTableLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiRuntimeServicesTableLib.h
@@ -44,6 +44,15 @@ struct MockUefiRuntimeServicesTableLib {
     (OUT  EFI_TIME                    *Time,
      OUT  EFI_TIME_CAPABILITIES       *Capabilities OPTIONAL)
     );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    gRT_ResetSystem,
+    (IN EFI_RESET_TYPE           ResetType,
+     IN EFI_STATUS               ResetStatus,
+     IN UINTN                    DataSize,
+     IN VOID                     *ResetData OPTIONAL)
+    );
 };
 
 #endif

--- a/MdePkg/Test/Mock/Include/GoogleTest/Ppi/MockPeiReportStatusCodeHandler.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Ppi/MockPeiReportStatusCodeHandler.h
@@ -1,0 +1,48 @@
+/** @file MockPeiReportStatusCodeHandler.h
+  This file declares a mock of Report Status Code Handler PPI.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_PEI_REPORT_STATUS_CODE_HANDLER_PPI_H
+#define MOCK_PEI_REPORT_STATUS_CODE_HANDLER_PPI_H
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+extern "C" {
+  #include <Uefi.h>
+  #include <Pi/PiPeiCis.h>
+  #include <Ppi/ReportStatusCodeHandler.h>
+}
+
+struct MockPeiReportStatusCodeHandler {
+  MOCK_INTERFACE_DECLARATION (MockPeiReportStatusCodeHandler);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    Register,
+    (IN EFI_PEI_RSC_HANDLER_CALLBACK Callback)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    Unregister,
+    (IN EFI_PEI_RSC_HANDLER_CALLBACK Callback)
+    );
+};
+
+MOCK_INTERFACE_DEFINITION (MockPeiReportStatusCodeHandler);
+MOCK_FUNCTION_DEFINITION (MockPeiReportStatusCodeHandler, Register, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPeiReportStatusCodeHandler, Unregister, 1, EFIAPI);
+
+EFI_PEI_RSC_HANDLER_PPI  PeiRscHandlerPpi = {
+  Register,
+  Unregister
+};
+
+extern "C" {
+  EFI_PEI_RSC_HANDLER_PPI  *PeiRscHandlerPpiServices = &PeiRscHandlerPpi;
+}
+
+#endif

--- a/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockReportStatusCodeHandler.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockReportStatusCodeHandler.h
@@ -1,0 +1,51 @@
+/** @file MockReportStatusCodeHandler.h
+  This file declares a mock of Report Status Code Handler Protocol.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_REPORT_STATUS_CODE_HANDLER_PROTOCOL_H
+#define MOCK_REPORT_STATUS_CODE_HANDLER_PROTOCOL_H
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Library/ReportStatusCodeLib.h>
+  #include <Protocol/ReportStatusCodeHandler.h>
+}
+
+struct MockReportStatusCodeHandler {
+  MOCK_INTERFACE_DECLARATION (MockReportStatusCodeHandler);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    Register,
+    (
+     IN EFI_RSC_HANDLER_CALLBACK   Callback,
+     IN EFI_TPL                    Tpl)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    Unregister,
+    (IN EFI_RSC_HANDLER_CALLBACK Callback)
+    );
+};
+
+MOCK_INTERFACE_DEFINITION (MockReportStatusCodeHandler);
+MOCK_FUNCTION_DEFINITION (MockReportStatusCodeHandler, Register, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockReportStatusCodeHandler, Unregister, 1, EFIAPI);
+
+EFI_RSC_HANDLER_PROTOCOL  RscHandlerProtocol = {
+  Register,
+  Unregister
+};
+
+extern "C" {
+  EFI_RSC_HANDLER_PROTOCOL  *RscHandlerProtocolServices = &RscHandlerProtocol;
+}
+
+#endif

--- a/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockSmmReportStatusCodeHandler.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockSmmReportStatusCodeHandler.h
@@ -1,0 +1,50 @@
+/** @file MockSmmReportStatusCodeHandler.h
+  This file declares a mock of SMM Report Status Code Handler Protocol.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_SMM_REPORT_STATUS_CODE_HANDLER_PROTOCOL_H
+#define MOCK_SMM_REPORT_STATUS_CODE_HANDLER_PROTOCOL_H
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Library/ReportStatusCodeLib.h>
+  #include <Protocol/SmmReportStatusCodeHandler.h>
+}
+
+struct MockReportStatusCodeHandler {
+  MOCK_INTERFACE_DECLARATION (MockReportStatusCodeHandler);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    Register,
+    (
+     IN EFI_SMM_RSC_HANDLER_CALLBACK   Callback)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    Unregister,
+    (IN EFI_SMM_RSC_HANDLER_CALLBACK Callback)
+    );
+};
+
+MOCK_INTERFACE_DEFINITION (MockReportStatusCodeHandler);
+MOCK_FUNCTION_DEFINITION (MockReportStatusCodeHandler, Register, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockReportStatusCodeHandler, Unregister, 1, EFIAPI);
+
+EFI_SMM_RSC_HANDLER_PROTOCOL  SmmRscHandlerProtocol = {
+  Register,
+  Unregister
+};
+
+extern "C" {
+  EFI_SMM_RSC_HANDLER_PROTOCOL  *SmmRscHandlerProtocolServices = &SmmRscHandlerProtocol;
+}
+
+#endif

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockDxeServicesTableLib/MockDxeServicesTableLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockDxeServicesTableLib/MockDxeServicesTableLib.cpp
@@ -1,0 +1,36 @@
+/** @file MockDxeServicesTableLib.cpp
+  Google Test mocks for DxeServicesTableLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#include <GoogleTest/Library/MockDxeServicesTableLib.h>
+
+MOCK_INTERFACE_DEFINITION (MockDxeServicesTableLib);
+MOCK_FUNCTION_DEFINITION (MockDxeServicesTableLib, gDS_Dispatch, 0, EFIAPI);
+
+static EFI_DXE_SERVICES  LocalDs = {
+  { 0, 0, 0, 0, 0 },                                                                   // EFI_TABLE_HEADER
+  NULL,                                                                                // EFI_ADD_MEMORY_SPACE
+  NULL,                                                                                // EFI_ALLOCATE_MEMORY_SPACE
+  NULL,                                                                                // EFI_FREE_MEMORY_SPACE
+  NULL,                                                                                // EFI_REMOVE_MEMORY_SPACE
+  NULL,                                                                                // EFI_GET_MEMORY_SPACE_DESCRIPTOR
+  NULL,                                                                                // EFI_SET_MEMORY_SPACE_ATTRIBUTES
+  NULL,                                                                                // EFI_GET_MEMORY_SPACE_MAP
+  NULL,                                                                                // EFI_ADD_IO_SPACE
+  NULL,                                                                                // EFI_ALLOCATE_IO_SPACE
+  NULL,                                                                                // EFI_FREE_IO_SPACE
+  NULL,                                                                                // EFI_REMOVE_IO_SPACE
+  NULL,                                                                                // EFI_GET_IO_SPACE_DESCRIPTOR
+  NULL,                                                                                // EFI_GET_IO_SPACE_MAP
+  gDS_Dispatch,                                                                        // EFI_DISPATCH
+  NULL,                                                                                // EFI_SCHEDULE
+  NULL,                                                                                // EFI_TRUST
+  NULL,                                                                                // EFI_PROCESS_FIRMWARE_VOLUME
+  NULL                                                                                 // EFI_SET_MEMORY_SPACE_CAPABILITIES
+};
+
+extern "C" {
+  EFI_DXE_SERVICES  *gDS = &LocalDs;
+}

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockDxeServicesTableLib/MockDxeServicesTableLib.inf
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockDxeServicesTableLib/MockDxeServicesTableLib.inf
@@ -1,0 +1,32 @@
+## @file MockDxeServicesTableLib.inf
+#  Mock implementation of the DXE Services Table Library.
+#
+#  Copyright (c) Microsoft Corporation.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MockDxeServicesTableLib
+  FILE_GUID                      = 8d9ce22b-2cf3-4646-ad0b-ce3cf1aea84d
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = DxeServicesTableLib
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64 EBC
+#
+
+[Sources]
+  MockDxeServicesTableLib.cpp
+
+[LibraryClasses]
+  GoogleTestLib
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHsc

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockUefiBootServicesTableLib/MockUefiBootServicesTableLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockUefiBootServicesTableLib/MockUefiBootServicesTableLib.cpp
@@ -13,6 +13,7 @@ MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_CloseEvent, 1, EFIAP
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_InstallProtocolInterface, 4, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_UninstallProtocolInterface, 3, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_HandleProtocol, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_RegisterProtocolNotify, 3, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_LocateHandleBuffer, 5, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_LocateProtocol, 3, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_CreateEventEx, 6, EFIAPI);
@@ -25,6 +26,8 @@ MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_LocateDevicePath, 3,
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_ReinstallProtocolInterface, 4, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_AllocatePool, 3, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_LocateHandle, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_ConnectController, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_DisconnectController, 3, EFIAPI);
 
 extern "C" {
   EFI_STATUS
@@ -118,7 +121,7 @@ static EFI_BOOT_SERVICES  LocalBs = {
   gBS_UninstallProtocolInterface,                                                      // EFI_UNINSTALL_PROTOCOL_INTERFACE
   gBS_HandleProtocol,                                                                  // EFI_HANDLE_PROTOCOL
   NULL,                                                                                // VOID
-  NULL,                                                                                // EFI_REGISTER_PROTOCOL_NOTIFY
+  gBS_RegisterProtocolNotify,                                                          // EFI_REGISTER_PROTOCOL_NOTIFY
   gBS_LocateHandle,                                                                    // EFI_LOCATE_HANDLE
   gBS_LocateDevicePath,                                                                // EFI_LOCATE_DEVICE_PATH
   NULL,                                                                                // EFI_INSTALL_CONFIGURATION_TABLE
@@ -130,8 +133,8 @@ static EFI_BOOT_SERVICES  LocalBs = {
   NULL,                                                                                // EFI_GET_NEXT_MONOTONIC_COUNT
   NULL,                                                                                // EFI_STALL
   NULL,                                                                                // EFI_SET_WATCHDOG_TIMER
-  NULL,                                                                                // EFI_CONNECT_CONTROLLER
-  NULL,                                                                                // EFI_DISCONNECT_CONTROLLER
+  gBS_ConnectController,                                                               // EFI_CONNECT_CONTROLLER
+  gBS_DisconnectController,                                                            // EFI_DISCONNECT_CONTROLLER
   gBS_OpenProtocol,                                                                    // EFI_OPEN_PROTOCOL
   gBS_CloseProtocol,                                                                   // EFI_CLOSE_PROTOCOL
   NULL,                                                                                // EFI_OPEN_PROTOCOL_INFORMATION

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockUefiRuntimeServicesTableLib/MockUefiRuntimeServicesTableLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockUefiRuntimeServicesTableLib/MockUefiRuntimeServicesTableLib.cpp
@@ -11,6 +11,7 @@ MOCK_INTERFACE_DEFINITION (MockUefiRuntimeServicesTableLib);
 MOCK_FUNCTION_DEFINITION (MockUefiRuntimeServicesTableLib, gRT_GetVariable, 5, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiRuntimeServicesTableLib, gRT_SetVariable, 5, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiRuntimeServicesTableLib, gRT_GetTime, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeServicesTableLib, gRT_ResetSystem, 4, EFIAPI);
 
 static EFI_RUNTIME_SERVICES  localRt = {
   { 0 },            // EFI_TABLE_HEADER
@@ -28,7 +29,7 @@ static EFI_RUNTIME_SERVICES  localRt = {
   gRT_SetVariable,  // EFI_SET_VARIABLE
 
   NULL,             // EFI_GET_NEXT_HIGH_MONO_COUNT
-  NULL,             // EFI_RESET_SYSTEM
+  gRT_ResetSystem,  // EFI_RESET_SYSTEM
 
   NULL,             // EFI_UPDATE_CAPSULE
   NULL,             // EFI_QUERY_CAPSULE_CAPABILITIES


### PR DESCRIPTION
## Description

Add mocks from 2311

Cherry picked and squashed the following commits:
a5ba951
5aa1be5

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested in 202311 CI
## Integration Instructions

N/A