### PR TITLE
WindowsVsToolChain: Filter vs vars on specific vc

### DIFF
--- a/BaseTools/Plugin/WindowsVsToolChain/WindowsVsToolChain.py
+++ b/BaseTools/Plugin/WindowsVsToolChain/WindowsVsToolChain.py
@@ -94,7 +94,7 @@ class WindowsVsToolChain(IUefiBuildPlugin):
                 shell_env = shell_environment.GetEnvironment()
                 # Use the tools lib to determine the correct values for the vars that interest us.
                 vs_vars = locate_tools.QueryVcVariables(
-                    interesting_keys, VC_HOST_ARCH_TRANSLATOR[HostType], vs_version="vs2017")
+                    interesting_keys, VC_HOST_ARCH_TRANSLATOR[HostType], vs_version="vs2017", vc_version=vc_ver)
                 for (k, v) in vs_vars.items():
                     shell_env.set_shell_var(k, v)
 
@@ -167,7 +167,7 @@ class WindowsVsToolChain(IUefiBuildPlugin):
                 shell_env = shell_environment.GetEnvironment()
                 # Use the tools lib to determine the correct values for the vars that interest us.
                 vs_vars = locate_tools.QueryVcVariables(
-                    interesting_keys, VC_HOST_ARCH_TRANSLATOR[HostType], vs_version="vs2019")
+                    interesting_keys, VC_HOST_ARCH_TRANSLATOR[HostType], vs_version="vs2019", vc_version=vc_ver)
                 for (k, v) in vs_vars.items():
                     shell_env.set_shell_var(k, v)
 
@@ -247,7 +247,7 @@ class WindowsVsToolChain(IUefiBuildPlugin):
                 shell_env = shell_environment.GetEnvironment()
                 # Use the tools lib to determine the correct values for the vars that interest us.
                 vs_vars = locate_tools.QueryVcVariables(
-                    interesting_keys, VC_HOST_ARCH_TRANSLATOR[HostType], vs_version="VS2022")
+                    interesting_keys, VC_HOST_ARCH_TRANSLATOR[HostType], vs_version="VS2022", vc_version=vc_ver)
                 for (k, v) in vs_vars.items():
                     shell_env.set_shell_var(k, v)
 
@@ -373,6 +373,10 @@ class WindowsVsToolChain(IUefiBuildPlugin):
                 self.Logger.critical(
                     "Failed to find VC tools.  Might need to check for VS install")
                 return vc_ver
-            vc_ver = os.listdir(p2)[-1].strip()  # get last in list
+            
+            dirs = os.listdir(p2)
+            if len(dirs) > 1:
+                logging.warning(f"Multiple VC versions found: [{', '.join(dirs)}]. Using {dirs[-1]}")
+            vc_ver = dirs[-1].strip()  # get last in list
             self.Logger.debug("Found VC Tool version is %s" % vc_ver)
         return vc_ver

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -12,7 +12,7 @@
 # https://www.python.org/dev/peps/pep-0440/#version-specifiers
 ##
 
-edk2-pytool-library~=0.22.5 # MU_CHANGE
+edk2-pytool-library~=0.23.1 # MU_CHANGE
 edk2-pytool-extensions~=0.28.3 # MU_CHANGE
 antlr4-python3-runtime==4.13.2
 lcov-cobertura==2.1.1


### PR DESCRIPTION
## Description

Filters the extra vs vars gathered via QueryVcVariables() to specifically be the ones associated with the vc version set in the same plugin. This is to prevent version of the compiler differing from the version of any included .c / .h files that are made available through the vs vars such as LIB, INCLUDE, etc.

Additionally, now logs a warning when the plugin detects multiple versions of the compiler in the environment.

Example of log:

<img width="469" alt="image" src="https://github.com/user-attachments/assets/a0b3ff99-f0fd-4396-b0b6-e506a5a63187" />


- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Validated the WindowsVsToolChain plugin correctly detects and logs when multiple versions of a particular vs toolchain are installed, and that the compiler version match the version of the include paths returned with the vc vars.

## Integration Instructions

Consumers of MU_BASECORE must ensure their version of edk2-pytool-library is 0.23.1 or greater.
