### PR TITLE
Temporarly remove VariableRuntimeDxeUnitTest from running in GCC

### DIFF
--- a/MdeModulePkg/MdeModulePkg.ci.yaml
+++ b/MdeModulePkg/MdeModulePkg.ci.yaml
@@ -79,7 +79,7 @@
     },
     ## options defined .pytool/Plugin/HostUnitTestDscCompleteCheck
     "HostUnitTestDscCompleteCheck": {
-        "IgnoreInf": [""],
+        "IgnoreInf": ["MdeModulePkg/Universal/Variable/RuntimeDxe/RuntimeDxeUnitTest/VariableRuntimeDxeUnitTest.inf"],
         "DscPath": "Test/MdeModulePkgHostTest.dsc"
     },
 

--- a/MdeModulePkg/Test/MdeModulePkgHostTest.dsc
+++ b/MdeModulePkg/Test/MdeModulePkgHostTest.dsc
@@ -44,6 +44,7 @@
   }
 
   # MU_CHANGE [BEGIN] - Add a host-based unit test for common variable services code.
+!if "MSFT" in $(FAMILY)
   MdeModulePkg/Universal/Variable/RuntimeDxe/RuntimeDxeUnitTest/VariableRuntimeDxeUnitTest.inf {
     <LibraryClasses>
       UefiLib|MdePkg/Test/Mock/Library/Stub/StubUefiLib/StubUefiLib.inf
@@ -70,6 +71,7 @@
       # SCT tests are noisy, so disable VERBOSE.
       gUnitTestFrameworkPkgTokenSpaceGuid.PcdUnitTestLogLevel|0x00000007
   }
+!endif
   # MU_CHANGE [END] - Add a host-based unit test for common variable services code.
 
   MdeModulePkg/Library/UefiSortLib/UnitTest/UefiSortLibUnitTest.inf {


### PR DESCRIPTION
## Description

In 202502 HostBasedUnitTests have enabled address sanitization for host based unit tests.

VariableRuntimeDxeUnitTest is working when compiled under VS2022/VS2019, but it is asserting when run with GCC.

Temporarily remove VariableRuntimeDxeUnitTest from running in GCC build environment.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Local CI runs under Ubuntu 24.01 using GCC. Failing before change, passing after. 

## Integration Instructions

None. 