### PR TITLE
[CHERRY-PICK] Create memory bin override library to allow for more extensive platform customization

### DIFF
--- a/MdeModulePkg/Core/Dxe/DxeMain.inf
+++ b/MdeModulePkg/Core/Dxe/DxeMain.inf
@@ -99,6 +99,7 @@
   ImagePropertiesRecordLib
   DxeMemoryProtectionHobLib ## MU_CHANGE
   SafeIntLib                ## MU_CHANGE
+  MemoryBinOverrideLib      ## MU_CHANGE
 
 [Guids]
   gEfiEventMemoryMapChangeGuid                  ## PRODUCES             ## Event

--- a/MdeModulePkg/Core/Dxe/Mem/Page.c
+++ b/MdeModulePkg/Core/Dxe/Mem/Page.c
@@ -10,6 +10,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include "Imem.h"
 #include "HeapGuard.h"
 #include <Pi/PiDxeCis.h>
+#include <Library/MemoryBinOverrideLib.h> // MU_CHANGE
 
 //
 // Entry for tracking the memory regions for each memory type to coalesce similar memory types
@@ -681,6 +682,7 @@ CoreAddMemoryDescriptor (
   EFI_STATUS            Status;
   UINTN                 Index;
   UINTN                 FreeIndex;
+  EFI_ALLOCATE_TYPE     AllocationType; // MU_CHANGE
 
   if ((Start & EFI_PAGE_MASK) != 0) {
     return;
@@ -730,16 +732,29 @@ CoreAddMemoryDescriptor (
     }
 
     if (gMemoryTypeInformation[Index].NumberOfPages != 0) {
+      // MU_CHANGE START Allow overriding of bin locations.
+      AllocationType = AllocateAnyPages;
+      GetMemoryBinOverride (
+        Type,
+        &mMemoryTypeStatistics[Type].BaseAddress,
+        &gMemoryTypeInformation[Index].NumberOfPages,
+        &AllocationType
+        );
+      // MU_CHANGE END
+
       //
       // Allocate pages for the current memory type from the top of available memory
       //
+
       Status = CoreAllocatePages (
-                 AllocateAnyPages,
+                 AllocationType, // MU_CHANGE
                  Type,
                  gMemoryTypeInformation[Index].NumberOfPages,
                  &mMemoryTypeStatistics[Type].BaseAddress
                  );
       if (EFI_ERROR (Status)) {
+        mMemoryTypeStatistics[Type].BaseAddress = 0; // MU_CHANGE
+
         //
         // If an error occurs allocating the pages for the current memory type, then
         // free all the pages allocates for the previous memory types and return.  This
@@ -806,6 +821,15 @@ CoreAddMemoryDescriptor (
       mMemoryTypeStatistics[Type].NumberOfPages   = gMemoryTypeInformation[Index].NumberOfPages;
       gMemoryTypeInformation[Index].NumberOfPages = 0;
     }
+
+    // MU_CHANGE START
+    ReportMemoryBinLocation (
+      Type,
+      mMemoryTypeStatistics[Type].BaseAddress,
+      mMemoryTypeStatistics[Type].NumberOfPages
+      );
+
+    // MU_CHANGE END
   }
 
   //

--- a/MdeModulePkg/Include/Library/MemoryBinOverrideLib.h
+++ b/MdeModulePkg/Include/Library/MemoryBinOverrideLib.h
@@ -1,0 +1,48 @@
+/** @file
+  Header definitions for the memory bin override library. This library allows
+  a platform to override the location or size of the memory type bins.
+
+  Copyright (c) Microsoft Corporation
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef MEMORY_BIN_OVERRIDE_LIB_H__
+#define MEMORY_BIN_OVERRIDE_LIB_H__
+
+/**
+  Reports a runtime memory bin location to the override library.
+
+  @param[in]  Type            The memory type for the reported bin.
+  @param[in]  BaseAddress     The base physical address of the reported bin.
+  @param[in]  NumberOfPages   The number of pages in the reported bin.
+**/
+VOID
+EFIAPI
+ReportMemoryBinLocation (
+  IN EFI_MEMORY_TYPE       Type,
+  IN EFI_PHYSICAL_ADDRESS  BaseAddress,
+  IN UINT64                NumberOfPages
+  );
+
+/**
+  Checks if the library needs to override the given memory bin allocation type,
+  location, and size. If this function encounters internal errors, the
+  parameters should remain unchanged.
+
+  @param[in]    Type            The memory type of the bin.
+  @param[out]   BaseAddress     The base address of the bin override on return.
+  @param[out]   NumberOfPages   The number of pages of the bin override on return.
+  @param[out]   AllocationType  The allocation type for the bin, AllocateAddress
+                                if an override was provided.
+**/
+VOID
+EFIAPI
+GetMemoryBinOverride (
+  IN EFI_MEMORY_TYPE        Type,
+  OUT EFI_PHYSICAL_ADDRESS  *BaseAddress,
+  OUT UINT32                *NumberOfPages,
+  OUT EFI_ALLOCATE_TYPE     *AllocationType
+  );
+
+#endif

--- a/MdeModulePkg/Library/MemoryBinOverrideLibNull/MemoryBinOverrideLibNull.c
+++ b/MdeModulePkg/Library/MemoryBinOverrideLibNull/MemoryBinOverrideLibNull.c
@@ -1,0 +1,52 @@
+/**
+  NULL implementation of the memory bin override lib.
+
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <Uefi.h>
+#include <Library/BaseLib.h>
+#include <Library/MemoryBinOverrideLib.h>
+
+/**
+  Reports a runtime memory bin location to the override library.
+
+  @param[in]  Type            The memory type for the reported bin.
+  @param[in]  BaseAddress     The base physical address of the reported bin.
+  @param[in]  NumberOfPages   The number of pages in the reported bin.
+**/
+VOID
+EFIAPI
+ReportMemoryBinLocation (
+  IN EFI_MEMORY_TYPE       Type,
+  IN EFI_PHYSICAL_ADDRESS  BaseAddress,
+  IN UINT64                NumberOfPages
+  )
+{
+  return;
+}
+
+/**
+  Checks if the library needs to override the given memory bin allocation type,
+  location, and size. If this function encounters internal errors, the
+  parameters should remain unchanged.
+
+  @param[in]    Type            The memory type of the bin.
+  @param[out]   BaseAddress     The base address of the bin override on return.
+  @param[out]   NumberOfPages   The number of pages of the bin override on return.
+  @param[out]   AllocationType  The allocation type for the bin, AllocateAddress
+                                if an override was provided.
+**/
+VOID
+EFIAPI
+GetMemoryBinOverride (
+  IN EFI_MEMORY_TYPE        Type,
+  OUT EFI_PHYSICAL_ADDRESS  *BaseAddress,
+  OUT UINT32                *NumberOfPages,
+  OUT EFI_ALLOCATE_TYPE     *AllocationType
+  )
+{
+  return;
+}

--- a/MdeModulePkg/Library/MemoryBinOverrideLibNull/MemoryBinOverrideLibNull.inf
+++ b/MdeModulePkg/Library/MemoryBinOverrideLibNull/MemoryBinOverrideLibNull.inf
@@ -1,0 +1,31 @@
+## @file
+# NULL implementation of the memory bin override lib.
+#
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 1.27
+  BASE_NAME                      = MemoryOverrideLibNull
+  FILE_GUID                      = 368687CE-3189-4C26-A6EB-615B64CAA911
+  MODULE_TYPE                    = DXE_CORE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = MemoryBinOverrideLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 AARCH64
+#
+
+[Sources]
+  MemoryBinOverrideLibNull.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[LibraryClasses]
+  BaseLib

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -232,6 +232,12 @@
   #
   MmMemoryProtectionHobLib|Include/Library/MmMemoryProtectionHobLib.h
 
+  # MU_CHANGE - Add MemoryBinOverrideLib to MdeModulePkg
+  ## @libraryclass Provides a way to override memory bin locations and sizes
+  #                dynamically.
+  #
+  MemoryBinOverrideLib|Include/Library/MemoryBinOverrideLib.h
+
 [Guids]
   ## MdeModule package token space guid
   # Include/Guid/MdeModulePkgTokenSpace.h

--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -152,6 +152,7 @@
   HobLib|MdePkg/Library/DxeCoreHobLib/DxeCoreHobLib.inf
   MemoryAllocationLib|MdeModulePkg/Library/DxeCoreMemoryAllocationLib/DxeCoreMemoryAllocationLib.inf
   ExtractGuidedSectionLib|MdePkg/Library/DxeExtractGuidedSectionLib/DxeExtractGuidedSectionLib.inf
+  MemoryBinOverrideLib|MdeModulePkg/Library/MemoryBinOverrideLibNull/MemoryBinOverrideLibNull.inf  # MU_CHANGE
 
 [LibraryClasses.common.DXE_DRIVER]
   HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
@@ -514,6 +515,7 @@
   MdeModulePkg/Library/BaseVariableFlashInfoLib/BaseVariableFlashInfoLib.inf
   MdeModulePkg/Library/PcdDatabaseLoaderLib/Pei/PcdDatabaseLoaderLibPei.inf   # MU_CHANGE
   MdeModulePkg/Library/PcdDatabaseLoaderLib/Dxe/PcdDatabaseLoaderLibDxe.inf   # MU_CHANGE
+  MdeModulePkg/Library/MemoryBinOverrideLibNull/MemoryBinOverrideLibNull.inf  # MU_CHANGE
 
 # MU_CHANGE START
 !if $(TOOLCHAIN) != VS2017 and $(TOOLCHAIN) != VS2019


### PR DESCRIPTION
## Description

Cherry-picks the change from this original PR that was dropped in the 2405 rebase. 

https://github.com/microsoft/mu_basecore/pull/194


- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Cherry pick from existing change.

## Integration Instructions

Add the new NULL version of the library to the platform DSC file

`MemoryBinOverrideLib|MdeModulePkg/Library/MemoryBinOverrideLibNull/MemoryBinOverrideLibNull.inf`