### PR TITLE
[CHERRY-PICK] MdePkg/SmBios.h: Add new Processor Upgrade definition for SMBIOS Type4 and Updated Type 4 Info as per Smbios 3.8.0

### DIFF
--- a/MdePkg/Include/IndustryStandard/SmBios.h
+++ b/MdePkg/Include/IndustryStandard/SmBios.h
@@ -887,7 +887,8 @@ typedef enum {
   ProcessorUpgradeSocketBGA2551   = 0x54,
   ProcessorUpgradeSocketLGA1851   = 0x55,
   ProcessorUpgradeSocketBGA2114   = 0x56,
-  ProcessorUpgradeSocketBGA2833   = 0x57
+  ProcessorUpgradeSocketBGA2833   = 0x57,
+  ProcessorUpgradeInvalid         = 0xFF
 } PROCESSOR_UPGRADE;
 
 ///

--- a/MdePkg/Include/IndustryStandard/SmBios.h
+++ b/MdePkg/Include/IndustryStandard/SmBios.h
@@ -706,6 +706,7 @@ typedef enum {
   ProcessorFamilyIntelCoreI5                     = 0xCD,
   ProcessorFamilyIntelCoreI3                     = 0xCE,
   ProcessorFamilyIntelCoreI9                     = 0xCF,
+  ProcessorFamilyIntelXeonD                      = 0xD0,  /// Smbios spec 3.8 updated this value
   ProcessorFamilyViaC7M                          = 0xD2,
   ProcessorFamilyViaC7D                          = 0xD3,
   ProcessorFamilyViaC7                           = 0xD4,


### PR DESCRIPTION
## Description

Cherry-picked the following SMBIOS commits from EDK2 for newer platforms that require them.

https://github.com/tianocore/edk2/commit/aebe9625c915c71c420d8ce6b15923dc01385436
https://github.com/tianocore/edk2/commit/9dc7fb819c87830bc0eb1081a21c194888a9ad67

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

N/A

## Integration Instructions

N/A