### PR TITLE
Complete MockBootServicesTableLib.cpp

### DIFF
--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiBootServicesTableLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockUefiBootServicesTableLib.h
@@ -1,4 +1,4 @@
-/** @file
+/** @file MockUefiBootServicesTableLib.h
   Google Test mocks for UefiBootServicesTableLib
 
   Copyright (c) Microsoft Corporation.
@@ -21,6 +21,40 @@ extern "C" {
 struct MockUefiBootServicesTableLib {
   MOCK_INTERFACE_DECLARATION (MockUefiBootServicesTableLib);
 
+  //
+  // Task Priority Services
+  //
+  MOCK_FUNCTION_DECLARATION (
+    EFI_TPL,
+    gBS_RaiseTpl,
+    (IN EFI_TPL NewTpl)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    gBS_RestoreTpl,
+    (IN EFI_TPL OldTpl)
+    );
+
+  //
+  // Memory Services
+  //
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_AllocatePages,
+    (IN     EFI_ALLOCATE_TYPE      Type,
+     IN     EFI_MEMORY_TYPE        MemoryType,
+     IN     UINTN                  Pages,
+     IN OUT EFI_PHYSICAL_ADDRESS    *Memory)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_FreePages,
+    (IN EFI_PHYSICAL_ADDRESS  Memory,
+     IN UINTN                Pages)
+    );
+
   MOCK_FUNCTION_DECLARATION (
     EFI_STATUS,
     gBS_GetMemoryMap,
@@ -33,6 +67,23 @@ struct MockUefiBootServicesTableLib {
 
   MOCK_FUNCTION_DECLARATION (
     EFI_STATUS,
+    gBS_AllocatePool,
+    (IN  EFI_MEMORY_TYPE              PoolType,
+     IN  UINTN                        Size,
+     OUT VOID                         **Buffer)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_FreePool,
+    (IN  VOID                         *Buffer)
+    );
+
+  //
+  // Event & Timer Services
+  //
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
     gBS_CreateEvent,
     (IN  UINT32           Type,
      IN  EFI_TPL          NotifyTpl,
@@ -43,10 +94,41 @@ struct MockUefiBootServicesTableLib {
 
   MOCK_FUNCTION_DECLARATION (
     EFI_STATUS,
+    gBS_SetTimer,
+    (IN EFI_EVENT  Event,
+     IN EFI_TIMER_DELAY  Type,
+     IN UINT64  TriggerTime)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_WaitForEvent,
+    (IN  UINTN       NumberOfEvents,
+     IN  EFI_EVENT   *Event,
+     OUT UINTN       *Index)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_SignalEvent,
+    (IN EFI_EVENT  Event)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
     gBS_CloseEvent,
     (IN EFI_EVENT Event)
     );
 
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_CheckEvent,
+    (IN EFI_EVENT  Event)
+    );
+
+  //
+  // Protocol Handler Services
+  //
   MOCK_FUNCTION_DECLARATION (
     EFI_STATUS,
     gBS_InstallProtocolInterface,
@@ -54,6 +136,15 @@ struct MockUefiBootServicesTableLib {
      IN EFI_GUID            *Protocol,
      IN EFI_INTERFACE_TYPE  InterfaceType,
      IN VOID                *Interface)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_ReinstallProtocolInterface,
+    (IN EFI_HANDLE  Handle,
+     IN EFI_GUID    *Protocol,
+     IN VOID        *OldInterface,
+     IN VOID        *NewInterface)
     );
 
   MOCK_FUNCTION_DECLARATION (
@@ -82,51 +173,120 @@ struct MockUefiBootServicesTableLib {
 
   MOCK_FUNCTION_DECLARATION (
     EFI_STATUS,
-    gBS_LocateHandleBuffer,
-    (
-     IN     EFI_LOCATE_SEARCH_TYPE       SearchType,
-     IN     EFI_GUID                     *Protocol       OPTIONAL,
-     IN     VOID                         *SearchKey      OPTIONAL,
-     OUT    UINTN                        *NoHandles,
-     OUT    EFI_HANDLE                   **Buffer
-    )
+    gBS_LocateHandle,
+    (IN     EFI_LOCATE_SEARCH_TYPE   SearchType,
+     IN     EFI_GUID                 *Protocol     OPTIONAL,
+     IN     VOID                     *SearchKey    OPTIONAL,
+     IN OUT UINTN                    *BufferSize,
+     OUT    EFI_HANDLE               *Buffer)
     );
 
   MOCK_FUNCTION_DECLARATION (
     EFI_STATUS,
-    gBS_LocateProtocol,
-    (IN  EFI_GUID *Protocol,
-     IN  VOID      *Registration  OPTIONAL,
-     OUT VOID      **Interface)
+    gBS_LocateDevicePath,
+    (IN     EFI_GUID                         *Protocol,
+     IN OUT EFI_DEVICE_PATH_PROTOCOL         **DevicePath,
+     OUT    EFI_HANDLE                       *Device)
     );
 
   MOCK_FUNCTION_DECLARATION (
     EFI_STATUS,
-    gBS_CreateEventEx,
-    (IN UINT32            Type,
-     IN EFI_TPL           NotifyTpl,
-     IN EFI_EVENT_NOTIFY  NotifyFunction OPTIONAL,
-     IN CONST VOID        *NotifyContext OPTIONAL,
-     IN CONST EFI_GUID    *EventGroup OPTIONAL,
-     OUT EFI_EVENT        *Event)
+    gBS_InstallConfigurationTable,
+    (IN EFI_GUID  *Guid,
+     IN VOID      *Table)
+    );
+
+  //
+  // Image Services
+  //
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_LoadImage,
+    (IN  BOOLEAN                    BootPolicy,
+     IN  EFI_HANDLE                 ParentImageHandle,
+     IN  EFI_DEVICE_PATH_PROTOCOL   *DevicePath,
+     IN  VOID                       *SourceBuffer  OPTIONAL,
+     IN  UINTN                      SourceSize,
+     OUT EFI_HANDLE                 *ImageHandle)
     );
 
   MOCK_FUNCTION_DECLARATION (
-    VOID,
-    gBS_SetMem,
-    (IN VOID     *Buffer,
-     IN UINTN    Size,
-     IN UINT8    Value)
+    EFI_STATUS,
+    gBS_StartImage,
+    (IN  EFI_HANDLE                 ImageHandle,
+     OUT UINTN                      *ExitDataSize,
+     OUT CHAR16                     **ExitData  OPTIONAL)
     );
 
   MOCK_FUNCTION_DECLARATION (
-    VOID,
-    gBS_CopyMem,
-    (IN VOID     *Destination,
-     IN VOID     *Source,
-     IN UINTN    Length)
+    EFI_STATUS,
+    gBS_Exit,
+    (IN EFI_HANDLE  ImageHandle,
+     IN EFI_STATUS  ExitStatus,
+     IN UINTN       ExitDataSize,
+     IN CHAR16      *ExitData  OPTIONAL)
     );
 
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_UnloadImage,
+    (IN EFI_HANDLE  ImageHandle)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_ExitBootServices,
+    (IN EFI_HANDLE  ImageHandle,
+     IN UINTN       MapKey)
+    );
+
+  //
+  // Miscellaneous Services
+  //
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_GetNextMonotonicCount,
+    (OUT UINT64  *Count)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_Stall,
+    (IN UINTN  Microseconds)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_SetWatchdogTimer,
+    (IN UINTN  Timeout,
+     IN UINT64 WatchdogCode,
+     IN UINTN DataSize,
+     IN CHAR16 *WatchdogData OPTIONAL)
+    );
+
+  //
+  // Driver Support Services
+  //
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_ConnectController,
+    (IN  EFI_HANDLE                    ControllerHandle,
+     IN  EFI_HANDLE                    *DriverImageHandle    OPTIONAL,
+     IN  EFI_DEVICE_PATH_PROTOCOL      *RemainingDevicePath  OPTIONAL,
+     IN  BOOLEAN                       Recursive)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_DisconnectController,
+    (IN  EFI_HANDLE                     ControllerHandle,
+     IN  EFI_HANDLE                     DriverImageHandle  OPTIONAL,
+     IN  EFI_HANDLE                     ChildHandle        OPTIONAL)
+    );
+
+  //
+  // Open and Close Protocol Services
+  //
   MOCK_FUNCTION_DECLARATION (
     EFI_STATUS,
     gBS_OpenProtocol,
@@ -149,73 +309,83 @@ struct MockUefiBootServicesTableLib {
 
   MOCK_FUNCTION_DECLARATION (
     EFI_STATUS,
-    gBS_FreePool,
-    (IN  VOID                         *Buffer)
+    gBS_OpenProtocolInformation,
+    (IN  EFI_HANDLE                            Handle,
+     IN  EFI_GUID                              *Protocol,
+     OUT EFI_OPEN_PROTOCOL_INFORMATION_ENTRY   **EntryBuffer,
+     OUT UINTN                                *EntryCount)
+    );
+
+  //
+  // Library Services
+  //
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_ProtocolsPerHandle,
+    (IN  EFI_HANDLE      Handle,
+     OUT EFI_GUID        ***ProtocolBuffer,
+     OUT UINTN           *ProtocolBufferCount)
     );
 
   MOCK_FUNCTION_DECLARATION (
     EFI_STATUS,
-    gBS_LocateDevicePath,
-    (IN     EFI_GUID                         *Protocol,
-     IN OUT EFI_DEVICE_PATH_PROTOCOL         **DevicePath,
-     OUT    EFI_HANDLE                       *Device)
+    gBS_LocateHandleBuffer,
+    (
+     IN     EFI_LOCATE_SEARCH_TYPE       SearchType,
+     IN     EFI_GUID                     *Protocol       OPTIONAL,
+     IN     VOID                         *SearchKey      OPTIONAL,
+     OUT    UINTN                        *NoHandles,
+     OUT    EFI_HANDLE                   **Buffer
+    )
     );
 
   MOCK_FUNCTION_DECLARATION (
     EFI_STATUS,
-    gBS_ReinstallProtocolInterface,
-    (IN EFI_HANDLE               Handle,
-     IN EFI_GUID                 *Protocol,
-     IN VOID                     *OldInterface,
-     IN VOID                     *NewInterface)
+    gBS_LocateProtocol,
+    (IN  EFI_GUID *Protocol,
+     IN  VOID      *Registration  OPTIONAL,
+     OUT VOID      **Interface)
     );
 
+  //
+  // 32-bit CRC Services
+  //
   MOCK_FUNCTION_DECLARATION (
     EFI_STATUS,
-    gBS_AllocatePool,
-    (IN  EFI_MEMORY_TYPE              PoolType,
-     IN  UINTN                        Size,
-     OUT VOID                         **Buffer)
+    gBS_CalculateCrc32,
+    (IN  VOID      *Data,
+     IN  UINTN     DataSize,
+     OUT UINT32    *Crc32)
     );
 
+  //
+  // Miscellaneous Services
+  //
   MOCK_FUNCTION_DECLARATION (
-    EFI_STATUS,
-    gBS_LocateHandle,
-    (IN     EFI_LOCATE_SEARCH_TYPE   SearchType,
-     IN     EFI_GUID                 *Protocol     OPTIONAL,
-     IN     VOID                     *SearchKey    OPTIONAL,
-     IN OUT UINTN                    *BufferSize,
-     OUT    EFI_HANDLE               *Buffer)
-    );
-
-  MOCK_FUNCTION_DECLARATION (
-    EFI_STATUS,
-    gBS_ConnectController,
-    (IN  EFI_HANDLE                    ControllerHandle,
-     IN  EFI_HANDLE                    *DriverImageHandle    OPTIONAL,
-     IN  EFI_DEVICE_PATH_PROTOCOL      *RemainingDevicePath  OPTIONAL,
-     IN  BOOLEAN                       Recursive)
-    );
-
-  MOCK_FUNCTION_DECLARATION (
-    EFI_STATUS,
-    gBS_DisconnectController,
-    (IN  EFI_HANDLE                     ControllerHandle,
-     IN  EFI_HANDLE                     DriverImageHandle  OPTIONAL,
-     IN  EFI_HANDLE                     ChildHandle        OPTIONAL)
-    );
-
-  MOCK_FUNCTION_DECLARATION (
-    EFI_TPL,
-    gBS_RaiseTpl,
-
-    (IN EFI_TPL      NewTpl)
+    VOID,
+    gBS_CopyMem,
+    (IN VOID     *Destination,
+     IN VOID     *Source,
+     IN UINTN    Length)
     );
 
   MOCK_FUNCTION_DECLARATION (
     VOID,
-    gBS_RestoreTpl,
-    (IN EFI_TPL      OldTpl)
+    gBS_SetMem,
+    (IN VOID     *Buffer,
+     IN UINTN    Size,
+     IN UINT8    Value)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    gBS_CreateEventEx,
+    (IN UINT32            Type,
+     IN EFI_TPL           NotifyTpl,
+     IN EFI_EVENT_NOTIFY  NotifyFunction OPTIONAL,
+     IN CONST VOID        *NotifyContext OPTIONAL,
+     IN CONST EFI_GUID    *EventGroup OPTIONAL,
+     OUT EFI_EVENT        *Event)
     );
 };
 

--- a/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockSimpleTextIn.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockSimpleTextIn.h
@@ -1,0 +1,45 @@
+/** @file MockSimpleTextIn.h
+    Google Test mocks for SimpleTextIn Protocol
+
+    Copyright (c) Microsoft Corporation.
+    SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_SIMPLE_TEXT_IN_PROTOCOL_H_
+#define MOCK_SIMPLE_TEXT_IN_PROTOCOL_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+extern "C" {
+  #include <Uefi.h>
+  #include <Protocol/SimpleTextIn.h>
+}
+struct MockEfiSimpleTextInputProtocol {
+  MOCK_INTERFACE_DECLARATION (MockEfiSimpleTextInputProtocol);
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    MockEfiSimpleTextInProtocolReset,
+    (IN EFI_SIMPLE_TEXT_INPUT_PROTOCOL  *This,
+     IN BOOLEAN                         ExtendedVerification)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ReadKeyStroke,
+    (IN EFI_SIMPLE_TEXT_INPUT_PROTOCOL  *This,
+     OUT EFI_INPUT_KEY                  *Key)
+    );
+};
+
+MOCK_INTERFACE_DEFINITION (MockEfiSimpleTextInputProtocol);
+MOCK_FUNCTION_DEFINITION (MockEfiSimpleTextInputProtocol, MockEfiSimpleTextInProtocolReset, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockEfiSimpleTextInputProtocol, ReadKeyStroke, 2, EFIAPI);
+
+#define MOCK_EFI_SIMPLE_TEXT_INPUT_PROTOCOL_INSTANCE(NAME)  \
+  EFI_SIMPLE_TEXT_INPUT_PROTOCOL NAME##_INSTANCE = {        \
+    (EFI_INPUT_RESET)     MockEfiSimpleTextInProtocolReset, \
+    (EFI_INPUT_READ_KEY)  ReadKeyStroke,                    \
+    NULL };                                                 \
+  EFI_SIMPLE_TEXT_INPUT_PROTOCOL  *NAME = &NAME##_INSTANCE;
+
+#endif // MOCK_SIMPLE_TEXT_IN_PROTOCOL_H_

--- a/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockSimpleTextOut.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockSimpleTextOut.h
@@ -1,0 +1,119 @@
+/** @file MockSimpleTextOut.h
+  Google Test mocks for SimpleTextOut Protocol
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_SIMPLE_TEXT_OUT_PROTOCOL_H_
+#define MOCK_SIMPLE_TEXT_OUT_PROTOCOL_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Protocol/SimpleTextOut.h>
+}
+struct MockEfiSimpleTextOutProtocol {
+  MOCK_INTERFACE_DECLARATION (MockEfiSimpleTextOutProtocol);
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    MockEfiSimpleTextOutProtocolReset,
+    (IN EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL  *This,
+     IN BOOLEAN                         ExtendedVerification)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    OutputString,
+    (IN EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL  *This,
+     IN CHAR16                          *String)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    TestString,
+    (IN EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL  *This,
+     IN CHAR16                          *String)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    QueryMode,
+    (IN EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL  *This,
+     IN UINTN                           ModeNumber,
+     OUT UINTN                          *Columns,
+     OUT UINTN                          *Rows)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+
+    SetMode,
+    (IN EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL  *This,
+     IN UINTN                           ModeNumber)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    SetAttribute,
+    (IN EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL  *This,
+     IN UINTN                           Attribute)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    ClearScreen,
+    (IN EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL  *This)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    SetCursorPosition,
+    (IN EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL  *This,
+     IN UINTN                           Column,
+     IN UINTN                           Row)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    EnableCursor,
+    (IN EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL  *This,
+     IN BOOLEAN                         Visible)
+    );
+};
+
+MOCK_INTERFACE_DEFINITION (MockEfiSimpleTextOutProtocol);
+MOCK_FUNCTION_DEFINITION (MockEfiSimpleTextOutProtocol, MockEfiSimpleTextOutProtocolReset, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockEfiSimpleTextOutProtocol, OutputString, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockEfiSimpleTextOutProtocol, TestString, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockEfiSimpleTextOutProtocol, QueryMode, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockEfiSimpleTextOutProtocol, SetMode, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockEfiSimpleTextOutProtocol, SetAttribute, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockEfiSimpleTextOutProtocol, ClearScreen, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockEfiSimpleTextOutProtocol, SetCursorPosition, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockEfiSimpleTextOutProtocol, EnableCursor, 2, EFIAPI);
+
+#define MOCK_EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL_INSTANCE(NAME) \
+  EFI_SIMPLE_TEXT_OUTPUT_MODE NAME##_MODE_INSTANCE = {  \
+    1,                                                  \
+    0,                                                  \
+    0,                                                  \
+    0,                                                  \
+    0,                                                  \
+    FALSE};                                             \
+  EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL NAME##_INSTANCE = {   \
+    (EFI_TEXT_RESET)                MockEfiSimpleTextOutProtocolReset,  \
+    (EFI_TEXT_STRING)               OutputString,                       \
+    (EFI_TEXT_TEST_STRING)          TestString,                         \
+    (EFI_TEXT_QUERY_MODE)           QueryMode,                          \
+    (EFI_TEXT_SET_MODE)             SetMode,                            \
+    (EFI_TEXT_SET_ATTRIBUTE)        SetAttribute,                       \
+    (EFI_TEXT_CLEAR_SCREEN)         ClearScreen,                        \
+    (EFI_TEXT_SET_CURSOR_POSITION)  SetCursorPosition,                  \
+    (EFI_TEXT_ENABLE_CURSOR)        EnableCursor,                       \
+    &NAME##_MODE_INSTANCE};                                             \
+  EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL  *NAME = &NAME##_INSTANCE;
+
+#endif // MOCK_SIMPLE_TEXT_OUT_PROTOCOL_H_

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockUefiBootServicesTableLib/MockUefiBootServicesTableLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockUefiBootServicesTableLib/MockUefiBootServicesTableLib.cpp
@@ -1,37 +1,62 @@
-/** @file
+/** @file MockUefiBootServicesTableLib.cpp
   Google Test mocks for UefiBootServicesTableLib
 
   Copyright (c) Microsoft Corporation.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 #include <GoogleTest/Library/MockUefiBootServicesTableLib.h>
+#include <GoogleTest/Protocol/MockSimpleTextOut.h>
+#include <GoogleTest/Protocol/MockSimpleTextIn.h>
 
 MOCK_INTERFACE_DEFINITION (MockUefiBootServicesTableLib);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_RaiseTpl, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_RestoreTpl, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_AllocatePages, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_FreePages, 2, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_GetMemoryMap, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_AllocatePool, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_FreePool, 1, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_CreateEvent, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_SetTimer, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_WaitForEvent, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_SignalEvent, 1, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_CloseEvent, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_CheckEvent, 1, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_InstallProtocolInterface, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_ReinstallProtocolInterface, 4, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_UninstallProtocolInterface, 3, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_HandleProtocol, 3, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_RegisterProtocolNotify, 3, EFIAPI);
-MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_LocateHandleBuffer, 5, EFIAPI);
-MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_LocateProtocol, 3, EFIAPI);
-MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_CreateEventEx, 6, EFIAPI);
-MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_SetMem, 3, EFIAPI);
-MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_CopyMem, 3, EFIAPI);
-MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_OpenProtocol, 6, EFIAPI);
-MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_CloseProtocol, 4, EFIAPI);
-MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_FreePool, 1, EFIAPI);
-MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_LocateDevicePath, 3, EFIAPI);
-MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_ReinstallProtocolInterface, 4, EFIAPI);
-MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_AllocatePool, 3, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_LocateHandle, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_LocateDevicePath, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_InstallConfigurationTable, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_LoadImage, 6, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_StartImage, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_Exit, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_UnloadImage, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_ExitBootServices, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_GetNextMonotonicCount, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_Stall, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_SetWatchdogTimer, 4, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_ConnectController, 4, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_DisconnectController, 3, EFIAPI);
-MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_RaiseTpl, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_OpenProtocol, 6, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_CloseProtocol, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_OpenProtocolInformation, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_ProtocolsPerHandle, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_LocateHandleBuffer, 5, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_LocateProtocol, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_CalculateCrc32, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_CopyMem, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_SetMem, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_CreateEventEx, 6, EFIAPI);
 
-MOCK_FUNCTION_DEFINITION (MockUefiBootServicesTableLib, gBS_RestoreTpl, 1, EFIAPI);
-
+//
+// Gmock does not support variadic functions, so we implement the following functions that process
+// multiple protocols in a single call.
+// Usage of these functions in a test will require EXPECT_CALLs to be used for each time the
+// a function processes a single protocol.
+//
 extern "C" {
   EFI_STATUS
   EFIAPI
@@ -104,57 +129,76 @@ extern "C" {
   }
 }
 
-static EFI_BOOT_SERVICES  LocalBs = {
-  { 0, 0, 0, 0, 0 },                                                                   // EFI_TABLE_HEADER
-  gBS_RaiseTpl,                                                                        // EFI_RAISE_TPL
+static EFI_BOOT_SERVICES  MockEfiBootServicesInstance = {
+  { 0, 0, 0, 0, 0 },  // EFI_TABLE_HEADER
+  (EFI_RAISE_TPL)gBS_RaiseTpl,
+  (EFI_RESTORE_TPL)gBS_RestoreTpl,
+  (EFI_ALLOCATE_PAGES)gBS_AllocatePages,
+  (EFI_FREE_PAGES)gBS_FreePages,
+  (EFI_GET_MEMORY_MAP)gBS_GetMemoryMap,
+  (EFI_ALLOCATE_POOL)gBS_AllocatePool,
+  (EFI_FREE_POOL)gBS_FreePool,
+  (EFI_CREATE_EVENT)gBS_CreateEvent,
+  (EFI_SET_TIMER)gBS_SetTimer,
+  (EFI_WAIT_FOR_EVENT)gBS_WaitForEvent,
+  (EFI_SIGNAL_EVENT)gBS_SignalEvent,
+  (EFI_CLOSE_EVENT)gBS_CloseEvent,
+  (EFI_CHECK_EVENT)gBS_CheckEvent,
+  (EFI_INSTALL_PROTOCOL_INTERFACE)gBS_InstallProtocolInterface,
+  (EFI_REINSTALL_PROTOCOL_INTERFACE)gBS_ReinstallProtocolInterface,
+  (EFI_UNINSTALL_PROTOCOL_INTERFACE)gBS_UninstallProtocolInterface,
+  (EFI_HANDLE_PROTOCOL)gBS_HandleProtocol,
+  NULL, // VOID* Reserved
+  (EFI_REGISTER_PROTOCOL_NOTIFY)gBS_RegisterProtocolNotify,
+  (EFI_LOCATE_HANDLE)gBS_LocateHandle,
+  (EFI_LOCATE_DEVICE_PATH)gBS_LocateDevicePath,
+  (EFI_INSTALL_CONFIGURATION_TABLE)gBS_InstallConfigurationTable,
+  (EFI_IMAGE_LOAD)gBS_LoadImage,
+  (EFI_IMAGE_START)gBS_StartImage,
+  (EFI_EXIT)gBS_Exit,
+  (EFI_IMAGE_UNLOAD)gBS_UnloadImage,
+  (EFI_EXIT_BOOT_SERVICES)gBS_ExitBootServices,
+  (EFI_GET_NEXT_MONOTONIC_COUNT)gBS_GetNextMonotonicCount,
+  (EFI_STALL)gBS_Stall,
+  (EFI_SET_WATCHDOG_TIMER)gBS_SetWatchdogTimer,
+  (EFI_CONNECT_CONTROLLER)gBS_ConnectController,
+  (EFI_DISCONNECT_CONTROLLER)gBS_DisconnectController,
+  (EFI_OPEN_PROTOCOL)gBS_OpenProtocol,
+  (EFI_CLOSE_PROTOCOL)gBS_CloseProtocol,
+  (EFI_OPEN_PROTOCOL_INFORMATION)gBS_OpenProtocolInformation,
+  (EFI_PROTOCOLS_PER_HANDLE)gBS_ProtocolsPerHandle,
+  (EFI_LOCATE_HANDLE_BUFFER)gBS_LocateHandleBuffer,
+  (EFI_LOCATE_PROTOCOL)gBS_LocateProtocol,
+  (EFI_INSTALL_MULTIPLE_PROTOCOL_INTERFACES)gBS_InstallMultipleProtocolInterfaces,
+  (EFI_UNINSTALL_MULTIPLE_PROTOCOL_INTERFACES)gBS_UninstallMultipleProtocolInterfaces,
+  (EFI_CALCULATE_CRC32)gBS_CalculateCrc32,
+  (EFI_COPY_MEM)gBS_CopyMem,
+  (EFI_SET_MEM)gBS_SetMem,
+  (EFI_CREATE_EVENT_EX)gBS_CreateEventEx
+};
 
-  gBS_RestoreTpl,                                                                      // EFI_RESTORE_TPL
-  NULL,                                                                                // EFI_ALLOCATE_PAGES
-  NULL,                                                                                // EFI_FREE_PAGES
-  gBS_GetMemoryMap,                                                                    // EFI_GET_MEMORY_MAP
-  gBS_AllocatePool,                                                                    // EFI_ALLOCATE_POOL
-  gBS_FreePool,                                                                        // EFI_FREE_POOL
-  gBS_CreateEvent,                                                                     // EFI_CREATE_EVENT
-  NULL,                                                                                // EFI_SET_TIMER
-  NULL,                                                                                // EFI_WAIT_FOR_EVENT
-  NULL,                                                                                // EFI_SIGNAL_EVENT
-  gBS_CloseEvent,                                                                      // EFI_CLOSE_EVENT
-  NULL,                                                                                // EFI_CHECK_EVENT
-  gBS_InstallProtocolInterface,                                                        // EFI_INSTALL_PROTOCOL_INTERFACE
-  gBS_ReinstallProtocolInterface,                                                      // EFI_REINSTALL_PROTOCOL_INTERFACE
-  gBS_UninstallProtocolInterface,                                                      // EFI_UNINSTALL_PROTOCOL_INTERFACE
-  gBS_HandleProtocol,                                                                  // EFI_HANDLE_PROTOCOL
-  NULL,                                                                                // VOID
-  gBS_RegisterProtocolNotify,                                                          // EFI_REGISTER_PROTOCOL_NOTIFY
-  gBS_LocateHandle,                                                                    // EFI_LOCATE_HANDLE
-  gBS_LocateDevicePath,                                                                // EFI_LOCATE_DEVICE_PATH
-  NULL,                                                                                // EFI_INSTALL_CONFIGURATION_TABLE
-  NULL,                                                                                // EFI_IMAGE_LOAD
-  NULL,                                                                                // EFI_IMAGE_START
-  NULL,                                                                                // EFI_EXIT
-  NULL,                                                                                // EFI_IMAGE_UNLOAD
-  NULL,                                                                                // EFI_EXIT_BOOT_SERVICES
-  NULL,                                                                                // EFI_GET_NEXT_MONOTONIC_COUNT
-  NULL,                                                                                // EFI_STALL
-  NULL,                                                                                // EFI_SET_WATCHDOG_TIMER
-  gBS_ConnectController,                                                               // EFI_CONNECT_CONTROLLER
-  gBS_DisconnectController,                                                            // EFI_DISCONNECT_CONTROLLER
-  gBS_OpenProtocol,                                                                    // EFI_OPEN_PROTOCOL
-  gBS_CloseProtocol,                                                                   // EFI_CLOSE_PROTOCOL
-  NULL,                                                                                // EFI_OPEN_PROTOCOL_INFORMATION
-  NULL,                                                                                // EFI_PROTOCOLS_PER_HANDLE
-  gBS_LocateHandleBuffer,                                                              // EFI_LOCATE_HANDLE_BUFFER
-  gBS_LocateProtocol,                                                                  // EFI_LOCATE_PROTOCOL
-  gBS_InstallMultipleProtocolInterfaces,                                               // EFI_INSTALL_MULTIPLE_PROTOCOL_INTERFACES
-  (EFI_UNINSTALL_MULTIPLE_PROTOCOL_INTERFACES)gBS_UninstallMultipleProtocolInterfaces, // EFI_UNINSTALL_MULTIPLE_PROTOCOL_INTERFACES
-  NULL,                                                                                // EFI_CALCULATE_CRC32
-  gBS_CopyMem,                                                                         // EFI_COPY_MEM
-  gBS_SetMem,                                                                          // EFI_SET_MEM
-  gBS_CreateEventEx                                                                    // EFI_CREATE_EVENT_EX
+MOCK_EFI_SIMPLE_TEXT_INPUT_PROTOCOL_INSTANCE (ConInMock)
+MOCK_EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL_INSTANCE (ConOutMock)
+MOCK_EFI_SIMPLE_TEXT_OUTPUT_PROTOCOL_INSTANCE (StdErrMock)
+
+EFI_SYSTEM_TABLE MockEfiSystemTableInstance = {
+  { 0, 0, 0, 0, 0 },          // EFI_TABLE_HEADER Hdr
+  NULL,                       // CHAR8* FirmwareVendor
+  0,                          // UINT32 FirmwareRevision
+  NULL,                       // EFI_HANDLE ConsoleInHandle
+  ConInMock,
+  NULL,                       // EFI_HANDLE ConsoleOutHandle
+  ConOutMock,
+  NULL,                       // EFI_HANDLE StdErrHandle
+  StdErrMock,
+  NULL,                       // EFI_RUNTIME_SERVICES*
+  &MockEfiBootServicesInstance,
+  0,                          // UINTN NumberOfTableEntries
+  NULL                        // EFI_CONFIGURATION_TABLE *ConfigurationTable
 };
 
 extern "C" {
-  EFI_BOOT_SERVICES  *gBS         = &LocalBs;
+  EFI_BOOT_SERVICES  *gBS         = &MockEfiBootServicesInstance;
   EFI_HANDLE         gImageHandle = NULL;
-  EFI_SYSTEM_TABLE   *gST         = NULL;
+  EFI_SYSTEM_TABLE   *gST         = &MockEfiSystemTableInstance;
 }


### PR DESCRIPTION
## Description

Completed the MockUefiBootServicesTableLib.cpp with missing functions. Also created a EFI_SYSTEM_TABLE instance with MockSimpleTextIn and MockSimpleTextOut

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Local CI ran

## Integration Instructions

N/A