### PR TITLE
MdeModulePkg: Add InsecureDeviceState PCD

### DIFF
--- a/MdeModulePkg/Include/Library/DeviceStateLib.h
+++ b/MdeModulePkg/Include/Library/DeviceStateLib.h
@@ -21,24 +21,27 @@ MU_CHANGE: new file
 #define DEVICE_STATE_UNDEFINED                  (1 << (4))
 #define DEVICE_STATE_UNIT_TEST_MODE             (1 << (5))
 
-#define DEVICE_STATE_PLATFORM_MODE_0  (1 << (20))
+#define DEVICE_STATE_PLATFORM_MODE_INDEX_START  20
+#define DEVICE_STATE_PLATFORM_MODE_INDEX_END    27
+
+#define DEVICE_STATE_PLATFORM_MODE_0  (1 << (DEVICE_STATE_PLATFORM_MODE_INDEX_START))
 #define DEVICE_STATE_PLATFORM_MODE_1  (1 << (21))
 #define DEVICE_STATE_PLATFORM_MODE_2  (1 << (22))
 #define DEVICE_STATE_PLATFORM_MODE_3  (1 << (23))
 #define DEVICE_STATE_PLATFORM_MODE_4  (1 << (24))
 #define DEVICE_STATE_PLATFORM_MODE_5  (1 << (25))
 #define DEVICE_STATE_PLATFORM_MODE_6  (1 << (26))
-#define DEVICE_STATE_PLATFORM_MODE_7  (1 << (27))
+#define DEVICE_STATE_PLATFORM_MODE_7  (1 << (DEVICE_STATE_PLATFORM_MODE_INDEX_END))
 
 #define DEVICE_STATE_MAX  (1 << (31))
 
-#define DEVICE_STATE_PLATFORM_MODE_INDEX_START  20
-#define DEVICE_STATE_PLATFORM_MODE_INDEX_END    27
-
 #define MAX_INSECURE_DEVICE_STATE_STRING_SIZE  512
 
+// The number of library-defined device states, not including OEM-defined states.
+#define NUMBER_OF_DEVICE_STATE_STRINGS  6
+
 //
-// DEFINE the device state strings here. These are used for logging and measuring purposes.
+// These strings are used to represent device state for logging and measurements.
 //
 #define DEVICE_STATE_SECUREBOOT_OFF_STRING             "SECURE_BOOT_OFF "
 #define DEVICE_STATE_MANUFACTURING_MODE_STRING         "MANUFACTURING_MODE "
@@ -51,48 +54,68 @@ MU_CHANGE: new file
 typedef UINT32 DEVICE_STATE;
 
 /**
- * Get String that represents the device's current insecure states, using the platform defined set of
- * insecure device states. This can be used to measure insecure device states into the TPM or perform
- * other required platform actions when the device enters an insecure state.
- *
- * @param[out] Buffer - Buffer to store the string
- * @param[in] MaxSize - Maximum size of the buffer
- * @retval The The number of characters in the string, including the null character.
- */
-UINTN
+  Get String that represents the device's current insecure states, using the platform defined set of
+  insecure device states. This can be used to measure insecure device states into the TPM or perform
+  other required platform actions when the device enters an insecure state.
+
+  The string convention to be returned is described as follows:
+  A concatenation of all the insecure device states that are currently active, represented in
+  MACRO_CASE, separated by a space. The string, if not empty, will end in a space followed by a Null terminator.
+
+  Examples:
+    - "SECUREBOOT_OFF MANUFACTURING_MODE "
+    - "DEVELOPMENT_BUILD_ENABLED SOURCE_DEBUG_ENABLED UNIT_TEST_MODE "
+
+  @param[out] Destination Buffer to write the string
+  @param[in]  DestMax     Maximum size of the destination buffer
+  @param[out] StringSize  Size of the Null-terminated Ascii string in bytes, including the Null terminator.
+
+  @retval EFI_SUCCESS            String is written to buffer.
+  @retval EFI_BUFFER_TOO_SMALL   If DestMax is NOT greater than StrLen to be written.
+  @retval EFI_INVALID_PARAMETER  If Destination is NULL.
+                                    If StringSize is NULL.
+                                    If DestMax is 0.
+                                    If the bitmask is out of range.
+ **/
+EFI_STATUS
 EFIAPI
 GetInsecureDeviceStateString (
-  IN OUT CHAR8  *Buffer,
-  IN UINTN      MaxSize
+  IN OUT CHAR8  *Destination,
+  IN UINTN      DestMax,
+  IN OUT UINTN  *StringSize
   );
 
 /**
- * Get the platform defined set of insecure device states. This can be used to measure insecure device
- * states into the TPM or perform other required platform actions when the device enters an insecure state.
- *
- * @retval The bitmask of insecure device states as defined by the platform.
- */
+  Get the platform defined set of insecure device states. This can be used to measure insecure device
+  states into the TPM or perform other required platform actions when the device enters an insecure state.
+
+  @return The bitmask of insecure device states as defined by the platform.
+**/
 DEVICE_STATE
 EFIAPI
 GetInsecureDeviceStateSetting (
   );
 
 /**
- * Function to Get current device state
- *
- * @retval the current DEVICE_STATE
- */
+  Get current device state
+
+  @return the current DEVICE_STATE
+**/
 DEVICE_STATE
 EFIAPI
 GetDeviceState (
+  VOID
   );
 
 /**
- * Function to Add additional bits to the device state
- *
- * @param[in] AdditionalState - additional state to set active
- * @retval Status of operation.  EFI_SUCCESS on successful update.
- */
+  Add an additional device state
+
+  @param[in] AdditionalState  The additional state to add.
+
+  @retval EFI_SUCCESS             The device state was added successfully.
+  @retval RETURN_OUT_OF_RESOURCES The device state could not be added due to lack of resources.
+  @retval RETURN_DEVICE_ERROR     The device state could not be added.
+**/
 RETURN_STATUS
 EFIAPI
 AddDeviceState (

--- a/MdeModulePkg/Include/Library/DeviceStateLib.h
+++ b/MdeModulePkg/Include/Library/DeviceStateLib.h
@@ -1,4 +1,4 @@
-/** @file
+/** @file DeviceStateLib.h
 Functions used to support Getting and Setting Device States.
 
 Copyright (C) Microsoft Corporation.
@@ -32,27 +32,71 @@ MU_CHANGE: new file
 
 #define DEVICE_STATE_MAX  (1 << (31))
 
+#define DEVICE_STATE_PLATFORM_MODE_INDEX_START  20
+#define DEVICE_STATE_PLATFORM_MODE_INDEX_END    27
+
+#define MAX_INSECURE_DEVICE_STATE_STRING_SIZE  512
+
+//
+// DEFINE the device state strings here. These are used for logging and measuring purposes.
+//
+#define DEVICE_STATE_SECUREBOOT_OFF_STRING             "SECURE_BOOT_OFF "
+#define DEVICE_STATE_MANUFACTURING_MODE_STRING         "MANUFACTURING_MODE "
+#define DEVICE_STATE_DEVELOPMENT_BUILD_ENABLED_STRING  "DEVELOPMENT_BUILD_ENABLED "
+#define DEVICE_STATE_SOURCE_DEBUG_ENABLED_STRING       "SOURCE_DEBUG_ENABLED "
+#define DEVICE_STATE_UNDEFINED_STRING                  "UNDEFINED "
+#define DEVICE_STATE_UNIT_TEST_MODE_STRING             "UNIT_TEST_MODE "
+#define DEVICE_STATE_PLATFORM_MODE_STRING              "OEM_DEFINED "
+
 typedef UINT32 DEVICE_STATE;
 
 /**
-Function to Get current device state
-@retval the current DEVICE_STATE
-**/
+ * Get String that represents the device's current insecure states, using the platform defined set of
+ * insecure device states. This can be used to measure insecure device states into the TPM or perform
+ * other required platform actions when the device enters an insecure state.
+ *
+ * @param[out] Buffer - Buffer to store the string
+ * @param[in] MaxSize - Maximum size of the buffer
+ * @retval The The number of characters in the string, including the null character.
+ */
+UINTN
+EFIAPI
+GetInsecureDeviceStateString (
+  IN OUT CHAR8  *Buffer,
+  IN UINTN      MaxSize
+  );
+
+/**
+ * Get the platform defined set of insecure device states. This can be used to measure insecure device
+ * states into the TPM or perform other required platform actions when the device enters an insecure state.
+ *
+ * @retval The bitmask of insecure device states as defined by the platform.
+ */
+DEVICE_STATE
+EFIAPI
+GetInsecureDeviceStateSetting (
+  );
+
+/**
+ * Function to Get current device state
+ *
+ * @retval the current DEVICE_STATE
+ */
 DEVICE_STATE
 EFIAPI
 GetDeviceState (
   );
 
 /**
-Function to Add additional bits to the device state
-
-@param AdditionalState - additional state to set active
-@retval Status of operation.  EFI_SUCCESS on successful update.
-**/
+ * Function to Add additional bits to the device state
+ *
+ * @param[in] AdditionalState - additional state to set active
+ * @retval Status of operation.  EFI_SUCCESS on successful update.
+ */
 RETURN_STATUS
 EFIAPI
 AddDeviceState (
-  DEVICE_STATE  AdditionalState
+  IN DEVICE_STATE  AdditionalState
   );
 
 #endif

--- a/MdeModulePkg/Library/DeviceStateLib/DeviceStateLib.c
+++ b/MdeModulePkg/Library/DeviceStateLib/DeviceStateLib.c
@@ -1,6 +1,7 @@
 /** @file DeviceStateLib.c
 Functions used to support Getting and Setting Device States.
-This library uses the PcdDeviceStateBitmask dynamic PCD to store the device state
+This library uses the PcdDeviceStateBitmask dynamic PCD to store the device state.
+It also uses the PcdInsecureDeviceState fixed PCD to retrieve the platform defined set of insecure device states.
 
 Copyright (C) Microsoft Corporation.
 SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -13,7 +14,7 @@ MU_CHANGE: new file
 #include <Library/DeviceStateLib.h>
 #include <Library/DebugLib.h>
 
-CHAR8  *DEVICE_STATE_STRINGS[6] = {
+CHAR8  *DEVICE_STATE_STRINGS[NUMBER_OF_DEVICE_STATE_STRINGS] = {
   DEVICE_STATE_SECUREBOOT_OFF_STRING,
   DEVICE_STATE_MANUFACTURING_MODE_STRING,
   DEVICE_STATE_DEVELOPMENT_BUILD_ENABLED_STRING,
@@ -23,70 +24,107 @@ CHAR8  *DEVICE_STATE_STRINGS[6] = {
 };
 
 /**
- * Get String that represents the device's current insecure states, using the platform defined set of
- * insecure device states. This can be used to measure insecure device states into the TPM or perform
- * other required platform actions when the device enters an insecure state.
- *
- * @param[out] Buffer - Buffer to store the string
- * @param[in] MaxSize - Maximum size of the buffer
- * @retval The The number of characters in the string, including the null character.
- */
-UINTN
+  Get String that represents the device's current insecure states, using the platform defined set of
+  insecure device states. This can be used to measure insecure device states into the TPM or perform
+  other required platform actions when the device enters an insecure state.
+
+  The string convention to be returned is described as follows:
+  A concatenation of all the insecure device states that are currently active, represented in
+  MACRO_CASE, separated by a space. The string, if not empty, will end in a space followed by a Null terminator.
+
+  Examples:
+    - "SECUREBOOT_OFF MANUFACTURING_MODE "
+    - "DEVELOPMENT_BUILD_ENABLED SOURCE_DEBUG_ENABLED UNIT_TEST_MODE "
+
+  @param[out] Destination Buffer to write the string
+  @param[in]  DestMax     Maximum size of the destination buffer
+  @param[out] StringSize  Size of the Null-terminated Ascii string in bytes, including the Null terminator.
+
+  @retval EFI_SUCCESS            String is written to buffer.
+  @retval EFI_BUFFER_TOO_SMALL   If DestMax is NOT greater than StrLen to be written.
+  @retval EFI_INVALID_PARAMETER  If Destination is NULL.
+                                    If StringSize is NULL.
+                                    If DestMax is 0.
+                                    If the bitmask is out of range.
+ **/
+EFI_STATUS
 EFIAPI
 GetInsecureDeviceStateString (
-  OUT CHAR8  *Buffer,
-  IN UINTN   MaxSize
+  IN OUT CHAR8  *Destination,
+  IN UINTN      DestMax,
+  IN OUT UINTN  *StringSize
   )
 {
+  EFI_STATUS    Status;
   CHAR8         *String;
+  UINTN         Index;
   DEVICE_STATE  BitmaskFromIndex;
   DEVICE_STATE  CurrentDeviceState         = GetDeviceState ();
   DEVICE_STATE  InsecureDeviceStateSetting = GetInsecureDeviceStateSetting ();
 
-  UINT32  NumberOfDeviceStates = sizeof (DEVICE_STATE_STRINGS) / sizeof (DEVICE_STATE_STRINGS[0]);
+  if ((Destination == NULL) || (DestMax == 0) || (StringSize == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
 
   //
   // Check standard device states
   //
-  for (UINT32 i = 0; i < NumberOfDeviceStates; i++) {
-    BitmaskFromIndex = 1 << i;
-    if ((InsecureDeviceStateSetting & BitmaskFromIndex != 0) &&
-        (CurrentDeviceState & BitmaskFromIndex != 0))
+  for (Index = 0; Index < NUMBER_OF_DEVICE_STATE_STRINGS; Index++) {
+    BitmaskFromIndex = 1 << Index;
+    if (BitmaskFromIndex > DEVICE_STATE_MAX) {
+      // TODO shouldn't this be known from the macro max ?
+      DEBUG ((DEBUG_ERROR, "Device State Bitmask is out of range. 0x%X\n", BitmaskFromIndex));
+      return EFI_INVALID_PARAMETER;
+    }
+
+    if (((InsecureDeviceStateSetting & BitmaskFromIndex) != 0) &&
+        ((CurrentDeviceState & BitmaskFromIndex) != 0))
     {
       //
       // An insecure device state is detected. Append to the insecure device state string.
       //
-      String = DEVICE_STATE_STRINGS[i];
-      AsciiStrnCatS (Buffer, MaxSize, String, AsciiStrLen (String));
+      String = DEVICE_STATE_STRINGS[Index];
+
+      Status = AsciiStrnCatS (Destination, DestMax, String, AsciiStrnLenS (String, DestMax));
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "Error creating insecure device state string. 0x%X\n", Status));
+        return Status;
+      }
     }
   }
 
   //
   // Check OEM-defined device states
   //
-  for (UINT32 i = DEVICE_STATE_PLATFORM_MODE_INDEX_START; i <= DEVICE_STATE_PLATFORM_MODE_INDEX_END; i++) {
-    BitmaskFromIndex = 1 << i;
-    if ((InsecureDeviceStateSetting & BitmaskFromIndex != 0) &&
-        (CurrentDeviceState & BitmaskFromIndex != 0))
+  for (Index = DEVICE_STATE_PLATFORM_MODE_INDEX_START; Index <= DEVICE_STATE_PLATFORM_MODE_INDEX_END; Index++) {
+    BitmaskFromIndex = 1 << Index;
+    if (((InsecureDeviceStateSetting & BitmaskFromIndex) != 0) &&
+        ((CurrentDeviceState & BitmaskFromIndex) != 0))
     {
       //
       // An OEM insecure device state is detected. Append to the insecure device state string.
       //
       String = DEVICE_STATE_PLATFORM_MODE_STRING;
-      AsciiStrnCatS (Buffer, MaxSize, String, AsciiStrLen (String));
+      Status = AsciiStrnCatS (Destination, DestMax, String, AsciiStrnLenS (String, DestMax));
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "Error creating insecure device state string. 0x%X\n", Status));
+        return Status;
+      }
+
       break;
     }
   }
 
-  return AsciiStrnLenS (Buffer, MaxSize) + 1;
+  *StringSize = AsciiStrnSizeS (Destination, DestMax);
+  return EFI_SUCCESS;
 }
 
 /**
- * Get the platform defined set of insecure device states. This can be used to measure insecure device
- * states into the TPM or perform other required platform actions when the device enters an insecure state.
- *
- * @retval The bitmask of insecure device states as defined by the platform.
- */
+  Get the platform defined set of insecure device states. This can be used to measure insecure device
+  states into the TPM or perform other required platform actions when the device enters an insecure state.
+
+  @return The bitmask of insecure device states as defined by the platform.
+**/
 DEVICE_STATE
 EFIAPI
 GetInsecureDeviceStateSetting (
@@ -96,32 +134,28 @@ GetInsecureDeviceStateSetting (
 }
 
 /**
- * Check if a specific bitmask is set in the device state
- *
- * @param[in] CurrentDeviceState - the current device state
- * @param[in] DeviceStateBitmask - the bitmask to check
- * @retval TRUE if all the bits in the bitmask are set, FALSE otherwise
- */
+  Get current device state
 
-/**
- * Function to Get current device state
- *
- * @retval the current DEVICE_STATE
- */
+  @return the current DEVICE_STATE
+**/
 DEVICE_STATE
 EFIAPI
 GetDeviceState (
+  VOID
   )
 {
   return PcdGet32 (PcdDeviceStateBitmask);
 }
 
 /**
- * Function to Add additional bits to the device state
- *
- * @param[in] AdditionalState - additional state to set active
- * @retval Status of operation.  EFI_SUCCESS on successful update.
- */
+  Add an additional device state
+
+  @param[in] AdditionalState  The additional state to add.
+
+  @retval EFI_SUCCESS             The device state was added successfully.
+  @retval RETURN_OUT_OF_RESOURCES The device state could not be added due to lack of resources.
+  @retval RETURN_DEVICE_ERROR     The device state could not be added.
+**/
 RETURN_STATUS
 EFIAPI
 AddDeviceState (

--- a/MdeModulePkg/Library/DeviceStateLib/DeviceStateLib.c
+++ b/MdeModulePkg/Library/DeviceStateLib/DeviceStateLib.c
@@ -1,4 +1,4 @@
-/** @file
+/** @file DeviceStateLib.c
 Functions used to support Getting and Setting Device States.
 This library uses the PcdDeviceStateBitmask dynamic PCD to store the device state
 
@@ -13,30 +13,119 @@ MU_CHANGE: new file
 #include <Library/DeviceStateLib.h>
 #include <Library/DebugLib.h>
 
+CHAR8  *DEVICE_STATE_STRINGS[6] = {
+  DEVICE_STATE_SECUREBOOT_OFF_STRING,
+  DEVICE_STATE_MANUFACTURING_MODE_STRING,
+  DEVICE_STATE_DEVELOPMENT_BUILD_ENABLED_STRING,
+  DEVICE_STATE_SOURCE_DEBUG_ENABLED_STRING,
+  DEVICE_STATE_UNDEFINED_STRING,
+  DEVICE_STATE_UNIT_TEST_MODE_STRING,
+};
+
 /**
-Function to Get current device state
-@retval the current DEVICE_STATE
-**/
+ * Get String that represents the device's current insecure states, using the platform defined set of
+ * insecure device states. This can be used to measure insecure device states into the TPM or perform
+ * other required platform actions when the device enters an insecure state.
+ *
+ * @param[out] Buffer - Buffer to store the string
+ * @param[in] MaxSize - Maximum size of the buffer
+ * @retval The The number of characters in the string, including the null character.
+ */
+UINTN
+EFIAPI
+GetInsecureDeviceStateString (
+  OUT CHAR8  *Buffer,
+  IN UINTN   MaxSize
+  )
+{
+  CHAR8         *String;
+  DEVICE_STATE  BitmaskFromIndex;
+  DEVICE_STATE  CurrentDeviceState         = GetDeviceState ();
+  DEVICE_STATE  InsecureDeviceStateSetting = GetInsecureDeviceStateSetting ();
+
+  UINT32  NumberOfDeviceStates = sizeof (DEVICE_STATE_STRINGS) / sizeof (DEVICE_STATE_STRINGS[0]);
+
+  //
+  // Check standard device states
+  //
+  for (UINT32 i = 0; i < NumberOfDeviceStates; i++) {
+    BitmaskFromIndex = 1 << i;
+    if ((InsecureDeviceStateSetting & BitmaskFromIndex != 0) &&
+        (CurrentDeviceState & BitmaskFromIndex != 0))
+    {
+      //
+      // An insecure device state is detected. Append to the insecure device state string.
+      //
+      String = DEVICE_STATE_STRINGS[i];
+      AsciiStrnCatS (Buffer, MaxSize, String, AsciiStrLen (String));
+    }
+  }
+
+  //
+  // Check OEM-defined device states
+  //
+  for (UINT32 i = DEVICE_STATE_PLATFORM_MODE_INDEX_START; i <= DEVICE_STATE_PLATFORM_MODE_INDEX_END; i++) {
+    BitmaskFromIndex = 1 << i;
+    if ((InsecureDeviceStateSetting & BitmaskFromIndex != 0) &&
+        (CurrentDeviceState & BitmaskFromIndex != 0))
+    {
+      //
+      // An OEM insecure device state is detected. Append to the insecure device state string.
+      //
+      String = DEVICE_STATE_PLATFORM_MODE_STRING;
+      AsciiStrnCatS (Buffer, MaxSize, String, AsciiStrLen (String));
+      break;
+    }
+  }
+
+  return AsciiStrnLenS (Buffer, MaxSize) + 1;
+}
+
+/**
+ * Get the platform defined set of insecure device states. This can be used to measure insecure device
+ * states into the TPM or perform other required platform actions when the device enters an insecure state.
+ *
+ * @retval The bitmask of insecure device states as defined by the platform.
+ */
+DEVICE_STATE
+EFIAPI
+GetInsecureDeviceStateSetting (
+  )
+{
+  return FixedPcdGet32 (PcdInsecureDeviceState);
+}
+
+/**
+ * Check if a specific bitmask is set in the device state
+ *
+ * @param[in] CurrentDeviceState - the current device state
+ * @param[in] DeviceStateBitmask - the bitmask to check
+ * @retval TRUE if all the bits in the bitmask are set, FALSE otherwise
+ */
+
+/**
+ * Function to Get current device state
+ *
+ * @retval the current DEVICE_STATE
+ */
 DEVICE_STATE
 EFIAPI
 GetDeviceState (
   )
 {
-  DEVICE_STATE  DevState = PcdGet32 (PcdDeviceStateBitmask);
-
-  return DevState;
+  return PcdGet32 (PcdDeviceStateBitmask);
 }
 
 /**
-Function to Add additional bits to the device state
-
-@param AdditionalState - additional state to set active
-@retval Status of operation.  EFI_SUCCESS on successful update.
-**/
+ * Function to Add additional bits to the device state
+ *
+ * @param[in] AdditionalState - additional state to set active
+ * @retval Status of operation.  EFI_SUCCESS on successful update.
+ */
 RETURN_STATUS
 EFIAPI
 AddDeviceState (
-  DEVICE_STATE  AdditionalState
+  IN DEVICE_STATE  AdditionalState
   )
 {
   DEVICE_STATE  DevState;

--- a/MdeModulePkg/Library/DeviceStateLib/DeviceStateLib.inf
+++ b/MdeModulePkg/Library/DeviceStateLib/DeviceStateLib.inf
@@ -1,4 +1,4 @@
-## @file
+## @file DeviceStateLib.inf
 # Library to get and set the device state
 #
 # Copyright (C) Microsoft Corporation.
@@ -31,3 +31,4 @@ DeviceStateLib.c
 
 [Pcd]
 gEfiMdeModulePkgTokenSpaceGuid.PcdDeviceStateBitmask
+gEfiMdeModulePkgTokenSpaceGuid.PcdInsecureDeviceState

--- a/MdeModulePkg/Library/DeviceStateLib/GoogleTest/DeviceStateLibGoogleTest.cpp
+++ b/MdeModulePkg/Library/DeviceStateLib/GoogleTest/DeviceStateLibGoogleTest.cpp
@@ -1,0 +1,95 @@
+/** @file DeviceStateLibGoogleTest.cpp
+
+  DeviceStateLib Google Test
+
+  Copyright (C) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/GoogleTestLib.h>
+#include <GoogleTest/Library/MockPcdLib.h>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Library/BaseLib.h>
+  #include <Library/DebugLib.h>
+  #include <Library/DeviceStateLib.h>
+}
+
+using namespace testing;
+
+/**
+  Test DeviceStateBitmaskIsSet function
+**/
+class DeviceStateBitmaskIsSetTest : public Test {
+protected:
+  StrictMock<MockPcdLib> PcdLibMock;
+  DEVICE_STATE CurrentDeviceStateMock;
+  DEVICE_STATE InsecureDeviceStateSettingMock;
+  CHAR8 Buffer[MAX_INSECURE_DEVICE_STATE_STRING_SIZE];
+  CHAR8 ExpectedString1[MAX_INSECURE_DEVICE_STATE_STRING_SIZE] = DEVICE_STATE_SOURCE_DEBUG_ENABLED_STRING;
+  CHAR8 ExpectedString2[MAX_INSECURE_DEVICE_STATE_STRING_SIZE] = "SOURCE_DEBUG_ENABLED UNIT_TEST_MODE ";
+  UINTN Length;
+
+  void
+  SetUp (
+    ) override
+  {
+    CurrentDeviceStateMock         = 0x000000000;
+    InsecureDeviceStateSettingMock = 0x000000000;
+    Buffer[0]                      = '\0';
+  }
+};
+
+/**
+  Test GetInsecureDeviceStateString function with one insecure state
+
+  The tested function calls GetInsecureDeviceStateSetting to get the FixedAtBuild PCD
+  defined in MdeModulePkg.dec
+**/
+TEST_F (DeviceStateBitmaskIsSetTest, GetInsecureDeviceStateStringTest1) {
+  CurrentDeviceStateMock |= DEVICE_STATE_SOURCE_DEBUG_ENABLED;
+
+  EXPECT_CALL (
+    PcdLibMock,
+    LibPcdGet32
+    )
+    .WillOnce (
+       Return (CurrentDeviceStateMock)
+       );
+
+  Length = GetInsecureDeviceStateString (Buffer, MAX_INSECURE_DEVICE_STATE_STRING_SIZE);
+  EXPECT_EQ (Length, AsciiStrnLenS (ExpectedString1, MAX_INSECURE_DEVICE_STATE_STRING_SIZE) + 1);
+}
+
+/**
+  Test GetInsecureDeviceStateString function with two insecure states
+
+  The tested function calls GetInsecureDeviceStateSetting to get the FixedAtBuild PCD
+  defined in MdeModulePkg.dec
+**/
+TEST_F (DeviceStateBitmaskIsSetTest, GetInsecureDeviceStateStringTest2) {
+  CurrentDeviceStateMock |= DEVICE_STATE_SOURCE_DEBUG_ENABLED;
+  CurrentDeviceStateMock |= DEVICE_STATE_UNIT_TEST_MODE;
+
+  EXPECT_CALL (
+    PcdLibMock,
+    LibPcdGet32
+    )
+    .WillOnce (
+       Return (CurrentDeviceStateMock)
+       );
+
+  Length = GetInsecureDeviceStateString (Buffer, MAX_INSECURE_DEVICE_STATE_STRING_SIZE);
+  EXPECT_EQ (Length, AsciiStrnLenS (ExpectedString2, MAX_INSECURE_DEVICE_STATE_STRING_SIZE) + 1);
+}
+
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  InitGoogleTest (&argc, argv);
+  return RUN_ALL_TESTS ();
+}

--- a/MdeModulePkg/Library/DeviceStateLib/GoogleTest/DeviceStateLibGoogleTest.inf
+++ b/MdeModulePkg/Library/DeviceStateLib/GoogleTest/DeviceStateLibGoogleTest.inf
@@ -1,0 +1,41 @@
+## @file DeviceStateLibGoogleTest.inf
+#
+#  Host-based GooglTest for DeviceStateLib
+#
+#  Copyright (C) Microsoft Corporation.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+INF_VERSION    = 0x00010017
+BASE_NAME      = DeviceStateLibGoogleTest
+FILE_GUID      = 4324664F-ACE2-4753-8CB7-B807DD569566
+MODULE_TYPE    = HOST_APPLICATION
+VERSION_STRING = 1.0
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  DeviceStateLibGoogleTest.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  GoogleTestLib
+  DeviceStateLib
+ # MemoryAllocationLib
+ # BaseMemoryLib
+  PcdLib
+  
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDeviceStateBitmask
+  gEfiMdeModulePkgTokenSpaceGuid.PcdInsecureDeviceState

--- a/MdeModulePkg/Library/DeviceStateLib/Readme.md
+++ b/MdeModulePkg/Library/DeviceStateLib/Readme.md
@@ -26,6 +26,20 @@ states or to define any of the unused bits:
 * BIT 26: DEVICE_STATE_PLATFORM_MODE_2
 * BIT 27: DEVICE_STATE_PLATFORM_MODE_3
 
+### Insecure Device State
+
+This library has a function, GetInsecureDeviceState, that retrieves the devices states that
+signify an insecure state.  In this library implementation a bitmask is stored in a
+FixedAtBuild PCD, `gMdeModulePkgTokenSpaceGuid.InsecureDeviceState` to signify what modes are
+insecure.
+This PCD, by default, ORs DEVICE_STATE_SOURCE_DEBUG_ENABLED with DEVICE_STATE_UNIT_TEST_MODE,
+but can be customized to include other states.
+
+Expected use cases include comparing this bitmask against the current device state to check
+for an insecure device state, then measuring into the TPM. A platform can update this PCD with
+any other states it considers to be insecure and can call this API to take action if an
+insecure device state has been entered.
+
 ## Copyright
 
 Copyright (C) Microsoft Corporation.

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -1386,6 +1386,13 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdMaxMemoryTypeInfoPages            |0x60000|UINT32|0x40000150
   # MU_CHANGE TCBZ1086 [END]
 
+  ## MU_CHANGE [BEGIN] - Add InsecureDeviceState to MdeModulePkg
+  # @Prompt Describes an insecure device state. 
+  # Default value is DEVICE_STATE_SOURCE_DEBUG_ENABLED | DEVICE_STATE_UNIT_TEST_MODE as defined in 
+  # Include/Library/DeviceStateLib.h
+  gEfiMdeModulePkgTokenSpaceGuid.PcdInsecureDeviceState|0x000000028|UINT32|0x40000153
+  # MU_CHANGE  [END]
+
 [PcdsFixedAtBuild, PcdsPatchableInModule]
   ## Dynamic type PCD can be registered callback function for Pcd setting action.
   #  PcdMaxPeiPcdCallBackNumberPerPcdEntry indicates the maximum number of callback function

--- a/MdeModulePkg/Test/MdeModulePkgHostTest.dsc
+++ b/MdeModulePkg/Test/MdeModulePkgHostTest.dsc
@@ -111,6 +111,15 @@
       NvmExpressDxe|MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressDxe.inf
   }
   # MU_CHANGE End - Add Media Sanitize
+
+  # MU_CHANGE [BEGIN] - Add a host-based unit test for DeviceStateLib
+  MdeModulePkg/Library/DeviceStateLib/GoogleTest/DeviceStateLibGoogleTest.inf {
+    <LibraryClasses>
+      DeviceStateLib|MdeModulePkg/Library/DeviceStateLib/DeviceStateLib.inf
+      PcdLib|MdePkg/Test/Mock/Library/GoogleTest/MockPcdLib/MockPcdLib.inf
+  }
+  # MU_CHANGE [END]
+
   #
   # Build HOST_APPLICATION Libraries
   #


### PR DESCRIPTION
## Description

Add PCD to provide a FixedAtBuild value to define what an insecure Device state is.

For example, the default value defines an insecure device state as a DEVICE_STATE with DEVICE_STATE_SOURCE_DEBUG_ENABLED, or DEVICE_STATE_UNIT_TEST_MODE.

Add a function to the DeviceStateLib, GetInsecureDeviceStateSettings, that retrieves the PCD. Expected use cases include comparing this PCD against current device state to check for an insecure device state, then measuring into the TPM.

This PR has a test that's dependent on a mock for PcdLib being added in MdePkg https://github.com/microsoft/mu_basecore/pull/1178

- [ ] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

DeviceStateLibGoogleTest.inf

## Integration Instructions

Update the FixedAtBuild PCD InsecureDeviceState to include any device states that the platform considers insecure. Call this API to take action if an insecure device state has been entered.

Expected use cases include comparing this bitmask against the current device state to check
for an insecure device state, then measuring into the TPM. 

Make any modifications needed to accommodate all OEM-defined device states. 

To add the measurement of this PCD in Tcg2Pei, update your mu_tiano_plus submodule to the release/202405 branch or release tag once this change is merged (https://github.com/microsoft/mu_tiano_plus/pull/342).