### PR TITLE
[Rebase & FF] Fix PI status code

### DIFF
--- a/MdePkg/Include/Pi/PiStatusCode.h
+++ b/MdePkg/Include/Pi/PiStatusCode.h
@@ -967,29 +967,27 @@ typedef struct {
 /// These are shared by all subclasses.
 ///
 ///@{
-#define EFI_SW_EC_NON_SPECIFIC                    0x00000000
-#define EFI_SW_EC_LOAD_ERROR                      0x00000001
-#define EFI_SW_EC_INVALID_PARAMETER               0x00000002
-#define EFI_SW_EC_UNSUPPORTED                     0x00000003
-#define EFI_SW_EC_INVALID_BUFFER                  0x00000004
-#define EFI_SW_EC_OUT_OF_RESOURCES                0x00000005
-#define EFI_SW_EC_ABORTED                         0x00000006
-#define EFI_SW_EC_ILLEGAL_SOFTWARE_STATE          0x00000007
-#define EFI_SW_EC_ILLEGAL_HARDWARE_STATE          0x00000008
-#define EFI_SW_EC_START_ERROR                     0x00000009
-#define EFI_SW_EC_BAD_DATE_TIME                   0x0000000A
-#define EFI_SW_EC_CFG_INVALID                     0x0000000B
-#define EFI_SW_EC_CFG_CLR_REQUEST                 0x0000000C
-#define EFI_SW_EC_CFG_DEFAULT                     0x0000000D
-#define EFI_SW_EC_PWD_INVALID                     0x0000000E
-#define EFI_SW_EC_PWD_CLR_REQUEST                 0x0000000F
-#define EFI_SW_EC_PWD_CLEARED                     0x00000010
-#define EFI_SW_EC_EVENT_LOG_FULL                  0x00000011
-#define EFI_SW_EC_WRITE_PROTECTED                 0x00000012
-#define EFI_SW_EC_FV_CORRUPTED                    0x00000013
-#define EFI_SW_EC_INCONSISTENT_MEMORY_MAP         0x00000014
-#define EFI_SW_EC_MEMORY_TYPE_INFORMATION_CHANGE  0x00000015 // MU_CHANGE
-#define EFI_SW_EC_RELEASE_ASSERT                  0x00000016 // MU_CHANGE
+#define EFI_SW_EC_NON_SPECIFIC             0x00000000
+#define EFI_SW_EC_LOAD_ERROR               0x00000001
+#define EFI_SW_EC_INVALID_PARAMETER        0x00000002
+#define EFI_SW_EC_UNSUPPORTED              0x00000003
+#define EFI_SW_EC_INVALID_BUFFER           0x00000004
+#define EFI_SW_EC_OUT_OF_RESOURCES         0x00000005
+#define EFI_SW_EC_ABORTED                  0x00000006
+#define EFI_SW_EC_ILLEGAL_SOFTWARE_STATE   0x00000007
+#define EFI_SW_EC_ILLEGAL_HARDWARE_STATE   0x00000008
+#define EFI_SW_EC_START_ERROR              0x00000009
+#define EFI_SW_EC_BAD_DATE_TIME            0x0000000A
+#define EFI_SW_EC_CFG_INVALID              0x0000000B
+#define EFI_SW_EC_CFG_CLR_REQUEST          0x0000000C
+#define EFI_SW_EC_CFG_DEFAULT              0x0000000D
+#define EFI_SW_EC_PWD_INVALID              0x0000000E
+#define EFI_SW_EC_PWD_CLR_REQUEST          0x0000000F
+#define EFI_SW_EC_PWD_CLEARED              0x00000010
+#define EFI_SW_EC_EVENT_LOG_FULL           0x00000011
+#define EFI_SW_EC_WRITE_PROTECTED          0x00000012
+#define EFI_SW_EC_FV_CORRUPTED             0x00000013
+#define EFI_SW_EC_INCONSISTENT_MEMORY_MAP  0x00000014
 ///@}
 
 //


### PR DESCRIPTION
## Description

We upstreamed the correct PI status code to PI spec and should get rid of MU_CHANGE to avoid conflict.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This change only involves definition migration.

## Integration Instructions

For applicable components, platform needs to update these definitions in their code.

`EFI_SW_EC_MEMORY_TYPE_INFORMATION_CHANGE` -> `EFI_SW_EC_ILLEGAL_SOFTWARE_STATE`
`EFI_SW_EC_RELEASE_ASSERT` -> `EFI_SW_EC_ILLEGAL_SOFTWARE_STATE`
