### PR TITLE
[Rebase & FF][FF-A] Supporting full 18 registers through DIRECT_REQ2 for Standalone MM

### DIFF
--- a/StandaloneMmPkg/Include/Library/Arm/StandaloneMmCoreEntryPoint.h
+++ b/StandaloneMmPkg/Include/Library/Arm/StandaloneMmCoreEntryPoint.h
@@ -23,8 +23,10 @@
 #ifndef __STANDALONEMMCORE_ENTRY_POINT_H__
 #define __STANDALONEMMCORE_ENTRY_POINT_H__
 
+#include <Library/PcdLib.h>
 #include <Library/ArmSvcLib.h>
 #include <Library/ArmFfaLib.h>
+#include <Library/ArmFfaLibEx.h>
 #include <Library/PeCoffLib.h>
 #include <Library/FvLib.h>
 
@@ -136,13 +138,13 @@ typedef struct FfaMsgInfo {
  */
 typedef struct {
   /// Service guid
-  EFI_GUID           HeaderGuid;
+  EFI_GUID              HeaderGuid;
 
   /// Length of Message. In case of misc service, sizeof (EventSvcArgs)
-  UINTN              MessageLength;
+  UINTN                 MessageLength;
 
   /// Delivered register values.
-  DIRECT_MSG_ARGS    DirectMsgArgs;
+  DIRECT_MSG_ARGS_EX    DirectMsgArgs;
 } MISC_MM_COMMUNICATE_BUFFER;
 
 typedef struct {

--- a/StandaloneMmPkg/Library/StandaloneMmCoreEntryPoint/StandaloneMmCoreEntryPoint.inf
+++ b/StandaloneMmPkg/Library/StandaloneMmCoreEntryPoint/StandaloneMmCoreEntryPoint.inf
@@ -57,7 +57,6 @@
 #   ArmTransferListLib
 #   ArmFfaLib
 # MU_CHANGE [END] - Remove ARM from this lib, since it requires too much from ArmPkg.
-  ArmTransferListLib
 
 [Guids]
   gMpInformationHobGuid

--- a/StandaloneMmPkg/StandaloneMmPkg.dsc
+++ b/StandaloneMmPkg/StandaloneMmPkg.dsc
@@ -74,9 +74,9 @@
   # ArmSmcLib|ArmPkg/Library/ArmSmcLib/ArmSmcLib.inf
   # ArmSvcLib|ArmPkg/Library/ArmSvcLib/ArmSvcLib.inf
   # CacheMaintenanceLib|ArmPkg/Library/ArmCacheMaintenanceLib/ArmCacheMaintenanceLib.inf
+  # ArmTransferListLib|ArmPkg/Library/ArmTransferListLib/ArmTransferListLib.inf
   # MU_CHANGE [END]: Remove ArmPkg Dependencies
   PeCoffExtraActionLib|StandaloneMmPkg/Library/StandaloneMmPeCoffExtraActionLib/StandaloneMmPeCoffExtraActionLib.inf
-  ArmTransferListLib|ArmPkg/Library/ArmTransferListLib/ArmTransferListLib.inf
 
 # MU_CHANGE [BEGIN]
   #NULL|ArmPkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
@@ -89,8 +89,10 @@
   # MU_CHANGE: Added core instance of MmServicesTableLib
   MmServicesTableLib|StandaloneMmPkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLibCore.inf
 
-[LibraryClasses.AARCH64.MM_CORE_STANDALONE, LibraryClasses.ARM.MM_CORE_STANDALONE]
-  ArmFfaLib|ArmPkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf
+# MU_CHANGE [BEGIN]
+# [LibraryClasses.AARCH64.MM_CORE_STANDALONE, LibraryClasses.ARM.MM_CORE_STANDALONE]
+#   ArmFfaLib|ArmPkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf
+# MU_CHANGE [END]
 
 [LibraryClasses.common.MM_STANDALONE]
   MemoryAllocationLib|StandaloneMmPkg/Library/StandaloneMmMemoryAllocationLib/StandaloneMmMemoryAllocationLib.inf


### PR DESCRIPTION
## Description

The existing solution for Standalone MM over FF-A does not support full 18-register communication over FF-A.

This change updated the Standalone MM core to dispatch content with full 18 registers.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

This was tested on QEMU SBSA.

## Integration Instructions

N/A
