### PR TITLE
[CHERRY-PICK][REBASE&FF] ImageValidation.py: Support gitignore style syntax for file exclusion

### DIFF
--- a/.pytool/Plugin/ImageValidation/ReadMe.md
+++ b/.pytool/Plugin/ImageValidation/ReadMe.md
@@ -64,7 +64,8 @@ X64:
 If your platform deems a particular binary does not, and cannot meet the
 requirements set by the Image Validation plugin, or the platform's custom
 config, it can be ignored by adding a `IGNORE_LIST = [...]` section to the
-configuration file provided via PE_VALIDATION_PATH.
+configuration file provided via PE_VALIDATION_PATH. gitignore style syntax
+is supported for ignoring multiple files.
 
 ## Common Errors
 


### PR DESCRIPTION
## Description

Cherry-pick of #1140 into dev/202405

This commit is also in release/202308

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Squash into 6310e1ecef38b2ebee0b352494b17913fc9c90b6

## How This Was Tested

Cherry-pick of #1140 into dev/202405

## Integration Instructions

Cherry-pick of #1140 into dev/202405
