### PR TITLE
[CHERRY-PICK] MdePkg/IndustryStandard: Adds SPMI macros

### DIFF
--- a/MdePkg/Include/IndustryStandard/ServiceProcessorManagementInterfaceTable.h
+++ b/MdePkg/Include/IndustryStandard/ServiceProcessorManagementInterfaceTable.h
@@ -3,6 +3,8 @@
   Intelligent Platform Management Interface Specification Second Generation.
 
   Copyright (c) 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved.
+
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
   @par Revision Reference:
@@ -94,5 +96,18 @@ typedef struct {
 } EFI_ACPI_SERVICE_PROCESSOR_MANAGEMENT_INTERFACE_TABLE;
 
 #pragma pack()
+
+///
+/// SPMI Revision (defined in spec)
+///
+#define EFI_ACPI_SERVICE_PROCESSOR_MANAGEMENT_INTERFACE_5_TABLE_REVISION  0x05
+
+///
+/// SPMI Interface Type
+///
+#define EFI_ACPI_SPMI_INTERFACE_TYPE_KCS   0x01
+#define EFI_ACPI_SPMI_INTERFACE_TYPE_SMIC  0x02
+#define EFI_ACPI_SPMI_INTERFACE_TYPE_BT    0x03
+#define EFI_ACPI_SPMI_INTERFACE_TYPE_SSIF  0x04
 
 #endif


### PR DESCRIPTION
## Description

Adds macro which defines SPMI table revision
and interface type as per the specification.

Cc: Michael D Kinney <michael.d.kinney@intel.com>
Cc: Liming Gao <gaoliming@byosoft.com.cn>
Cc: Zhiguang Liu <zhiguang.liu@intel.com>
Cc: Sami Mujawar <Sami.Mujawar@arm.com>
Cc: Pierre Gondois <pierre.gondois@arm.com>
Signed-off-by: Abdul Lateef Attar <AbdulLateef.Attar@amd.com>
(cherry picked from commit 0958b762fb1858f9ddf8c1e55fe853a3ee7e3461)

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [X] Backport to release branch?

## How This Was Tested

Built successfully

## Integration Instructions

N/A