### PR TITLE
[Cherry-Pick] StandaloneMmPkg: Disable assert when gMmCommBufferHobGuid not found.

### DIFF
--- a/StandaloneMmPkg/Core/StandaloneMmCore.c
+++ b/StandaloneMmPkg/Core/StandaloneMmCore.c
@@ -446,8 +446,9 @@ MmCorePrepareCommunicationBuffer (
   mInternalCommBufferCopy = NULL;
 
   GuidHob = GetFirstGuidHob (&gMmCommBufferHobGuid);
-  ASSERT (GuidHob != NULL);
   if (GuidHob == NULL) {
+    DEBUG ((DEBUG_ERROR, "Failed to find MM Communication Buffer HOB\n"));
+    DEBUG ((DEBUG_ERROR, "Only Root MMI Handlers will be supported!\n"));
     return;
   }
 


### PR DESCRIPTION

## Description

StandaloneMmPkg: Disable assert when gMmCommBufferHobGuid not found.

For AARCH64 using StandaloneMmPkg, gMmCommBufferHobGuid will not exist. Aarch64 makes use of their own Root MmiHandler that will get the communication buffer out of a separate buffer, and will call MmiMange directly with the information.

For x64, where gMmCommBufferHobGuid is expected to be supplied in the hob list passed to StandaloneCore, if the hob does not exist, print out a debug message describing the failure scenario.

Its important to note that a mising gMmCommBufferHobGuid will mean non-root MmiHandlers will not be dispatched in the x64 scenario, but that root MmiHandlers will still be dispatched.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested
Booted SBSA without fix, and system would hang at assert gMmCommBufferHobGuid  was not found.
After fix, system was able to boot to Uefi shell and Windows. 

## Integration Instructions
N/A