### PR TITLE
[Cherry-Pick] UefiCpuPkg: Enable MM_CORE_STANDALONE for IntelMmSaveStateLib, SmmCpuPlatformHookLibNull

### DIFF
--- a/UefiCpuPkg/Library/MmSaveStateLib/IntelMmSaveStateLib.inf
+++ b/UefiCpuPkg/Library/MmSaveStateLib/IntelMmSaveStateLib.inf
@@ -16,7 +16,7 @@
   FILE_GUID                      = 37E8137B-9F74-4250-8951-7A970A3C39C0
   MODULE_TYPE                    = DXE_SMM_DRIVER
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = MmSaveStateLib|DXE_SMM_DRIVER MM_STANDALONE
+  LIBRARY_CLASS                  = MmSaveStateLib|DXE_SMM_DRIVER MM_STANDALONE MM_CORE_STANDALONE
 
 [Sources]
   MmSaveState.h

--- a/UefiCpuPkg/Library/SmmCpuPlatformHookLibNull/SmmCpuPlatformHookLibNull.inf
+++ b/UefiCpuPkg/Library/SmmCpuPlatformHookLibNull/SmmCpuPlatformHookLibNull.inf
@@ -18,7 +18,7 @@
   FILE_GUID                      = D6494E1B-E06F-4ab5-B64D-48B25AA9EB33
   MODULE_TYPE                    = DXE_DRIVER
   VERSION_STRING                 = 1.0
-  LIBRARY_CLASS                  = SmmCpuPlatformHookLib|DXE_SMM_DRIVER MM_STANDALONE
+  LIBRARY_CLASS                  = SmmCpuPlatformHookLib|DXE_SMM_DRIVER MM_STANDALONE MM_CORE_STANDALONE
 
 #
 # The following information is for reference only and not required by the build tools.


### PR DESCRIPTION
## Description

MmSupervisorPkg's MmSupervisorCore.inf  (MM_CORE_STANDALONE) uses Both SmmCpuPlatformHookLib and MmSaveStateLib.

Edk2 limited the scope of the libraries to not support MM_CORE_STANDALONE, and this works okay for the Edk2's StandaloneMmPkg, but it breaks the expectations of the MmSupervisorPkg's Core.


Add MM_CORE_STANDALONE as an allowed Module Type for these libraries. 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested
Building on silicon vendor codebase which consumed MmSupervisorCore.

## Integration Instructions
No integration required. 