### PR TITLE
[REBASE&FF] MdeModulePkg/SMM: Initialize 'WillReturn' variable

### DIFF
--- a/MdeModulePkg/Core/PiSmmCore/Smi.c
+++ b/MdeModulePkg/Core/PiSmmCore/Smi.c
@@ -152,6 +152,7 @@ SmiManage (
 
   PERF_FUNCTION_BEGIN ();
   mSmiManageCallingDepth++;
+  WillReturn   = FALSE;
   Status       = EFI_NOT_FOUND;
   ReturnStatus = Status;
   if (HandlerType == NULL) {


### PR DESCRIPTION
## Description

The local variable 'WillReturn' was being used without prior initialization in some code paths.
This patch ensures that 'WillReturn' is properly initialized to prevent undefined behavior.

Cherry-pick from EDKII https://github.com/tianocore/edk2/commit/30b6d08e27c767ba9756a244099d73c826abcc8d
Cherry-pick from dev/202405 https://github.com/microsoft/mu_basecore/commit/36f763d4f61ed9dbdb0bcc2835cca6407c8c69db

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Cherry-pick from EDKII https://github.com/tianocore/edk2/commit/30b6d08e27c767ba9756a244099d73c826abcc8d

## Integration Instructions

Cherry-pick from EDKII https://github.com/tianocore/edk2/commit/30b6d08e27c767ba9756a244099d73c826abcc8d
