### PR TITLE
[SQUASH ON REBASE] Remove Windows ARM BaseTools Build

### DIFF
--- a/.github/workflows/release-basetools.yml
+++ b/.github/workflows/release-basetools.yml
@@ -31,11 +31,6 @@ jobs:
 
           - os: windows-2022
             tool_chain: VS2022
-            output_dir: "BaseTools\\Bin\\Win32"
-            target: ARM
-
-          - os: windows-2022
-            tool_chain: VS2022
             output_dir: "BaseTools\\Bin\\Win64"
             target: AARCH64
 
@@ -121,7 +116,6 @@ jobs:
           mv ${{ runner.temp }}/artifacts/basetools-GCC5-AARCH64   ${{ runner.temp }}/basetools/Linux-ARM-64 ;
           chmod a+x ${{ runner.temp }}/basetools/Linux-ARM-64/* ;
           mv ${{ runner.temp }}/artifacts/basetools-VS2022-IA32    ${{ runner.temp }}/basetools/Windows-x86 ;
-          mv ${{ runner.temp }}/artifacts/basetools-VS2022-ARM     ${{ runner.temp }}/basetools/Windows-ARM ;
           mv ${{ runner.temp }}/artifacts/basetools-VS2022-AARCH64 ${{ runner.temp }}/basetools/Windows-ARM-64 ;
 
       - name: Package Files


### PR DESCRIPTION
## Description

The Windows ARM BaseTools build is not used any longer, it used to work on Windows ARM64, but that support is not there anymore. Windows ARM64 is built for BaseTools instead and there are no current Windows ARM hosts, nor likely ever to be any more.

This commit removes the GitHub workflow, which was not removed in the first commit removing the publishing flow.

This can be squashed with the original commit adding CI (or the commit adding these BaseTool builds, if separate).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Workflow change.

## Integration Instructions

N/A.