### PR TITLE
MdePkg: Add Google Test Mock Library and Mock Protocol

### DIFF
--- a/MdePkg/Test/MdePkgHostTest.dsc
+++ b/MdePkg/Test/MdePkgHostTest.dsc
@@ -66,4 +66,7 @@
   MdePkg/Test/Mock/Library/GoogleTest/MockDxeServicesTableLib/MockDxeServicesTableLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockPciLib/MockPciLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockPcdLib/MockPcdLib.inf
+  MdePkg/Test/Mock/Library/GoogleTest/MockCpuLib/MockCpuLib.inf
+  MdePkg/Test/Mock/Library/GoogleTest/MockPciSegmentLib/MockPciSegmentLib.inf
+  MdePkg/Test/Mock/Library/GoogleTest/MockReportStatusCodeLib/MockReportStatusCodeLib.inf
   # MU_CHANGE [END]

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockCpuLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockCpuLib.h
@@ -1,0 +1,64 @@
+/** @file MockCpuLib.h
+  Google Test mocks for the CPU Library
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_CPU_LIB_H_
+#define MOCK_CPU_LIB_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+
+extern "C" {
+  #include <Uefi.h>
+}
+
+struct MockCpuLib {
+  MOCK_INTERFACE_DECLARATION (MockCpuLib);
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    CpuSleep,
+    (
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    CpuFlushTlb,
+    (
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    InitializeFloatingPointUnits,
+    (
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    StandardSignatureIsAuthenticAMD,
+    (
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT32,
+    GetCpuFamilyModel,
+    (
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT8,
+    GetCpuSteppingId,
+    (
+    )
+    );
+};
+
+#endif

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockPciSegmentLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockPciSegmentLib.h
@@ -1,0 +1,350 @@
+/** @file MockPciSegmentLib.h
+  Google Test mocks for PciSegmentLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_PCISEGMENTLIB_H_
+#define MOCK_PCISEGMENTLIB_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+
+extern "C" {
+  #include <Uefi.h>
+}
+
+struct MockPciSegmentLib {
+  MOCK_INTERFACE_DECLARATION (MockPciSegmentLib);
+
+  MOCK_FUNCTION_DECLARATION (
+    RETURN_STATUS,
+    PciSegmentRegisterForRuntimeAccess,
+    (
+     IN UINTN  Address
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT8,
+    PciSegmentRead8,
+    (
+     IN UINT64  Address
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT8,
+    PciSegmentWrite8,
+    (
+     IN UINT64  Address,
+     IN UINT8   Value
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT8,
+    PciSegmentOr8,
+    (
+     IN UINT64  Address,
+     IN UINT8   OrData
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT8,
+    PciSegmentAnd8,
+    (
+     IN UINT64  Address,
+     IN UINT8   AndData
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT8,
+    PciSegmentAndThenOr8,
+    (
+     IN UINT64  Address,
+     IN UINT8   AndData,
+     IN UINT8   OrData
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT8,
+    PciSegmentBitFieldRead8,
+    (
+     IN UINT64  Address,
+     IN UINTN   StartBit,
+     IN UINTN   EndBit
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT8,
+    PciSegmentBitFieldWrite8,
+    (
+     IN UINT64  Address,
+     IN UINTN   StartBit,
+     IN UINTN   EndBit,
+     IN UINT8   Value
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT8,
+    PciSegmentBitFieldOr8,
+    (
+     IN UINT64  Address,
+     IN UINTN   StartBit,
+     IN UINTN   EndBit,
+     IN UINT8   OrData
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT8,
+    PciSegmentBitFieldAnd8,
+    (
+     IN UINT64  Address,
+     IN UINTN   StartBit,
+     IN UINTN   EndBit,
+     IN UINT8   AndData
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT8,
+    PciSegmentBitFieldAndThenOr8,
+    (
+     IN UINT64  Address,
+     IN UINTN   StartBit,
+     IN UINTN   EndBit,
+     IN UINT8   AndData,
+     IN UINT8   OrData
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT16,
+    PciSegmentRead16,
+    (
+     IN UINT64  Address
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT16,
+    PciSegmentWrite16,
+    (
+     IN UINT64  Address,
+     IN UINT16  Value
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT16,
+    PciSegmentOr16,
+    (
+     IN UINT64  Address,
+     IN UINT16  OrData
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT16,
+    PciSegmentAnd16,
+    (
+     IN UINT64  Address,
+     IN UINT16  AndData
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT16,
+    PciSegmentAndThenOr16,
+    (
+     IN UINT64  Address,
+     IN UINT16  AndData,
+     IN UINT16  OrData
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT16,
+    PciSegmentBitFieldRead16,
+    (
+     IN UINT64  Address,
+     IN UINTN   StartBit,
+     IN UINTN   EndBit
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT16,
+    PciSegmentBitFieldWrite16,
+    (
+     IN UINT64  Address,
+     IN UINTN   StartBit,
+     IN UINTN   EndBit,
+     IN UINT16  Value
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT16,
+    PciSegmentBitFieldOr16,
+    (
+     IN UINT64  Address,
+     IN UINTN   StartBit,
+     IN UINTN   EndBit,
+     IN UINT16  OrData
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT16,
+    PciSegmentBitFieldAnd16,
+    (
+     IN UINT64  Address,
+     IN UINTN   StartBit,
+     IN UINTN   EndBit,
+     IN UINT16  AndData
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT16,
+    PciSegmentBitFieldAndThenOr16,
+    (
+     IN UINT64  Address,
+     IN UINTN   StartBit,
+     IN UINTN   EndBit,
+     IN UINT16  AndData,
+     IN UINT16  OrData
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT32,
+    PciSegmentRead32,
+    (
+     IN UINT64  Address
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT32,
+    PciSegmentWrite32,
+    (
+     IN UINT64  Address,
+     IN UINT32  Value
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT32,
+    PciSegmentOr32,
+    (
+     IN UINT64  Address,
+     IN UINT32  OrData
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT32,
+    PciSegmentAnd32,
+    (
+     IN UINT64  Address,
+     IN UINT32  AndData
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT32,
+    PciSegmentAndThenOr32,
+    (
+     IN UINT64  Address,
+     IN UINT32  AndData,
+     IN UINT32  OrData
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT32,
+    PciSegmentBitFieldRead32,
+    (
+     IN UINT64  Address,
+     IN UINTN   StartBit,
+     IN UINTN   EndBit
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT32,
+    PciSegmentBitFieldWrite32,
+    (
+     IN UINT64  Address,
+     IN UINTN   StartBit,
+     IN UINTN   EndBit,
+     IN UINT32  Value
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT32,
+    PciSegmentBitFieldOr32,
+    (
+     IN UINT64  Address,
+     IN UINTN   StartBit,
+     IN UINTN   EndBit,
+     IN UINT32  OrData
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT32,
+    PciSegmentBitFieldAnd32,
+    (
+     IN UINT64  Address,
+     IN UINTN   StartBit,
+     IN UINTN   EndBit,
+     IN UINT32  AndData
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT32,
+    PciSegmentBitFieldAndThenOr32,
+    (
+     IN UINT64  Address,
+     IN UINTN   StartBit,
+     IN UINTN   EndBit,
+     IN UINT32  AndData,
+     IN UINT32  OrData
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINTN,
+    PciSegmentReadBuffer,
+    (
+     IN  UINT64  StartAddress,
+     IN  UINTN   Size,
+     OUT VOID    *Buffer
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINTN,
+    PciSegmentWriteBuffer,
+    (
+     IN UINT64  StartAddress,
+     IN UINTN   Size,
+     IN VOID    *Buffer
+    )
+    );
+};
+
+#endif

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockReportStatusCodeLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockReportStatusCodeLib.h
@@ -1,0 +1,29 @@
+/** @file MockReportStatusCodeLib.h
+  Google Test mocks for ReportStatusCodeLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_REPORT_STATUS_CODE_LIB_H_
+#define MOCK_REPORT_STATUS_CODE_LIB_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Library/ReportStatusCodeLib.h>
+}
+
+struct MockReportStatusCodeLib {
+  MOCK_INTERFACE_DECLARATION (MockReportStatusCodeLib);
+
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    ReportProgressCodeEnabled,
+    ()
+    );
+};
+
+#endif //MOCK_REPORT_STATUS_CODE_LIB_H_

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockSmmServicesTableLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockSmmServicesTableLib.h
@@ -25,9 +25,9 @@ struct MockSmmServicesTableLib {
     EFI_STATUS,
     gSmst_SmmAllocatePool,
     (
-     IN  EFI_MEMORY_TYPE              PoolType,
-     IN  UINTN                        Size,
-     OUT VOID                         **Buffer
+     IN  EFI_MEMORY_TYPE             PoolType,
+     IN  UINTN                       Size,
+     OUT VOID                        **Buffer
     )
     );
 
@@ -35,17 +35,38 @@ struct MockSmmServicesTableLib {
     EFI_STATUS,
     gSmst_SmmFreePool,
     (
-     IN  VOID                         *Buffer
+     IN  VOID                        *Buffer
     )
     );
 
   MOCK_FUNCTION_DECLARATION (
     EFI_STATUS,
+    gSmst_SmmAllocatePages,
+    (
+     IN  EFI_ALLOCATE_TYPE           Type,
+     IN  EFI_MEMORY_TYPE             MemoryType,
+     IN  UINTN                       Pages,
+     OUT EFI_PHYSICAL_ADDRESS        *Memory
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gSmst_SmmFreePages,
+    (
+     IN  EFI_PHYSICAL_ADDRESS        Memory,
+     IN  UINTN                       Pages
+    )
+    );
+
+  // MP service
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
     gSmst_SmmStartupThisAp,
     (
-     IN EFI_AP_PROCEDURE  Procedure,
-     IN UINTN             CpuNumber,
-     IN OUT VOID          *ProcArguments OPTIONAL
+     IN     EFI_AP_PROCEDURE  Procedure,
+     IN     UINTN             CpuNumber,
+     IN OUT VOID              *ProcArguments OPTIONAL
     )
     );
 
@@ -62,6 +83,26 @@ struct MockSmmServicesTableLib {
 
   MOCK_FUNCTION_DECLARATION (
     EFI_STATUS,
+    gSmst_SmmUninstallProtocolInterface,
+    (
+     IN EFI_HANDLE               Handle,
+     IN EFI_GUID                 *Protocol,
+     IN VOID                     *Interface
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gSmst_SmmHandleProtocol,
+    (
+     IN  EFI_HANDLE              Handle,
+     IN  EFI_GUID                *Protocol,
+     OUT VOID                    **Interface
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
     gSmst_SmmRegisterProtocolNotify,
     (
      IN  CONST EFI_GUID     *Protocol,
@@ -72,11 +113,52 @@ struct MockSmmServicesTableLib {
 
   MOCK_FUNCTION_DECLARATION (
     EFI_STATUS,
+    gSmst_SmmLocateHandle,
+    (
+     IN     EFI_LOCATE_SEARCH_TYPE  SearchType,
+     IN     EFI_GUID                *Protocol,
+     IN     VOID                    *SearchKey,
+     IN OUT UINTN                   *BufferSize,
+     OUT    EFI_HANDLE              *Buffer
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
     gSmst_SmmLocateProtocol,
     (
      IN  EFI_GUID  *Protocol,
      IN  VOID      *Registration  OPTIONAL,
      OUT VOID      **Interface
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gSmst_SmiManage,
+    (
+     IN CONST EFI_GUID  *HandlerType,
+     IN CONST VOID      *Context,
+     IN OUT VOID        *CommBuffer,
+     IN OUT UINTN       *CommBufferSize
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gSmst_SmmInterruptRegister,
+    (
+     IN  EFI_SMM_HANDLER_ENTRY_POINT2 Handler,
+     IN  CONST EFI_GUID *HandlerType,
+     OUT EFI_HANDLE    *DispatchHandle
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gSmst_SmmInterruptUnRegister,
+    (
+     IN EFI_HANDLE  DispatchHandle
     )
     );
 };

--- a/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockMpService.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockMpService.h
@@ -1,0 +1,124 @@
+/** @file MockMpService.h
+  This file declares a mock of MP service Protocol.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_MP_SERVICE_H_
+#define MOCK_MP_SERVICE_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Protocol/MpService.h>
+}
+
+struct MockMpService {
+  MOCK_INTERFACE_DECLARATION (MockMpService);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    GetNumberOfProcessors,
+    (
+     IN  EFI_MP_SERVICES_PROTOCOL  *This,
+     OUT UINTN                     *NumberOfProcessors,
+     OUT UINTN                     *NumberOfEnabledProcessors
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    GetProcessorInfo,
+    (
+     IN  EFI_MP_SERVICES_PROTOCOL   *This,
+     IN  UINTN                      ProcessorNumber,
+     OUT EFI_PROCESSOR_INFORMATION  *ProcessorInfoBuffer
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    StartupAllAPs,
+    (
+     IN  EFI_MP_SERVICES_PROTOCOL  *This,
+     IN  EFI_AP_PROCEDURE          Procedure,
+     IN  BOOLEAN                   SingleThread,
+     IN  EFI_EVENT                 WaitEvent               OPTIONAL,
+     IN  UINTN                     TimeoutInMicroSeconds,
+     IN  VOID                      *ProcedureArgument      OPTIONAL,
+     OUT UINTN                     **FailedCpuList         OPTIONAL
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    StartupThisAP,
+    (
+     IN  EFI_MP_SERVICES_PROTOCOL  *This,
+     IN  EFI_AP_PROCEDURE          Procedure,
+     IN  UINTN                     ProcessorNumber,
+     IN  EFI_EVENT                 WaitEvent               OPTIONAL,
+     IN  UINTN                     TimeoutInMicroseconds,
+     IN  VOID                      *ProcedureArgument      OPTIONAL,
+     OUT BOOLEAN                   *Finished               OPTIONAL
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    SwitchBSP,
+    (
+     IN EFI_MP_SERVICES_PROTOCOL  *This,
+     IN  UINTN                    ProcessorNumber,
+     IN  BOOLEAN                  EnableOldBSP
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EnableDisableAP,
+    (
+     IN  EFI_MP_SERVICES_PROTOCOL  *This,
+     IN  UINTN                     ProcessorNumber,
+     IN  BOOLEAN                   EnableAP,
+     IN  UINT32                    *HealthFlag OPTIONAL
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    WhoAmI,
+    (
+     IN EFI_MP_SERVICES_PROTOCOL  *This,
+     OUT UINTN                    *ProcessorNumber
+    )
+    );
+};
+
+MOCK_INTERFACE_DEFINITION (MockMpService);
+MOCK_FUNCTION_DEFINITION (MockMpService, GetNumberOfProcessors, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMpService, GetProcessorInfo, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMpService, StartupAllAPs, 7, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMpService, StartupThisAP, 7, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMpService, SwitchBSP, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMpService, EnableDisableAP, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMpService, WhoAmI, 2, EFIAPI);
+
+static EFI_MP_SERVICES_PROTOCOL  MP_SERVICE_PROTOCOL_INSTANCE = {
+  GetNumberOfProcessors,
+  GetProcessorInfo,
+  StartupAllAPs,
+  StartupThisAP,
+  SwitchBSP,
+  EnableDisableAP,
+  WhoAmI
+};
+
+extern "C" {
+  EFI_MP_SERVICES_PROTOCOL  *gMpServiceProtocol = &MP_SERVICE_PROTOCOL_INSTANCE;
+}
+
+#endif // MOCK_MP_SERVICE_H_

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockCpuLib/MockCpuLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockCpuLib/MockCpuLib.cpp
@@ -1,0 +1,17 @@
+/** @file MockCpuLib.cpp
+  Google Test mocks for BaseLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <GoogleTest/Library/MockCpuLib.h>
+
+MOCK_INTERFACE_DEFINITION (MockCpuLib);
+
+MOCK_FUNCTION_DEFINITION (MockCpuLib, CpuSleep, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockCpuLib, CpuFlushTlb, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockCpuLib, InitializeFloatingPointUnits, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockCpuLib, StandardSignatureIsAuthenticAMD, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockCpuLib, GetCpuFamilyModel, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockCpuLib, GetCpuSteppingId, 0, EFIAPI);

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockCpuLib/MockCpuLib.inf
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockCpuLib/MockCpuLib.inf
@@ -1,0 +1,33 @@
+## @file MockCpuLib.inf
+# Mock implementation of the CPU library
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MockCpuLib
+  FILE_GUID                      = 8544B3FE-D1A8-4037-A8A9-43DC8D07077C
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = CpuLib
+  PI_SPECIFICATION_VERSION       = 0x0001000A
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  MockCpuLib.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHsc

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockPciSegmentLib/MockPciSegmentLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockPciSegmentLib/MockPciSegmentLib.cpp
@@ -1,0 +1,43 @@
+/** @file MockPciSegmentLib.cpp
+  Google Test mocks for PciSegmentLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <GoogleTest/Library/MockPciSegmentLib.h>
+
+MOCK_INTERFACE_DEFINITION (MockPciSegmentLib);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentRegisterForRuntimeAccess, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentRead8, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentWrite8, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentOr8, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentAnd8, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentAndThenOr8, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentBitFieldRead8, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentBitFieldWrite8, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentBitFieldOr8, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentBitFieldAnd8, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentBitFieldAndThenOr8, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentRead16, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentWrite16, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentOr16, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentAnd16, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentAndThenOr16, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentBitFieldRead16, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentBitFieldWrite16, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentBitFieldOr16, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentBitFieldAnd16, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentBitFieldAndThenOr16, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentRead32, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentWrite32, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentOr32, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentAnd32, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentAndThenOr32, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentBitFieldRead32, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentBitFieldWrite32, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentBitFieldOr32, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentBitFieldAnd32, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentBitFieldAndThenOr32, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentReadBuffer, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPciSegmentLib, PciSegmentWriteBuffer, 3, EFIAPI);

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockPciSegmentLib/MockPciSegmentLib.inf
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockPciSegmentLib/MockPciSegmentLib.inf
@@ -1,0 +1,33 @@
+## @file MockPciSegmentLib.inf
+# Mock implementation of the PCI Segment Library
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MockPciSegmentLib
+  FILE_GUID                      = 0C5E46F6-82DF-45DF-9750-E231110681D1
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = PciSegmentLib
+  PI_SPECIFICATION_VERSION       = 0x0001000A
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  MockPciSegmentLib.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHsc

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockReportStatusCodeLib/MockReportStatusCodeLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockReportStatusCodeLib/MockReportStatusCodeLib.cpp
@@ -1,0 +1,11 @@
+/** @file MockReportStatusCodeLib.cpp
+  Google Test mocks for ReportStatusCodeLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <GoogleTest/Library/MockReportStatusCodeLib.h>
+
+MOCK_INTERFACE_DEFINITION (MockReportStatusCodeLib);
+MOCK_FUNCTION_DEFINITION (MockReportStatusCodeLib, ReportProgressCodeEnabled, 0, EFIAPI);

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockReportStatusCodeLib/MockReportStatusCodeLib.inf
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockReportStatusCodeLib/MockReportStatusCodeLib.inf
@@ -1,0 +1,33 @@
+## @file MockReportStatusCodeLib.inf
+# Google Test mocks for ReportStatusCodeLib
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MockReportStatusCodeLib
+  FILE_GUID                      = 3DFF7308-AC32-4BE9-9D01-B6F25E9161C3
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = ReportStatusCodeLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  MockReportStatusCodeLib.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHsc

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockSmmServicesTableLib/MockSmmServicesTableLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockSmmServicesTableLib/MockSmmServicesTableLib.cpp
@@ -7,39 +7,48 @@
 #include <GoogleTest/Library/MockSmmServicesTableLib.h>
 
 MOCK_INTERFACE_DEFINITION (MockSmmServicesTableLib);
+
 MOCK_FUNCTION_DEFINITION (MockSmmServicesTableLib, gSmst_SmmAllocatePool, 3, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockSmmServicesTableLib, gSmst_SmmFreePool, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockSmmServicesTableLib, gSmst_SmmAllocatePages, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockSmmServicesTableLib, gSmst_SmmFreePages, 2, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockSmmServicesTableLib, gSmst_SmmStartupThisAp, 3, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockSmmServicesTableLib, gSmst_SmmInstallProtocolInterface, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockSmmServicesTableLib, gSmst_SmmUninstallProtocolInterface, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockSmmServicesTableLib, gSmst_SmmHandleProtocol, 3, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockSmmServicesTableLib, gSmst_SmmRegisterProtocolNotify, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockSmmServicesTableLib, gSmst_SmmLocateHandle, 5, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockSmmServicesTableLib, gSmst_SmmLocateProtocol, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockSmmServicesTableLib, gSmst_SmiManage, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockSmmServicesTableLib, gSmst_SmmInterruptRegister, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockSmmServicesTableLib, gSmst_SmmInterruptUnRegister, 1, EFIAPI);
 
 static EFI_SMM_SYSTEM_TABLE2  LocalSmst = {
-  { 0, 0, 0, 0, 0 },                 // EFI_TABLE_HEADER
-  NULL,                              // SmmFirmwareVendor
-  0,                                 // SmmFirmwareRevision
-  NULL,                              // EFI_SMM_INSTALL_CONFIGURATION_TABLE2
-  { NULL },                          // EFI_SMM_CPU_IO2_PROTOCOL
-  gSmst_SmmAllocatePool,             // EFI_ALLOCATE_POOL
-  gSmst_SmmFreePool,                 // EFI_FREE_POOL
-  NULL,                              // EFI_ALLOCATE_PAGES
-  NULL,                              // EFI_FREE_PAGES
-  gSmst_SmmStartupThisAp,            // EFI_SMM_STARTUP_THIS_AP
-  0,                                 // CurrentlyExecutingCpu
-  0,                                 // NumberOfCpus
-  NULL,                              // CpuSaveStateSize
-  NULL,                              // CpuSaveState
-  0,                                 // NumberOfTableEntries
-  NULL,                              // EFI_CONFIGURATION_TABLE
-  gSmst_SmmInstallProtocolInterface, // EFI_INSTALL_PROTOCOL_INTERFACE
-  NULL,                              // EFI_UNINSTALL_PROTOCOL_INTERFACE
-  NULL,                              // EFI_HANDLE_PROTOCOL
-  gSmst_SmmRegisterProtocolNotify,   // EFI_SMM_REGISTER_PROTOCOL_NOTIFY
-  NULL,                              // EFI_LOCATE_HANDLE
-  gSmst_SmmLocateProtocol,           // EFI_LOCATE_PROTOCOL
-  NULL,                              // EFI_SMM_INTERRUPT_MANAGE
-  NULL,                              // EFI_SMM_INTERRUPT_REGISTER
-  NULL                               // SmiHandlerUnRegister
+  { 0, 0, 0, 0, 0 },                   // EFI_TABLE_HEADER
+  NULL,                                // SmmFirmwareVendor
+  0,                                   // SmmFirmwareRevision
+  NULL,                                // EFI_SMM_INSTALL_CONFIGURATION_TABLE2
+  { NULL },                            // EFI_SMM_CPU_IO2_PROTOCOL
+  gSmst_SmmAllocatePool,               // EFI_ALLOCATE_POOL
+  gSmst_SmmFreePool,                   // EFI_FREE_POOL
+  gSmst_SmmAllocatePages,              // EFI_ALLOCATE_PAGES
+  gSmst_SmmFreePages,                  // EFI_FREE_PAGES
+  gSmst_SmmStartupThisAp,              // EFI_SMM_STARTUP_THIS_AP
+  0,                                   // CurrentlyExecutingCpu
+  0,                                   // NumberOfCpus
+  NULL,                                // CpuSaveStateSize
+  NULL,                                // CpuSaveState
+  0,                                   // NumberOfTableEntries
+  NULL,                                // EFI_CONFIGURATION_TABLE
+  gSmst_SmmInstallProtocolInterface,   // EFI_INSTALL_PROTOCOL_INTERFACE
+  gSmst_SmmUninstallProtocolInterface, // EFI_UNINSTALL_PROTOCOL_INTERFACE
+  gSmst_SmmHandleProtocol,             // EFI_HANDLE_PROTOCOL
+  gSmst_SmmRegisterProtocolNotify,     // EFI_SMM_REGISTER_PROTOCOL_NOTIFY
+  gSmst_SmmLocateHandle,               // EFI_LOCATE_HANDLE
+  gSmst_SmmLocateProtocol,             // EFI_LOCATE_PROTOCOL
+  gSmst_SmiManage,                     // EFI_SMM_INTERRUPT_MANAGE
+  gSmst_SmmInterruptRegister,          // EFI_SMM_INTERRUPT_REGISTER
+  gSmst_SmmInterruptUnRegister         // EFI_SMM_INTERRUPT_UNREGISTER
 };
 
 extern "C" {


### PR DESCRIPTION
## Description

Added the following mock function.
1. Mock Libraries:
 MdePkg\Test\Mock\Library\GoogleTest\MockCpuLib
 MdePkg\Test\Mock\Library\GoogleTest\MockPciSegmentLib
 MdePkg\Test\Mock\Library\GoogleTest\MockReportStatusCodeLib
 MdePkg\Test\Mock\Library\GoogleTest\MockSmmServicesTableLib

2. Mock Protocol:
 MdePkg\Test\Mock\Include\GoogleTest\Protocol\MockMpService.h

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Consumed in a GoogleTest

## Integration Instructions

N/A
