### PR TITLE
MdeModulePkg/Variable: Init var policy after SMM variable is ready

### DIFF
--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariablePolicySmmDxe.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariablePolicySmmDxe.c
@@ -813,7 +813,7 @@ VariablePolicyVirtualAddressCallback (
   The driver's entry point.
 
   @param[in] ImageHandle  The firmware allocated handle for the EFI image.
-  @param[in] SystemTable  A pointer to the EFI System Table.
+  // @param[in] SystemTable  A pointer to the EFI System Table. // MU_CHANGE - Initialize var policy after SMM Variable is ready
 
   @retval EFI_SUCCESS     The entry point executed successfully.
   @retval other           Some error occured when executing this entry point.
@@ -822,8 +822,8 @@ VariablePolicyVirtualAddressCallback (
 EFI_STATUS
 EFIAPI
 VariablePolicySmmDxeMain (
-  IN    EFI_HANDLE        ImageHandle,
-  IN    EFI_SYSTEM_TABLE  *SystemTable
+  IN    EFI_HANDLE  ImageHandle             // MU_CHANGE - Initialize var policy after SMM Variable is ready
+  // IN    EFI_SYSTEM_TABLE  *SystemTable   // MU_CHANGE - Initialize var policy after SMM Variable is ready
   )
 {
   EFI_STATUS  Status;

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
@@ -73,8 +73,8 @@ EDKII_VAR_CHECK_PROTOCOL        mVarCheck;
 EFI_STATUS
 EFIAPI
 VariablePolicySmmDxeMain (
-  IN    EFI_HANDLE        ImageHandle,
-  IN    EFI_SYSTEM_TABLE  *SystemTable
+  IN    EFI_HANDLE  ImageHandle             // MU_CHANGE - Initialize var policy after SMM Variable is ready
+  // IN    EFI_SYSTEM_TABLE  *SystemTable   // MU_CHANGE - Initialize var policy after SMM Variable is ready
   );
 
 /**
@@ -1692,6 +1692,7 @@ SmmVariableReady (
   )
 {
   EFI_STATUS  Status;
+  EFI_HANDLE  VariablePolicyHandle;   // MU_CHANGE - Initialize var policy after SMM Variable is ready
 
   Status = gBS->LocateProtocol (&gEfiSmmVariableProtocolGuid, NULL, (VOID **)&mSmmVariable);
   if (EFI_ERROR (Status)) {
@@ -1757,6 +1758,16 @@ SmmVariableReady (
   gRT->GetNextVariableName = RuntimeServiceGetNextVariableName;
   gRT->SetVariable         = RuntimeServiceSetVariable;
   gRT->QueryVariableInfo   = RuntimeServiceQueryVariableInfo;
+
+  // MU_CHANGE [BEGIN] - Initialize var policy after SMM Variable is ready
+  VariablePolicyHandle = (Context != NULL) ? Context : mHandle;
+  if (Context == NULL) {
+    DEBUG ((DEBUG_ERROR, "Variable policy was installed on a handle other than the variable image handle.\n"));
+  }
+
+  // Initialize the VariablePolicy protocol and engine.
+  VariablePolicySmmDxeMain (VariablePolicyHandle);
+  // MU_CHANGE [END] - Initialize var policy after SMM Variable is ready
 
   //
   // Install the Variable Architectural Protocol on a new handle.
@@ -1868,7 +1879,7 @@ VariableSmmRuntimeInitialize (
     &gEfiSmmVariableProtocolGuid,
     TPL_CALLBACK,
     SmmVariableReady,
-    NULL,
+    ImageHandle,                    // MU_CHANGE - Initialize var policy after SMM Variable is ready
     &SmmVariableRegistration
     );
 
@@ -1930,8 +1941,10 @@ VariableSmmRuntimeInitialize (
          &mVirtualAddressChangeEvent
          );
 
-  // Initialize the VariablePolicy protocol and engine.
-  VariablePolicySmmDxeMain (ImageHandle, SystemTable);
+  // MU_CHANGE [BEGIN] - Initialize var policy after SMM Variable is ready
+  // // Initialize the VariablePolicy protocol and engine.
+  // VariablePolicySmmDxeMain (ImageHandle, SystemTable);
+  // MU_CHANGE [END] - Initialize var policy after SMM Variable is ready
 
   return EFI_SUCCESS;
 }


### PR DESCRIPTION
## Description

This series is going to edk2 but it is being made available in parallel to Project Mu since the edk2 202502 soft freeze began today. The plan is to not backport this Mu series but keep in the "dev" branch. Once the changes are in edk2, we can pull this into the next Mu release branch if we'd like.

---

On a MM system, the main UEFI variable logic resides in MMRAM. In that case, the variable policy logic in `VarCheckPolicyLib`, such as `VarCheckPolicyLibStandaloneMm` is linked against the MM driver also in that case `VariableStandaloneMm`.

The MM variable driver indicates its presence to the RT DXE driver via `gEfiSmmVariableProtocolGuid` to indicate variable read support is available from MM. This triggers installation of the variable architectural protocol in DXE.

Today, variable policy is initialized by calling `VariablePolicySmmDxeMain()` in `VariableSmmRuntimeInitialize()`. In turn, this installs `gEdkiiVariablePolicyProtocolGuid`. Functions in `gEdkiiVariablePolicyProtocolGuid` may trigger MMIs. However, it is possible that the MM variable driver which is linked against the code with the variable policy MMI handlers (i.e. `VarCheckPolicyLib`) is not loaded yet.

Therefore, this change moves invocation of `VariablePolicySmmDxeMain()` to `SmmVariableReady()` which is called on installation of `gEfiSmmVariableProtocolGuid` indicating variable MM services are ready. `gEdkiiVariablePolicyProtocolGuid` is still installed prior to the variable architectural protocol being installed.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

- Verify variable policy is initialized as expected on QEMU Q35/SBSA and a physical Intel system.
- Check that the variable image handle passed to `VariablePolicySmmDxeMain()` is correct.

## Integration Instructions

N/A - Some drivers may dispatch differently if they depend on `gEdkiiVariablePolicyProtocolGuid`. However, this is not considered breaking as that is an inherent expectation in dispatch based on dependency expressions.