### PR TITLE
[Cherry-Pick] StandaloneMmPkg: Initialize 'WillReturn' variable

### DIFF
--- a/StandaloneMmPkg/Core/Mmi.c
+++ b/StandaloneMmPkg/Core/Mmi.c
@@ -174,6 +174,7 @@ MmiManage (
   EFI_STATUS   Status;
 
   mMmiManageCallingDepth++;
+  WillReturn   = FALSE;
   Status       = EFI_NOT_FOUND;
   ReturnStatus = Status;
   if (HandlerType == NULL) {


### PR DESCRIPTION
## Description

The local variable 'WillReturn' was being used without prior initialization in some code paths.
This patch ensures that 'WillReturn' is properly initialized to prevent undefined behavior.

cherry-picked from edk2 https://github.com/tianocore/edk2/commit/30b6d08e27c767ba9756a244099d73c826abcc8d
- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
A platform using StandaloneMM failed to dispatch some handlers. It was tracked back to needing this edk2 cherry-pick is needed to handle the paths through the code.

## Integration Instructions
N/A