### PR TITLE
[Cherry-Pick] MdePkg/SmBios.h: Add new Socket Type for SMBIOS Type4

### DIFF
--- a/MdePkg/Include/IndustryStandard/SmBios.h
+++ b/MdePkg/Include/IndustryStandard/SmBios.h
@@ -1020,6 +1020,10 @@ typedef struct {
   // Add for smbios 3.6
   //
   UINT16                 ThreadEnabled;
+  //
+  // Add for smbios 3.8
+  //
+  SMBIOS_TABLE_STRING    SocketType;
 } SMBIOS_TABLE_TYPE4;
 
 ///


### PR DESCRIPTION
The patch adds new socket type(Type 4, Offset 32h) for SMBIOS Type4 based on SMBIOS v3.8.0.

## Description

The patch adds new socket type(Type 4, Offset 32h) for SMBIOS Type4 based on SMBIOS v3.8.0.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Build and boot on Intel platforms to make sure no errors or boot hang issue happens.

## Integration Instructions

N/A
