### PR TITLE
[Cherry-Pick] [RB&FF] MdeModulePkg/HiiDatabaseDxe: Remove assert for VarStoreId = 0

### DIFF
--- a/MdeModulePkg/Universal/HiiDatabaseDxe/ConfigKeywordHandler.c
+++ b/MdeModulePkg/Universal/HiiDatabaseDxe/ConfigKeywordHandler.c
@@ -2119,8 +2119,9 @@ ExtractConfigRequest (
       //
       // Header->VarStoreId == 0 means no storage for this question.
       //
-      ASSERT (Header->VarStoreId != 0);
-      DEBUG ((DEBUG_INFO, "Varstore Id: 0x%x\n", Header->VarStoreId));
+      if (Header->VarStoreId == 0) {
+        continue;
+      }
 
       Storage = FindStorageFromVarId (FormPackage, Header->VarStoreId);
       ASSERT (Storage != NULL);


### PR DESCRIPTION


## Description

It is legal for the VarStoreId of a question to
be 0 per the UEFI spec:
"Specifies the identifier of a previously
declared variable store to use when storing the
question’s value. A value of zero indicates
no associated variable store."

Instead of hitting an assert just skip this
question as there is no value to return.

