### PR TITLE
Configure Terminal to be picked up by Consplitter

### DIFF
--- a/MdeModulePkg/Universal/Console/TerminalDxe/Terminal.c
+++ b/MdeModulePkg/Universal/Console/TerminalDxe/Terminal.c
@@ -800,6 +800,10 @@ TerminalDriverBindingStart (
                   &TerminalDevice->SimpleTextOutput,
                   &gEfiDevicePathProtocolGuid,
                   TerminalDevice->DevicePath,
+                  &gEfiConsoleOutDeviceGuid,
+                  NULL,                                     // Terminal is a ConOut device (picked up by Consplitter).
+                  &gEfiConsoleInDeviceGuid,
+                  NULL,                                     // Terminal is a ConIn device (picked up by Consplitter).
                   NULL
                   );
   if (!EFI_ERROR (Status)) {
@@ -1002,6 +1006,10 @@ TerminalDriverBindingStop (
                       &TerminalDevice->SimpleTextOutput,
                       &gEfiDevicePathProtocolGuid,
                       TerminalDevice->DevicePath,
+                      &gEfiConsoleOutDeviceGuid,
+                      NULL,
+                      &gEfiConsoleInDeviceGuid,
+                      NULL,
                       NULL
                       );
       if (EFI_ERROR (Status)) {

--- a/MdeModulePkg/Universal/Console/TerminalDxe/TerminalDxe.inf
+++ b/MdeModulePkg/Universal/Console/TerminalDxe/TerminalDxe.inf
@@ -74,6 +74,8 @@
   gEdkiiVT400Guid                               ## SOMETIMES_CONSUMES ## GUID # used with a Vendor-Defined Messaging Device Path
   gEdkiiSCOTermGuid                             ## SOMETIMES_CONSUMES ## GUID # used with a Vendor-Defined Messaging Device Path
   gEdkiiStatusCodeDataTypeVariableGuid          ## SOMETIMES_CONSUMES ## GUID
+  gEfiConsoleOutDeviceGuid                      ## SOMETIMES_CONSUMES ## MU_CHANGE
+  gEfiConsoleInDeviceGuid                       ## SOMETIMES_CONSUMES ## MU_CHANGE
 
 [Protocols]
   gEfiSerialIoProtocolGuid                      ## TO_START


### PR DESCRIPTION
## Description

Add the terminal device to be picked up by Consplitter so we can interact with UEFI VMs over serial console terminals like Putty.

Cherry-Pick of 2fefff5fb699121eb69b6bdd7ae4b32df564317b
- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested
Without the change, devices that did not install gEfiConsoleOutDeviceGuid would not be managed by ConSplitter.
After the changes, terminal devices were detected by consplitter and resulted in display on the serial devices.

## Integration Instructions
No changes required. 