### PR TITLE
[CHERRY-PICK] UnitTestFrameworkPkg: Use TianoCore mirror of subhook s…

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,7 +16,7 @@
 	url = https://github.com/google/googletest.git
 [submodule "UnitTestFrameworkPkg/Library/SubhookLib/subhook"]
 	path = UnitTestFrameworkPkg/Library/SubhookLib/subhook
-	url = https://github.com/Zeex/subhook.git
+	url = https://github.com/tianocore/edk2-subhook.git
 [submodule "MdePkg/Library/BaseFdtLib/libfdt"]
 	path = MdePkg/Library/BaseFdtLib/libfdt
 	url = https://github.com/devicetree-org/pylibfdt.git

--- a/UnitTestFrameworkPkg/ReadMe.md
+++ b/UnitTestFrameworkPkg/ReadMe.md
@@ -487,8 +487,8 @@ function to be compiled into the test application and then hooked to during a
 test.
 
 This library is mainly a wrapper around the
-[subhook](https://github.com/Zeex/subhook) header and source files. It is
-important to note that the use of the mock function macros and the creation
+[subhook](https://github.com/tianocore/edk2-subhook) header and source files. It
+is important to note that the use of the mock function macros and the creation
 of mock functions requires no knowledge about the SubhookLib. The SubhookLib
 library is entirely hidden and encapsulated within FunctionMockLib, and it
 is only mentioned here to provide a complete explanation on all the libraries


### PR DESCRIPTION
## Description

Change subhook url from https://github.com/Zeex/subhook to https://github.com/tianocore/edk2-subhook because old url is no longer available.

Also align .gitmodules file to use consistent LF line endings.

Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>
(cherry picked from edk2 commit 95d8a1c255cfb8e063d679930d08ca6426eb5701)

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Build and CI

## Integration Instructions

- Update all repos to use this new submodule URL for subhook
  since the original repo is no longer available.