### PR TITLE
BaseTools\HostbasedUnittestRunner: Add support to exclude files from codecoverage. [RB & FF]

### DIFF
--- a/BaseTools/Plugin/HostBasedUnitTestRunner/HostBasedUnitTestRunner.py
+++ b/BaseTools/Plugin/HostBasedUnitTestRunner/HostBasedUnitTestRunner.py
@@ -12,7 +12,6 @@ import stat
 import xml.etree.ElementTree
 from edk2toolext.environment.plugintypes.uefi_build_plugin import IUefiBuildPlugin
 from edk2toolext import edk2_logging
-import edk2toollib.windows.locate_tools as locate_tools
 from edk2toolext.environment import shell_environment
 from edk2toollib.utility_functions import RunCmd
 from edk2toollib.utility_functions import GetHostInfo
@@ -293,13 +292,14 @@ class HostBasedUnitTestRunner(IUefiBuildPlugin):
         package = thebuilder.env.GetValue("CI_PACKAGE_NAME", "")
         file_out = package + "_coverage.xml"
         cov_file = os.path.join(buildOutputBase, file_out)
+        exclude = thebuilder.env.GetValue("CC_EXCLUDE", "*NULL*,*Null*,*null*")
 
         params = f"--database {db_path} coverage {cov_file} -o {cov_file} --by-package -ws {workspace}"
 
         params += f" -p {package}" * int(package != "")
         params += " --full" * int(thebuilder.env.GetValue("CC_FULL", "FALSE") == "TRUE")
         params += " --flatten" * int(thebuilder.env.GetValue("CC_FLATTEN", "FALSE") == "TRUE")
-
+        params += f" --exclude {exclude}" * int(exclude != "")
         return RunCmd("stuart_report", params)
 
     def parse_workspace(self, thebuilder) -> str:

--- a/BaseTools/Plugin/HostBasedUnitTestRunner/HostBasedUnitTestRunner.py
+++ b/BaseTools/Plugin/HostBasedUnitTestRunner/HostBasedUnitTestRunner.py
@@ -12,6 +12,7 @@ import stat
 import xml.etree.ElementTree
 from edk2toolext.environment.plugintypes.uefi_build_plugin import IUefiBuildPlugin
 from edk2toolext import edk2_logging
+import edk2toollib.windows.locate_tools as locate_tools
 from edk2toolext.environment import shell_environment
 from edk2toollib.utility_functions import RunCmd
 from edk2toollib.utility_functions import GetHostInfo
@@ -298,7 +299,7 @@ class HostBasedUnitTestRunner(IUefiBuildPlugin):
         params += f" -p {package}" * int(package != "")
         params += " --full" * int(thebuilder.env.GetValue("CC_FULL", "FALSE") == "TRUE")
         params += " --flatten" * int(thebuilder.env.GetValue("CC_FLATTEN", "FALSE") == "TRUE")
-        params += " --exclude *NULL*,*Null*,*null*"
+
         return RunCmd("stuart_report", params)
 
     def parse_workspace(self, thebuilder) -> str:

--- a/UnitTestFrameworkPkg/ReadMe.md
+++ b/UnitTestFrameworkPkg/ReadMe.md
@@ -1516,8 +1516,10 @@ or FALSE e.g. `CC_REORGANIZE=TRUE`:
 1. `CC_FULL`: Generates zero'd out coverage data for untested source files in the package.
    Default: `FALSE`
 1. `CC_FLATTEN`: Groups all source files together, rather than by INF. Default: `FALSE`
+1. `CC_EXCLUDE`: Comma separated list of fnmatch expressions to exclude from results.
+   Default: \*NULL\*,\*Null\*,\*null\*
 
-** NOTE: `CC_FULL` and `CC_FLATTEN` values only matter if `CC_REORGANIZE=TRUE`, as they only
+** NOTE: `CC_FULL` and `CC_FLATTEN` and `CC_EXCLUDE` values only matter if `CC_REORGANIZE=TRUE`, as they only
 effect how the coverage report is reorganized.
 
 **TIP: `CC_FLATTEN=TRUE/FALSE` will produce different coverage percentage results as `TRUE` de-duplicates source files


### PR DESCRIPTION
## Description

When Unit tests are run, the generated report includes null libraries in the calculation.
Modifying the organize_coverage to exclude null libraries from the code coverage results.
These changes only effect the case when CC_REORGANIZE is set to true in the project.

add CC_EXCLUDE option, which defaults to exclude files/libraries with Null in their name. Can be over-ridden by adding CC_EXCLUDE to comandline.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested
Ran on private repo which contained a lot of NULL libraries. Prior to change, Null libraries were included in the report, after the modification, they were not

Tested modifying CC_EXCLUDE on command line to verify that specific libraries/folders can be targeted by exclude statement.

## Integration Instructions
No changes required.
coverage report will look different if CC_REORGANIZE is set to True as NULL libraries will be excluded.
to restore to original functionality, specify CC_EXCLUDE= on the command line.