### PR TITLE
[CHERRY-PICK] Bring in more mocks from release/202311

### DIFF
--- a/MdeModulePkg/Test/MdeModulePkgHostTest.dsc
+++ b/MdeModulePkg/Test/MdeModulePkgHostTest.dsc
@@ -115,4 +115,6 @@
   # Build HOST_APPLICATION Libraries
   #
   MdeModulePkg/Test/Mock/Library/GoogleTest/MockPciHostBridgeLib/MockPciHostBridgeLib.inf
+  MdeModulePkg/Test/Mock/Library/GoogleTest/MockCapsuleLib/MockCapsuleLib.inf
+  MdeModulePkg/Test/Mock/Library/GoogleTest/MockUefiBootManagerLib/MockUefiBootManagerLib.inf
   MdeModulePkg/Test/Mock/Library/GoogleTest/MockPlatformHookLib/MockPlatformHookLib.inf

--- a/MdeModulePkg/Test/Mock/Include/GoogleTest/Library/MockCapsuleLib.h
+++ b/MdeModulePkg/Test/Mock/Include/GoogleTest/Library/MockCapsuleLib.h
@@ -1,0 +1,71 @@
+/** @file
+  Google Test mocks for CapsuleLib
+
+  Copyright (c) 2022, Intel Corporation. All rights reserved.
+  Copyright (C) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_CAPSULE_LIB_H_
+#define MOCK_CAPSULE_LIB_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+extern "C" {
+  #include <Uefi.h>
+  #include <Library/CapsuleLib.h>
+}
+
+struct MockCapsuleLib {
+  MOCK_INTERFACE_DECLARATION (MockCapsuleLib);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    SupportCapsuleImage,
+    (IN EFI_CAPSULE_HEADER  *CapsuleHeader)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ProcessCapsuleImage,
+    (IN EFI_CAPSULE_HEADER  *CapsuleHeader)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    StageCapsuleImage,
+    (IN EFI_CAPSULE_HEADER  *CapsuleHeader)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ProcessCapsules,
+    ()
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    CoDCheckCapsuleOnDiskFlag,
+    ()
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    CoDClearCapsuleOnDiskFlag,
+    ()
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    CoDRelocateCapsule,
+    (UINTN  MaxRetry)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    CoDRemoveTempFile,
+    (UINTN  MaxRetry)
+    );
+};
+
+#endif

--- a/MdeModulePkg/Test/Mock/Include/GoogleTest/Library/MockUefiBootManagerLib.h
+++ b/MdeModulePkg/Test/Mock/Include/GoogleTest/Library/MockUefiBootManagerLib.h
@@ -1,0 +1,234 @@
+/** @file
+  Google Test mocks for UefiBootManagerLib
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.
+  Copyright (C) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_UEFI_BOOT_MANAGER_LIB_H_
+#define MOCK_UEFI_BOOT_MANAGER_LIB_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+extern "C" {
+  #include <Uefi.h>
+  #include <Library/UefiBootManagerLib.h>
+}
+
+struct MockUefiBootManagerLib {
+  MOCK_INTERFACE_DECLARATION (MockUefiBootManagerLib);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_BOOT_MANAGER_LOAD_OPTION *,
+    EfiBootManagerGetLoadOptions,
+    (OUT UINTN                             *LoadOptionCount,
+     IN EFI_BOOT_MANAGER_LOAD_OPTION_TYPE  LoadOptionType)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiBootManagerFreeLoadOptions,
+    (IN  EFI_BOOT_MANAGER_LOAD_OPTION  *LoadOptions,
+     IN  UINTN                         LoadOptionCount)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiBootManagerInitializeLoadOption,
+    (IN OUT EFI_BOOT_MANAGER_LOAD_OPTION    *Option,
+     IN  UINTN                              OptionNumber,
+     IN  EFI_BOOT_MANAGER_LOAD_OPTION_TYPE  OptionType,
+     IN  UINT32                             Attributes,
+     IN  CHAR16                             *Description,
+     IN  EFI_DEVICE_PATH_PROTOCOL           *FilePath,
+     IN  UINT8                              *OptionalData,
+     IN  UINT32                             OptionalDataSize)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiBootManagerFreeLoadOption,
+    (IN  EFI_BOOT_MANAGER_LOAD_OPTION  *LoadOption)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiBootManagerVariableToLoadOption,
+    (IN CHAR16                            *VariableName,
+     IN OUT EFI_BOOT_MANAGER_LOAD_OPTION  *LoadOption)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiBootManagerAddLoadOptionVariable,
+    (IN OUT EFI_BOOT_MANAGER_LOAD_OPTION  *Option,
+     IN     UINTN                         Position)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiBootManagerDeleteLoadOptionVariable,
+    (IN UINTN                              OptionNumber,
+     IN EFI_BOOT_MANAGER_LOAD_OPTION_TYPE  OptionType)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    EfiBootManagerSortLoadOptionVariable,
+    (IN EFI_BOOT_MANAGER_LOAD_OPTION_TYPE  OptionType,
+     IN SORT_COMPARE                       CompareFunction)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    INTN,
+    EfiBootManagerFindLoadOption,
+    (IN CONST EFI_BOOT_MANAGER_LOAD_OPTION  *Key,
+     IN CONST EFI_BOOT_MANAGER_LOAD_OPTION  *Array,
+     IN UINTN                               Count)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiBootManagerStartHotkeyService,
+    (IN EFI_EVENT  *HotkeyTriggered)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    EfiBootManagerHotkeyBoot,
+    ()
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    EfiBootManagerRefreshAllBootOption,
+    ()
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    EfiBootManagerBoot,
+    (IN  EFI_BOOT_MANAGER_LOAD_OPTION  *LoadOption)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiBootManagerGetBootManagerMenu,
+    (IN  EFI_BOOT_MANAGER_LOAD_OPTION  *LoadOption)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_DEVICE_PATH_PROTOCOL *,
+    EfiBootManagerGetNextLoadOptionDevicePath,
+    (IN  EFI_DEVICE_PATH_PROTOCOL  *FilePath,
+     IN  EFI_DEVICE_PATH_PROTOCOL  *FullPath)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    EfiBootManagerGetLoadOptionBuffer,
+    (IN  EFI_DEVICE_PATH_PROTOCOL  *FilePath,
+     OUT EFI_DEVICE_PATH_PROTOCOL  **FullPath,
+     OUT UINTN                     *FileSize)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    EfiBootManagerRegisterLegacyBootSupport,
+    (EFI_BOOT_MANAGER_REFRESH_LEGACY_BOOT_OPTION  RefreshLegacyBootOption,
+     EFI_BOOT_MANAGER_LEGACY_BOOT                 LegacyBoot)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiBootManagerRegisterBootDescriptionHandler,
+    (IN EFI_BOOT_MANAGER_BOOT_DESCRIPTION_HANDLER  Handler)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    EfiBootManagerConnectAll,
+    ()
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiBootManagerConnectDevicePath,
+    (EFI_DEVICE_PATH_PROTOCOL  *DevicePathToConnect,
+     EFI_HANDLE                *MatchingHandle)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    EfiBootManagerDisconnectAll,
+    ()
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiBootManagerConnectAllDefaultConsoles,
+    ()
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiBootManagerUpdateConsoleVariable,
+    (IN  CONSOLE_TYPE              ConsoleType,
+     IN  EFI_DEVICE_PATH_PROTOCOL  *CustomizedConDevicePath,
+     IN  EFI_DEVICE_PATH_PROTOCOL  *ExclusiveDevicePath)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiBootManagerConnectConsoleVariable,
+    (IN  CONSOLE_TYPE  ConsoleType)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_DEVICE_PATH_PROTOCOL *,
+    EfiBootManagerGetGopDevicePath,
+    (IN  EFI_HANDLE  VideoController)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiBootManagerConnectVideoController,
+    (EFI_HANDLE  VideoController  OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_BOOT_MANAGER_DRIVER_HEALTH_INFO *,
+    EfiBootManagerGetDriverHealthInfo,
+    (UINTN  *Count)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiBootManagerFreeDriverHealthInfo,
+    (EFI_BOOT_MANAGER_DRIVER_HEALTH_INFO  *DriverHealthInfo,
+     UINTN                                Count)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiBootManagerProcessLoadOption,
+    (EFI_BOOT_MANAGER_LOAD_OPTION  *LoadOption)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    EfiBootManagerIsValidLoadOptionVariableName,
+    (IN CHAR16                              *VariableName,
+     OUT EFI_BOOT_MANAGER_LOAD_OPTION_TYPE  *OptionType   OPTIONAL,
+     OUT UINT16                             *OptionNumber OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiBootManagerDispatchDeferredImages,
+    ()
+    );
+};
+
+#endif

--- a/MdeModulePkg/Test/Mock/Library/GoogleTest/MockCapsuleLib/MockCapsuleLib.cpp
+++ b/MdeModulePkg/Test/Mock/Library/GoogleTest/MockCapsuleLib/MockCapsuleLib.cpp
@@ -1,0 +1,20 @@
+/** @file
+  Google Test mocks for CapsuleLib
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.
+  Copyright (C) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <GoogleTest/Library/MockCapsuleLib.h>
+
+MOCK_INTERFACE_DEFINITION (MockCapsuleLib);
+
+MOCK_FUNCTION_DEFINITION (MockCapsuleLib, SupportCapsuleImage, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockCapsuleLib, ProcessCapsuleImage, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockCapsuleLib, StageCapsuleImage, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockCapsuleLib, ProcessCapsules, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockCapsuleLib, CoDCheckCapsuleOnDiskFlag, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockCapsuleLib, CoDClearCapsuleOnDiskFlag, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockCapsuleLib, CoDRelocateCapsule, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockCapsuleLib, CoDRemoveTempFile, 1, EFIAPI);

--- a/MdeModulePkg/Test/Mock/Library/GoogleTest/MockCapsuleLib/MockCapsuleLib.inf
+++ b/MdeModulePkg/Test/Mock/Library/GoogleTest/MockCapsuleLib/MockCapsuleLib.inf
@@ -1,0 +1,35 @@
+## @file
+# Google Test mocks for CapsuleLib
+#
+# Copyright (c) 2023, Intel Corporation. All rights reserved.
+# Copyright (C) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MockCapsuleLib
+  FILE_GUID                      = 850d769f-d56f-4553-af6f-5704e24a2ef3
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = CapsuleLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  MockCapsuleLib.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHsc

--- a/MdeModulePkg/Test/Mock/Library/GoogleTest/MockUefiBootManagerLib/MockUefiBootManagerLib.cpp
+++ b/MdeModulePkg/Test/Mock/Library/GoogleTest/MockUefiBootManagerLib/MockUefiBootManagerLib.cpp
@@ -1,0 +1,43 @@
+/** @file
+  Google Test mocks for UefiBootManagerLib
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.
+  Copyright (C) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <GoogleTest/Library/MockUefiBootManagerLib.h>
+
+MOCK_INTERFACE_DEFINITION (MockUefiBootManagerLib);
+
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerGetLoadOptions, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerFreeLoadOptions, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerInitializeLoadOption, 8, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerFreeLoadOption, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerVariableToLoadOption, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerAddLoadOptionVariable, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerDeleteLoadOptionVariable, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerSortLoadOptionVariable, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerFindLoadOption, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerStartHotkeyService, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerHotkeyBoot, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerRefreshAllBootOption, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerBoot, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerGetBootManagerMenu, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerGetNextLoadOptionDevicePath, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerGetLoadOptionBuffer, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerRegisterLegacyBootSupport, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerRegisterBootDescriptionHandler, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerConnectAll, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerConnectDevicePath, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerDisconnectAll, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerConnectAllDefaultConsoles, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerUpdateConsoleVariable, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerConnectConsoleVariable, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerGetGopDevicePath, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerConnectVideoController, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerGetDriverHealthInfo, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerFreeDriverHealthInfo, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerProcessLoadOption, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerIsValidLoadOptionVariableName, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootManagerLib, EfiBootManagerDispatchDeferredImages, 0, EFIAPI);

--- a/MdeModulePkg/Test/Mock/Library/GoogleTest/MockUefiBootManagerLib/MockUefiBootManagerLib.inf
+++ b/MdeModulePkg/Test/Mock/Library/GoogleTest/MockUefiBootManagerLib/MockUefiBootManagerLib.inf
@@ -1,0 +1,35 @@
+## @file
+# Google Test mocks for UefiBootManagerLib
+#
+# Copyright (c) 2024, Intel Corporation. All rights reserved.
+# Copyright (C) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MockUefiBootManagerLib
+  FILE_GUID                      = a6d8906f-46db-482a-9264-75547e6462ca
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = UefiBootManagerLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  MockUefiBootManagerLib.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHsc

--- a/MdePkg/Test/MdePkgHostTest.dsc
+++ b/MdePkg/Test/MdePkgHostTest.dsc
@@ -63,6 +63,7 @@
   MdePkg/Test/Mock/Library/Stub/StubUefiLib/StubUefiLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockPciExpressLib/MockPciExpressLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockUefiDevicePathLib/MockUefiDevicePathLib.inf
+  MdePkg/Test/Mock/Library/GoogleTest/MockPerformanceLib/MockPerformanceLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockDxeServicesTableLib/MockDxeServicesTableLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockPciLib/MockPciLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockPcdLib/MockPcdLib.inf

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockPerformanceLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockPerformanceLib.h
@@ -1,0 +1,106 @@
+/** @file
+  Google Test mocks for PerformanceLib
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.
+  Copyright (C) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_PERFORMANCE_LIB_H_
+#define MOCK_PERFORMANCE_LIB_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+extern "C" {
+  #include <Uefi.h>
+  #include <Library/PerformanceLib.h>
+}
+
+struct MockPerformanceLib {
+  MOCK_INTERFACE_DECLARATION (MockPerformanceLib);
+
+  MOCK_FUNCTION_DECLARATION (
+    RETURN_STATUS,
+    StartPerformanceMeasurement,
+    (IN CONST VOID   *Handle   OPTIONAL,
+     IN CONST CHAR8  *Token    OPTIONAL,
+     IN CONST CHAR8  *Module   OPTIONAL,
+     IN UINT64       TimeStamp)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    RETURN_STATUS,
+    EndPerformanceMeasurement,
+    (IN CONST VOID   *Handle   OPTIONAL,
+     IN CONST CHAR8  *Token    OPTIONAL,
+     IN CONST CHAR8  *Module   OPTIONAL,
+     IN UINT64       TimeStamp)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINTN,
+    GetPerformanceMeasurement,
+    (IN  UINTN        LogEntryKey,
+     OUT CONST VOID   **Handle,
+     OUT CONST CHAR8  **Token,
+     OUT CONST CHAR8  **Module,
+     OUT UINT64       *StartTimeStamp,
+     OUT UINT64       *EndTimeStamp)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    RETURN_STATUS,
+    StartPerformanceMeasurementEx,
+    (IN CONST VOID   *Handle   OPTIONAL,
+     IN CONST CHAR8  *Token    OPTIONAL,
+     IN CONST CHAR8  *Module   OPTIONAL,
+     IN UINT64       TimeStamp,
+     IN UINT32       Identifier)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    RETURN_STATUS,
+    EndPerformanceMeasurementEx,
+    (IN CONST VOID   *Handle   OPTIONAL,
+     IN CONST CHAR8  *Token    OPTIONAL,
+     IN CONST CHAR8  *Module   OPTIONAL,
+     IN UINT64       TimeStamp,
+     IN UINT32       Identifier)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINTN,
+    GetPerformanceMeasurementEx,
+    (IN  UINTN        LogEntryKey,
+     OUT CONST VOID   **Handle,
+     OUT CONST CHAR8  **Token,
+     OUT CONST CHAR8  **Module,
+     OUT UINT64       *StartTimeStamp,
+     OUT UINT64       *EndTimeStamp,
+     OUT UINT32       *Identifier)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    PerformanceMeasurementEnabled,
+    ()
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    LogPerformanceMeasurementEnabled,
+    (IN  CONST UINTN  Type)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    RETURN_STATUS,
+    LogPerformanceMeasurement,
+    (IN CONST VOID   *CallerIdentifier  OPTIONAL,
+     IN CONST VOID   *Guid     OPTIONAL,
+     IN CONST CHAR8  *String   OPTIONAL,
+     IN UINT64       Address   OPTIONAL,
+     IN UINT32       Identifier)
+    );
+};
+
+#endif

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiLib.h
@@ -2,6 +2,7 @@
   Google Test mocks for UefiLib
 
   Copyright (c) 2022, Intel Corporation. All rights reserved.
+  Copyright (C) Microsoft Corporation.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -88,6 +89,12 @@ struct MockUefiLib {
      IN EFI_HANDLE                          DriverBindingHandle,
      IN CONST EFI_COMPONENT_NAME_PROTOCOL   *ComponentName        OPTIONAL,
      IN CONST EFI_COMPONENT_NAME2_PROTOCOL  *ComponentName2       OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EfiEventGroupSignal,
+    (IN CONST EFI_GUID  *EventGroup)
     );
 
   MOCK_FUNCTION_DECLARATION (

--- a/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockGenericMemoryTest.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockGenericMemoryTest.h
@@ -1,0 +1,80 @@
+/** @file MockGenericMemoryTest.h
+  This file declares a mock of generic memory test Protocol.
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_GENERIC_MEMORY_TEST_H_
+#define MOCK_GENERIC_MEMORY_TEST_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Protocol/GenericMemoryTest.h>
+}
+struct MockMemTestProtocol {
+  MOCK_INTERFACE_DECLARATION (MockMemTestProtocol);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    MemoryTestInit,
+    (
+     IN  EFI_GENERIC_MEMORY_TEST_PROTOCOL         *This,
+     IN  EXTENDMEM_COVERAGE_LEVEL                 Level,
+     OUT BOOLEAN                                  *RequireSoftECCInit
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    PerformMemoryTest,
+    (
+     IN  EFI_GENERIC_MEMORY_TEST_PROTOCOL         *This,
+     OUT UINT64                                   *TestedMemorySize,
+     OUT UINT64                                   *TotalMemorySize,
+     OUT BOOLEAN                                  *ErrorOut,
+     IN  BOOLEAN                                  IfTestAbort
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    Finished,
+    (
+     IN  EFI_GENERIC_MEMORY_TEST_PROTOCOL         *This
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    CompatibleRangeTest,
+    (
+     IN  EFI_GENERIC_MEMORY_TEST_PROTOCOL         *This,
+     IN  EFI_PHYSICAL_ADDRESS                     StartAddress,
+     IN  UINT64                                   Length
+    )
+    );
+};
+
+MOCK_INTERFACE_DEFINITION (MockMemTestProtocol);
+MOCK_FUNCTION_DEFINITION (MockMemTestProtocol, MemoryTestInit, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMemTestProtocol, PerformMemoryTest, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMemTestProtocol, Finished, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMemTestProtocol, CompatibleRangeTest, 3, EFIAPI);
+
+EFI_GENERIC_MEMORY_TEST_PROTOCOL  MEMORY_TEST_PROTOCOL_INSTANCE = {
+  MemoryTestInit,                                                                       // EFI_MEMORY_TEST_INIT
+  PerformMemoryTest,                                                                    // EFI_PERFORM_MEMORY_TEST
+  Finished,                                                                             // EFI_MEMORY_TEST_FINISHED
+  CompatibleRangeTest                                                                   // EFI_MEMORY_TEST_COMPATIBLE_RANGE
+};
+
+extern "C" {
+  EFI_GENERIC_MEMORY_TEST_PROTOCOL  *gMemTestProtocol = &MEMORY_TEST_PROTOCOL_INSTANCE;
+}
+
+#endif // MOCK_GENERIC_MEMORY_TEST_H_

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockPerformanceLib/MockPerformanceLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockPerformanceLib/MockPerformanceLib.cpp
@@ -1,0 +1,21 @@
+/** @file
+  Google Test mocks for PerformanceLib
+
+  Copyright (c) 2023, Intel Corporation. All rights reserved.
+  Copyright (C) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <GoogleTest/Library/MockPerformanceLib.h>
+
+MOCK_INTERFACE_DEFINITION (MockPerformanceLib);
+
+MOCK_FUNCTION_DEFINITION (MockPerformanceLib, StartPerformanceMeasurement, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPerformanceLib, EndPerformanceMeasurement, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPerformanceLib, GetPerformanceMeasurement, 6, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPerformanceLib, StartPerformanceMeasurementEx, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPerformanceLib, EndPerformanceMeasurementEx, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPerformanceLib, GetPerformanceMeasurementEx, 7, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPerformanceLib, PerformanceMeasurementEnabled, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPerformanceLib, LogPerformanceMeasurementEnabled, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPerformanceLib, LogPerformanceMeasurement, 5, EFIAPI);

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockPerformanceLib/MockPerformanceLib.inf
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockPerformanceLib/MockPerformanceLib.inf
@@ -1,0 +1,34 @@
+## @file
+# Google Test mocks for PerformanceLib
+#
+# Copyright (c) 2023, Intel Corporation. All rights reserved.
+# Copyright (C) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MockPerformanceLib
+  FILE_GUID                      = 93baa3b4-9bb7-4ff7-89c7-95e4e08bb4be
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = PerformanceLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  MockPerformanceLib.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHsc

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockUefiLib/MockUefiLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockUefiLib/MockUefiLib.cpp
@@ -2,6 +2,7 @@
   Google Test mocks for UefiLib
 
   Copyright (c) 2022, Intel Corporation. All rights reserved.
+  Copyright (C) Microsoft Corporation.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 #include <GoogleTest/Library/MockUefiLib.h>
@@ -16,4 +17,5 @@ MOCK_FUNCTION_DEFINITION (MockUefiLib, LookupUnicodeString2, 5, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiLib, AddUnicodeString2, 5, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiLib, FreeUnicodeStringTable, 1, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiLib, EfiLibInstallDriverBindingComponentName2, 6, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiLib, EfiEventGroupSignal, 1, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiLib, EfiCreateEventReadyToBootEx, 4, EFIAPI);


### PR DESCRIPTION
## Description

Cherry-picked from dev/202405: https://github.com/microsoft/mu_basecore/pull/1182


Add mock functions under MockUefiLib and Create Mock for CapsuleLib, PerformanceLib and GenericMemoryTestProtocol



- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Unit tests component can call these mock functions success

## Integration Instructions

N/A
