### PR TITLE
[CHERRY-PICK] Fix lcov 2.0 in HostBasedUnitTestRunner [Rebase & FF]

### DIFF
--- a/BaseTools/Plugin/HostBasedUnitTestRunner/HostBasedUnitTestRunner.py
+++ b/BaseTools/Plugin/HostBasedUnitTestRunner/HostBasedUnitTestRunner.py
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
+import io
+import re
 import os
 import logging
 import glob
@@ -171,6 +173,16 @@ class HostBasedUnitTestRunner(IUefiBuildPlugin):
         # MU_CHANGE [END] - Check for invalid tests
         return failure_count
 
+    def get_lcov_version(self):
+        """Get lcov version number"""
+        lcov_ver = io.StringIO()
+        ret = RunCmd("lcov", "--version", outstream=lcov_ver)
+        if ret != 0:
+            return None
+        (major, _minor) = re.search(r"version (\d+)\.(\d+)", lcov_ver.getvalue()).groups()
+        return int(major)
+
+
     def gen_code_coverage_gcc(self, thebuilder):
         logging.info("Generating UnitTest code coverage")
 
@@ -180,6 +192,12 @@ class HostBasedUnitTestRunner(IUefiBuildPlugin):
         regex_exclude = r"^.*UnitTest\|^.*MU\|^.*Mock\|^.*DEBUG"
         # MU_CHANGE end - regex string for exclude paths
 
+        lcov_version_major = self.get_lcov_version()
+        if not lcov_version_major:
+            logging.error("UnitTest Coverage: Failed to determine lcov version")
+            return 1
+        logging.info(f"Got lcov version {lcov_version_major}")
+
         # Generate base code coverage for all source files
         ret = RunCmd("lcov", f"--no-external --capture --initial --directory {buildOutputBase} --output-file {buildOutputBase}/cov-base.info --rc lcov_branch_coverage=1")
         if ret != 0:
@@ -188,7 +206,8 @@ class HostBasedUnitTestRunner(IUefiBuildPlugin):
 
         # Coverage data for tested files only
         # `--ignore-errors mismatch` needed to make lcov v2.0+/gcov work.
-        ret = RunCmd("lcov", f"--capture --directory {buildOutputBase}/ --output-file {buildOutputBase}/coverage-test.info --rc lcov_branch_coverage=1 --ignore-errors mismatch")
+        lcov_error_settings = "--ignore-errors mismatch" if lcov_version_major >= 2 else ""
+        ret = RunCmd("lcov", f"--capture --directory {buildOutputBase}/ --output-file {buildOutputBase}/coverage-test.info --rc lcov_branch_coverage=1 {lcov_error_settings}")
         if ret != 0:
             logging.error("UnitTest Coverage: Failed to build coverage data for tested files.")
             return 1

--- a/BaseTools/Plugin/HostBasedUnitTestRunner/HostBasedUnitTestRunner.py
+++ b/BaseTools/Plugin/HostBasedUnitTestRunner/HostBasedUnitTestRunner.py
@@ -187,7 +187,8 @@ class HostBasedUnitTestRunner(IUefiBuildPlugin):
             return 1
 
         # Coverage data for tested files only
-        ret = RunCmd("lcov", f"--capture --directory {buildOutputBase}/ --output-file {buildOutputBase}/coverage-test.info --rc lcov_branch_coverage=1")
+        # `--ignore-errors mismatch` needed to make lcov v2.0+/gcov work.
+        ret = RunCmd("lcov", f"--capture --directory {buildOutputBase}/ --output-file {buildOutputBase}/coverage-test.info --rc lcov_branch_coverage=1 --ignore-errors mismatch")
         if ret != 0:
             logging.error("UnitTest Coverage: Failed to build coverage data for tested files.")
             return 1


### PR DESCRIPTION
## Description

Fixes issues encountered with lcov 2.0 after moving to the new Ubuntu 24.04 image. Already encountered in the edk2 Fedora container. Commits made there after the 2411 stable tag are cherry-picked here.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

- Container build with code coverage enabled in Ubuntu 24.04

## Integration Instructions

- N/A