### PR TITLE
[CHERRY-PICK] UnitTestFrameworkPkg: Use TianoCore mirror of subhook s…

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,4 +19,4 @@
 	url = https://github.com/google/googletest.git
 [submodule "UnitTestFrameworkPkg/Library/SubhookLib/subhook"]
 	path = UnitTestFrameworkPkg/Library/SubhookLib/subhook
-	url = https://github.com/Zeex/subhook.git
+	url = https://github.com/tianocore/edk2-subhook.git


### PR DESCRIPTION
## Description

Change subhook url from https://github.com/Zeex/subhook to https://github.com/tianocore/edk2-subhook because old url is no longer available.

Also align .gitmodules file to use consistent LF line endings.

Signed-off-by: Michael D Kinney <michael.d.kinney@intel.com>
(cherry picked from edk2 commit 95d8a1c255cfb8e063d679930d08ca6426eb5701)

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Build and CI

## Integration Instructions

- Update all repos to use this new submodule URL for subhook
  since the original repo is no longer available.