### PR TITLE
MdePkg: Add mocks for AcpiTable and more

### DIFF
--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiLib.h
@@ -89,6 +89,15 @@ struct MockUefiLib {
      IN CONST EFI_COMPONENT_NAME_PROTOCOL   *ComponentName        OPTIONAL,
      IN CONST EFI_COMPONENT_NAME2_PROTOCOL  *ComponentName2       OPTIONAL)
     );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiCreateEventReadyToBootEx,
+    (IN  EFI_TPL           NotifyTpl,
+     IN  EFI_EVENT_NOTIFY  NotifyFunction   OPTIONAL,
+     IN  VOID              *NotifyContext   OPTIONAL,
+     OUT EFI_EVENT         *ReadyToBootEvent)
+    );
 };
 
 #endif

--- a/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockAcpiSystemDescriptionTable.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockAcpiSystemDescriptionTable.h
@@ -1,0 +1,139 @@
+/** @file MockAcpiSystemDescriptionTable.h
+  This file declares a mock of ACPI system description tables protocol.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_ACPI_SYSTEM_DESCRIPTION_TABLE_H_
+#define MOCK_ACPI_SYSTEM_DESCRIPTION_TABLE_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Protocol/AcpiSystemDescriptionTable.h>
+}
+
+struct MockAcpiSdtProtocol {
+  MOCK_INTERFACE_DECLARATION (MockAcpiSdtProtocol);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    GetAcpiTable,
+    (
+     IN    UINTN                   Index,
+     OUT   EFI_ACPI_SDT_HEADER     **Table,
+     OUT   EFI_ACPI_TABLE_VERSION  *Version,
+     OUT   UINTN                   *TableKey
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    RegisterNotify,
+    (
+     IN BOOLEAN                    Register,
+     IN EFI_ACPI_NOTIFICATION_FN   Notification
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    Open,
+    (
+     IN    VOID            *Buffer,
+     OUT   EFI_ACPI_HANDLE *Handle
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    OpenSdt,
+    (
+     IN    UINTN           TableKey,
+     OUT   EFI_ACPI_HANDLE *Handle
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    Close,
+    (
+     IN EFI_ACPI_HANDLE Handle
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    GetChild,
+    (
+     IN EFI_ACPI_HANDLE        ParentHandle,
+     IN OUT EFI_ACPI_HANDLE    *Handle
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    GetOption,
+    (
+     IN        EFI_ACPI_HANDLE     Handle,
+     IN        UINTN               Index,
+     OUT       EFI_ACPI_DATA_TYPE  *DataType,
+     OUT CONST VOID                **Data,
+     OUT       UINTN               *DataSize
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    SetOption,
+    (
+     IN        EFI_ACPI_HANDLE Handle,
+     IN        UINTN           Index,
+     IN CONST  VOID            *Data,
+     IN        UINTN           DataSize
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    FindPath,
+    (
+     IN    EFI_ACPI_HANDLE HandleIn,
+     IN    VOID            *AcpiPath,
+     OUT   EFI_ACPI_HANDLE *HandleOut
+    )
+    );
+};
+
+MOCK_INTERFACE_DEFINITION (MockAcpiSdtProtocol);
+MOCK_FUNCTION_DEFINITION (MockAcpiSdtProtocol, GetAcpiTable, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockAcpiSdtProtocol, RegisterNotify, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockAcpiSdtProtocol, Open, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockAcpiSdtProtocol, OpenSdt, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockAcpiSdtProtocol, Close, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockAcpiSdtProtocol, GetChild, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockAcpiSdtProtocol, GetOption, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockAcpiSdtProtocol, SetOption, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockAcpiSdtProtocol, FindPath, 3, EFIAPI);
+
+EFI_ACPI_SDT_PROTOCOL  ACPI_SDT_PROTOCOL_INSTANCE = {
+  0,
+  GetAcpiTable,   // EFI_ACPI_TABLE_INSTALL_ACPI_TABLE
+  RegisterNotify, // EFI_ACPI_TABLE_UNINSTALL_ACPI_TABLE
+  Open,
+  OpenSdt,
+  Close,
+  GetChild,
+  GetOption,
+  SetOption,
+  FindPath
+};
+
+extern "C" {
+  EFI_ACPI_SDT_PROTOCOL  *gAcpiSdtProtocol = &ACPI_SDT_PROTOCOL_INSTANCE;
+}
+
+#endif // MOCK_ACPI_SYSTEM_DESCRIPTION_TABLE_H_

--- a/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockAcpiTable.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockAcpiTable.h
@@ -1,0 +1,56 @@
+/** @file MockAcpiTable.h
+  This file declares a mock of Acpi table protocol.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_ACPI_TABLE_H_
+#define MOCK_ACPI_TABLE_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Protocol/AcpiTable.h>
+}
+
+struct MockAcpiTableProtocol {
+  MOCK_INTERFACE_DECLARATION (MockAcpiTableProtocol);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    InstallAcpiTable,
+    (
+     IN   EFI_ACPI_TABLE_PROTOCOL       *This,
+     IN   VOID                          *AcpiTableBuffer,
+     IN   UINTN                         AcpiTableBufferSize,
+     OUT  UINTN                         *TableKey
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    UninstallAcpiTable,
+    (
+     IN  EFI_ACPI_TABLE_PROTOCOL       *This,
+     IN  UINTN                         TableKey
+    )
+    );
+};
+
+MOCK_INTERFACE_DEFINITION (MockAcpiTableProtocol);
+MOCK_FUNCTION_DEFINITION (MockAcpiTableProtocol, InstallAcpiTable, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockAcpiTableProtocol, UninstallAcpiTable, 2, EFIAPI);
+
+EFI_ACPI_TABLE_PROTOCOL  ACPI_TABLE_PROTOCOL_INSTANCE = {
+  InstallAcpiTable,   // EFI_ACPI_TABLE_INSTALL_ACPI_TABLE
+  UninstallAcpiTable  // EFI_ACPI_TABLE_UNINSTALL_ACPI_TABLE
+};
+
+extern "C" {
+  EFI_ACPI_TABLE_PROTOCOL  *gAcpiTableProtocol = &ACPI_TABLE_PROTOCOL_INSTANCE;
+}
+
+#endif // MOCK_ACPI_TABLE_H_

--- a/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockFirmwareVolume2.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockFirmwareVolume2.h
@@ -1,0 +1,144 @@
+/** @file MockFirmwareVolume2.h
+  This file declares a mock of Firmware Volume Protocol.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_FIRMWARE_VOLUME2_H_
+#define MOCK_FIRMWARE_VOLUME2_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Pi/PiFirmwareVolume.h>
+  #include <Pi/PiFirmwareFile.h>
+  #include <Protocol/FirmwareVolume2.h>
+}
+
+struct MockFirmwareVolume2Protocol {
+  MOCK_INTERFACE_DECLARATION (MockFirmwareVolume2Protocol);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    GetVolumeAttributes,
+    (
+     IN CONST  EFI_FIRMWARE_VOLUME2_PROTOCOL *This,
+     OUT       EFI_FV_ATTRIBUTES             *FvAttributes
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    SetVolumeAttributes,
+    (
+     IN CONST  EFI_FIRMWARE_VOLUME2_PROTOCOL *This,
+     IN OUT    EFI_FV_ATTRIBUTES             *FvAttributes
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    FvReadFile,
+    (
+     IN CONST  EFI_FIRMWARE_VOLUME2_PROTOCOL *This,
+     IN CONST  EFI_GUID                      *NameGuid,
+     IN OUT    VOID                          **Buffer,
+     IN OUT    UINTN                         *BufferSize,
+     OUT       EFI_FV_FILETYPE               *FoundType,
+     OUT       EFI_FV_FILE_ATTRIBUTES        *FileAttributes,
+     OUT       UINT32                        *AuthenticationStatus
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ReadSection,
+    (
+     IN CONST  EFI_FIRMWARE_VOLUME2_PROTOCOL *This,
+     IN CONST  EFI_GUID                      *NameGuid,
+     IN        EFI_SECTION_TYPE              SectionType,
+     IN        UINTN                         SectionInstance,
+     IN OUT    VOID                          **Buffer,
+     IN OUT    UINTN                         *BufferSize,
+     OUT       UINT32                        *AuthenticationStatus
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    FvWriteFile,
+    (
+     IN CONST  EFI_FIRMWARE_VOLUME2_PROTOCOL *This,
+     IN        UINT32                        NumberOfFiles,
+     IN        EFI_FV_WRITE_POLICY           WritePolicy,
+     IN        EFI_FV_WRITE_FILE_DATA        *FileData
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    GetNextFile,
+    (
+     IN CONST  EFI_FIRMWARE_VOLUME2_PROTOCOL *This,
+     IN OUT    VOID                          *Key,
+     IN OUT    EFI_FV_FILETYPE               *FileType,
+     OUT       EFI_GUID                      *NameGuid,
+     OUT       EFI_FV_FILE_ATTRIBUTES        *Attributes,
+     OUT       UINTN                         *Size
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    GetInfo,
+    (
+     IN CONST  EFI_FIRMWARE_VOLUME2_PROTOCOL *This,
+     IN CONST  EFI_GUID                      *InformationType,
+     IN OUT    UINTN                         *BufferSize,
+     OUT       VOID                          *Buffer
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    SetInfo,
+    (
+     IN CONST  EFI_FIRMWARE_VOLUME2_PROTOCOL *This,
+     IN CONST  EFI_GUID                      *InformationType,
+     IN        UINTN                         BufferSize,
+     IN CONST  VOID                          *Buffer
+    )
+    );
+};
+
+MOCK_INTERFACE_DEFINITION (MockFirmwareVolume2Protocol);
+MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, GetVolumeAttributes, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, SetVolumeAttributes, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, FV_ReadFile, 7, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, ReadSection, 7, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, FV_WriteFile, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, GetNextFile, 6, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, GetInfo, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, SetInfo, 4, EFIAPI);
+
+EFI_FIRMWARE_VOLUME2_PROTOCOL  FIRMWARE_VOLUME2_PROTOCOL_MOCK = {
+  GetVolumeAttributes,   // EFI_FV_GET_ATTRIBUTES    GetVolumeAttributes;
+  SetVolumeAttributes,   // EFI_FV_SET_ATTRIBUTES    SetVolumeAttributes;
+  FvReadFile,            // EFI_FV_READ_FILE         ReadFile;
+  ReadSection,           // EFI_FV_READ_SECTION      ReadSection;
+  FvWriteFile,           // EFI_FV_WRITE_FILE        WriteFile;
+  GetNextFile,           // EFI_FV_GET_NEXT_FILE     GetNextFile;
+  0,                     // UINT32                   KeySize;
+  0,                     // EFI_HANDLE               ParentHandle;
+  GetInfo,               // EFI_FV_GET_INFO          GetInfo;
+  SetInfo                // EFI_FV_SET_INFO          SetInfo;
+};
+
+extern "C" {
+  EFI_FIRMWARE_VOLUME2_PROTOCOL  *gFirmwareVolume2Protocol = &FIRMWARE_VOLUME2_PROTOCOL_MOCK;
+}
+
+#endif // MOCK_FIRMWARE_VOLUME2_H_

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockUefiLib/MockUefiLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockUefiLib/MockUefiLib.cpp
@@ -16,3 +16,4 @@ MOCK_FUNCTION_DEFINITION (MockUefiLib, LookupUnicodeString2, 5, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiLib, AddUnicodeString2, 5, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiLib, FreeUnicodeStringTable, 1, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiLib, EfiLibInstallDriverBindingComponentName2, 6, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiLib, EfiCreateEventReadyToBootEx, 4, EFIAPI);


### PR DESCRIPTION
## Description

Create mock for AcpiTable, FirmwareVolume2 and AcpiSystemDescriptionTable protocols.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Mock consumed in local unit test.

## Integration Instructions
N/A

