### PR TITLE
[SQUASH ON REBASE] Remove Windows ARM BaseTools Build

### DIFF
--- a/.azurepipelines/BaseTools-Build-For-Publication.yml
+++ b/.azurepipelines/BaseTools-Build-For-Publication.yml
@@ -87,9 +87,6 @@ jobs:
         TARGET_x86:
           Build.Targets: 'IA32'
           Build.TargetFolder: 'Win32'
-        TARGET_ARM:
-          Build.Targets: 'ARM'
-          Build.TargetFolder: 'Win32'
         TARGET_AArch64:
           Build.Targets: 'AARCH64'
           Build.TargetFolder: 'Win64'
@@ -192,7 +189,6 @@ jobs:
         mv $(Pipeline.Workspace)/$(linux_artifact_name)_X64 $(Build.StagingDirectory)/$(temp_publication_directory)/Linux-x86;
         mv $(Pipeline.Workspace)/$(linux_artifact_name)_AARCH64 $(Build.StagingDirectory)/$(temp_publication_directory)/Linux-ARM-64;
         mv $(Pipeline.Workspace)/$(windows_artifact_name)_IA32 $(Build.StagingDirectory)/$(temp_publication_directory)/Windows-x86;
-        mv $(Pipeline.Workspace)/$(windows_artifact_name)_ARM $(Build.StagingDirectory)/$(temp_publication_directory)/Windows-ARM;
         mv $(Pipeline.Workspace)/$(windows_artifact_name)_AARCH64 $(Build.StagingDirectory)/$(temp_publication_directory)/Windows-ARM-64;
       displayName: Stage Package Files
 


### PR DESCRIPTION
## Description

The Windows ARM BaseTools build is not used any longer, it used to work on Windows ARM64, but that support is not there anymore. Windows ARM64 is built for BaseTools instead and there are no current Windows ARM hosts, nor likely ever to be any more. The Windows ARM pipeline is also failing due to a change in VS, so this fixes a pipeline break.

This can be squashed with the original commit adding CI (or the commit adding these BaseTools builds, if separate).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Dropping pipeline.

## Integration Instructions

This is listed as a breaking change because a formerly published package is no longer published, but this package is not used by any consumer, so it is safe to backport to the release branch. It will fix the same pipeline error there.