### PR TITLE
BaseTools HostBasedUnittestRunner Modify CC_REORGANIZE to exclude Null implementations.

### DIFF
--- a/BaseTools/Plugin/HostBasedUnitTestRunner/HostBasedUnitTestRunner.py
+++ b/BaseTools/Plugin/HostBasedUnitTestRunner/HostBasedUnitTestRunner.py
@@ -12,7 +12,6 @@ import stat
 import xml.etree.ElementTree
 from edk2toolext.environment.plugintypes.uefi_build_plugin import IUefiBuildPlugin
 from edk2toolext import edk2_logging
-import edk2toollib.windows.locate_tools as locate_tools
 from edk2toolext.environment import shell_environment
 from edk2toollib.utility_functions import RunCmd
 from edk2toollib.utility_functions import GetHostInfo
@@ -299,7 +298,7 @@ class HostBasedUnitTestRunner(IUefiBuildPlugin):
         params += f" -p {package}" * int(package != "")
         params += " --full" * int(thebuilder.env.GetValue("CC_FULL", "FALSE") == "TRUE")
         params += " --flatten" * int(thebuilder.env.GetValue("CC_FLATTEN", "FALSE") == "TRUE")
-
+        params += " --exclude *NULL*,*Null*,*null*"
         return RunCmd("stuart_report", params)
 
     def parse_workspace(self, thebuilder) -> str:


### PR DESCRIPTION
## Description

When Unit tests are run, the generated report includes null libraries in the calculation.

Modifying the organize_coverage to exclude null libraries from the code coverage results.

These changes only effect the case when CC_REORGANIZE is set to true in the project. 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Ran on private repo which contained a lot of NULL libraries. Prior to change, Null libraries were included in the report, after the modification, they were not 

## Integration Instructions

No changes required, but coverage report will look different if CC_REORGANIZE is set to True.