### PR TITLE
MdeModulePkg/SmmCorePerformanceLib: Remove offset from comm buffer dest space

### DIFF
--- a/MdeModulePkg/Library/SmmCorePerformanceLib/MmCorePerformanceLib.c
+++ b/MdeModulePkg/Library/SmmCorePerformanceLib/MmCorePerformanceLib.c
@@ -877,7 +877,7 @@ FpdtSmiHandler (
       }
 
       // Note: Comm size passed to this handler already has OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, Data) removed.
-      if ((SmmCommData->BootRecordData == NULL) && (BootRecordSize - BootRecordOffset > TempCommBufferSize - sizeof (SMM_BOOT_RECORD_COMMUNICATE))) {
+      if ((SmmCommData->BootRecordData == NULL) && (BootRecordSize > TempCommBufferSize - sizeof (SMM_BOOT_RECORD_COMMUNICATE))) {
         Status = EFI_BUFFER_TOO_SMALL;
         break;
       }


### PR DESCRIPTION
## Description

A check validates that if perf records are being written to the comm buffer (not a buffer pointed to from the comm buffer) that enough space is available after the `SMM_BOOT_RECORD_COMMUNICATE` header in the comm buffer for the boot record size requested. That check currently removes the offset from the boot record size but that is not needed since the offset is applied to the source buffer and the record size is what is copied into the destination (comm buffer).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

- Send multiple rounds of perf data across the comm buffer using offsets across the calls.

## Integration Instructions

- N/A