### PR TITLE
Correct function naming in MockFirmwareVolume2.h

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciLib.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciLib.c
@@ -1306,7 +1306,7 @@ PciScanBus (
                                           PciDevice->DevicePath,
                                           PciAddress,
                                           &State,
-                                          (VOID **)&Descriptors, // MU_CHANGE - CodeQL Change
+                                          (VOID **)&DescriptorsBuffer, // MU_CHANGE - CodeQL Change
                                           &Attributes
                                           );
 

--- a/MdePkg/Test/MdePkgHostTest.dsc
+++ b/MdePkg/Test/MdePkgHostTest.dsc
@@ -63,5 +63,6 @@
   MdePkg/Test/Mock/Library/Stub/StubUefiLib/StubUefiLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockPciExpressLib/MockPciExpressLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockUefiDevicePathLib/MockUefiDevicePathLib.inf
+  MdePkg/Test/Mock/Library/GoogleTest/MockDxeServicesTableLib/MockDxeServicesTableLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockPciLib/MockPciLib.inf
   # MU_CHANGE [END]

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockDxeServicesTableLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockDxeServicesTableLib.h
@@ -1,0 +1,31 @@
+/** @file MockDxeServicesTableLib.h
+  Google Test mocks for DxeServicesTableLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_DXE_SERVICES_TABLE_LIB_H_
+#define MOCK_DXE_SERVICES_TABLE_LIB_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+extern "C" {
+  #include <Uefi.h>
+  #include <Pi/PiDxeCis.h>
+}
+
+//
+// Declarations to handle usage of the DxeServicesTableLib by creating mock
+//
+struct MockDxeServicesTableLib {
+  MOCK_INTERFACE_DECLARATION (MockDxeServicesTableLib);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gDS_Dispatch,
+    ()
+    );
+};
+
+#endif // MOCK_UEFI_DXE_SERVICES_TABLE_LIB_H_

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiBootServicesTableLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiBootServicesTableLib.h
@@ -74,6 +74,14 @@ struct MockUefiBootServicesTableLib {
 
   MOCK_FUNCTION_DECLARATION (
     EFI_STATUS,
+    gBS_RegisterProtocolNotify,
+    (IN  EFI_GUID                 *Protocol,
+     IN  EFI_EVENT                Event,
+     OUT VOID                     **Registration)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
     gBS_LocateHandleBuffer,
     (
      IN     EFI_LOCATE_SEARCH_TYPE       SearchType,
@@ -178,6 +186,23 @@ struct MockUefiBootServicesTableLib {
      IN     VOID                     *SearchKey    OPTIONAL,
      IN OUT UINTN                    *BufferSize,
      OUT    EFI_HANDLE               *Buffer)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_ConnectController,
+    (IN  EFI_HANDLE                    ControllerHandle,
+     IN  EFI_HANDLE                    *DriverImageHandle    OPTIONAL,
+     IN  EFI_DEVICE_PATH_PROTOCOL      *RemainingDevicePath  OPTIONAL,
+     IN  BOOLEAN                       Recursive)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_DisconnectController,
+    (IN  EFI_HANDLE                     ControllerHandle,
+     IN  EFI_HANDLE                     DriverImageHandle  OPTIONAL,
+     IN  EFI_HANDLE                     ChildHandle        OPTIONAL)
     );
 };
 

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiLib.h
@@ -89,6 +89,15 @@ struct MockUefiLib {
      IN CONST EFI_COMPONENT_NAME_PROTOCOL   *ComponentName        OPTIONAL,
      IN CONST EFI_COMPONENT_NAME2_PROTOCOL  *ComponentName2       OPTIONAL)
     );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiCreateEventReadyToBootEx,
+    (IN  EFI_TPL           NotifyTpl,
+     IN  EFI_EVENT_NOTIFY  NotifyFunction   OPTIONAL,
+     IN  VOID              *NotifyContext   OPTIONAL,
+     OUT EFI_EVENT         *ReadyToBootEvent)
+    );
 };
 
 #endif

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiRuntimeServicesTableLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiRuntimeServicesTableLib.h
@@ -44,6 +44,15 @@ struct MockUefiRuntimeServicesTableLib {
     (OUT  EFI_TIME                    *Time,
      OUT  EFI_TIME_CAPABILITIES       *Capabilities OPTIONAL)
     );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    gRT_ResetSystem,
+    (IN EFI_RESET_TYPE           ResetType,
+     IN EFI_STATUS               ResetStatus,
+     IN UINTN                    DataSize,
+     IN VOID                     *ResetData OPTIONAL)
+    );
 };
 
 #endif

--- a/MdePkg/Test/Mock/Include/GoogleTest/Ppi/MockPeiReportStatusCodeHandler.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Ppi/MockPeiReportStatusCodeHandler.h
@@ -1,0 +1,48 @@
+/** @file MockPeiReportStatusCodeHandler.h
+  This file declares a mock of Report Status Code Handler PPI.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_PEI_REPORT_STATUS_CODE_HANDLER_PPI_H
+#define MOCK_PEI_REPORT_STATUS_CODE_HANDLER_PPI_H
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+extern "C" {
+  #include <Uefi.h>
+  #include <Pi/PiPeiCis.h>
+  #include <Ppi/ReportStatusCodeHandler.h>
+}
+
+struct MockPeiReportStatusCodeHandler {
+  MOCK_INTERFACE_DECLARATION (MockPeiReportStatusCodeHandler);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    Register,
+    (IN EFI_PEI_RSC_HANDLER_CALLBACK Callback)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    Unregister,
+    (IN EFI_PEI_RSC_HANDLER_CALLBACK Callback)
+    );
+};
+
+MOCK_INTERFACE_DEFINITION (MockPeiReportStatusCodeHandler);
+MOCK_FUNCTION_DEFINITION (MockPeiReportStatusCodeHandler, Register, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPeiReportStatusCodeHandler, Unregister, 1, EFIAPI);
+
+EFI_PEI_RSC_HANDLER_PPI  PeiRscHandlerPpi = {
+  Register,
+  Unregister
+};
+
+extern "C" {
+  EFI_PEI_RSC_HANDLER_PPI  *PeiRscHandlerPpiServices = &PeiRscHandlerPpi;
+}
+
+#endif

--- a/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockAcpiSystemDescriptionTable.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockAcpiSystemDescriptionTable.h
@@ -1,0 +1,139 @@
+/** @file MockAcpiSystemDescriptionTable.h
+  This file declares a mock of ACPI system description tables protocol.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_ACPI_SYSTEM_DESCRIPTION_TABLE_H_
+#define MOCK_ACPI_SYSTEM_DESCRIPTION_TABLE_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Protocol/AcpiSystemDescriptionTable.h>
+}
+
+struct MockAcpiSdtProtocol {
+  MOCK_INTERFACE_DECLARATION (MockAcpiSdtProtocol);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    GetAcpiTable,
+    (
+     IN    UINTN                   Index,
+     OUT   EFI_ACPI_SDT_HEADER     **Table,
+     OUT   EFI_ACPI_TABLE_VERSION  *Version,
+     OUT   UINTN                   *TableKey
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    RegisterNotify,
+    (
+     IN BOOLEAN                    Register,
+     IN EFI_ACPI_NOTIFICATION_FN   Notification
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    Open,
+    (
+     IN    VOID            *Buffer,
+     OUT   EFI_ACPI_HANDLE *Handle
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    OpenSdt,
+    (
+     IN    UINTN           TableKey,
+     OUT   EFI_ACPI_HANDLE *Handle
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    Close,
+    (
+     IN EFI_ACPI_HANDLE Handle
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    GetChild,
+    (
+     IN EFI_ACPI_HANDLE        ParentHandle,
+     IN OUT EFI_ACPI_HANDLE    *Handle
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    GetOption,
+    (
+     IN        EFI_ACPI_HANDLE     Handle,
+     IN        UINTN               Index,
+     OUT       EFI_ACPI_DATA_TYPE  *DataType,
+     OUT CONST VOID                **Data,
+     OUT       UINTN               *DataSize
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    SetOption,
+    (
+     IN        EFI_ACPI_HANDLE Handle,
+     IN        UINTN           Index,
+     IN CONST  VOID            *Data,
+     IN        UINTN           DataSize
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    FindPath,
+    (
+     IN    EFI_ACPI_HANDLE HandleIn,
+     IN    VOID            *AcpiPath,
+     OUT   EFI_ACPI_HANDLE *HandleOut
+    )
+    );
+};
+
+MOCK_INTERFACE_DEFINITION (MockAcpiSdtProtocol);
+MOCK_FUNCTION_DEFINITION (MockAcpiSdtProtocol, GetAcpiTable, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockAcpiSdtProtocol, RegisterNotify, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockAcpiSdtProtocol, Open, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockAcpiSdtProtocol, OpenSdt, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockAcpiSdtProtocol, Close, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockAcpiSdtProtocol, GetChild, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockAcpiSdtProtocol, GetOption, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockAcpiSdtProtocol, SetOption, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockAcpiSdtProtocol, FindPath, 3, EFIAPI);
+
+EFI_ACPI_SDT_PROTOCOL  ACPI_SDT_PROTOCOL_INSTANCE = {
+  0,
+  GetAcpiTable,   // EFI_ACPI_TABLE_INSTALL_ACPI_TABLE
+  RegisterNotify, // EFI_ACPI_TABLE_UNINSTALL_ACPI_TABLE
+  Open,
+  OpenSdt,
+  Close,
+  GetChild,
+  GetOption,
+  SetOption,
+  FindPath
+};
+
+extern "C" {
+  EFI_ACPI_SDT_PROTOCOL  *gAcpiSdtProtocol = &ACPI_SDT_PROTOCOL_INSTANCE;
+}
+
+#endif // MOCK_ACPI_SYSTEM_DESCRIPTION_TABLE_H_

--- a/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockAcpiTable.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockAcpiTable.h
@@ -1,0 +1,56 @@
+/** @file MockAcpiTable.h
+  This file declares a mock of Acpi table protocol.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_ACPI_TABLE_H_
+#define MOCK_ACPI_TABLE_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Protocol/AcpiTable.h>
+}
+
+struct MockAcpiTableProtocol {
+  MOCK_INTERFACE_DECLARATION (MockAcpiTableProtocol);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    InstallAcpiTable,
+    (
+     IN   EFI_ACPI_TABLE_PROTOCOL       *This,
+     IN   VOID                          *AcpiTableBuffer,
+     IN   UINTN                         AcpiTableBufferSize,
+     OUT  UINTN                         *TableKey
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    UninstallAcpiTable,
+    (
+     IN  EFI_ACPI_TABLE_PROTOCOL       *This,
+     IN  UINTN                         TableKey
+    )
+    );
+};
+
+MOCK_INTERFACE_DEFINITION (MockAcpiTableProtocol);
+MOCK_FUNCTION_DEFINITION (MockAcpiTableProtocol, InstallAcpiTable, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockAcpiTableProtocol, UninstallAcpiTable, 2, EFIAPI);
+
+EFI_ACPI_TABLE_PROTOCOL  ACPI_TABLE_PROTOCOL_INSTANCE = {
+  InstallAcpiTable,   // EFI_ACPI_TABLE_INSTALL_ACPI_TABLE
+  UninstallAcpiTable  // EFI_ACPI_TABLE_UNINSTALL_ACPI_TABLE
+};
+
+extern "C" {
+  EFI_ACPI_TABLE_PROTOCOL  *gAcpiTableProtocol = &ACPI_TABLE_PROTOCOL_INSTANCE;
+}
+
+#endif // MOCK_ACPI_TABLE_H_

--- a/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockFirmwareVolume2.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockFirmwareVolume2.h
@@ -117,9 +117,9 @@ struct MockFirmwareVolume2Protocol {
 MOCK_INTERFACE_DEFINITION (MockFirmwareVolume2Protocol);
 MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, GetVolumeAttributes, 2, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, SetVolumeAttributes, 2, EFIAPI);
-MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, FV_ReadFile, 7, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, FvReadFile, 7, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, ReadSection, 7, EFIAPI);
-MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, FV_WriteFile, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, FvWriteFile, 4, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, GetNextFile, 6, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, GetInfo, 4, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, SetInfo, 4, EFIAPI);

--- a/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockFirmwareVolume2.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockFirmwareVolume2.h
@@ -1,0 +1,144 @@
+/** @file MockFirmwareVolume2.h
+  This file declares a mock of Firmware Volume Protocol.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_FIRMWARE_VOLUME2_H_
+#define MOCK_FIRMWARE_VOLUME2_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Pi/PiFirmwareVolume.h>
+  #include <Pi/PiFirmwareFile.h>
+  #include <Protocol/FirmwareVolume2.h>
+}
+
+struct MockFirmwareVolume2Protocol {
+  MOCK_INTERFACE_DECLARATION (MockFirmwareVolume2Protocol);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    GetVolumeAttributes,
+    (
+     IN CONST  EFI_FIRMWARE_VOLUME2_PROTOCOL *This,
+     OUT       EFI_FV_ATTRIBUTES             *FvAttributes
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    SetVolumeAttributes,
+    (
+     IN CONST  EFI_FIRMWARE_VOLUME2_PROTOCOL *This,
+     IN OUT    EFI_FV_ATTRIBUTES             *FvAttributes
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    FvReadFile,
+    (
+     IN CONST  EFI_FIRMWARE_VOLUME2_PROTOCOL *This,
+     IN CONST  EFI_GUID                      *NameGuid,
+     IN OUT    VOID                          **Buffer,
+     IN OUT    UINTN                         *BufferSize,
+     OUT       EFI_FV_FILETYPE               *FoundType,
+     OUT       EFI_FV_FILE_ATTRIBUTES        *FileAttributes,
+     OUT       UINT32                        *AuthenticationStatus
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ReadSection,
+    (
+     IN CONST  EFI_FIRMWARE_VOLUME2_PROTOCOL *This,
+     IN CONST  EFI_GUID                      *NameGuid,
+     IN        EFI_SECTION_TYPE              SectionType,
+     IN        UINTN                         SectionInstance,
+     IN OUT    VOID                          **Buffer,
+     IN OUT    UINTN                         *BufferSize,
+     OUT       UINT32                        *AuthenticationStatus
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    FvWriteFile,
+    (
+     IN CONST  EFI_FIRMWARE_VOLUME2_PROTOCOL *This,
+     IN        UINT32                        NumberOfFiles,
+     IN        EFI_FV_WRITE_POLICY           WritePolicy,
+     IN        EFI_FV_WRITE_FILE_DATA        *FileData
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    GetNextFile,
+    (
+     IN CONST  EFI_FIRMWARE_VOLUME2_PROTOCOL *This,
+     IN OUT    VOID                          *Key,
+     IN OUT    EFI_FV_FILETYPE               *FileType,
+     OUT       EFI_GUID                      *NameGuid,
+     OUT       EFI_FV_FILE_ATTRIBUTES        *Attributes,
+     OUT       UINTN                         *Size
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    GetInfo,
+    (
+     IN CONST  EFI_FIRMWARE_VOLUME2_PROTOCOL *This,
+     IN CONST  EFI_GUID                      *InformationType,
+     IN OUT    UINTN                         *BufferSize,
+     OUT       VOID                          *Buffer
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    SetInfo,
+    (
+     IN CONST  EFI_FIRMWARE_VOLUME2_PROTOCOL *This,
+     IN CONST  EFI_GUID                      *InformationType,
+     IN        UINTN                         BufferSize,
+     IN CONST  VOID                          *Buffer
+    )
+    );
+};
+
+MOCK_INTERFACE_DEFINITION (MockFirmwareVolume2Protocol);
+MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, GetVolumeAttributes, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, SetVolumeAttributes, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, FV_ReadFile, 7, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, ReadSection, 7, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, FV_WriteFile, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, GetNextFile, 6, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, GetInfo, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, SetInfo, 4, EFIAPI);
+
+EFI_FIRMWARE_VOLUME2_PROTOCOL  FIRMWARE_VOLUME2_PROTOCOL_MOCK = {
+  GetVolumeAttributes,   // EFI_FV_GET_ATTRIBUTES    GetVolumeAttributes;
+  SetVolumeAttributes,   // EFI_FV_SET_ATTRIBUTES    SetVolumeAttributes;
+  FvReadFile,            // EFI_FV_READ_FILE         ReadFile;
+  ReadSection,           // EFI_FV_READ_SECTION      ReadSection;
+  FvWriteFile,           // EFI_FV_WRITE_FILE        WriteFile;
+  GetNextFile,           // EFI_FV_GET_NEXT_FILE     GetNextFile;
+  0,                     // UINT32                   KeySize;
+  0,                     // EFI_HANDLE               ParentHandle;
+  GetInfo,               // EFI_FV_GET_INFO          GetInfo;
+  SetInfo                // EFI_FV_SET_INFO          SetInfo;
+};
+
+extern "C" {
+  EFI_FIRMWARE_VOLUME2_PROTOCOL  *gFirmwareVolume2Protocol = &FIRMWARE_VOLUME2_PROTOCOL_MOCK;
+}
+
+#endif // MOCK_FIRMWARE_VOLUME2_H_

--- a/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockReportStatusCodeHandler.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockReportStatusCodeHandler.h
@@ -1,0 +1,51 @@
+/** @file MockReportStatusCodeHandler.h
+  This file declares a mock of Report Status Code Handler Protocol.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_REPORT_STATUS_CODE_HANDLER_PROTOCOL_H
+#define MOCK_REPORT_STATUS_CODE_HANDLER_PROTOCOL_H
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Library/ReportStatusCodeLib.h>
+  #include <Protocol/ReportStatusCodeHandler.h>
+}
+
+struct MockReportStatusCodeHandler {
+  MOCK_INTERFACE_DECLARATION (MockReportStatusCodeHandler);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    Register,
+    (
+     IN EFI_RSC_HANDLER_CALLBACK   Callback,
+     IN EFI_TPL                    Tpl)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    Unregister,
+    (IN EFI_RSC_HANDLER_CALLBACK Callback)
+    );
+};
+
+MOCK_INTERFACE_DEFINITION (MockReportStatusCodeHandler);
+MOCK_FUNCTION_DEFINITION (MockReportStatusCodeHandler, Register, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockReportStatusCodeHandler, Unregister, 1, EFIAPI);
+
+EFI_RSC_HANDLER_PROTOCOL  RscHandlerProtocol = {
+  Register,
+  Unregister
+};
+
+extern "C" {
+  EFI_RSC_HANDLER_PROTOCOL  *RscHandlerProtocolServices = &RscHandlerProtocol;
+}
+
+#endif

--- a/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockSmmReportStatusCodeHandler.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockSmmReportStatusCodeHandler.h
@@ -1,0 +1,50 @@
+/** @file MockSmmReportStatusCodeHandler.h
+  This file declares a mock of SMM Report Status Code Handler Protocol.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_SMM_REPORT_STATUS_CODE_HANDLER_PROTOCOL_H
+#define MOCK_SMM_REPORT_STATUS_CODE_HANDLER_PROTOCOL_H
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Library/ReportStatusCodeLib.h>
+  #include <Protocol/SmmReportStatusCodeHandler.h>
+}
+
+struct MockReportStatusCodeHandler {
+  MOCK_INTERFACE_DECLARATION (MockReportStatusCodeHandler);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    Register,
+    (
+     IN EFI_SMM_RSC_HANDLER_CALLBACK   Callback)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    Unregister,
+    (IN EFI_SMM_RSC_HANDLER_CALLBACK Callback)
+    );
+};
+
+MOCK_INTERFACE_DEFINITION (MockReportStatusCodeHandler);
+MOCK_FUNCTION_DEFINITION (MockReportStatusCodeHandler, Register, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockReportStatusCodeHandler, Unregister, 1, EFIAPI);
+
+EFI_SMM_RSC_HANDLER_PROTOCOL  SmmRscHandlerProtocol = {
+  Register,
+  Unregister
+};
+
+extern "C" {
+  EFI_SMM_RSC_HANDLER_PROTOCOL  *SmmRscHandlerProtocolServices = &SmmRscHandlerProtocol;
+}
+
+#endif

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockDxeServicesTableLib/MockDxeServicesTableLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockDxeServicesTableLib/MockDxeServicesTableLib.cpp
@@ -1,0 +1,36 @@
+/** @file MockDxeServicesTableLib.cpp
+  Google Test mocks for DxeServicesTableLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#include <GoogleTest/Library/MockDxeServicesTableLib.h>
+
+MOCK_INTERFACE_DEFINITION (MockDxeServicesTableLib);
+MOCK_FUNCTION_DEFINITION (MockDxeServicesTableLib, gDS_Dispatch, 0, EFIAPI);
+
+static EFI_DXE_SERVICES  LocalDs = {
+  { 0, 0, 0, 0, 0 },                                                                   // EFI_TABLE_HEADER
+  NULL,                                                                                // EFI_ADD_MEMORY_SPACE
+  NULL,                                                                                // EFI_ALLOCATE_MEMORY_SPACE
+  NULL,                                                                                // EFI_FREE_MEMORY_SPACE
+  NULL,                                                                                // EFI_REMOVE_MEMORY_SPACE
+  NULL,                                                                                // EFI_GET_MEMORY_SPACE_DESCRIPTOR
+  NULL,                                                                                // EFI_SET_MEMORY_SPACE_ATTRIBUTES
+  NULL,                                                                                // EFI_GET_MEMORY_SPACE_MAP
+  NULL,                                                                                // EFI_ADD_IO_SPACE
+  NULL,                                                                                // EFI_ALLOCATE_IO_SPACE
+  NULL,                                                                                // EFI_FREE_IO_SPACE
+  NULL,                                                                                // EFI_REMOVE_IO_SPACE
+  NULL,                                                                                // EFI_GET_IO_SPACE_DESCRIPTOR
+  NULL,                                                                                // EFI_GET_IO_SPACE_MAP
+  gDS_Dispatch,                                                                        // EFI_DISPATCH
+  NULL,                                                                                // EFI_SCHEDULE
+  NULL,                                                                                // EFI_TRUST
+  NULL,                                                                                // EFI_PROCESS_FIRMWARE_VOLUME
+  NULL                                                                                 // EFI_SET_MEMORY_SPACE_CAPABILITIES
+};
+
+extern "C" {
+  EFI_DXE_SERVICES  *gDS = &LocalDs;
+}

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockDxeServicesTableLib/MockDxeServicesTableLib.inf
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockDxeServicesTableLib/MockDxeServicesTableLib.inf
@@ -1,0 +1,32 @@
+## @file MockDxeServicesTableLib.inf
+#  Mock implementation of the DXE Services Table Library.
+#
+#  Copyright (c) Microsoft Corporation.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MockDxeServicesTableLib
+  FILE_GUID                      = 8d9ce22b-2cf3-4646-ad0b-ce3cf1aea84d
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = DxeServicesTableLib
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64 EBC
+#
+
+[Sources]
+  MockDxeServicesTableLib.cpp
+
+[LibraryClasses]
+  GoogleTestLib
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHsc

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockUefiBootServicesTableLib/MockUefiBootServicesTableLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockUefiBootServicesTableLib/MockUefiBootServicesTableLib.cpp
@@ -13,6 +13,7 @@ MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_CloseEvent, 1, EFIAP
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_InstallProtocolInterface, 4, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_UninstallProtocolInterface, 3, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_HandleProtocol, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_RegisterProtocolNotify, 3, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_LocateHandleBuffer, 5, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_LocateProtocol, 3, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_CreateEventEx, 6, EFIAPI);
@@ -25,6 +26,8 @@ MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_LocateDevicePath, 3,
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_ReinstallProtocolInterface, 4, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_AllocatePool, 3, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_LocateHandle, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_ConnectController, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_DisconnectController, 3, EFIAPI);
 
 extern "C" {
   EFI_STATUS
@@ -118,7 +121,7 @@ static EFI_BOOT_SERVICES  LocalBs = {
   gBS_UninstallProtocolInterface,                                                      // EFI_UNINSTALL_PROTOCOL_INTERFACE
   gBS_HandleProtocol,                                                                  // EFI_HANDLE_PROTOCOL
   NULL,                                                                                // VOID
-  NULL,                                                                                // EFI_REGISTER_PROTOCOL_NOTIFY
+  gBS_RegisterProtocolNotify,                                                          // EFI_REGISTER_PROTOCOL_NOTIFY
   gBS_LocateHandle,                                                                    // EFI_LOCATE_HANDLE
   gBS_LocateDevicePath,                                                                // EFI_LOCATE_DEVICE_PATH
   NULL,                                                                                // EFI_INSTALL_CONFIGURATION_TABLE
@@ -130,8 +133,8 @@ static EFI_BOOT_SERVICES  LocalBs = {
   NULL,                                                                                // EFI_GET_NEXT_MONOTONIC_COUNT
   NULL,                                                                                // EFI_STALL
   NULL,                                                                                // EFI_SET_WATCHDOG_TIMER
-  NULL,                                                                                // EFI_CONNECT_CONTROLLER
-  NULL,                                                                                // EFI_DISCONNECT_CONTROLLER
+  gBS_ConnectController,                                                               // EFI_CONNECT_CONTROLLER
+  gBS_DisconnectController,                                                            // EFI_DISCONNECT_CONTROLLER
   gBS_OpenProtocol,                                                                    // EFI_OPEN_PROTOCOL
   gBS_CloseProtocol,                                                                   // EFI_CLOSE_PROTOCOL
   NULL,                                                                                // EFI_OPEN_PROTOCOL_INFORMATION

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockUefiLib/MockUefiLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockUefiLib/MockUefiLib.cpp
@@ -16,3 +16,4 @@ MOCK_FUNCTION_DEFINITION (MockUefiLib, LookupUnicodeString2, 5, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiLib, AddUnicodeString2, 5, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiLib, FreeUnicodeStringTable, 1, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiLib, EfiLibInstallDriverBindingComponentName2, 6, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiLib, EfiCreateEventReadyToBootEx, 4, EFIAPI);

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockUefiRuntimeServicesTableLib/MockUefiRuntimeServicesTableLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockUefiRuntimeServicesTableLib/MockUefiRuntimeServicesTableLib.cpp
@@ -11,6 +11,7 @@ MOCK_INTERFACE_DEFINITION (MockUefiRuntimeServicesTableLib);
 MOCK_FUNCTION_DEFINITION (MockUefiRuntimeServicesTableLib, gRT_GetVariable, 5, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiRuntimeServicesTableLib, gRT_SetVariable, 5, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiRuntimeServicesTableLib, gRT_GetTime, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeServicesTableLib, gRT_ResetSystem, 4, EFIAPI);
 
 static EFI_RUNTIME_SERVICES  localRt = {
   { 0 },            // EFI_TABLE_HEADER
@@ -28,7 +29,7 @@ static EFI_RUNTIME_SERVICES  localRt = {
   gRT_SetVariable,  // EFI_SET_VARIABLE
 
   NULL,             // EFI_GET_NEXT_HIGH_MONO_COUNT
-  NULL,             // EFI_RESET_SYSTEM
+  gRT_ResetSystem,  // EFI_RESET_SYSTEM
 
   NULL,             // EFI_UPDATE_CAPSULE
   NULL,             // EFI_QUERY_CAPSULE_CAPABILITIES

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcBoot.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcBoot.c
@@ -1276,5 +1276,12 @@ ON_EXIT:
     AsciiPrint ("\n  PXE-E99: Unexpected network error.\n");
   }
 
+  REPORT_STATUS_CODE_WITH_EXTENDED_DATA (
+    EFI_ERROR_CODE,
+    (EFI_STATUS_CODE_VALUE)(EFI_IO_BUS_IP_NETWORK | EFI_OEM_SPECIFIC | ((EFI_STATUS_CODE_VALUE)(Status & 0x1F))),
+    (VOID *)&(PxeBcMode->UsingIpv6),
+    sizeof (PxeBcMode->UsingIpv6)
+    );
+
   return Status;
 }

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcImpl.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcImpl.c
@@ -72,6 +72,13 @@ EfiPxeBcStart (
     return EFI_UNSUPPORTED;
   }
 
+  REPORT_STATUS_CODE_WITH_EXTENDED_DATA (
+    EFI_PROGRESS_CODE,
+    EFI_IO_BUS_IP_NETWORK | EFI_IOB_PC_RECONFIG,
+    (VOID *)&(Mode->UsingIpv6),
+    sizeof (Mode->UsingIpv6)
+    );
+
   if (Mode->UsingIpv6) {
     AsciiPrint ("\n>>Start PXE over IPv6");
     //

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcImpl.h
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcImpl.h
@@ -48,6 +48,7 @@
 #include <Library/DpcLib.h>
 #include <Library/DevicePathLib.h>
 #include <Library/PcdLib.h>
+#include <Library/ReportStatusCodeLib.h>
 
 typedef struct _PXEBC_PRIVATE_DATA      PXEBC_PRIVATE_DATA;
 typedef struct _PXEBC_PRIVATE_PROTOCOL  PXEBC_PRIVATE_PROTOCOL;

--- a/NetworkPkg/UefiPxeBcDxe/UefiPxeBcDxe.inf
+++ b/NetworkPkg/UefiPxeBcDxe/UefiPxeBcDxe.inf
@@ -62,6 +62,7 @@
   DpcLib
   DevicePathLib
   PcdLib
+  ReportStatusCodeLib
 
 [Protocols]
   ## TO_START


### PR DESCRIPTION
## Description

Correct function naming in MockFirmwareVolume2.h

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Unit tests component can call these mock functions success

## Integration Instructions

N/A
