### PR TITLE
[SQUASH_ON_REBASE] Remove unused variable in DEBUG_CLEAR_MEMORY call

### DIFF
--- a/UnitTestFrameworkPkg/Library/Posix/MemoryAllocationLibPosix/MemoryAllocationLibPosix.c
+++ b/UnitTestFrameworkPkg/Library/Posix/MemoryAllocationLibPosix/MemoryAllocationLibPosix.c
@@ -274,7 +274,8 @@ FreeAlignedPages (
 {
   PAGE_HEAD  *PageHeadPtr;
   VOID       *AllocatedBuffer;
-  //UINTN      Length;  MU_CHANGE
+
+  // UINTN      Length;  MU_CHANGE
 
   ASSERT (Buffer != NULL);
 
@@ -288,6 +289,7 @@ FreeAlignedPages (
   AllocatedBuffer = PageHeadPtr->AllocatedBuffer;
 
   // MU_CHANGE [START]: Remove variable that isn't used in project MU
+
   /* Length          = EFI_PAGES_TO_SIZE (PageHeadPtr->TotalPages);
 
   DEBUG_CLEAR_MEMORY (AllocatedBuffer, Length); */

--- a/UnitTestFrameworkPkg/Library/Posix/MemoryAllocationLibPosix/MemoryAllocationLibPosix.c
+++ b/UnitTestFrameworkPkg/Library/Posix/MemoryAllocationLibPosix/MemoryAllocationLibPosix.c
@@ -274,7 +274,7 @@ FreeAlignedPages (
 {
   PAGE_HEAD  *PageHeadPtr;
   VOID       *AllocatedBuffer;
-  UINTN      Length;
+  //UINTN      Length;  MU_CHANGE
 
   ASSERT (Buffer != NULL);
 
@@ -286,9 +286,13 @@ FreeAlignedPages (
   ASSERT (PageHeadPtr->AllocatedBuffer != NULL);
 
   AllocatedBuffer = PageHeadPtr->AllocatedBuffer;
-  Length          = EFI_PAGES_TO_SIZE (PageHeadPtr->TotalPages);
 
-  DEBUG_CLEAR_MEMORY (AllocatedBuffer, Length);
+  // MU_CHANGE [START]: Remove variable that isn't used in project MU
+  /* Length          = EFI_PAGES_TO_SIZE (PageHeadPtr->TotalPages);
+
+  DEBUG_CLEAR_MEMORY (AllocatedBuffer, Length); */
+  DEBUG_CLEAR_MEMORY (AllocatedBuffer, EFI_PAGES_TO_SIZE (PageHeadPtr->TotalPages));
+  // MU_CHANGE [END]: Remove variable that isn't used in project MU
 
   free (AllocatedBuffer);
 }


### PR DESCRIPTION
## Description

In project MU we changed the DEBUG_CLEAR_MEMORY define to do nothing.  This causes an issue in the new file MemoryAllocationLibPosix.c which calls it with a newly defined variable.  To get around this variable is removed and instead we use what it was deriving its value from instead.

This should be merged with [230503 ](https://github.com/microsoft/mu_basecore/commit/234050304aa77dd1e7e7164b1e7c5074a063c566) on a rebase

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Tested on the pipelines.  No issues

## Integration Instructions

N/A