### PR TITLE
Inital StackCookie implementation for MSVC AARCH64

### DIFF
--- a/MdePkg/Library/StackCheckLibNull/AARCH64/StackCheckFunctionsMsvc.asm
+++ b/MdePkg/Library/StackCheckLibNull/AARCH64/StackCheckFunctionsMsvc.asm
@@ -1,0 +1,80 @@
+;------------------------------------------------------------------------------
+; AARCH64/StackCheckFunctionsMsvc.nasm
+;
+; Copyright (c) Microsoft Corporation.
+; SPDX-License-Identifier: BSD-2-Clause-Patent
+;------------------------------------------------------------------------------
+
+    EXPORT __report_rangecheckfailure
+    EXPORT __GSHandlerCheck
+    EXPORT __security_check_cookie
+    EXPORT __security_push_cookie
+    EXPORT __security_pop_cookie
+
+    AREA |.text|, CODE, READONLY
+
+;------------------------------------------------------------------------------
+; Calls an interrupt using the vector specified by PcdStackCookieExceptionVector
+;
+; VOID
+; TriggerStackCookieInterrupt (
+;   VOID
+;   );
+;------------------------------------------------------------------------------
+__report_rangecheckfailure PROC
+    RET
+__report_rangecheckfailure ENDP
+
+;------------------------------------------------------------------------------
+; Calls an interrupt using the vector specified by PcdStackCookieExceptionVector
+;
+; VOID
+; __GSHandlerCheck (
+;   VOID
+;   );
+;------------------------------------------------------------------------------
+__GSHandlerCheck PROC
+    RET
+__GSHandlerCheck ENDP
+
+;------------------------------------------------------------------------------
+; Checks the stack cookie value against passed __security_cookie. Take
+; appropiate action on a mismatch (stack smashed case)
+;
+; VOID
+; EFIAPI
+; __security_check_cookie (
+;   IN UINTN CheckValue
+;   );
+;------------------------------------------------------------------------------
+__security_check_cookie PROC
+    RET
+__security_check_cookie ENDP
+
+
+;------------------------------------------------------------------------------
+; Pop the cookie off the stack (recommended in 16 bytes)
+;
+; VOID
+; __security_push_cookie (
+;   VOID
+;   );
+;------------------------------------------------------------------------------
+__security_pop_cookie PROC
+    RET
+__security_pop_cookie ENDP
+
+
+;------------------------------------------------------------------------------
+; Push a Security Cookie onto the stack (recommended is 16 bytes)
+;
+; VOID
+; __security_push_cookie (
+;   VOID
+;   );
+;------------------------------------------------------------------------------
+__security_push_cookie PROC
+    RET
+__security_push_cookie ENDP
+
+    END

--- a/MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
+++ b/MdePkg/Library/StackCheckLibNull/StackCheckLibNull.inf
@@ -24,6 +24,9 @@
 [Sources.X64]
   X64/StackCheckFunctionsMsvc.nasm | MSFT
 
+[Sources.AARCH64]
+  AARCH64/StackCheckFunctionsMsvc.asm | MSFT
+
 [Packages]
   MdePkg/MdePkg.dec
 


### PR DESCRIPTION
## Description

MSVC AARCH64 /GS support is untested. When it is enabled, the StackCheckLibNull does not satisfy the required externs required by the linker.

Adding support to StackCheckibNull for MSVC.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested
Compilation passes.

## Integration Instructions
No changes required