### PR TITLE
MdePkg: Add Google Mock Library for SmmMemLib

### DIFF
--- a/MdePkg/Test/MdePkgHostTest.dsc
+++ b/MdePkg/Test/MdePkgHostTest.dsc
@@ -72,4 +72,5 @@
   MdePkg/Test/Mock/Library/GoogleTest/MockReportStatusCodeLib/MockReportStatusCodeLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockPostCodeLib/MockPostCodeLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockSafeIntLib/MockSafeIntLib.inf
+  MdePkg/Test/Mock/Library/GoogleTest/MockSmmMemLib/MockSmmMemLib.inf
   # MU_CHANGE [END]

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockSmmMemLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockSmmMemLib.h
@@ -1,0 +1,83 @@
+/** @file MockSmmMemLib.h
+  Google Test mocks for SmmMemLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_SMM_MEM_LIB_H_
+#define MOCK_SMM_MEM_LIB_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+extern "C" {
+  #include <Uefi.h>
+  #include <Library/SmmMemLib.h>
+}
+
+//
+// Declarations to handle usage of the SmmMemLib by creating mock
+//
+struct MockSmmMemLib {
+  MOCK_INTERFACE_DECLARATION (MockSmmMemLib);
+
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    SmmIsBufferOutsideSmmValid,
+    (
+     IN EFI_PHYSICAL_ADDRESS  Buffer,
+     IN UINT64                Length
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    SmmCopyMemToSmram,
+    (
+     OUT VOID       *DestinationBuffer,
+     IN CONST VOID  *SourceBuffer,
+     IN UINTN       Length
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    SmmCopyMemFromSmram,
+    (
+     OUT VOID       *DestinationBuffer,
+     IN CONST VOID  *SourceBuffer,
+     IN UINTN       Length
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    SmmCopyMem,
+    (
+     OUT VOID       *DestinationBuffer,
+     IN CONST VOID  *SourceBuffer,
+     IN UINTN       Length
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    SmmSetMem,
+    (
+     OUT VOID  *Buffer,
+     IN UINTN  Length,
+     IN UINT8  Value
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    SmmCommBufferValid,
+    (
+     IN EFI_PHYSICAL_ADDRESS  Buffer,
+     IN UINT64                Length
+    )
+    );
+};
+
+#endif

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockSmmMemLib/MockSmmMemLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockSmmMemLib/MockSmmMemLib.cpp
@@ -1,0 +1,16 @@
+/** @file MockSmmMemLib.cpp
+  Google Test mocks for SmmMemLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#include <GoogleTest/Library/MockSmmMemLib.h>
+
+MOCK_INTERFACE_DEFINITION (MockSmmMemLib);
+
+MOCK_FUNCTION_DEFINITION (MockSmmMemLib, SmmIsBufferOutsideSmmValid, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockSmmMemLib, SmmCopyMemToSmram, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockSmmMemLib, SmmCopyMemFromSmram, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockSmmMemLib, SmmCopyMem, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockSmmMemLib, SmmSetMem, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockSmmMemLib, SmmCommBufferValid, 2, EFIAPI);

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockSmmMemLib/MockSmmMemLib.inf
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockSmmMemLib/MockSmmMemLib.inf
@@ -1,0 +1,33 @@
+## @file MockSmmMemLib.inf
+# Google Test mocks for SmmMemLib
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MockSmmMemLib
+  FILE_GUID                      = FA50DD00-8D5B-437C-91C7-664C55D8C386
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = SmmMemLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  MockSmmMemLib.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHsc


### PR DESCRIPTION
## Description

Added MockSmmMemLib to be used by Googletests

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Added MockSmmMemLib to GoogleTests and able to successfully include its functions

## Integration Instructions

N/A
