### PR TITLE
MdePkg: Add all mock functions in the MockMmServicesTableLib

### DIFF
--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockMmServicesTableLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockMmServicesTableLib.h
@@ -23,6 +23,55 @@ struct MockMmServicesTableLib {
 
   MOCK_FUNCTION_DECLARATION (
     EFI_STATUS,
+    gMmst_MmAllocatePool,
+    (
+     IN  EFI_MEMORY_TYPE             PoolType,
+     IN  UINTN                       Size,
+     OUT VOID                        **Buffer
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gMmst_MmFreePool,
+    (
+     IN  VOID                        *Buffer
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gMmst_MmAllocatePages,
+    (
+     IN  EFI_ALLOCATE_TYPE           Type,
+     IN  EFI_MEMORY_TYPE             MemoryType,
+     IN  UINTN                       Pages,
+     OUT EFI_PHYSICAL_ADDRESS        *Memory
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gMmst_MmFreePages,
+    (
+     IN  EFI_PHYSICAL_ADDRESS        Memory,
+     IN  UINTN                       Pages
+    )
+    );
+
+  // MP service
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gMmst_MmStartupThisAp,
+    (
+     IN     EFI_AP_PROCEDURE  Procedure,
+     IN     UINTN             CpuNumber,
+     IN OUT VOID              *ProcArguments OPTIONAL
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
     gMmst_MmInstallProtocolInterface,
     (
      IN OUT EFI_HANDLE               *Handle,
@@ -44,6 +93,16 @@ struct MockMmServicesTableLib {
 
   MOCK_FUNCTION_DECLARATION (
     EFI_STATUS,
+    gMmst_MmHandleProtocol,
+    (
+     IN  EFI_HANDLE              Handle,
+     IN  EFI_GUID                *Protocol,
+     OUT VOID                    **Interface
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
     gMmst_MmRegisterProtocolNotify,
     (
      IN  CONST EFI_GUID     *Protocol,
@@ -54,11 +113,52 @@ struct MockMmServicesTableLib {
 
   MOCK_FUNCTION_DECLARATION (
     EFI_STATUS,
+    gMmst_MmLocateHandle,
+    (
+     IN     EFI_LOCATE_SEARCH_TYPE  SearchType,
+     IN     EFI_GUID                *Protocol,
+     IN     VOID                    *SearchKey,
+     IN OUT UINTN                   *BufferSize,
+     OUT    EFI_HANDLE              *Buffer
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
     gMmst_MmLocateProtocol,
     (
      IN  EFI_GUID  *Protocol,
      IN  VOID      *Registration  OPTIONAL,
      OUT VOID      **Interface
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gMmst_MmiManage,
+    (
+     IN CONST EFI_GUID  *HandlerType,
+     IN CONST VOID      *Context,
+     IN OUT VOID        *CommBuffer,
+     IN OUT UINTN       *CommBufferSize
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gMmst_MmInterruptRegister,
+    (
+     IN  EFI_MM_HANDLER_ENTRY_POINT Handler,
+     IN  CONST EFI_GUID *HandlerType,
+     OUT EFI_HANDLE    *DispatchHandle
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gMmst_MmInterruptUnRegister,
+    (
+     IN EFI_HANDLE  DispatchHandle
     )
     );
 };

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockMmServicesTableLib/MockMmServicesTableLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockMmServicesTableLib/MockMmServicesTableLib.cpp
@@ -7,10 +7,20 @@
 #include <GoogleTest/Library/MockMmServicesTableLib.h>
 
 MOCK_INTERFACE_DEFINITION (MockMmServicesTableLib);
+MOCK_FUNCTION_DEFINITION (MockMmServicesTableLib, gMmst_MmAllocatePool, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMmServicesTableLib, gMmst_MmFreePool, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMmServicesTableLib, gMmst_MmAllocatePages, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMmServicesTableLib, gMmst_MmFreePages, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMmServicesTableLib, gMmst_MmStartupThisAp, 3, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockMmServicesTableLib, gMmst_MmInstallProtocolInterface, 4, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockMmServicesTableLib, gMmst_MmUninstallProtocolInterface, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMmServicesTableLib, gMmst_MmHandleProtocol, 3, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockMmServicesTableLib, gMmst_MmRegisterProtocolNotify, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMmServicesTableLib, gMmst_MmLocateHandle, 5, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockMmServicesTableLib, gMmst_MmLocateProtocol, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMmServicesTableLib, gMmst_MmiManage, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMmServicesTableLib, gMmst_MmInterruptRegister, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMmServicesTableLib, gMmst_MmInterruptUnRegister, 1, EFIAPI);
 
 static EFI_MM_SYSTEM_TABLE  LocalMmst = {
   { 0, 0, 0, 0, 0 },                  // EFI_TABLE_HEADER
@@ -18,11 +28,11 @@ static EFI_MM_SYSTEM_TABLE  LocalMmst = {
   0,                                  // MmFirmwareRevision
   NULL,                               // EFI_MM_INSTALL_CONFIGURATION_TABLE
   { NULL },                           // EFI_MM_CPU_IO_PROTOCOL
-  NULL,                               // EFI_ALLOCATE_POOL
-  NULL,                               // EFI_FREE_POOL
-  NULL,                               // EFI_ALLOCATE_PAGES
-  NULL,                               // EFI_FREE_PAGES
-  NULL,                               // EFI_MM_STARTUP_THIS_AP
+  gMmst_MmAllocatePool,               // EFI_ALLOCATE_POOL
+  gMmst_MmFreePool,                   // EFI_FREE_POOL
+  gMmst_MmAllocatePages,              // EFI_ALLOCATE_PAGES
+  gMmst_MmFreePages,                  // EFI_FREE_PAGES
+  gMmst_MmStartupThisAp,              // EFI_MM_STARTUP_THIS_AP
   0,                                  // CurrentlyExecutingCpu
   0,                                  // NumberOfCpus
   NULL,                               // CpuSaveStateSize
@@ -31,13 +41,13 @@ static EFI_MM_SYSTEM_TABLE  LocalMmst = {
   NULL,                               // EFI_CONFIGURATION_TABLE
   gMmst_MmInstallProtocolInterface,   // EFI_INSTALL_PROTOCOL_INTERFACE
   gMmst_MmUninstallProtocolInterface, // EFI_UNINSTALL_PROTOCOL_INTERFACE
-  NULL,                               // EFI_HANDLE_PROTOCOL
+  gMmst_MmHandleProtocol,             // EFI_HANDLE_PROTOCOL
   gMmst_MmRegisterProtocolNotify,     // EFI_MM_REGISTER_PROTOCOL_NOTIFY
-  NULL,                               // EFI_LOCATE_HANDLE
+  gMmst_MmLocateHandle,               // EFI_LOCATE_HANDLE
   gMmst_MmLocateProtocol,             // EFI_LOCATE_PROTOCOL
-  NULL,                               // EFI_MM_INTERRUPT_MANAGE
-  NULL,                               // EFI_MM_INTERRUPT_REGISTER
-  NULL                                // EFI_MM_INTERRUPT_UNREGISTER
+  gMmst_MmiManage,                    // EFI_MM_INTERRUPT_MANAGE
+  gMmst_MmInterruptRegister,          // EFI_MM_INTERRUPT_REGISTER
+  gMmst_MmInterruptUnRegister         // EFI_MM_INTERRUPT_UNREGISTER
 };
 
 extern "C" {


### PR DESCRIPTION
## Description

Add all mock functions in the MockMmServicesTableLib

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Fill all functions in the MockMmServicesTableLib and able to successfully
include its functions

## Integration Instructions

N/A
