### PR TITLE
MdePkg: Add Google Mock Library for BaseMemoryLib

### DIFF
--- a/MdePkg/Test/MdePkgHostTest.dsc
+++ b/MdePkg/Test/MdePkgHostTest.dsc
@@ -73,4 +73,5 @@
   MdePkg/Test/Mock/Library/GoogleTest/MockPostCodeLib/MockPostCodeLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockSafeIntLib/MockSafeIntLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockSmmMemLib/MockSmmMemLib.inf
+  MdePkg/Test/Mock/Library/GoogleTest/MockBaseMemoryLib/MockBaseMemoryLib.inf
   # MU_CHANGE [END]

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockBaseMemoryLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockBaseMemoryLib.h
@@ -1,0 +1,199 @@
+/** @file MockBaseMemoryLib.h
+  Google Test mocks for BaseMemoryLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_BASE_MEMORY_LIB_H_
+#define MOCK_BASE_MEMORY_LIB_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+extern "C" {
+  #include <Uefi.h>
+  #include <Library/BaseMemoryLib.h>
+}
+
+//
+// Declarations to handle usage of the BaseMemoryLib by creating mock
+//
+struct MockBaseMemoryLib {
+  MOCK_INTERFACE_DECLARATION (MockBaseMemoryLib);
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    CopyMem,
+    (
+     OUT VOID       *DestinationBuffer,
+     IN CONST VOID  *SourceBuffer,
+     IN UINTN       Length
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    SetMem,
+    (
+     OUT VOID  *Buffer,
+     IN UINTN  Length,
+     IN UINT8  Value
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    SetMem16,
+    (
+     OUT VOID   *Buffer,
+     IN UINTN   Length,
+     IN UINT16  Value
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    SetMem32,
+    (
+     OUT VOID   *Buffer,
+     IN UINTN   Length,
+     IN UINT32  Value
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    SetMem64,
+    (
+     OUT VOID   *Buffer,
+     IN UINTN   Length,
+     IN UINT64  Value
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    SetMemN,
+    (
+     OUT VOID  *Buffer,
+     IN UINTN  Length,
+     IN UINTN  Value
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    ZeroMem,
+    (
+     OUT VOID  *Buffer,
+     IN UINTN  Length
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    INTN,
+    CompareMem,
+    (
+     IN CONST VOID  *DestinationBuffer,
+     IN CONST VOID  *SourceBuffer,
+     IN UINTN       Length
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    ScanMem8,
+    (
+     IN CONST VOID  *Buffer,
+     IN UINTN       Length,
+     IN UINT8       Value
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    ScanMem16,
+    (
+     IN CONST VOID  *Buffer,
+     IN UINTN       Length,
+     IN UINT16      Value
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    ScanMem32,
+    (
+     IN CONST VOID  *Buffer,
+     IN UINTN       Length,
+     IN UINT32      Value
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    ScanMem64,
+    (
+     IN CONST VOID  *Buffer,
+     IN UINTN       Length,
+     IN UINT64      Value
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    ScanMemN,
+    (
+     IN CONST VOID  *Buffer,
+     IN UINTN       Length,
+     IN UINTN       Value
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    GUID *,
+    CopyGuid,
+    (
+     OUT GUID       *DestinationGuid,
+     IN CONST GUID  *SourceGuid
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    CompareGuid,
+    (
+     IN CONST GUID  *Guid1,
+     IN CONST GUID  *Guid2
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    ScanGuid,
+    (
+     IN CONST VOID  *Buffer,
+     IN UINTN       Length,
+     IN CONST GUID  *Guid
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    IsZeroGuid,
+    (
+     IN CONST GUID  *Guid
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    IsZeroBuffer,
+    (
+     IN CONST VOID  *Buffer,
+     IN UINTN       Length
+    )
+    );
+};
+
+#endif

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockBaseMemoryLib/MockBaseMemoryLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockBaseMemoryLib/MockBaseMemoryLib.cpp
@@ -1,0 +1,28 @@
+/** @file MockBaseMemoryLib.cpp
+  Google Test mocks for BaseMemoryLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#include <GoogleTest/Library/MockBaseMemoryLib.h>
+
+MOCK_INTERFACE_DEFINITION (MockBaseMemoryLib);
+
+MOCK_FUNCTION_DEFINITION (MockBaseMemoryLib, CopyMem, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockBaseMemoryLib, SetMem, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockBaseMemoryLib, SetMem16, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockBaseMemoryLib, SetMem32, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockBaseMemoryLib, SetMem64, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockBaseMemoryLib, SetMemN, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockBaseMemoryLib, ZeroMem, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockBaseMemoryLib, CompareMem, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockBaseMemoryLib, ScanMem8, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockBaseMemoryLib, ScanMem16, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockBaseMemoryLib, ScanMem32, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockBaseMemoryLib, ScanMem64, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockBaseMemoryLib, ScanMemN, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockBaseMemoryLib, CopyGuid, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockBaseMemoryLib, CompareGuid, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockBaseMemoryLib, ScanGuid, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockBaseMemoryLib, IsZeroGuid, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockBaseMemoryLib, IsZeroBuffer, 2, EFIAPI);

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockBaseMemoryLib/MockBaseMemoryLib.inf
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockBaseMemoryLib/MockBaseMemoryLib.inf
@@ -1,0 +1,33 @@
+## @file MockBaseMemoryLib.inf
+# Google Test mocks for BaseMemoryLib
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MockBaseMemoryLib
+  FILE_GUID                      = D2EA60E6-AA16-4DFF-BBAD-215C975C995C
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = BaseMemoryLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  MockBaseMemoryLib.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHsc


### PR DESCRIPTION
## Description

Added MockBaseMemoryLib to be used by Googletests

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Added MockBaseMemoryLib to GoogleTests and able to successfully include its functions

## Integration Instructions

N/A
