### PR TITLE
[CHERRY-PICK] VS22 linker changes from edk2 [Rebase & FF]

### DIFF
--- a/MdeModulePkg/Universal/HiiDatabaseDxe/Image.c
+++ b/MdeModulePkg/Universal/HiiDatabaseDxe/Image.c
@@ -242,19 +242,19 @@ Output1bitPixel (
   IN EFI_HII_IMAGE_PALETTE_INFO  *PaletteInfo
   )
 {
-  UINT16                         Xpos;
-  UINT16                         Ypos;
-  UINTN                          OffsetY;
-  UINT8                          Index;
-  EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *BitMapPtr;
-  EFI_GRAPHICS_OUTPUT_BLT_PIXEL  PaletteValue[2];
-  EFI_HII_IMAGE_PALETTE_INFO     *Palette;
-  UINTN                          PaletteSize;
-  UINT8                          Byte;
+  UINT16                               Xpos;
+  UINT16                               Ypos;
+  UINTN                                OffsetY;
+  UINT8                                Index;
+  EFI_GRAPHICS_OUTPUT_BLT_PIXEL_UNION  *BitMapPtr;
+  EFI_GRAPHICS_OUTPUT_BLT_PIXEL_UNION  PaletteValue[2];
+  EFI_HII_IMAGE_PALETTE_INFO           *Palette;
+  UINTN                                PaletteSize;
+  UINT8                                Byte;
 
   ASSERT (Image != NULL && Data != NULL && PaletteInfo != NULL);
 
-  BitMapPtr = Image->Bitmap;
+  BitMapPtr = (EFI_GRAPHICS_OUTPUT_BLT_PIXEL_UNION *)Image->Bitmap;
 
   //
   // First entry corresponds to color 0 and second entry corresponds to color 1.
@@ -271,8 +271,8 @@ Output1bitPixel (
   CopyMem (Palette, PaletteInfo, PaletteSize);
 
   ZeroMem (PaletteValue, sizeof (PaletteValue));
-  CopyRgbToGopPixel (&PaletteValue[0], &Palette->PaletteValue[0], 1);
-  CopyRgbToGopPixel (&PaletteValue[1], &Palette->PaletteValue[1], 1);
+  CopyRgbToGopPixel (&PaletteValue[0].Pixel, &Palette->PaletteValue[0], 1);
+  CopyRgbToGopPixel (&PaletteValue[1].Pixel, &Palette->PaletteValue[1], 1);
   FreePool (Palette);
   Palette = NULL;                                     // MU_CHANGE - Make sure to manage this pointer safely.
 
@@ -288,9 +288,9 @@ Output1bitPixel (
       Byte = *(Data + OffsetY + Xpos);
       for (Index = 0; Index < 8; Index++) {
         if ((Byte & (1 << Index)) != 0) {
-          CopyMem (&BitMapPtr[Ypos * Image->Width + Xpos * 8 + (8 - Index - 1)], &PaletteValue[1], sizeof (*BitMapPtr));
+          BitMapPtr[Ypos * Image->Width + Xpos * 8 + (8 - Index - 1)].Raw = PaletteValue[1].Raw;
         } else {
-          CopyMem (&BitMapPtr[Ypos * Image->Width + Xpos * 8 + (8 - Index - 1)], &PaletteValue[0], sizeof (*BitMapPtr));
+          BitMapPtr[Ypos * Image->Width + Xpos * 8 + (8 - Index - 1)].Raw = PaletteValue[0].Raw;
         }
       }
     }
@@ -303,9 +303,9 @@ Output1bitPixel (
       for (Index = 0; (UINT16)Index < (UINT16)(Image->Width % 8); Index++) {
         // MU_CHANGE - CodeQL Change - comparison-with-wider-type
         if ((Byte & (1 << (8 - Index - 1))) != 0) {
-          CopyMem (&BitMapPtr[Ypos * Image->Width + Xpos * 8 + Index], &PaletteValue[1], sizeof (*BitMapPtr));
+          BitMapPtr[Ypos * Image->Width + Xpos * 8 + Index].Raw = PaletteValue[1].Raw;
         } else {
-          CopyMem (&BitMapPtr[Ypos * Image->Width + Xpos * 8 + Index], &PaletteValue[0], sizeof (*BitMapPtr));
+          BitMapPtr[Ypos * Image->Width + Xpos * 8 + Index].Raw = PaletteValue[0].Raw;
         }
       }
     }
@@ -333,19 +333,19 @@ Output4bitPixel (
   IN EFI_HII_IMAGE_PALETTE_INFO  *PaletteInfo
   )
 {
-  UINT16                         Xpos;
-  UINT16                         Ypos;
-  UINTN                          OffsetY;
-  EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *BitMapPtr;
-  EFI_GRAPHICS_OUTPUT_BLT_PIXEL  PaletteValue[16];
-  EFI_HII_IMAGE_PALETTE_INFO     *Palette;
-  UINTN                          PaletteSize;
-  UINT16                         PaletteNum;
-  UINT8                          Byte;
+  UINT16                               Xpos;
+  UINT16                               Ypos;
+  UINTN                                OffsetY;
+  EFI_GRAPHICS_OUTPUT_BLT_PIXEL_UNION  *BitMapPtr;
+  EFI_GRAPHICS_OUTPUT_BLT_PIXEL_UNION  PaletteValue[16];
+  EFI_HII_IMAGE_PALETTE_INFO           *Palette;
+  UINTN                                PaletteSize;
+  UINT16                               PaletteNum;
+  UINT8                                Byte;
 
   ASSERT (Image != NULL && Data != NULL && PaletteInfo != NULL);
 
-  BitMapPtr = Image->Bitmap;
+  BitMapPtr = (EFI_GRAPHICS_OUTPUT_BLT_PIXEL_UNION *)Image->Bitmap;
 
   //
   // The bitmap should allocate each color index starting from 0.
@@ -363,7 +363,7 @@ Output4bitPixel (
   PaletteNum = (UINT16)(Palette->PaletteSize / sizeof (EFI_HII_RGB_PIXEL));
 
   ZeroMem (PaletteValue, sizeof (PaletteValue));
-  CopyRgbToGopPixel (PaletteValue, Palette->PaletteValue, MIN (PaletteNum, ARRAY_SIZE (PaletteValue)));
+  CopyRgbToGopPixel (&PaletteValue->Pixel, Palette->PaletteValue, MIN (PaletteNum, ARRAY_SIZE (PaletteValue)));
   FreePool (Palette);
   Palette = NULL;                                     // MU_CHANGE - Make sure to manage this pointer safely.
 
@@ -376,17 +376,17 @@ Output4bitPixel (
     // All bits in these bytes are meaningful
     //
     for (Xpos = 0; Xpos < Image->Width / 2; Xpos++) {
-      Byte = *(Data + OffsetY + Xpos);
-      CopyMem (&BitMapPtr[Ypos * Image->Width + Xpos * 2], &PaletteValue[Byte >> 4], sizeof (*BitMapPtr));
-      CopyMem (&BitMapPtr[Ypos * Image->Width + Xpos * 2 + 1], &PaletteValue[Byte & 0x0F], sizeof (*BitMapPtr));
+      Byte                                              = *(Data + OffsetY + Xpos);
+      BitMapPtr[Ypos * Image->Width + Xpos * 2].Raw     = PaletteValue[Byte >> 4].Raw;
+      BitMapPtr[Ypos * Image->Width + Xpos * 2 + 1].Raw = PaletteValue[Byte & 0x0F].Raw;
     }
 
     if (Image->Width % 2 != 0) {
       //
       // Padding bits in this byte should be ignored.
       //
-      Byte = *(Data + OffsetY + Xpos);
-      CopyMem (&BitMapPtr[Ypos * Image->Width + Xpos * 2], &PaletteValue[Byte >> 4], sizeof (*BitMapPtr));
+      Byte                                          = *(Data + OffsetY + Xpos);
+      BitMapPtr[Ypos * Image->Width + Xpos * 2].Raw = PaletteValue[Byte >> 4].Raw;
     }
   }
 }
@@ -412,19 +412,19 @@ Output8bitPixel (
   IN EFI_HII_IMAGE_PALETTE_INFO  *PaletteInfo
   )
 {
-  UINT16                         Xpos;
-  UINT16                         Ypos;
-  UINTN                          OffsetY;
-  EFI_GRAPHICS_OUTPUT_BLT_PIXEL  *BitMapPtr;
-  EFI_GRAPHICS_OUTPUT_BLT_PIXEL  PaletteValue[256];
-  EFI_HII_IMAGE_PALETTE_INFO     *Palette;
-  UINTN                          PaletteSize;
-  UINT16                         PaletteNum;
-  UINT8                          Byte;
+  UINT16                               Xpos;
+  UINT16                               Ypos;
+  UINTN                                OffsetY;
+  EFI_GRAPHICS_OUTPUT_BLT_PIXEL_UNION  *BitMapPtr;
+  EFI_GRAPHICS_OUTPUT_BLT_PIXEL_UNION  PaletteValue[256];
+  EFI_HII_IMAGE_PALETTE_INFO           *Palette;
+  UINTN                                PaletteSize;
+  UINT16                               PaletteNum;
+  UINT8                                Byte;
 
   ASSERT (Image != NULL && Data != NULL && PaletteInfo != NULL);
 
-  BitMapPtr = Image->Bitmap;
+  BitMapPtr = (EFI_GRAPHICS_OUTPUT_BLT_PIXEL_UNION *)Image->Bitmap;
 
   //
   // The bitmap should allocate each color index starting from 0.
@@ -441,7 +441,7 @@ Output8bitPixel (
   CopyMem (Palette, PaletteInfo, PaletteSize);
   PaletteNum = (UINT16)(Palette->PaletteSize / sizeof (EFI_HII_RGB_PIXEL));
   ZeroMem (PaletteValue, sizeof (PaletteValue));
-  CopyRgbToGopPixel (PaletteValue, Palette->PaletteValue, MIN (PaletteNum, ARRAY_SIZE (PaletteValue)));
+  CopyRgbToGopPixel (&PaletteValue->Pixel, Palette->PaletteValue, MIN (PaletteNum, ARRAY_SIZE (PaletteValue)));
   FreePool (Palette);
   Palette = NULL;                                     // MU_CHANGE - Make sure to manage this pointer safely.
 
@@ -454,8 +454,8 @@ Output8bitPixel (
     // All bits are meaningful since the bitmap is 8 bits per pixel.
     //
     for (Xpos = 0; Xpos < Image->Width; Xpos++) {
-      Byte = *(Data + OffsetY + Xpos);
-      CopyMem (&BitMapPtr[OffsetY + Xpos], &PaletteValue[Byte], sizeof (*BitMapPtr));
+      Byte                          = *(Data + OffsetY + Xpos);
+      BitMapPtr[OffsetY + Xpos].Raw = PaletteValue[Byte].Raw;
     }
   }
 }
@@ -525,13 +525,15 @@ ImageToBlt (
   IN OUT EFI_IMAGE_OUTPUT           **Blt
   )
 {
-  EFI_IMAGE_OUTPUT               *ImageOut;
-  UINTN                          Xpos;
-  UINTN                          Ypos;
-  UINTN                          OffsetY1;     // src buffer
-  UINTN                          OffsetY2;     // dest buffer
-  EFI_GRAPHICS_OUTPUT_BLT_PIXEL  SrcPixel;
-  EFI_GRAPHICS_OUTPUT_BLT_PIXEL  ZeroPixel;
+  EFI_IMAGE_OUTPUT                     *ImageOut;
+  UINTN                                Xpos;
+  UINTN                                Ypos;
+  UINTN                                OffsetY1; // src buffer
+  UINTN                                OffsetY2; // dest buffer
+  EFI_GRAPHICS_OUTPUT_BLT_PIXEL_UNION  SrcPixel;
+  EFI_GRAPHICS_OUTPUT_BLT_PIXEL_UNION  ZeroPixel;
+  EFI_GRAPHICS_OUTPUT_BLT_PIXEL_UNION  *BltBufferPixel;
+  EFI_GRAPHICS_OUTPUT_BLT_PIXEL_UNION  *ImageBitmap;
 
   if ((BltBuffer == NULL) || (Blt == NULL) || (*Blt == NULL)) {
     return EFI_INVALID_PARAMETER;
@@ -549,17 +551,20 @@ ImageToBlt (
 
   ZeroMem (&ZeroPixel, sizeof (EFI_GRAPHICS_OUTPUT_BLT_PIXEL));
 
+  BltBufferPixel = (EFI_GRAPHICS_OUTPUT_BLT_PIXEL_UNION *)BltBuffer;
+  ImageBitmap    = (EFI_GRAPHICS_OUTPUT_BLT_PIXEL_UNION *)ImageOut->Image.Bitmap;
+
   for (Ypos = 0; Ypos < Height; Ypos++) {
     OffsetY1 = Width * Ypos;
     OffsetY2 = ImageOut->Width * (BltY + Ypos);
     for (Xpos = 0; Xpos < Width; Xpos++) {
-      CopyMem (&SrcPixel, &BltBuffer[OffsetY1 + Xpos], sizeof (SrcPixel));
+      SrcPixel.Raw = BltBufferPixel[OffsetY1 + Xpos].Raw;
       if (Transparent) {
-        if (CompareMem (&SrcPixel, &ZeroPixel, 3) != 0) { \
-          CopyMem (&ImageOut->Image.Bitmap[OffsetY2 + BltX + Xpos], &SrcPixel, sizeof (SrcPixel));
+        if (CompareMem (&SrcPixel, &ZeroPixel, 3) != 0) {
+          ImageBitmap[OffsetY2 + BltX + Xpos].Raw = SrcPixel.Raw;
         }
       } else {
-        CopyMem (&ImageOut->Image.Bitmap[OffsetY2 + BltX + Xpos], &SrcPixel, sizeof (SrcPixel));
+        ImageBitmap[OffsetY2 + BltX + Xpos].Raw = SrcPixel.Raw;
       }
     }
   }

--- a/MdeModulePkg/Universal/HiiDatabaseDxe/Image.c
+++ b/MdeModulePkg/Universal/HiiDatabaseDxe/Image.c
@@ -1292,7 +1292,6 @@ HiiDrawImage (
   UINTN                          BufferLen;
   UINT16                         Width;
   UINT16                         Height;
-  UINTN                          Xpos;
   UINTN                          Ypos;
   UINTN                          OffsetY1;
   UINTN                          OffsetY2;
@@ -1394,9 +1393,11 @@ HiiDrawImage (
       for (Ypos = 0; Ypos < Height; Ypos++) {
         OffsetY1 = Image->Width * Ypos;
         OffsetY2 = Width * Ypos;
-        for (Xpos = 0; Xpos < Width; Xpos++) {
-          CopyMem (&BltBuffer[OffsetY2 + Xpos], &Image->Bitmap[OffsetY1 + Xpos], sizeof (*BltBuffer));
-        }
+        CopyMem (
+          &BltBuffer[OffsetY2],
+          &Image->Bitmap[OffsetY1],
+          Width * sizeof (*BltBuffer)
+          );
       }
     }
 

--- a/MdePkg/Library/BaseMemoryLib/MemLibGeneric.c
+++ b/MdePkg/Library/BaseMemoryLib/MemLibGeneric.c
@@ -32,8 +32,6 @@ InternalMemSetMem16 (
   )
 {
   for ( ; Length != 0; Length--) {
-    // MU_CHANGE use a pointer to volatile data to prevent Visual Studio 17.5 (VS2022)
-    // from replacing the assignment with a `memset()` intrinsic
     ((volatile UINT16 *)Buffer)[Length - 1] = Value;
   }
 
@@ -59,8 +57,6 @@ InternalMemSetMem32 (
   )
 {
   for ( ; Length != 0; Length--) {
-    // MU_CHANGE use a pointer to volatile data to prevent Visual Studio 17.5 (VS2022)
-    // from replacing the assignment with a `memset()` intrinsic
     ((volatile UINT32 *)Buffer)[Length - 1] = Value;
   }
 
@@ -86,8 +82,6 @@ InternalMemSetMem64 (
   )
 {
   for ( ; Length != 0; Length--) {
-    // MU_CHANGE use a pointer to volatile data to prevent Visual Studio 17.5 (VS2022)
-    // from replacing the assignment with a `memset()` intrinsic
     ((volatile UINT64 *)Buffer)[Length - 1] = Value;
   }
 


### PR DESCRIPTION
## Description

Cherry picks a commit upstreamed (reworked from Mu original) and a similar commit made upstream to eliminate Mu delta.

---

**[NEW] MdeModulePkg/HiiDatabaseDxe: Avoid struct assignment**

Struct assignments are not permitted in EDK2, as they may be converted
by the compiler into calls to the 'memcpy' intrinsic, which is not
guaranteed to be available in EDK2.

So replace the assignment with a call to CopyMem (), and -while at it-
replace the loop with a single CopyMem () call, as the loop operates on
items that are contiguous in memory.

---

**[NON-FUNCTIONAL REFACTOR] MdeModulePkg/HiiDatabaseDxe: Prevent linker error**

Prevent an issue where `memcpy()` instrinsic is being used after
recent MSVC linker update in windows-2022 VM image from 14.31.31103
to 14.32.31326.

---

**[DROP MU_CHANGE TAGS] MdePkg/BaseMemoryLib: Prevent potential VS2022 linker failure**

After updating between various VS2022 versions such as 17.4 to
17.5, , linker failures began to appear in several modules because
`memset` is an unresolved symbol.

The following functions in BaseMemoryLib/MemLibGeneric.c have their
loop pattern replaced with the `memset` intrinsic function:

- `InternalMemSetMem16()`
- `InternalMemSetMem32()`
- `InternalMemSetMem64()`

An example of an error related to `InternalMemSetMem64()` in
VariableSmmRuntimeDxe is shown below:

```
INFO - BaseMemoryLib.lib(MemLibGeneric.obj) : error LNK2001:
         unresolved external symbol memset
INFO - <...>\VariableSmmRuntimeDxe.dll : fatal error LNK1120:
         1 unresolved externals
```

This was reproduced in several environments including:

- Public VM image:
  https://github.com/actions/runner-images/blob/win22/20230226.1/images/win/Windows2022-Readme.md

- Locally when updating from 17.4.4 to 17.5.1

> Note: This image (with 17.4) does not have this issue
  https://github.com/actions/runner-images/blob/win22/20230219.1/images/win/Windows2022-Readme.md

This change updates the type cast for the destination buffer to be
a pointer to `volatile` data to prevent this optimization with a
relatively minimum delta to prior implementation.

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

- VS22 build and CI.
- QEMU boot.

## Integration Instructions

- N/A