### PR TITLE
[Cherry-Pick] Fix naming convention in FirmwareVolume2 gmock

### DIFF
--- a/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockFirmwareVolume2.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockFirmwareVolume2.h
@@ -117,9 +117,9 @@ struct MockFirmwareVolume2Protocol {
 MOCK_INTERFACE_DEFINITION (MockFirmwareVolume2Protocol);
 MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, GetVolumeAttributes, 2, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, SetVolumeAttributes, 2, EFIAPI);
-MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, FV_ReadFile, 7, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, FvReadFile, 7, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, ReadSection, 7, EFIAPI);
-MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, FV_WriteFile, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, FvWriteFile, 4, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, GetNextFile, 6, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, GetInfo, 4, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockFirmwareVolume2Protocol, SetInfo, 4, EFIAPI);


### PR DESCRIPTION
## Description

Fix naming convention for FirmwareVolume2 gmock.
- Rename `FV_ReadFile` -> `FvReadFile`
- Rename `FV_WriteFile` -> `FvWriteFile`

cherry-pick of <c564cd698a19998e3862d0258e6e368e3d9e3a4e> 

----

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Unit tests component can call these mock functions success

## Integration Instructions

N/A