### PR TITLE
[CHERRY-PICK] DebugMacroCheck: Do not show progress bar with zero items

### DIFF
--- a/BaseTools/Plugin/DebugMacroCheck/DebugMacroCheck.py
+++ b/BaseTools/Plugin/DebugMacroCheck/DebugMacroCheck.py
@@ -577,6 +577,9 @@ def _show_progress(step: int, total: int, suffix: str = '') -> None:
     """
     global _progress_start_time
 
+    if total == 0:
+        return
+
     if step == 0:
         _progress_start_time = timeit.default_timer()
 


### PR DESCRIPTION
## Description

In the case that the total provided to the `_show_progress()` function is zero, do not show a progress bar to prevent aborts `ZeroDivisionError` when calculating the progress percentage.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

- Test progress bar with zero and non-zero total

## Integration Instructions

- N/A