### PR TITLE
[DO NOT MERGE] [PROTOTYPE] Stabilizing PCR4 Measurements

### DIFF
--- a/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
@@ -1919,6 +1919,20 @@ EfiBootManagerBoot (
     return;
   }
 
+  // MU_CHANGE [BEGIN]
+  //
+  // 0. Determine if the file path exists. (I.E we can't load it if it doesnt)
+  //
+  FilePath = BootOption->FilePath;
+  Status   = gBS->LocateDevicePath (&gEfiFirmwareVolume2ProtocolGuid, &FilePath, &ImageHandle);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: LocateDevicePath Failed (%r)\n", __func__, Status));
+    BootOption->Status = Status;
+    return;
+  }
+
+  // MU_CHANGE [END]
+
   //
   // 1. Create Boot#### for a temporary boot if there is no match Boot#### (i.e. a boot by selected a EFI Shell using "Boot From File")
   //
@@ -1962,7 +1976,16 @@ EfiBootManagerBoot (
   if (BmIsBootManagerMenuFilePath (BootOption->FilePath)) {
     DEBUG ((DEBUG_INFO, "[Bds] Booting Boot Manager Menu.\n"));
     BmStopHotkeyService (NULL, NULL);
-  } else {
+  }
+  // MU_CHANGE [BEGIN]
+  else if (BmIsFvFilePath (BootOption->FilePath)) {
+    //
+    // Do nothing. This file originates from a measured FV and is an extension of the BDS environment
+    // We should not signal ready to boot.
+    // We will still need to load / start it.
+  }
+  // MU_CHANGE [END]
+  else {
     PERF_EVENT_SIGNAL_BEGIN (&gEfiEventPreReadyToBootGuid); // MU_CHANGE
     EfiEventGroupSignal (&gEfiEventPreReadyToBootGuid);     // MU_CHANGE
     PERF_EVENT_SIGNAL_END (&gEfiEventPreReadyToBootGuid);   // MU_CHANGE
@@ -2043,6 +2066,10 @@ EfiBootManagerBoot (
                       &ImageHandle
                       );
     }
+
+    // MU_CHANGE [BEGIN]
+    DEBUG ((DEBUG_ERROR, "%a: LoadImage returned %r\n", __func__, Status));
+    // MU CHANGE [END]
 
     if (FileBuffer != NULL) {
       FreePool (FileBuffer);


### PR DESCRIPTION
## Description

This is an effort to stabilize PCR4 measurements. 

There are a few known issues with PCR4 measurements that need to be addressed.
1. Applications that originate from a measured FV and are an extension of the BDS environment should not signal ready to boot nor be measured into PCR4.
2. File paths that do not exist should not be loaded thus should not signal ready to boot nor should they be measured into PCR4.
3. Applications that originate from a measured FV should not be measured into PCR4 (https://github.com/microsoft/mu_tiano_plus/pull/330)

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [X] Impacts functionality?
- [X] Impacts security?
- [X] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?


## Related Pull Requests
https://github.com/microsoft/mu_plus/pull/637
https://github.com/microsoft/mu_tiano_plus/pull/330

## How This Was Tested

Various Boot Paths

## Integration Instructions

N/A (TODO)