### PR TITLE
[202311] ImageValidation.py: Support gitignore style syntax for file exclusion

### DIFF
--- a/.pytool/Plugin/ImageValidation/ImageValidation.py
+++ b/.pytool/Plugin/ImageValidation/ImageValidation.py
@@ -17,6 +17,7 @@ from edk2toolext.image_validation import (
 from edk2toollib.uefi.edk2.parsers.fdf_parser import FdfParser
 from edk2toollib.uefi.edk2.parsers.dsc_parser import DscParser
 from edk2toollib.uefi.edk2.parsers.inf_parser import InfParser
+from edk2toollib.gitignore_parser import parse_gitignore_lines
 import yaml
 from typing import List
 import logging
@@ -124,7 +125,9 @@ class ImageValidation(IUefiBuildPlugin):
 
         self.test_manager.config_data = config_data
         self.config_data = config_data
-        self.ignore_list = config_data["IGNORE_LIST"]
+        self.ignore = parse_gitignore_lines(config_data.get("IGNORE_LIST", []), os.path.join(
+            thebuilder.ws, "nofile.txt"), thebuilder.ws)
+
         self.arch_dict = config_data["TARGET_ARCH"]
 
         count = 0
@@ -169,7 +172,7 @@ class ImageValidation(IUefiBuildPlugin):
                             logging.warning(
                                 "Unable to parse the path to the pre-compiled efi")
                             continue
-                        if os.path.basename(efi_path) in self.ignore_list:
+                        if self.ignore(efi_path):
                             continue
                         logging.debug(
                             f'Performing Image Verification ... {os.path.basename(efi_path)}')
@@ -186,7 +189,7 @@ class ImageValidation(IUefiBuildPlugin):
                 ['.efi'], f'{thebuilder.env.GetValue("BUILD_OUTPUT_BASE")}/{arch}')
 
             for efi_path in efi_path_list:
-                if os.path.basename(efi_path) in self.ignore_list:
+                if self.ignore(efi_path):
                     continue
 
                 # Perform Image Verification on any output efi's

--- a/.pytool/Plugin/ImageValidation/ReadMe.md
+++ b/.pytool/Plugin/ImageValidation/ReadMe.md
@@ -64,7 +64,8 @@ X64:
 If your platform deems a particular binary does not, and cannot meet the
 requirements set by the Image Validation plugin, or the platform's custom
 config, it can be ignored by adding a `IGNORE_LIST = [...]` section to the
-configuration file provided via PE_VALIDATION_PATH.
+configuration file provided via PE_VALIDATION_PATH. gitignore style syntax
+is supported for ignoring multiple files.
 
 ## Common Errors
 


### PR DESCRIPTION
## Description

Add gitignore style syntax for file exclusion

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Ensured existing syntax (filename only) continues to work. Ensured gitignore style syntax now works.

## Integration Instructions

N/A
