### PR TITLE
Added MockHiiLib, MockShellLib, MockHiiDatabase protocol

### DIFF
--- a/MdeModulePkg/Test/MdeModulePkgHostTest.dsc
+++ b/MdeModulePkg/Test/MdeModulePkgHostTest.dsc
@@ -119,3 +119,4 @@
   MdeModulePkg/Test/Mock/Library/GoogleTest/MockUefiBootManagerLib/MockUefiBootManagerLib.inf
   MdeModulePkg/Test/Mock/Library/GoogleTest/MockPlatformHookLib/MockPlatformHookLib.inf
   MdeModulePkg/Test/Mock/Library/GoogleTest/MockVariablePolicyHelperLib/MockVariablePolicyHelperLib.inf
+  MdeModulePkg/Test/Mock/Library/GoogleTest/MockHiiLib/MockHiiLib.inf

--- a/MdeModulePkg/Test/Mock/Include/GoogleTest/Library/MockHiiLib.h
+++ b/MdeModulePkg/Test/Mock/Include/GoogleTest/Library/MockHiiLib.h
@@ -1,4 +1,4 @@
-/** @file
+/** @file MockHiiLib.h
   Google Test mocks for HiiLib
 
   Copyright (c) Microsoft Corporation.

--- a/MdeModulePkg/Test/Mock/Include/GoogleTest/Library/MockHiiLib.h
+++ b/MdeModulePkg/Test/Mock/Include/GoogleTest/Library/MockHiiLib.h
@@ -1,0 +1,360 @@
+/** @file
+  Google Test mocks for HiiLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_HII_LIB_H_
+#define MOCK_HII_LIB_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+extern "C" {
+  #include <PiPei.h>
+  #include <PiDxe.h>
+  #include <PiSmm.h>
+  #include <PiMm.h>
+  #include <Uefi.h>
+  #include <Library/HiiLib.h>
+}
+
+struct MockHiiLib {
+  MOCK_INTERFACE_DECLARATION (MockHiiLib);
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    HiiRemovePackages,
+    (IN EFI_HII_HANDLE  HiiHandle)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STRING_ID,
+    HiiSetString,
+    (IN       EFI_HII_HANDLE  HiiHandle,
+     IN       EFI_STRING_ID   StringId OPTIONAL,
+     IN CONST EFI_STRING      String,
+     IN CONST CHAR8           *SupportedLanguages OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STRING,
+    HiiGetString,
+    (IN       EFI_HII_HANDLE  HiiHandle,
+     IN       EFI_STRING_ID   StringId,
+     IN CONST CHAR8           *Language OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STRING,
+    HiiGetStringEx,
+    (IN       EFI_HII_HANDLE  HiiHandle,
+     IN       EFI_STRING_ID   StringId,
+     IN CONST CHAR8           *Language OPTIONAL,
+     IN       BOOLEAN         TryBestLanguage)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STRING,
+    HiiGetPackageString,
+    (IN CONST EFI_GUID       *PackageListGuid,
+     IN       EFI_STRING_ID  StringId,
+     IN CONST CHAR8          *Language OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_HII_HANDLE *,
+    HiiGetHiiHandles,
+    (IN CONST EFI_GUID  *PackageListGuid OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    HiiGetFormSetFromHiiHandle,
+    (IN  EFI_HII_HANDLE    Handle,
+     OUT EFI_IFR_FORM_SET  **Buffer,
+     OUT UINTN             *BufferSize)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    CHAR8 *,
+    HiiGetSupportedLanguages,
+    (IN EFI_HII_HANDLE  HiiHandle)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STRING,
+    HiiConstructConfigHdr,
+    (IN CONST EFI_GUID    *Guid OPTIONAL,
+     IN CONST CHAR16      *Name OPTIONAL,
+     IN       EFI_HANDLE  DriverHandle)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    HiiSetToDefaults,
+    (IN CONST EFI_STRING  Request OPTIONAL,
+     IN       UINT16      DefaultId)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    HiiValidateSettings,
+    (IN CONST EFI_STRING  Request OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    HiiIsConfigHdrMatch,
+    (IN CONST EFI_STRING  ConfigHdr,
+     IN CONST EFI_GUID    *Guid OPTIONAL,
+     IN CONST CHAR16      *Name OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    HiiGetBrowserData,
+    (IN CONST EFI_GUID  *VariableGuid OPTIONAL,
+     IN CONST CHAR16    *VariableName OPTIONAL,
+     IN       UINTN     BufferSize,
+     OUT      UINT8     *Buffer)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    HiiSetBrowserData,
+    (IN CONST EFI_GUID  *VariableGuid OPTIONAL,
+     IN CONST CHAR16    *VariableName OPTIONAL,
+     IN       UINTN     BufferSize,
+     IN CONST UINT8     *Buffer,
+     IN CONST CHAR16    *RequestElement OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    HiiAllocateOpCodeHandle,
+    ()
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    HiiFreeOpCodeHandle,
+    (VOID  *OpCodeHandle)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT8 *,
+    HiiCreateRawOpCodes,
+    (IN VOID   *OpCodeHandle,
+     IN UINT8  *RawBuffer,
+     IN UINTN  RawBufferSize)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT8 *,
+    HiiCreateEndOpCode,
+    (IN VOID  *OpCodeHandle)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT8 *,
+    HiiCreateOneOfOptionOpCode,
+    (IN VOID    *OpCodeHandle,
+     IN UINT16  StringId,
+     IN UINT8   Flags,
+     IN UINT8   Type,
+     IN UINT64  Value)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT8 *,
+    HiiCreateDefaultOpCode,
+    (IN VOID    *OpCodeHandle,
+     IN UINT16  DefaultId,
+     IN UINT8   Type,
+     IN UINT64  Value)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT8 *,
+    HiiCreateGuidOpCode,
+    (IN       VOID      *OpCodeHandle,
+     IN CONST EFI_GUID  *Guid,
+     IN CONST VOID      *GuidOpCode OPTIONAL,
+     IN       UINTN     OpCodeSize)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT8 *,
+    HiiCreateActionOpCode,
+    (IN VOID             *OpCodeHandle,
+     IN EFI_QUESTION_ID  QuestionId,
+     IN EFI_STRING_ID    Prompt,
+     IN EFI_STRING_ID    Help,
+     IN UINT8            QuestionFlags,
+     IN EFI_STRING_ID    QuestionConfig)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT8 *,
+    HiiCreateSubTitleOpCode,
+    (IN VOID           *OpCodeHandle,
+     IN EFI_STRING_ID  Prompt,
+     IN EFI_STRING_ID  Help,
+     IN UINT8          Flags,
+     IN UINT8          Scope)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT8 *,
+    HiiCreateGotoOpCode,
+    (IN VOID             *OpCodeHandle,
+     IN EFI_FORM_ID      FormId,
+     IN EFI_STRING_ID    Prompt,
+     IN EFI_STRING_ID    Help,
+     IN UINT8            QuestionFlags,
+     IN EFI_QUESTION_ID  QuestionId)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT8 *,
+    HiiCreateGotoExOpCode,
+    (IN VOID             *OpCodeHandle,
+     IN EFI_FORM_ID      RefFormId,
+     IN EFI_STRING_ID    Prompt,
+     IN EFI_STRING_ID    Help,
+     IN UINT8            QuestionFlags,
+     IN EFI_QUESTION_ID  QuestionId,
+     IN EFI_QUESTION_ID  RefQuestionId,
+     IN EFI_GUID         *RefFormSetId OPTIONAL,
+     IN EFI_STRING_ID    RefDevicePath)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT8 *,
+    HiiCreateCheckBoxOpCode,
+    (IN VOID             *OpCodeHandle,
+     IN EFI_QUESTION_ID  QuestionId,
+     IN EFI_VARSTORE_ID  VarStoreId,
+     IN UINT16           VarOffset,
+     IN EFI_STRING_ID    Prompt,
+     IN EFI_STRING_ID    Help,
+     IN UINT8            QuestionFlags,
+     IN UINT8            CheckBoxFlags,
+     IN VOID             *DefaultsOpCodeHandle OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT8 *,
+    HiiCreateNumericOpCode,
+    (IN VOID             *OpCodeHandle,
+     IN EFI_QUESTION_ID  QuestionId,
+     IN EFI_VARSTORE_ID  VarStoreId,
+     IN UINT16           VarOffset,
+     IN EFI_STRING_ID    Prompt,
+     IN EFI_STRING_ID    Help,
+     IN UINT8            QuestionFlags,
+     IN UINT8            NumericFlags,
+     IN UINT64           Minimum,
+     IN UINT64           Maximum,
+     IN UINT64           Step,
+     IN VOID             *DefaultsOpCodeHandle OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT8 *,
+    HiiCreateStringOpCode,
+    (IN VOID             *OpCodeHandle,
+     IN EFI_QUESTION_ID  QuestionId,
+     IN EFI_VARSTORE_ID  VarStoreId,
+     IN UINT16           VarOffset,
+     IN EFI_STRING_ID    Prompt,
+     IN EFI_STRING_ID    Help,
+     IN UINT8            QuestionFlags,
+     IN UINT8            StringFlags,
+     IN UINT8            MinSize,
+     IN UINT8            MaxSize,
+     IN VOID             *DefaultsOpCodeHandle OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT8 *,
+    HiiCreateOneOfOpCode,
+    (IN VOID             *OpCodeHandle,
+     IN EFI_QUESTION_ID  QuestionId,
+     IN EFI_VARSTORE_ID  VarStoreId,
+     IN UINT16           VarOffset,
+     IN EFI_STRING_ID    Prompt,
+     IN EFI_STRING_ID    Help,
+     IN UINT8            QuestionFlags,
+     IN UINT8            OneOfFlags,
+     IN VOID             *OptionsOpCodeHandle,
+     IN VOID             *DefaultsOpCodeHandle OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT8 *,
+    HiiCreateOrderedListOpCode,
+    (IN VOID             *OpCodeHandle,
+     IN EFI_QUESTION_ID  QuestionId,
+     IN EFI_VARSTORE_ID  VarStoreId,
+     IN UINT16           VarOffset,
+     IN EFI_STRING_ID    Prompt,
+     IN EFI_STRING_ID    Help,
+     IN UINT8            QuestionFlags,
+     IN UINT8            OrderedListFlags,
+     IN UINT8            DataType,
+     IN UINT8            MaxContainers,
+     IN VOID             *OptionsOpCodeHandle,
+     IN VOID             *DefaultsOpCodeHandle OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT8 *,
+    HiiCreateTextOpCode,
+    (IN VOID           *OpCodeHandle,
+     IN EFI_STRING_ID  Prompt,
+     IN EFI_STRING_ID  Help,
+     IN EFI_STRING_ID  TextTwo)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT8 *,
+    HiiCreateDateOpCode,
+    (IN VOID             *OpCodeHandle,
+     IN EFI_QUESTION_ID  QuestionId,
+     IN EFI_VARSTORE_ID  VarStoreId OPTIONAL,
+     IN UINT16           VarOffset OPTIONAL,
+     IN EFI_STRING_ID    Prompt,
+     IN EFI_STRING_ID    Help,
+     IN UINT8            QuestionFlags,
+     IN UINT8            DateFlags,
+     IN VOID             *DefaultsOpCodeHandle OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT8 *,
+    HiiCreateTimeOpCode,
+    (IN VOID             *OpCodeHandle,
+     IN EFI_QUESTION_ID  QuestionId,
+     IN EFI_VARSTORE_ID  VarStoreId OPTIONAL,
+     IN UINT16           VarOffset OPTIONAL,
+     IN EFI_STRING_ID    Prompt,
+     IN EFI_STRING_ID    Help,
+     IN UINT8            QuestionFlags,
+     IN UINT8            TimeFlags,
+     IN VOID             *DefaultsOpCodeHandle OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    HiiUpdateForm,
+    (IN EFI_HII_HANDLE  HiiHandle,
+     IN EFI_GUID        *FormSetGuid OPTIONAL,
+     IN EFI_FORM_ID     FormId,
+     IN VOID            *StartOpCodeHandle,
+     IN VOID            *EndOpCodeHandle OPTIONAL)
+    );
+};
+
+#endif

--- a/MdeModulePkg/Test/Mock/Library/GoogleTest/MockHiiLib/MockHiiLib.cpp
+++ b/MdeModulePkg/Test/Mock/Library/GoogleTest/MockHiiLib/MockHiiLib.cpp
@@ -1,4 +1,4 @@
-/** @file
+/** @file MockHiiLib.cpp
   Google Test mocks for HiiLib
 
   Copyright (c) Microsoft Corporation.

--- a/MdeModulePkg/Test/Mock/Library/GoogleTest/MockHiiLib/MockHiiLib.cpp
+++ b/MdeModulePkg/Test/Mock/Library/GoogleTest/MockHiiLib/MockHiiLib.cpp
@@ -1,0 +1,49 @@
+/** @file
+  Google Test mocks for HiiLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <GoogleTest/Library/MockHiiLib.h>
+
+//
+// Global Variables that are not const
+//
+
+MOCK_INTERFACE_DEFINITION (MockHiiLib);
+
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiRemovePackages, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiSetString, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiGetString, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiGetStringEx, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiGetPackageString, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiGetHiiHandles, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiGetFormSetFromHiiHandle, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiGetSupportedLanguages, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiConstructConfigHdr, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiSetToDefaults, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiValidateSettings, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiIsConfigHdrMatch, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiGetBrowserData, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiSetBrowserData, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiAllocateOpCodeHandle, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiFreeOpCodeHandle, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiCreateRawOpCodes, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiCreateEndOpCode, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiCreateOneOfOptionOpCode, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiCreateDefaultOpCode, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiCreateGuidOpCode, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiCreateActionOpCode, 6, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiCreateSubTitleOpCode, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiCreateGotoOpCode, 6, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiCreateGotoExOpCode, 9, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiCreateCheckBoxOpCode, 9, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiCreateNumericOpCode, 12, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiCreateStringOpCode, 11, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiCreateOneOfOpCode, 10, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiCreateOrderedListOpCode, 12, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiCreateTextOpCode, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiCreateDateOpCode, 9, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiCreateTimeOpCode, 9, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiLib, HiiUpdateForm, 5, EFIAPI);

--- a/MdeModulePkg/Test/Mock/Library/GoogleTest/MockHiiLib/MockHiiLib.inf
+++ b/MdeModulePkg/Test/Mock/Library/GoogleTest/MockHiiLib/MockHiiLib.inf
@@ -1,0 +1,34 @@
+## @file
+# Google Test mocks for HiiLib
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MockHiiLib
+  FILE_GUID                      = d29d29fa-e62f-543a-8d6d-793858ac7f35
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = HiiLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  MockHiiLib.cpp
+
+[Packages]
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHs /bigobj

--- a/MdeModulePkg/Test/Mock/Library/GoogleTest/MockHiiLib/MockHiiLib.inf
+++ b/MdeModulePkg/Test/Mock/Library/GoogleTest/MockHiiLib/MockHiiLib.inf
@@ -1,4 +1,4 @@
-## @file
+## @file MockHiiLib.inf
 # Google Test mocks for HiiLib
 #
 # Copyright (c) Microsoft Corporation.

--- a/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockHiiDatabase.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockHiiDatabase.h
@@ -1,0 +1,162 @@
+/** @file MockHiiDatabase.h
+  This file declares a mock of HiiDatabase Protocol.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_HII_DATABASE_H
+#define MOCK_HII_DATABASE_H
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Protocol/HiiDatabase.h>
+}
+
+struct MockHiiDatabaseProtocol {
+  MOCK_INTERFACE_DECLARATION (MockHiiDatabaseProtocol);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    NewPackageList,
+    (
+     IN CONST  EFI_HII_DATABASE_PROTOCOL   *This,
+     IN CONST  EFI_HII_PACKAGE_LIST_HEADER *PackageList,
+     IN        EFI_HANDLE                  DriverHandle  OPTIONAL,
+     OUT       EFI_HII_HANDLE               *Handle
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    RemovePackageList,
+    (
+     IN CONST  EFI_HII_DATABASE_PROTOCOL *This,
+     IN        EFI_HII_HANDLE             Handle
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    UpdatePackageList,
+    (
+     IN CONST  EFI_HII_DATABASE_PROTOCOL   *This,
+     IN        EFI_HII_HANDLE               Handle,
+     IN CONST  EFI_HII_PACKAGE_LIST_HEADER *PackageList
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ListPackageLists,
+    (
+     IN CONST  EFI_HII_DATABASE_PROTOCOL *This,
+     IN        UINT8                     PackageType,
+     IN CONST  EFI_GUID                  *PackageGuid,
+     IN OUT    UINTN                     *HandleBufferLength,
+     OUT       EFI_HII_HANDLE            *Handle
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ExportPackageLists,
+    (
+     IN CONST  EFI_HII_DATABASE_PROTOCOL      *This,
+     IN        EFI_HII_HANDLE                 Handle,
+     IN OUT    UINTN                          *BufferSize,
+     OUT       EFI_HII_PACKAGE_LIST_HEADER    *Buffer
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    RegisterPackageNotify,
+    (
+     IN CONST  EFI_HII_DATABASE_PROTOCOL     *This,
+     IN        UINT8                         PackageType,
+     IN CONST  EFI_GUID                      *PackageGuid,
+     IN        EFI_HII_DATABASE_NOTIFY       PackageNotifyFn,
+     IN        EFI_HII_DATABASE_NOTIFY_TYPE  NotifyType,
+     OUT       EFI_HANDLE                    *NotifyHandle
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    UnregisterPackageNotify,
+    (
+     IN CONST  EFI_HII_DATABASE_PROTOCOL *This,
+     IN        EFI_HANDLE                NotificationHandle
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    FindKeyboardLayouts,
+    (
+     IN CONST  EFI_HII_DATABASE_PROTOCOL *This,
+     IN OUT    UINT16                    *KeyGuidBufferLength,
+     OUT       EFI_GUID                  *KeyGuidBuffer
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    GetKeyboardLayout,
+    (IN CONST  EFI_HII_DATABASE_PROTOCOL *This,
+     IN CONST  EFI_GUID                  *KeyGuid,
+     IN OUT UINT16                       *KeyboardLayoutLength,
+     OUT       EFI_HII_KEYBOARD_LAYOUT   *KeyboardLayout)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    SetKeyboardLayout,
+    (IN CONST  EFI_HII_DATABASE_PROTOCOL *This,
+     IN CONST  EFI_GUID                  *KeyGuid)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    GetPackageListHandle,
+    (
+     IN CONST  EFI_HII_DATABASE_PROTOCOL *This,
+     IN        EFI_HII_HANDLE             PackageListHandle,
+     OUT       EFI_HANDLE                *DriverHandle
+    )
+    );
+};
+
+MOCK_INTERFACE_DEFINITION (MockHiiDatabaseProtocol);
+MOCK_FUNCTION_DEFINITION (MockHiiDatabaseProtocol, NewPackageList, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiDatabaseProtocol, RemovePackageList, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiDatabaseProtocol, UpdatePackageList, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiDatabaseProtocol, ListPackageLists, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiDatabaseProtocol, ExportPackageLists, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiDatabaseProtocol, RegisterPackageNotify, 6, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiDatabaseProtocol, UnregisterPackageNotify, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiDatabaseProtocol, FindKeyboardLayouts, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiDatabaseProtocol, GetKeyboardLayout, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiDatabaseProtocol, SetKeyboardLayout, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockHiiDatabaseProtocol, GetPackageListHandle, 3, EFIAPI);
+
+#define MOCK_EFI_HII_DATABASE_PROTOCOL_INSTANCE(NAME) \
+  EFI_HII_DATABASE_PROTOCOL NAME##_INSTANCE = {       \
+    NewPackageList,                                   \
+    RemovePackageList,                                \
+    UpdatePackageList,                                \
+    ListPackageLists,                                 \
+    ExportPackageLists,                               \
+    RegisterPackageNotify,                            \
+    UnregisterPackageNotify,                          \
+    FindKeyboardLayouts,                              \
+    GetKeyboardLayout,                                \
+    SetKeyboardLayout,                                \
+    GetPackageListHandle };                           \
+  EFI_HII_DATABASE_PROTOCOL  *NAME =  &NAME##_INSTANCE;
+
+#endif

--- a/ShellPkg/ShellPkg.ci.yaml
+++ b/ShellPkg/ShellPkg.ci.yaml
@@ -40,7 +40,9 @@
             "NetworkPkg/NetworkPkg.dec"
         ],
         # For host based unit tests
-        "AcceptableDependencies-HOST_APPLICATION":[],
+        "AcceptableDependencies-HOST_APPLICATION":[
+            "UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec"
+        ],
         # For UEFI shell based apps
         "AcceptableDependencies-UEFI_APPLICATION":[],
         "IgnoreInf": []

--- a/ShellPkg/ShellPkg.dec
+++ b/ShellPkg/ShellPkg.dec
@@ -17,6 +17,7 @@
 
 [Includes]
   Include
+  Test/Mock/Include
 
 [LibraryClasses]
   ##  @libraryclass  Provides most Shell APIs. Only available for Shell applications

--- a/ShellPkg/Test/Mock/Include/GoogleTest/Library/MockShellLib.h
+++ b/ShellPkg/Test/Mock/Include/GoogleTest/Library/MockShellLib.h
@@ -1,0 +1,399 @@
+/** @file MockShellLib.h
+  Google Test mocks for ShellLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_SHELL_LIB_H_
+#define MOCK_SHELL_LIB_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+extern "C" {
+  #include <PiPei.h>
+  #include <PiDxe.h>
+  #include <PiSmm.h>
+  #include <PiMm.h>
+  #include <Uefi.h>
+  #include <Library/ShellLib.h>
+}
+
+struct MockShellLib {
+  MOCK_INTERFACE_DECLARATION (MockShellLib);
+
+  MOCK_FUNCTION_DECLARATION (
+    CHAR16 *,
+    FullyQualifyPath,
+    (IN CONST CHAR16  *Path)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_FILE_INFO *,
+    ShellGetFileInfo,
+    (IN SHELL_FILE_HANDLE  FileHandle)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellSetFileInfo,
+    (IN SHELL_FILE_HANDLE  FileHandle,
+     IN EFI_FILE_INFO      *FileInfo)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellOpenFileByDevicePath,
+    (IN OUT EFI_DEVICE_PATH_PROTOCOL  **FilePath,
+     OUT    SHELL_FILE_HANDLE         *FileHandle,
+     IN     UINT64                    OpenMode,
+     IN     UINT64                    Attributes)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellOpenFileByName,
+    (IN CONST CHAR16             *FileName,
+     OUT      SHELL_FILE_HANDLE  *FileHandle,
+     IN       UINT64             OpenMode,
+     IN       UINT64             Attributes)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellCreateDirectory,
+    (IN CONST CHAR16             *DirectoryName,
+     OUT      SHELL_FILE_HANDLE  *FileHandle)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellReadFile,
+    (IN     SHELL_FILE_HANDLE  FileHandle,
+     IN OUT UINTN              *ReadSize,
+     OUT    VOID               *Buffer)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellWriteFile,
+    (IN     SHELL_FILE_HANDLE  FileHandle,
+     IN OUT UINTN              *BufferSize,
+     IN     VOID               *Buffer)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellCloseFile,
+    (IN SHELL_FILE_HANDLE  *FileHandle)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellDeleteFile,
+    (IN SHELL_FILE_HANDLE  *FileHandle)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellSetFilePosition,
+    (IN SHELL_FILE_HANDLE  FileHandle,
+     IN UINT64             Position)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellGetFilePosition,
+    (IN  SHELL_FILE_HANDLE  FileHandle,
+     OUT UINT64             *Position)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellFlushFile,
+    (IN SHELL_FILE_HANDLE  FileHandle)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellFindFirstFile,
+    (IN  SHELL_FILE_HANDLE  DirHandle,
+     OUT EFI_FILE_INFO      **Buffer)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellFindNextFile,
+    (IN     SHELL_FILE_HANDLE  DirHandle,
+     IN OUT EFI_FILE_INFO      *Buffer,
+     IN OUT BOOLEAN            *NoFile)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellGetFileSize,
+    (IN  SHELL_FILE_HANDLE  FileHandle,
+     OUT UINT64             *Size)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    ShellGetExecutionBreakFlag,
+    ()
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    CONST CHAR16 *,
+    ShellGetEnvironmentVariable,
+    (IN CONST CHAR16  *EnvKey)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellSetEnvironmentVariable,
+    (IN CONST CHAR16   *EnvKey,
+     IN CONST CHAR16   *EnvVal,
+     IN       BOOLEAN  Volatile)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellExecute,
+    (IN  EFI_HANDLE  *ParentHandle,
+     IN  CHAR16      *CommandLine,
+     IN  BOOLEAN     Output,
+     IN  CHAR16      **EnvironmentVariables,
+     OUT EFI_STATUS  *Status)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    CONST CHAR16 *,
+    ShellGetCurrentDir,
+    (IN CHAR16  *CONST DeviceName OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    ShellSetPageBreakMode,
+    (IN BOOLEAN  CurrentState)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellOpenFileMetaArg,
+    (IN     CHAR16               *Arg,
+     IN     UINT64               OpenMode,
+     IN OUT EFI_SHELL_FILE_INFO  **ListHead)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellCloseFileMetaArg,
+    (IN OUT EFI_SHELL_FILE_INFO  **ListHead)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    CHAR16 *,
+    ShellFindFilePath,
+    (IN CONST CHAR16  *FileName)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    CHAR16 *,
+    ShellFindFilePathEx,
+    (IN CONST CHAR16  *FileName,
+     IN CONST CHAR16  *FileExtension)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellCommandLineParseEx,
+    (IN CONST SHELL_PARAM_ITEM  *CheckList,
+     OUT      LIST_ENTRY        **CheckPackage,
+     OUT      CHAR16            **ProblemParam OPTIONAL,
+     IN       BOOLEAN           AutoPageBreak,
+     IN       BOOLEAN           AlwaysAllowNumbers)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    ShellCommandLineFreeVarList,
+    (IN LIST_ENTRY  *CheckPackage)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    ShellCommandLineGetFlag,
+    (IN CONST LIST_ENTRY  *CONST CheckPackage,
+     IN CONST CHAR16      *CONST KeyString)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    CONST CHAR16 *,
+    ShellCommandLineGetValue,
+    (IN CONST LIST_ENTRY  *CheckPackage,
+     IN       CHAR16      *KeyString)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    CONST CHAR16 *,
+    ShellCommandLineGetRawValue,
+    (IN CONST LIST_ENTRY  *CONST CheckPackage,
+     IN       UINTN       Position)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINTN,
+    ShellCommandLineGetCount,
+    (IN CONST LIST_ENTRY  *CheckPackage)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellCommandLineCheckDuplicate,
+    (IN CONST LIST_ENTRY  *CheckPackage,
+     OUT      CHAR16      **Param)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellInitialize,
+    ()
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellIsDirectory,
+    (IN CONST CHAR16  *DirName)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellIsFile,
+    (IN CONST CHAR16  *Name)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellIsFileInPath,
+    (IN CONST CHAR16  *Name)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINTN,
+    ShellStrToUintn,
+    (IN CONST CHAR16  *String)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINTN,
+    ShellHexStrToUintn,
+    (IN CONST CHAR16  *String)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    CHAR16 *,
+    StrnCatGrow,
+    (IN OUT   CHAR16  **Destination,
+     IN OUT   UINTN   *CurrentSize,
+     IN CONST CHAR16  *Source,
+     IN       UINTN   Count)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellCopySearchAndReplace,
+    (IN CONST CHAR16   *SourceString,
+     IN OUT   CHAR16   *NewString,
+     IN       UINTN    NewSize,
+     IN CONST CHAR16   *FindTarget,
+     IN CONST CHAR16   *ReplaceWith,
+     IN CONST BOOLEAN  SkipPreCarrot,
+     IN CONST BOOLEAN  ParameterReplacing)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    ShellIsHexaDecimalDigitCharacter,
+    (IN CHAR16  Char)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    ShellIsDecimalDigitCharacter,
+    (IN CHAR16  Char)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellPromptForResponse,
+    (IN     SHELL_PROMPT_REQUEST_TYPE  Type,
+     IN     CHAR16                     *Prompt OPTIONAL,
+     IN OUT VOID                       **Response OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellPromptForResponseHii,
+    (IN       SHELL_PROMPT_REQUEST_TYPE  Type,
+     IN CONST EFI_STRING_ID              HiiFormatStringId,
+     IN CONST EFI_HII_HANDLE             HiiFormatHandle,
+     IN OUT   VOID                       **Response)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    ShellIsHexOrDecimalNumber,
+    (IN CONST CHAR16   *String,
+     IN CONST BOOLEAN  ForceHex,
+     IN CONST BOOLEAN  StopAtSpace)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellConvertStringToUint64,
+    (IN CONST CHAR16   *String,
+     OUT      UINT64   *Value,
+     IN CONST BOOLEAN  ForceHex,
+     IN CONST BOOLEAN  StopAtSpace)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellFileExists,
+    (IN CONST CHAR16  *Name)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    CHAR16 *,
+    ShellFileHandleReturnLine,
+    (IN     SHELL_FILE_HANDLE  Handle,
+     IN OUT BOOLEAN            *Ascii)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellFileHandleReadLine,
+    (IN     SHELL_FILE_HANDLE  Handle,
+     IN OUT CHAR16             *Buffer,
+     IN OUT UINTN              *Size,
+     IN     BOOLEAN            Truncate,
+     IN OUT BOOLEAN            *Ascii)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellDeleteFileByName,
+    (IN CONST CHAR16  *FileName)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ShellPrintHelp,
+    (IN CONST CHAR16   *CommandToGetHelpOn,
+     IN CONST CHAR16   *SectionToGetHelpOn,
+     IN       BOOLEAN  PrintCommandText)
+    );
+};
+
+#endif

--- a/ShellPkg/Test/Mock/Library/GoogleTest/MockShellLib/MockShellLib.cpp
+++ b/ShellPkg/Test/Mock/Library/GoogleTest/MockShellLib/MockShellLib.cpp
@@ -1,0 +1,71 @@
+/** @file MockShellLib.cpp
+  Google Test mocks for ShellLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <GoogleTest/Library/MockShellLib.h>
+
+//
+// Global Variables that are not const
+//
+EFI_SHELL_PARAMETERS_PROTOCOL  *gEfiShellParametersProtocol;
+EFI_SHELL_PROTOCOL             *gEfiShellProtocol;
+SHELL_PARAM_ITEM               EmptyParamList[];
+SHELL_PARAM_ITEM               SfoParamList[];
+
+MOCK_INTERFACE_DEFINITION (MockShellLib);
+
+MOCK_FUNCTION_DEFINITION (MockShellLib, FullyQualifyPath, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellGetFileInfo, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellSetFileInfo, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellOpenFileByDevicePath, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellOpenFileByName, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellCreateDirectory, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellReadFile, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellWriteFile, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellCloseFile, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellDeleteFile, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellSetFilePosition, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellGetFilePosition, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellFlushFile, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellFindFirstFile, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellFindNextFile, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellGetFileSize, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellGetExecutionBreakFlag, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellGetEnvironmentVariable, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellSetEnvironmentVariable, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellExecute, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellGetCurrentDir, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellSetPageBreakMode, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellOpenFileMetaArg, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellCloseFileMetaArg, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellFindFilePath, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellFindFilePathEx, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellCommandLineParseEx, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellCommandLineFreeVarList, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellCommandLineGetFlag, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellCommandLineGetValue, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellCommandLineGetRawValue, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellCommandLineGetCount, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellCommandLineCheckDuplicate, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellInitialize, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellIsDirectory, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellIsFile, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellIsFileInPath, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellStrToUintn, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellHexStrToUintn, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, StrnCatGrow, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellCopySearchAndReplace, 7, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellIsHexaDecimalDigitCharacter, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellIsDecimalDigitCharacter, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellPromptForResponse, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellPromptForResponseHii, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellIsHexOrDecimalNumber, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellConvertStringToUint64, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellFileExists, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellFileHandleReturnLine, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellFileHandleReadLine, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellDeleteFileByName, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockShellLib, ShellPrintHelp, 3, EFIAPI);

--- a/ShellPkg/Test/Mock/Library/GoogleTest/MockShellLib/MockShellLib.inf
+++ b/ShellPkg/Test/Mock/Library/GoogleTest/MockShellLib/MockShellLib.inf
@@ -1,0 +1,34 @@
+## @file MockShellLib.inf
+# Google Test mocks for ShellLib
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MockShellLib
+  FILE_GUID                      = 6014c132-e682-556d-b2d6-afee4fea7cc2
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = ShellLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  MockShellLib.cpp
+
+[Packages]
+  ShellPkg/ShellPkg.dec
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHs /bigobj

--- a/ShellPkg/Test/ShellPkgHostTest.dsc
+++ b/ShellPkg/Test/ShellPkgHostTest.dsc
@@ -1,0 +1,31 @@
+## @file    ShellPkgHostTest.dsc
+#
+#  Copyright (c) Microsoft Corporation.
+#  Your use of this software is governed by the terms of the Microsoft agreement under which you obtained the software.
+#
+#  Description
+#
+##
+
+[Defines]
+PLATFORM_NAME           = ShellPkgHostTest
+PLATFORM_GUID           = DE1A879F-BB19-44D8-A24F-21E79DB2A502
+PLATFORM_VERSION        = 0.1
+DSC_SPECIFICATION       = 0x00010005
+OUTPUT_DIRECTORY        = Build/ShellPkg/HostTest
+SUPPORTED_ARCHITECTURES = IA32|X64|AARCH64
+BUILD_TARGETS           = NOOPT
+SKUID_IDENTIFIER        = DEFAULT
+
+!include UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
+
+[LibraryClasses.common.HOST_APPLICATION]
+
+[Components]
+#
+# List of Unit test packages
+#
+  #
+  # Build HOST_APPLICATION Libraries With GoogleTest
+  #
+  ShellPkg/Test/Mock/Library/GoogleTest/MockShellLib/MockShellLib.inf


### PR DESCRIPTION
## Description

Added MockHiiLib, MockShellLib, MockHiiDatabase protocol to be used by GoogleTests

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [X] Backport to release branch?

## How This Was Tested

Consumed these mocks in Googletests of other repos and build successful

## Integration Instructions

N/A
