### PR TITLE
Update shared crypto to v1.0.0

### DIFF
--- a/CryptoPkg/Binaries/BaseCryptoDriver_ext_dep.json
+++ b/CryptoPkg/Binaries/BaseCryptoDriver_ext_dep.json
@@ -3,7 +3,7 @@
   "type": "nuget",
   "name": "edk2-basecrypto-driver-bin",
   "source": "https://pkgs.dev.azure.com/projectmu/mu/_packaging/Mu-Public/nuget/v3/index.json",
-  "version": "2023.12.2",
+  "version": "1.0.0",
   "flags": ["set_build_var"],
   "var_name": "BLD_*_SHARED_CRYPTO_PATH"
 }


### PR DESCRIPTION
## Description

#### Major Changes:

- Note: Shared Crypto now follows straightforward [semantic versioning](https://semver.org/). The version number is incremented based on the type of changes made to the shared crypto binaries. The version number is not tied to the version of the underlying crypto provider.

- Note: Prior to adopting semantic versioning in the `1.0.0` release, the version number followed a form of `YYYY.MM.PATCH`. The `1.0.0` release was the first to use semantic versioning and proceeds any of those versions.

---

See https://github.com/microsoft/mu_crypto_release/releases/tag/v1.0.0 for the detailed set of changes.

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

- Use shared crypto ext dep on a platform already using it
- Integration on a X64 MM Supervisor Standalone MM platform
- Integration on a X64 non-MM Supervisor Standalone MM platform

## Integration Instructions

#### Breaking Change - Standalone MM Integration

Two options are now provided for Standalone MM. **It is important to select the option based on the Standalone MM core used on your platform**:

- [StandaloneMmPkg](https://github.com/tianocore/edk2/tree/master/StandaloneMmPkg/Core)
  - Use `STANDALONEMM_CRYPTO_SERVICES`
- [MmSupervisorPkg](https://github.com/microsoft/mu_feature_mm_supv/tree/main/MmSupervisorPkg/Core)
  - Use `STANDALONEMM_MMSUPV_CRYPTO_SERVICES`

Since the MM Supervisor currently does not support `AARCH64`, only a `X64` MM Supervisor Standalone MM binary is available. A platform should not have both `STANDALONEMM_CRYPTO_SERVICES` and `STANDALONEMM_MMSUPV_CRYPTO_SERVICES` set to non-`NONE` values.