### PR TITLE
Update release drafter for dev branches

### DIFF
--- a/.github/release-draft-config-n-1-dev.yml
+++ b/.github/release-draft-config-n-1-dev.yml
@@ -22,7 +22,6 @@ tag-template: 'dev-v$RESOLVED_VERSION'
 
 commitish: refs/heads/dev/202311
 filter-by-commitish: true
-include-labels: ["type:backport"]
 
 template: |
   # What's Changed

--- a/.github/release-draft-config-n-dev.yml
+++ b/.github/release-draft-config-n-dev.yml
@@ -20,9 +20,8 @@
 name-template: 'dev-v$RESOLVED_VERSION'
 tag-template: 'dev-v$RESOLVED_VERSION'
 
-commitish: refs/heads/dev/202311
+commitish: refs/heads/dev/202405
 filter-by-commitish: true
-include-labels: ["type:backport"]
 
 template: |
   # What's Changed

--- a/.github/release-draft-config-n.yml
+++ b/.github/release-draft-config-n.yml
@@ -17,11 +17,12 @@
 # For more information, see:
 # https://github.com/release-drafter/release-drafter
 
-name-template: 'v$RESOLVED_VERSION'
-tag-template: 'v$RESOLVED_VERSION'
+name-template: 'dev-v$RESOLVED_VERSION'
+tag-template: 'dev-v$RESOLVED_VERSION'
 
-commitish: refs/heads/release/202405
+commitish: refs/heads/dev/202405
 filter-by-commitish: true
+include-labels: ["type:backport"]
 
 template: |
   # What's Changed

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -23,14 +23,17 @@ name: Update Release Draft
 on:
   push:
     branches:
-      - release/202405
+      - dev/202405
 
 jobs:
-  draft:
+  dev_draft:
+    name: Draft Releases
 
     permissions:
       contents: write
       pull-requests: write
 
-    uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@v12.2.0
+    # The "release_drafter_update_for_release_branches" branch is temporarily being used to test release
+    # drafter changes on that branch in Mu Basecore before merging them into the main branch.
+    uses: microsoft/mu_devops/.github/workflows/ReleaseDrafter.yml@release_drafter_update_for_release_branches
     secrets: inherit


### PR DESCRIPTION
## Description

This change is currently being prototyped in Mu Basecore.

Further changes may be made before syncing to other repos. During this time anyone making releases should pay careful attention to the versions and notes drafted and report any issues.

The `release-drafter` action takes some inputs by config file so a couple new config files are added. These originate from a single copy (template) of the file in mu_devops so we'd still only be maintaining one actual release drafter config file.

---

A release will be drafted for the dev branch and the release branch. The releases are differentiated by both their release title and tag.

- Release Branch
  - Title: `release-v<version>`
  - Tag: `v<version>`
- Dev Branch
  - Title: `dev-v<version>`
  - Tag: `dev-v<version>`

Note that the tag for the release branch follows the same convention as existing release tags.

The "release branch" release includes all pull requests made to the dev branch with the `type:backport` label since the last "dev branch" release. For this reason, the "dev branch" and "release branch" should be released at the same time. Then, this effectively results in the "release branch" having all relevant changes since the last release. The "dev branch" release will be based at the same point in history as the "release branch" release but include all changes not just those with the `type:backport` label.

The "release branch" release for the current release branch should be marked as "latest". For example, if "release/202311" and "release/202405" exist, the "release/202405" "release branch" release should be marked as latest when making the release.

When making releases, the "dev branch" release should be made first and then the "release branch" release.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

- Generate "dev branch" and "release branch" on fork with various combinations of changes.

## Integration Instructions

N/A