### PR TITLE
[Cherry-Pick] MdePkg: Add rest mock functions for Mock UefiRuntimeServicesTableLib

### DIFF
--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiRuntimeServicesTableLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiRuntimeServicesTableLib.h
@@ -60,7 +60,7 @@ struct MockUefiRuntimeServicesTableLib {
     gRT_ConvertPointer,
     (IN     UINTN                      DebugDisposition,
      IN OUT VOID                       **Address)
-  );
+    );
 
   MOCK_FUNCTION_DECLARATION (
     EFI_STATUS,

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiRuntimeServicesTableLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiRuntimeServicesTableLib.h
@@ -20,12 +20,64 @@ struct MockUefiRuntimeServicesTableLib {
 
   MOCK_FUNCTION_DECLARATION (
     EFI_STATUS,
+    gRT_GetTime,
+    (OUT  EFI_TIME                    *Time,
+     OUT  EFI_TIME_CAPABILITIES       *Capabilities OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gRT_SetTime,
+    (IN  EFI_TIME                     *Time)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gRT_GetWakeupTime,
+    (OUT BOOLEAN                     *Enabled,
+     OUT BOOLEAN                     *Pending,
+     OUT EFI_TIME                    *Time)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gRT_SetWakeupTime,
+    (IN  BOOLEAN                      Enable,
+     IN  EFI_TIME                     *Time   OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gRT_SetVirtualAddressMap,
+    (IN  UINTN                        MemoryMapSize,
+     IN  UINTN                        DescriptorSize,
+     IN  UINT32                       DescriptorVersion,
+     IN  EFI_MEMORY_DESCRIPTOR        *VirtualMap)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gRT_ConvertPointer,
+    (IN     UINTN                      DebugDisposition,
+     IN OUT VOID                       **Address)
+  );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
     gRT_GetVariable,
     (IN      CHAR16    *VariableName,
      IN      EFI_GUID  *VendorGuid,
      OUT     UINT32    *Attributes OPTIONAL,
      IN OUT  UINTN     *DataSize,
      OUT     VOID      *Data)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gRT_GetNextVariableName,
+    (IN OUT UINTN                    *VariableNameSize,
+     IN OUT CHAR16                   *VariableName,
+     IN OUT EFI_GUID                 *VendorGuid)
     );
 
   MOCK_FUNCTION_DECLARATION (
@@ -40,9 +92,43 @@ struct MockUefiRuntimeServicesTableLib {
 
   MOCK_FUNCTION_DECLARATION (
     EFI_STATUS,
-    gRT_GetTime,
-    (OUT  EFI_TIME                    *Time,
-     OUT  EFI_TIME_CAPABILITIES       *Capabilities OPTIONAL)
+    gRT_GetNextHighMonotonicCount,
+    (OUT UINT32                  *HighCount)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    gRT_ResetSystem,
+    (IN EFI_RESET_TYPE           ResetType,
+     IN EFI_STATUS               ResetStatus,
+     IN UINTN                    DataSize,
+     IN VOID                     *ResetData OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gRT_UpdateCapsule,
+    (IN EFI_CAPSULE_HEADER     **CapsuleHeaderArray,
+     IN UINTN                  CapsuleCount,
+     IN EFI_PHYSICAL_ADDRESS   ScatterGatherList   OPTIONAL)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gRT_QueryCapsuleCapabilities,
+    (IN  EFI_CAPSULE_HEADER     **CapsuleHeaderArray,
+     IN  UINTN                  CapsuleCount,
+     OUT UINT64                 *MaximumCapsuleSize,
+     OUT EFI_RESET_TYPE         *ResetType)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gRT_QueryVariableInfo,
+    (IN  UINT32            Attributes,
+     OUT UINT64            *MaximumVariableStorageSize,
+     OUT UINT64            *RemainingVariableStorageSize,
+     OUT UINT64            *MaximumVariableSize)
     );
 
   MOCK_FUNCTION_DECLARATION (

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockUefiRuntimeServicesTableLib/MockUefiRuntimeServicesTableLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockUefiRuntimeServicesTableLib/MockUefiRuntimeServicesTableLib.cpp
@@ -8,33 +8,48 @@
 
 MOCK_INTERFACE_DEFINITION (MockUefiRuntimeServicesTableLib);
 
-MOCK_FUNCTION_DEFINITION (MockUefiRuntimeServicesTableLib, gRT_GetVariable, 5, EFIAPI);
-MOCK_FUNCTION_DEFINITION (MockUefiRuntimeServicesTableLib, gRT_SetVariable, 5, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiRuntimeServicesTableLib, gRT_GetTime, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeServicesTableLib, gRT_SetTime, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeServicesTableLib, gRT_GetWakeupTime, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeServicesTableLib, gRT_SetWakeupTime, 2, EFIAPI);
+
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeServicesTableLib, gRT_SetVirtualAddressMap, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeServicesTableLib, gRT_ConvertPointer, 2, EFIAPI);
+
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeServicesTableLib, gRT_GetVariable, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeServicesTableLib, gRT_GetNextVariableName, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeServicesTableLib, gRT_SetVariable, 5, EFIAPI);
+
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeServicesTableLib, gRT_GetNextHighMonotonicCount, 1, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiRuntimeServicesTableLib, gRT_ResetSystem, 4, EFIAPI);
 
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeServicesTableLib, gRT_UpdateCapsule, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeServicesTableLib, gRT_QueryCapsuleCapabilities, 4, EFIAPI);
+
+MOCK_FUNCTION_DEFINITION (MockUefiRuntimeServicesTableLib, gRT_QueryVariableInfo, 4, EFIAPI);
+
 static EFI_RUNTIME_SERVICES  localRt = {
-  { 0 },            // EFI_TABLE_HEADER
+  { 0 },                          // EFI_TABLE_HEADER
 
-  gRT_GetTime,      // EFI_GET_TIME
-  NULL,             // EFI_SET_TIME
-  NULL,             // EFI_GET_WAKEUP_TIME
-  NULL,             // EFI_SET_WAKEUP_TIME
+  gRT_GetTime,                    // EFI_GET_TIME
+  gRT_SetTime,                    // EFI_SET_TIME
+  gRT_GetWakeupTime,              // EFI_GET_WAKEUP_TIME
+  gRT_SetWakeupTime,              // EFI_SET_WAKEUP_TIME
 
-  NULL,             // EFI_SET_VIRTUAL_ADDRESS_MAP
-  NULL,             // EFI_CONVERT_POINTER
+  gRT_SetVirtualAddressMap,       // EFI_SET_VIRTUAL_ADDRESS_MAP
+  gRT_ConvertPointer,             // EFI_CONVERT_POINTER
 
-  gRT_GetVariable,  // EFI_GET_VARIABLE
-  NULL,             // EFI_GET_NEXT_VARIABLE_NAME
-  gRT_SetVariable,  // EFI_SET_VARIABLE
+  gRT_GetVariable,                // EFI_GET_VARIABLE
+  gRT_GetNextVariableName,        // EFI_GET_NEXT_VARIABLE_NAME
+  gRT_SetVariable,                // EFI_SET_VARIABLE
 
-  NULL,             // EFI_GET_NEXT_HIGH_MONO_COUNT
-  gRT_ResetSystem,  // EFI_RESET_SYSTEM
+  gRT_GetNextHighMonotonicCount,  // EFI_GET_NEXT_HIGH_MONO_COUNT
+  gRT_ResetSystem,                // EFI_RESET_SYSTEM
 
-  NULL,             // EFI_UPDATE_CAPSULE
-  NULL,             // EFI_QUERY_CAPSULE_CAPABILITIES
+  gRT_UpdateCapsule,              // EFI_UPDATE_CAPSULE
+  gRT_QueryCapsuleCapabilities,   // EFI_QUERY_CAPSULE_CAPABILITIES
 
-  NULL,             // EFI_QUERY_VARIABLE_INFO
+  gRT_QueryVariableInfo,          // EFI_QUERY_VARIABLE_INFO
 };
 
 extern "C" {


### PR DESCRIPTION
## Description
Add rest mock functions for Mock UefiRuntimeServicesTableLib for google test.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [X] Includes tests?
- [ ] Includes documentation?
- [X] Backport to release branch?

## How This Was Tested
Tested in module integrated with this MockUefiRuntimeServicesTableLib and the result is passed.

## Integration Instructions
Include the MockUefiRuntimeServicesTableLib.inf in the LibraryClasses section of a dsc file.
