### PR TITLE
[Merge && FF] CI: Limit CI runs to AARCH64, IA32, X64.

### DIFF
--- a/.azurepipelines/Ubuntu-GCC5.yml
+++ b/.azurepipelines/Ubuntu-GCC5.yml
@@ -15,7 +15,7 @@
 ##
 
 variables:
-- group: architectures-arm-64-x86-64
+- group: architectures-arm64-x86-64
 - group: tool-chain-ubuntu-gcc
 - group: coverage
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,10 +29,12 @@ on:
     branches:
       - main
       - release/*
+      - dev/*
   pull_request:
     branches:
       - main
       - release/*
+      - dev/*
     paths-ignore:
       - '!**.c'
       - '!**.h'
@@ -179,7 +181,7 @@ jobs:
           return response
 
         GITHUB_REPO = "sagiegurari/cargo-make"
-        api_url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/tags/0.37.9"
+        api_url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/tags/0.37.24"
 
         response = get_response_with_retries(api_url)
         if response.status_code == 200:
@@ -214,7 +216,7 @@ jobs:
 
     - name: Download cargo-make
       if: steps.cargo_make_cache.outputs.cache-hit != 'true'
-      uses: robinraju/release-downloader@v1.10
+      uses: robinraju/release-downloader@v1.11
       with:
         repository: 'sagiegurari/cargo-make'
         tag: '${{ steps.get_cargo_tool_details.outputs.cargo_make_version }}'


### PR DESCRIPTION

## Description
Remove ARM as a target for CI runs.

Only target AARCH64, IA32, X64 for GCC CI.

Fix codeql to run on dev/ branches. Will also be handled when FileSync runs, but to unblock current dev branch.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested
Local CI builds. 

## Integration Instructions
Not Applicable since it is a CI change. 