### PR TITLE
Added missing fix for ProductDataFormatter missed from 202311

### DIFF
--- a/BaseTools/Source/Python/ProductDataFormatter/ProductDataFormatter.py
+++ b/BaseTools/Source/Python/ProductDataFormatter/ProductDataFormatter.py
@@ -12,6 +12,7 @@ import io
 import os
 import struct
 from collections import namedtuple
+from pathlib import Path
 
 
 class ProductDataFormatter:
@@ -24,11 +25,10 @@ class ProductDataFormatter:
             raise NotADirectoryError(
                 f"{directory_path} is an invalid directory!")
 
-        self._directory_path = directory_path
+        self._directory_path = Path(directory_path)
 
     def _get_bins(self):
-        return glob.glob(os.path.join(
-            self._directory_path, '*.productdatabin.i'))
+            return self._directory_path.rglob('*.productdatabin.i')
 
     def _get_signed_item(self, file_path):
         with open(file_path, 'rb') as bin_file:


### PR DESCRIPTION
## Description

A fix for the ProductDataFormatter script was missed during the transition from 202311 to 202405.  This just adds it back.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on physical hardware.  Product Data is correctly being found.

## Integration Instructions

N/A
