### PR TITLE
StandaloneMmPkg: Add Google Mock Library for StandaloneMmMemLib

### DIFF
--- a/StandaloneMmPkg/StandaloneMmPkg.dec
+++ b/StandaloneMmPkg/StandaloneMmPkg.dec
@@ -16,6 +16,7 @@
 
 [Includes]
   Include
+  Test/Mock/Include
 
 [LibraryClasses]
 

--- a/StandaloneMmPkg/Test/Mock/Include/GoogleTest/Library/MockStandaloneMmMemLib.h
+++ b/StandaloneMmPkg/Test/Mock/Include/GoogleTest/Library/MockStandaloneMmMemLib.h
@@ -1,0 +1,85 @@
+/** @file MockStandaloneMmMemLib.h
+  Google Test mocks for StandaloneMmMemLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_MM_MEM_LIB_H_
+#define MOCK_MM_MEM_LIB_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+extern "C" {
+  #include <Uefi.h>
+  #include <Library/StandaloneMmMemLib.h>
+}
+
+//
+// Declarations to handle usage of the MmMemLib by creating mock
+//
+struct MockMmMemLib {
+  MOCK_INTERFACE_DECLARATION (MockMmMemLib);
+
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    MmIsBufferOutsideMmValid,
+    (
+     IN EFI_PHYSICAL_ADDRESS  Buffer,
+     IN UINT64                Length
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    MmCopyMemToMmram,
+    (
+     OUT VOID       *DestinationBuffer,
+     IN CONST VOID  *SourceBuffer,
+     IN UINTN       Length
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    MmCopyMemFromMmram,
+    (
+     OUT VOID       *DestinationBuffer,
+     IN CONST VOID  *SourceBuffer,
+     IN UINTN       Length
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    MmCopyMem,
+    (
+     OUT VOID       *DestinationBuffer,
+     IN CONST VOID  *SourceBuffer,
+     IN UINTN       Length
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    MmSetMem,
+    (
+     OUT VOID  *Buffer,
+     IN UINTN  Length,
+     IN UINT8  Value
+    )
+    );
+
+  // MU_CHANGE Start: Add Communication Buffer Validation
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    MmCommBufferValid,
+    (
+     IN EFI_PHYSICAL_ADDRESS  Buffer,
+     IN UINT64                Length
+    )
+    );
+  // MU_CHANGE End: Add Communication Buffer Validation
+};
+
+#endif

--- a/StandaloneMmPkg/Test/Mock/Library/GoogleTest/MockStandaloneMmMemLib/MockStandaloneMmMemLib.cpp
+++ b/StandaloneMmPkg/Test/Mock/Library/GoogleTest/MockStandaloneMmMemLib/MockStandaloneMmMemLib.cpp
@@ -1,0 +1,18 @@
+/** @file MockStandaloneMmMemLib.cpp
+  Google Test mocks for StandaloneMmMemLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#include <GoogleTest/Library/MockStandaloneMmMemLib.h>
+
+MOCK_INTERFACE_DEFINITION (MockMmMemLib);
+
+MOCK_FUNCTION_DEFINITION (MockMmMemLib, MmIsBufferOutsideMmValid, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMmMemLib, MmCopyMemToMmram, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMmMemLib, MmCopyMemFromMmram, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMmMemLib, MmCopyMem, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockMmMemLib, MmSetMem, 3, EFIAPI);
+// MU_CHANGE Start: Add Communication Buffer Validation
+MOCK_FUNCTION_DEFINITION (MockMmMemLib, MmCommBufferValid, 2, EFIAPI);
+// MU_CHANGE End: Add Communication Buffer Validation

--- a/StandaloneMmPkg/Test/Mock/Library/GoogleTest/MockStandaloneMmMemLib/MockStandaloneMmMemLib.inf
+++ b/StandaloneMmPkg/Test/Mock/Library/GoogleTest/MockStandaloneMmMemLib/MockStandaloneMmMemLib.inf
@@ -1,0 +1,34 @@
+## @file MockStandaloneMmMemLib.inf
+# Google Test mocks for StandaloneMmMemLib
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MockStandaloneMmMemLib
+  FILE_GUID                      = 925CFA0C-2B5C-487B-8B93-3031EA16CEB2
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = MemLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  MockStandaloneMmMemLib.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  StandaloneMmPkg/StandaloneMmPkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHsc


### PR DESCRIPTION
## Description

Added StandaloneMmMemLib to be used by Googletests

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Added StandaloneMmMemLib to GoogleTests and able to successfully include its functions

## Integration Instructions

N/A
