### PR TITLE
[CHERRY-PICK] MdeModulePkg/DxeCapsuleLibFmp: Check for NULL in IsValidCapsuleHeader

### DIFF
--- a/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.c
+++ b/MdeModulePkg/Library/DxeCapsuleLibFmp/DxeCapsuleLib.c
@@ -171,6 +171,10 @@ IsValidCapsuleHeader (
   IN UINT64              CapsuleSize
   )
 {
+  if (CapsuleHeader == NULL) {
+    return FALSE;
+  }
+
   if (CapsuleHeader->CapsuleImageSize != CapsuleSize) {
     return FALSE;
   }


### PR DESCRIPTION
## Description

Add a NULL check in `IsValidCapsuleHeader` before dereferencing `CapsuleHeader`

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Published HOB with `EFI_HOB_TYPE_UEFI_CAPSULE` and `BaseAddress = 0`.
Confirmed `IsValidCapsuleHeader` returned FALSE instead of crashing.

## Integration Instructions

N/A
