### PR TITLE
Mock Functions for MmReportStatusCodeHandler

### DIFF
--- a/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockMmReportStatusCodeHandler.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockMmReportStatusCodeHandler.h
@@ -1,0 +1,50 @@
+/** @file MockMmReportStatusCodeHandler.h
+  This file declares a mock of Standalone MM Report Status Code Handler Protocol.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_MM_REPORT_STATUS_CODE_HANDLER_PROTOCOL_H
+#define MOCK_MM_REPORT_STATUS_CODE_HANDLER_PROTOCOL_H
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Library/ReportStatusCodeLib.h>
+  #include <Protocol/MmReportStatusCodeHandler.h>
+}
+
+struct MockReportStatusCodeHandler {
+  MOCK_INTERFACE_DECLARATION (MockReportStatusCodeHandler);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    Register,
+    (
+     IN EFI_MM_RSC_HANDLER_CALLBACK   Callback)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    Unregister,
+    (IN EFI_MM_RSC_HANDLER_CALLBACK Callback)
+    );
+};
+
+MOCK_INTERFACE_DEFINITION (MockReportStatusCodeHandler);
+MOCK_FUNCTION_DEFINITION (MockReportStatusCodeHandler, Register, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockReportStatusCodeHandler, Unregister, 1, EFIAPI);
+
+EFI_MM_RSC_HANDLER_PROTOCOL  MmRscHandlerProtocol = {
+  Register,
+  Unregister
+};
+
+extern "C" {
+  EFI_MM_RSC_HANDLER_PROTOCOL  *MmRscHandlerProtocolServices = &MmRscHandlerProtocol;
+}
+
+#endif

--- a/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockMmReportStatusCodeHandler.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockMmReportStatusCodeHandler.h
@@ -17,8 +17,8 @@ extern "C" {
   #include <Protocol/MmReportStatusCodeHandler.h>
 }
 
-struct MockReportStatusCodeHandler {
-  MOCK_INTERFACE_DECLARATION (MockReportStatusCodeHandler);
+struct MockEfiMmRscHandlerProtocol {
+  MOCK_INTERFACE_DECLARATION (MockEfiMmRscHandlerProtocol);
 
   MOCK_FUNCTION_DECLARATION (
     EFI_STATUS,
@@ -34,17 +34,14 @@ struct MockReportStatusCodeHandler {
     );
 };
 
-MOCK_INTERFACE_DEFINITION (MockReportStatusCodeHandler);
-MOCK_FUNCTION_DEFINITION (MockReportStatusCodeHandler, Register, 1, EFIAPI);
-MOCK_FUNCTION_DEFINITION (MockReportStatusCodeHandler, Unregister, 1, EFIAPI);
+MOCK_INTERFACE_DEFINITION (MockEfiMmRscHandlerProtocol);
+MOCK_FUNCTION_DEFINITION (MockEfiMmRscHandlerProtocol, Register, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockEfiMmRscHandlerProtocol, Unregister, 1, EFIAPI);
 
-EFI_MM_RSC_HANDLER_PROTOCOL  MmRscHandlerProtocol = {
-  Register,
-  Unregister
-};
-
-extern "C" {
-  EFI_MM_RSC_HANDLER_PROTOCOL  *MmRscHandlerProtocolServices = &MmRscHandlerProtocol;
-}
+#define MOCK_EFI_MM_RSC_HANDLER_PROTOCOL_INSTANCE(NAME) \
+  EFI_MM_RSC_HANDLER_PROTOCOL NAME##_INSTANCE = {       \
+    Register,                                           \
+    Unregister };                                       \
+  EFI_MM_RSC_HANDLER_PROTOCOL  *NAME = &NAME##_INSTANCE;
 
 #endif


### PR DESCRIPTION
## Description

Added Mock Functions for MmReportStatusCodeHandler

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [X] Backport to release branch?

## How This Was Tested

Unit tests component can call these mock functions success

## Integration Instructions

N/A
