### PR TITLE
CryptoPkg: Require exact crypto version match

### DIFF
--- a/CryptoPkg/Library/BaseCryptLibOnProtocolPpi/DxeCryptLib.c
+++ b/CryptoPkg/Library/BaseCryptLibOnProtocolPpi/DxeCryptLib.c
@@ -66,9 +66,9 @@ DxeCryptLibConstructor (
   }
 
   Version = mCryptoProtocol->GetVersion ();
-  if (Version < EDKII_CRYPTO_VERSION) {
+  if (Version != EDKII_CRYPTO_VERSION) {
     DEBUG ((DEBUG_ERROR, "[DxeCryptLib] Crypto Protocol unsupported version %d\n", Version));
-    ASSERT (Version >= EDKII_CRYPTO_VERSION);
+    ASSERT (Version == EDKII_CRYPTO_VERSION);
     mCryptoProtocol = NULL;
     return EFI_NOT_FOUND;
   }

--- a/CryptoPkg/Library/BaseCryptLibOnProtocolPpi/PeiCryptLib.c
+++ b/CryptoPkg/Library/BaseCryptLibOnProtocolPpi/PeiCryptLib.c
@@ -47,9 +47,9 @@ GetCryptoServices (
   }
 
   Version = CryptoPpi->GetVersion ();
-  if (Version < EDKII_CRYPTO_VERSION) {
+  if (Version != EDKII_CRYPTO_VERSION) {
     DEBUG ((DEBUG_ERROR, "[PeiCryptLib] Crypto PPI unsupported version %d\n", Version));
-    ASSERT (Version >= EDKII_CRYPTO_VERSION);
+    ASSERT (Version == EDKII_CRYPTO_VERSION);
     return NULL;
   }
 

--- a/CryptoPkg/Library/BaseCryptLibOnProtocolPpi/RuntimeDxeCryptLib.c
+++ b/CryptoPkg/Library/BaseCryptLibOnProtocolPpi/RuntimeDxeCryptLib.c
@@ -110,9 +110,9 @@ RuntimeDxeCryptLibConstructor (
   }
 
   Version = mCryptoProtocol->GetVersion ();
-  if (Version < EDKII_CRYPTO_VERSION) {
+  if (Version != EDKII_CRYPTO_VERSION) {
     DEBUG ((DEBUG_ERROR, "[%a] Crypto Protocol unsupported version %u.\n", __func__, Version));
-    ASSERT (Version >= EDKII_CRYPTO_VERSION);
+    ASSERT (Version == EDKII_CRYPTO_VERSION);
     mCryptoProtocol = NULL;
     return EFI_NOT_FOUND;
   }

--- a/CryptoPkg/Library/BaseCryptLibOnProtocolPpi/SmmCryptLib.c
+++ b/CryptoPkg/Library/BaseCryptLibOnProtocolPpi/SmmCryptLib.c
@@ -68,9 +68,9 @@ SmmCryptLibConstructor (
   }
 
   Version = mSmmCryptoProtocol->GetVersion ();
-  if (Version < EDKII_CRYPTO_VERSION) {
+  if (Version != EDKII_CRYPTO_VERSION) {
     DEBUG ((DEBUG_ERROR, "[SmmCryptLib] Crypto SMM Protocol unsupported version %d\n", Version));
-    ASSERT (Version >= EDKII_CRYPTO_VERSION);
+    ASSERT (Version == EDKII_CRYPTO_VERSION);
     mSmmCryptoProtocol = NULL;
     return EFI_NOT_FOUND;
   }

--- a/CryptoPkg/Library/BaseCryptLibOnProtocolPpi/StandaloneMmCryptLib.c
+++ b/CryptoPkg/Library/BaseCryptLibOnProtocolPpi/StandaloneMmCryptLib.c
@@ -68,9 +68,9 @@ StandaloneMmCryptLibConstructor (
   }
 
   Version = mSmmCryptoProtocol->GetVersion ();
-  if (Version < EDKII_CRYPTO_VERSION) {
+  if (Version != EDKII_CRYPTO_VERSION) {
     DEBUG ((DEBUG_ERROR, "[StandaloneMmCryptLib] Crypto SMM Protocol unsupported version %d\n", Version));
-    ASSERT (Version >= EDKII_CRYPTO_VERSION);
+    ASSERT (Version == EDKII_CRYPTO_VERSION);
     mSmmCryptoProtocol = NULL;
     return EFI_NOT_FOUND;
   }


### PR DESCRIPTION

## Description

Crypto versioning is not currently backwards compatible.  This change updates the check to require an exact match of the crypto version.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
