### PR TITLE
ShellPkg: Removed EmptyParamList and SfoParamList from MockShellLib.cpp

### DIFF
--- a/ShellPkg/Test/Mock/Library/GoogleTest/MockShellLib/MockShellLib.cpp
+++ b/ShellPkg/Test/Mock/Library/GoogleTest/MockShellLib/MockShellLib.cpp
@@ -12,8 +12,6 @@
 //
 EFI_SHELL_PARAMETERS_PROTOCOL  *gEfiShellParametersProtocol;
 EFI_SHELL_PROTOCOL             *gEfiShellProtocol;
-SHELL_PARAM_ITEM               EmptyParamList[];
-SHELL_PARAM_ITEM               SfoParamList[];
 
 MOCK_INTERFACE_DEFINITION (MockShellLib);
 


### PR DESCRIPTION
## Description

Removed EmptyParamList and SfoParamList from MockShellLib.cpp, since these are already defined as externs under ShellLib.h.

Please refer to edk2 PR, where they suggested to remove EmptyParamList and SfoParamList, since it was giving GCC build Error.
https://github.com/tianocore/edk2/pull/10582

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [X] Backport to release branch?

## How This Was Tested

Added MockShellLib to GoogleTests and able to successfully include its functions

## Integration Instructions

N/A