### PR TITLE
[CHERRY-PICK] Reconcile Upstream Standalone MM Perf Changes Back to Mu Basecore [Rebase & FF]

### DIFF
--- a/MdeModulePkg/Library/DxeCorePerformanceLib/DxeCorePerformanceLib.c
+++ b/MdeModulePkg/Library/DxeCorePerformanceLib/DxeCorePerformanceLib.c
@@ -235,11 +235,11 @@ InternalGetSmmPerfData (
   EDKII_PI_SMM_COMMUNICATION_REGION_TABLE  *SmmCommRegionTable;
   EFI_MEMORY_DESCRIPTOR                    *SmmCommMemRegion;
   UINTN                                    Index;
-  VOID                                     *CurrentBootRecordData;    // MU_CHANGE - Standalone MM Perf Support
+  VOID                                     *CurrentBootRecordData;
   VOID                                     *SmmBootRecordData;
   UINTN                                    SmmBootRecordDataSize;
   UINTN                                    ReservedMemSize;
-  UINTN                                    BootRecordDataPayloadSize; // MU_CHANGE - Standalone MM Perf Support
+  UINTN                                    BootRecordDataPayloadSize;
   UINTN                                    SmmBootRecordDataRetrieved;
 
   //
@@ -294,7 +294,6 @@ InternalGetSmmPerfData (
         SmmCommData->Function       = SMM_FPDT_FUNCTION_GET_BOOT_RECORD_SIZE;
         SmmCommData->BootRecordData = NULL;
         Status                      = Communication->Communicate (Communication, SmmBootRecordCommBuffer, &CommSize);
-        // MU_CHANGE [BEGIN] - Standalone MM Perf Support
         if (EFI_ERROR (Status)) {
           DEBUG ((DEBUG_WARN, "Perf handler MMI not found or communicate failed. Status = %r.\n", Status));
         } else if (EFI_ERROR (SmmCommData->ReturnStatus)) {
@@ -317,14 +316,13 @@ InternalGetSmmPerfData (
           SmmBootRecordData             = AllocateZeroPool (SmmBootRecordDataSize);
           SmmBootRecordDataRetrieved    = 0;
           ASSERT (SmmBootRecordData  != NULL);
-          // MU_CHANGE [BEGIN] - Standalone MM Perf Support
           if (SmmBootRecordData != NULL) {
             CurrentBootRecordData = (VOID *)((UINTN)SmmCommMemRegion->PhysicalStart + SMM_BOOT_RECORD_COMM_SIZE);
             while (SmmBootRecordDataRetrieved < SmmBootRecordDataSize) {
               // Note: Maximum comm buffer data payload size is ReservedMemSize - SMM_BOOT_RECORD_COMM_SIZE
               BootRecordDataPayloadSize = MIN (
                                             ReservedMemSize - SMM_BOOT_RECORD_COMM_SIZE,
-                                            SmmBootRecordDataSize - SmmBootRecordDataRetrieved
+                                            SmmBootRecordDataSize - SmmBootRecordDataRetrieved - SMM_BOOT_RECORD_COMM_SIZE
                                             );
 
               MmCommBufferHeader->MessageLength = sizeof (SMM_BOOT_RECORD_COMMUNICATE) + BootRecordDataPayloadSize;
@@ -351,8 +349,6 @@ InternalGetSmmPerfData (
             *SmmPerfData     = SmmBootRecordData;
             *SmmPerfDataSize = SmmBootRecordDataSize;
           }
-
-          // MU_CHANGE [END] - Standalone MM Perf Support
         }
       }
     }

--- a/MdeModulePkg/Library/DxeCorePerformanceLib/DxeCorePerformanceLib.c
+++ b/MdeModulePkg/Library/DxeCorePerformanceLib/DxeCorePerformanceLib.c
@@ -22,12 +22,10 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 // Data for FPDT performance records.
 //
-// MU_CHANGE [BEGIN] - Standalone MM Perf Support
 #define SMM_BOOT_RECORD_COMM_SIZE  (OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, Data) + sizeof(SMM_BOOT_RECORD_COMMUNICATE))
-// MU_CHANGE [END] - Standalone MM Perf Support
-#define STRING_SIZE              (FPDT_STRING_EVENT_RECORD_NAME_LENGTH * sizeof (CHAR8))
-#define FIRMWARE_RECORD_BUFFER   0x10000
-#define CACHE_HANDLE_GUID_COUNT  0x800
+#define STRING_SIZE                (FPDT_STRING_EVENT_RECORD_NAME_LENGTH * sizeof (CHAR8))
+#define FIRMWARE_RECORD_BUFFER     0x10000
+#define CACHE_HANDLE_GUID_COUNT    0x800
 
 BOOT_PERFORMANCE_TABLE  *mAcpiBootPerformanceTable    = NULL;
 BOOT_PERFORMANCE_TABLE  mBootPerformanceTableTemplate = {
@@ -230,7 +228,7 @@ InternalGetSmmPerfData (
 {
   EFI_STATUS                               Status;
   UINT8                                    *SmmBootRecordCommBuffer;
-  EFI_MM_COMMUNICATE_HEADER                *MmCommBufferHeader;      // MU_CHANGE - Standalone MM Perf Support
+  EFI_MM_COMMUNICATE_HEADER                *MmCommBufferHeader;
   SMM_BOOT_RECORD_COMMUNICATE              *SmmCommData;
   UINTN                                    CommSize;
   EFI_SMM_COMMUNICATION_PROTOCOL           *Communication;
@@ -282,12 +280,12 @@ InternalGetSmmPerfData (
       //
       if (ReservedMemSize > SMM_BOOT_RECORD_COMM_SIZE) {
         SmmBootRecordCommBuffer = (VOID *)(UINTN)SmmCommMemRegion->PhysicalStart;
-        MmCommBufferHeader      = (EFI_MM_COMMUNICATE_HEADER *)SmmBootRecordCommBuffer;     // MU_CHANGE - Standalone MM Perf Support
-        SmmCommData             = (SMM_BOOT_RECORD_COMMUNICATE *)MmCommBufferHeader->Data;  // MU_CHANGE - Standalone MM Perf Support
+        MmCommBufferHeader      = (EFI_MM_COMMUNICATE_HEADER *)SmmBootRecordCommBuffer;
+        SmmCommData             = (SMM_BOOT_RECORD_COMMUNICATE *)MmCommBufferHeader->Data;
         ZeroMem ((UINT8 *)SmmCommData, sizeof (SMM_BOOT_RECORD_COMMUNICATE));
 
-        CopyGuid (&MmCommBufferHeader->HeaderGuid, &gEfiFirmwarePerformanceGuid);           // MU_CHANGE - Standalone MM Perf Support
-        MmCommBufferHeader->MessageLength = sizeof (SMM_BOOT_RECORD_COMMUNICATE);           // MU_CHANGE - Standalone MM Perf Support
+        CopyGuid (&MmCommBufferHeader->HeaderGuid, &gEfiFirmwarePerformanceGuid);
+        MmCommBufferHeader->MessageLength = sizeof (SMM_BOOT_RECORD_COMMUNICATE);
         CommSize                          = SMM_BOOT_RECORD_COMM_SIZE;
 
         //

--- a/MdeModulePkg/Library/DxeCorePerformanceLib/DxeCorePerformanceLib.c
+++ b/MdeModulePkg/Library/DxeCorePerformanceLib/DxeCorePerformanceLib.c
@@ -322,11 +322,12 @@ InternalGetSmmPerfData (
               // Note: Maximum comm buffer data payload size is ReservedMemSize - SMM_BOOT_RECORD_COMM_SIZE
               BootRecordDataPayloadSize = MIN (
                                             ReservedMemSize - SMM_BOOT_RECORD_COMM_SIZE,
-                                            SmmBootRecordDataSize - SmmBootRecordDataRetrieved - SMM_BOOT_RECORD_COMM_SIZE
+                                            SmmBootRecordDataSize - SmmBootRecordDataRetrieved
                                             );
+              SmmCommData->BootRecordSize = BootRecordDataPayloadSize;
 
               MmCommBufferHeader->MessageLength = sizeof (SMM_BOOT_RECORD_COMMUNICATE) + BootRecordDataPayloadSize;
-              CommSize                          = sizeof (EFI_MM_COMMUNICATE_HEADER) + (UINTN)MmCommBufferHeader->MessageLength;
+              CommSize                          = OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, Data) + (UINTN)MmCommBufferHeader->MessageLength;
 
               Status = Communication->Communicate (Communication, SmmBootRecordCommBuffer, &CommSize);
               ASSERT_EFI_ERROR (Status);

--- a/MdeModulePkg/Library/SmmCorePerformanceLib/MmCorePerformanceLib.c
+++ b/MdeModulePkg/Library/SmmCorePerformanceLib/MmCorePerformanceLib.c
@@ -14,8 +14,6 @@
   Copyright (c) Microsoft Corporation.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
-  MU_CHANGE [WHOLE FILE] - Standalone MM Perf Support
-
 **/
 
 #include "SmmCorePerformanceLibInternal.h"
@@ -178,6 +176,10 @@ GetModuleNameFromPdbString (
   }
 
   PdbFileName = PeCoffLoaderGetPdbPointer (ImageBase);
+
+  if (PdbFileName == NULL) {
+    return EFI_NOT_FOUND;
+  }
 
   for (StartIndex = 0, Index = 0; PdbFileName[Index] != 0; Index++) {
     if ((PdbFileName[Index] == '\\') || (PdbFileName[Index] == '/')) {
@@ -827,7 +829,7 @@ FpdtSmiHandler (
     return EFI_SUCCESS;
   }
 
-  if (!IsCommBufferValidInternal ((UINTN)CommBuffer, TempCommBufferSize)) {
+  if (!MmCorePerformanceIsPrimaryBufferValid ((UINTN)CommBuffer, TempCommBufferSize)) {
     ASSERT (FALSE);
     return EFI_SUCCESS;
   }
@@ -864,7 +866,7 @@ FpdtSmiHandler (
 
       if (BootRecordData == NULL) {
         BootRecordData = (UINT8 *)SmmCommData + sizeof (SMM_BOOT_RECORD_COMMUNICATE);
-      } else if (!IsBufferOutsideMmValidInternal ((UINTN)BootRecordData, BootRecordSize)) {
+      } else if (!MmCorePerformanceIsNonPrimaryBufferValid ((UINTN)BootRecordData, BootRecordSize)) {
         Status = EFI_ACCESS_DENIED;
         break;
       }
@@ -933,12 +935,14 @@ SmmCorePerformanceLibExitBootServicesCallback (
 /**
   Common initialization code for the MM Core Performance Library.
 
+  @param[in] ExitBootServicesProtocolGuid  The GUID of the ExitBootServices protocol.
+
   @retval     EFI_SUCCESS           The MM Core Performance Library was initialized successfully.
   @retval     Others                The MM Core Performance Library was not initialized successfully.
  **/
 EFI_STATUS
 InitializeMmCorePerformanceLibCommon (
-  VOID
+  IN CONST EFI_GUID  *ExitBootServicesProtocolGuid
   )
 {
   EFI_STATUS  Status;
@@ -976,7 +980,7 @@ InitializeMmCorePerformanceLibCommon (
   // Register callback function for ExitBootServices event.
   //
   Status = gMmst->MmRegisterProtocolNotify (
-                    &gEdkiiSmmExitBootServicesProtocolGuid,
+                    ExitBootServicesProtocolGuid,
                     SmmCorePerformanceLibExitBootServicesCallback,
                     &Registration
                     );

--- a/MdeModulePkg/Library/SmmCorePerformanceLib/SmmCorePerformanceLib.c
+++ b/MdeModulePkg/Library/SmmCorePerformanceLib/SmmCorePerformanceLib.c
@@ -31,9 +31,9 @@ MU_CHANGE [WHOLE FILE] - Standalone MM Perf Support
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiLib.h>
 #include <Protocol/SmmBase2.h>
+#include <Protocol/SmmExitBootServices.h>
 
 PERFORMANCE_PROPERTY  mPerformanceProperty;
-extern BOOLEAN        mPerformanceMeasurementEnabled;
 
 /**
   A library internal MM-instance specific implementation to check if a buffer outside MM is valid.
@@ -48,7 +48,7 @@ extern BOOLEAN        mPerformanceMeasurementEnabled;
   @retval FALSE This buffer is not valid per processor architecture.
 **/
 BOOLEAN
-IsBufferOutsideMmValidInternal (
+MmCorePerformanceIsNonPrimaryBufferValid (
   IN EFI_PHYSICAL_ADDRESS  Buffer,
   IN UINT64                Length
   )
@@ -69,7 +69,7 @@ IsBufferOutsideMmValidInternal (
   @retval FALSE This communicate buffer is not valid per processor architecture.
 **/
 BOOLEAN
-IsCommBufferValidInternal (
+MmCorePerformanceIsPrimaryBufferValid (
   IN EFI_PHYSICAL_ADDRESS  Buffer,
   IN UINT64                Length
   )
@@ -135,7 +135,7 @@ GetLoadedImageProtocol (
 }
 
 /**
-  Get the module name from the PDB file name in the image header.
+  Get the module name from the user interface section.
 
   @param[in]  ModuleGuid    The GUID of the module.
   @param[out] NameString    The buffer to store the name string.
@@ -195,7 +195,7 @@ InitializeSmmCorePerformanceLib (
   EFI_STATUS            Status;
   PERFORMANCE_PROPERTY  *PerformanceProperty;
 
-  Status = InitializeMmCorePerformanceLibCommon ();
+  Status = InitializeMmCorePerformanceLibCommon (&gEdkiiSmmExitBootServicesProtocolGuid);
   ASSERT_EFI_ERROR (Status);
 
   Status = EfiGetSystemConfigurationTable (&gPerformanceProtocolGuid, (VOID **)&PerformanceProperty);

--- a/MdeModulePkg/Library/SmmCorePerformanceLib/SmmCorePerformanceLib.inf
+++ b/MdeModulePkg/Library/SmmCorePerformanceLib/SmmCorePerformanceLib.inf
@@ -9,19 +9,19 @@
 #  SMM Performance and PerformanceEx Protocol are installed at the very beginning of SMM phase.
 #
 #  Copyright (c) 2011 - 2023, Intel Corporation. All rights reserved.<BR>
-#  Copyright (c) Microsoft Corporation.                                     MU_CHANGE - Standalone MM Perf Support
+#  Copyright (c) Microsoft Corporation.
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
 ##
 
 [Defines]
-  INF_VERSION                    = 0x0001001B                             # MU_CHANGE - Standalone MM Perf Support
+  INF_VERSION                    = 0x0001001B
   BASE_NAME                      = SmmCorePerformanceLib
   MODULE_UNI_FILE                = SmmCorePerformanceLib.uni
   FILE_GUID                      = 36290D10-0F47-42c1-BBCE-E191C7928DCF
   MODULE_TYPE                    = SMM_CORE
   VERSION_STRING                 = 1.0
-  PI_SPECIFICATION_VERSION       = 0x00010032                             # MU_CHANGE - Standalone MM Perf Support
+  PI_SPECIFICATION_VERSION       = 0x00010032
   LIBRARY_CLASS                  = PerformanceLib|SMM_CORE
   CONSTRUCTOR                    = SmmCorePerformanceLibConstructor
 
@@ -32,7 +32,7 @@
 #
 
 [Sources]
-  MmCorePerformanceLib.c                # MU_CHANGE - Standalone MM Perf Support
+  MmCorePerformanceLib.c
   SmmCorePerformanceLibInternal.h
   SmmCorePerformanceLib.c
 
@@ -40,7 +40,6 @@
   MdePkg/MdePkg.dec
   MdeModulePkg/MdeModulePkg.dec
 
-# MU_CHANGE [BEGIN] - Standalone MM Perf Support
 [LibraryClasses]
   BaseLib
   BaseMemoryLib
@@ -55,12 +54,11 @@
   TimerLib
   UefiBootServicesTableLib
   UefiLib
-# MU_CHANGE [END] - Standalone MM Perf Support
 
 [Protocols]
   gEfiSmmBase2ProtocolGuid                  ## CONSUMES
-  gEdkiiSmmExitBootServicesProtocolGuid     ## CONSUMES ## NOTIFY         # MU_CHANGE - Standalone MM Perf Support
-  gEfiLoadedImageProtocolGuid               ## CONSUMES                   # MU_CHANGE - Standalone MM Perf Support
+  gEdkiiSmmExitBootServicesProtocolGuid     ## CONSUMES ## NOTIFY
+  gEfiLoadedImageProtocolGuid               ## CONSUMES
 
 [Guids]
   ## PRODUCES ## SystemTable

--- a/MdeModulePkg/Library/SmmCorePerformanceLib/SmmCorePerformanceLibInternal.h
+++ b/MdeModulePkg/Library/SmmCorePerformanceLib/SmmCorePerformanceLibInternal.h
@@ -5,7 +5,7 @@
   library instance at its constructor.
 
 Copyright (c) 2011 - 2018, Intel Corporation. All rights reserved.<BR>
-Copyright (c) Microsoft Corporation.                                        MU_CHANGE - Standalone MM Perf Support
+Copyright (c) Microsoft Corporation.
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
@@ -13,7 +13,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #ifndef _SMM_CORE_PERFORMANCE_LIB_INTERNAL_H_
 #define _SMM_CORE_PERFORMANCE_LIB_INTERNAL_H_
 
-// MU_CHANGE [BEGIN] - Standalone MM Perf Support
 #include <Guid/EventGroup.h>
 #include <Guid/ExtendedFirmwarePerformance.h>
 #include <Guid/FirmwarePerformance.h>
@@ -39,6 +38,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define STRING_SIZE              (FPDT_STRING_EVENT_RECORD_NAME_LENGTH * sizeof (CHAR8))
 #define FIRMWARE_RECORD_BUFFER   0x1000
 #define CACHE_HANDLE_GUID_COUNT  0x100
+
+extern BOOLEAN  mPerformanceMeasurementEnabled;
 
 //
 // Library internal function declarations
@@ -76,7 +77,7 @@ GetModuleNameFromPdbString (
   );
 
 /**
-  Get the module name from the PDB file name in the image header.
+  Get the module name from the user interface section.
 
   @param[in]  ModuleGuid    The GUID of the module.
   @param[out] NameString    The buffer to store the name string.
@@ -96,13 +97,14 @@ GetNameFromUiSection (
 /**
   Common initialization code for the MM Core Performance Library.
 
+  @param[in] ExitBootServicesProtocolGuid  The GUID of the ExitBootServices protocol.
+
   @retval     EFI_SUCCESS           The MM Core Performance Library was initialized successfully.
-  @retval     EFI_OUT_OF_RESOURCES  There are not enough resources to initialize the MM Core Performance Library.
   @retval     Others                The MM Core Performance Library was not initialized successfully.
  **/
 EFI_STATUS
 InitializeMmCorePerformanceLibCommon (
-  VOID
+  IN CONST EFI_GUID  *ExitBootServicesProtocolGuid
   );
 
 /**
@@ -118,7 +120,7 @@ InitializeMmCorePerformanceLibCommon (
   @retval FALSE This buffer is not valid per processor architecture.
 **/
 BOOLEAN
-IsBufferOutsideMmValidInternal (
+MmCorePerformanceIsNonPrimaryBufferValid (
   IN EFI_PHYSICAL_ADDRESS  Buffer,
   IN UINT64                Length
   );
@@ -136,12 +138,10 @@ IsBufferOutsideMmValidInternal (
   @retval FALSE This communicate buffer is not valid per processor architecture.
 **/
 BOOLEAN
-IsCommBufferValidInternal (
+MmCorePerformanceIsPrimaryBufferValid (
   IN EFI_PHYSICAL_ADDRESS  Buffer,
   IN UINT64                Length
   );
-
-// MU_CHANGE [END] - Standalone MM Perf Support
 
 //
 // Interface declarations for SMM PerformanceMeasurement Protocol.

--- a/MdeModulePkg/Library/SmmCorePerformanceLib/StandaloneMmCorePerformanceLib.c
+++ b/MdeModulePkg/Library/SmmCorePerformanceLib/StandaloneMmCorePerformanceLib.c
@@ -12,15 +12,12 @@
   Copyright (c) Microsoft Corporation.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
-  MU_CHANGE [WHOLE FILE] - Standalone MM Perf Support
-
 **/
 
 #include "SmmCorePerformanceLibInternal.h"
 
+#include <Guid/EventGroup.h>
 #include <Library/StandaloneMmMemLib.h>
-
-extern BOOLEAN  mPerformanceMeasurementEnabled;
 
 /**
   A library internal MM-instance specific implementation to check if a buffer outside MM is valid.
@@ -35,7 +32,7 @@ extern BOOLEAN  mPerformanceMeasurementEnabled;
   @retval FALSE This buffer is not valid per processor architecture.
 **/
 BOOLEAN
-IsBufferOutsideMmValidInternal (
+MmCorePerformanceIsNonPrimaryBufferValid (
   IN EFI_PHYSICAL_ADDRESS  Buffer,
   IN UINT64                Length
   )
@@ -56,12 +53,12 @@ IsBufferOutsideMmValidInternal (
   @retval FALSE This communicate buffer is not valid per processor architecture.
 **/
 BOOLEAN
-IsCommBufferValidInternal (
+MmCorePerformanceIsPrimaryBufferValid (
   IN EFI_PHYSICAL_ADDRESS  Buffer,
   IN UINT64                Length
   )
 {
-  return MmCommBufferValid (Buffer, Length);
+  return MmCommBufferValid (Buffer, Length);  // MU_CHANGE - Use Mu Standalone MM Comm Buffer Validation
 }
 
 /**
@@ -92,7 +89,7 @@ GetLoadedImageProtocol (
 }
 
 /**
-  Get the module name from the PDB file name in the image header.
+  Get the module name from the user interface section.
 
   @param[in]  ModuleGuid    The GUID of the module.
   @param[out] NameString    The buffer to store the name string.
@@ -143,7 +140,7 @@ StandaloneMmCorePerformanceLibConstructor (
     return EFI_SUCCESS;
   }
 
-  Status = InitializeMmCorePerformanceLibCommon ();
+  Status = InitializeMmCorePerformanceLibCommon (&gEfiEventExitBootServicesGuid);
   ASSERT_EFI_ERROR (Status);
 
   return EFI_SUCCESS;

--- a/MdeModulePkg/Library/SmmCorePerformanceLib/StandaloneMmCorePerformanceLib.inf
+++ b/MdeModulePkg/Library/SmmCorePerformanceLib/StandaloneMmCorePerformanceLib.inf
@@ -42,13 +42,13 @@
   TimerLib
 
 [Protocols]
-  gEdkiiSmmExitBootServicesProtocolGuid         ## CONSUMES ## NOTIFY
   gEfiLoadedImageProtocolGuid                   ## CONSUMES
 
 [Guids]
   gEfiFirmwarePerformanceGuid                   ## SOMETIMES_PRODUCES         # SmiHandlerRegister
   gEdkiiSmmPerformanceMeasurementProtocolGuid   ## PRODUCES                   # Install protocol
   gZeroGuid                                     ## SOMETIMES_CONSUMES ## GUID
+  gEfiEventExitBootServicesGuid                 ## CONSUMES ## NOTIFY
 
 [FixedPcd]
   gEfiMdePkgTokenSpaceGuid.PcdPerformanceLibraryPropertyMask        ## CONSUMES

--- a/MdeModulePkg/Library/SmmCorePerformanceLib/StandaloneMmCorePerformanceLib.inf
+++ b/MdeModulePkg/Library/SmmCorePerformanceLib/StandaloneMmCorePerformanceLib.inf
@@ -1,12 +1,12 @@
 ## @file
-# Performance library instance used by a Standalone MM Core or very early Standlaone MM module.
+# Performance library instance used by a Standalone MM Core or an early Standlaone MM module that
+# should install performance measurement services.
 #
 # Installs the MM performance measurement protocol and returns MM performance data via MM communicate.
 #
 # Copyright (c) Microsoft Corporation.
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 #
-# MU_CHANGE [WHOLE FILE] - Standalone MM Perf Support
 ##
 
 [Defines]

--- a/MdeModulePkg/Library/SmmPerformanceLib/SmmPerformanceLib.c
+++ b/MdeModulePkg/Library/SmmPerformanceLib/SmmPerformanceLib.c
@@ -14,17 +14,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
   - All contents moved except the constructor and destructor
 **/
 
-#include <Guid/PerformanceMeasurement.h>
-
-#include <Library/DebugLib.h>
-#include <Library/MmServicesTableLib.h>
-#include <Library/PcdLib.h>
-#include <Library/PerformanceLib.h>
-
+#include <PiMm.h>
+#include <Protocol/SmmExitBootServices.h>
 #include "SmmPerformanceLibInternal.h"
-
-extern BOOLEAN  mPerformanceMeasurementEnabled;
-extern VOID     *mPerformanceLibExitBootServicesRegistration;
 
 /**
   The constructor function initializes the Performance Measurement Enable flag.
@@ -42,18 +34,7 @@ SmmPerformanceLibConstructor (
   IN EFI_SYSTEM_TABLE  *SystemTable
   )
 {
-  EFI_STATUS  Status;
-
-  mPerformanceMeasurementEnabled =  (BOOLEAN)((PcdGet8 (PcdPerformanceLibraryPropertyMask) & PERFORMANCE_LIBRARY_PROPERTY_MEASUREMENT_ENABLED) != 0);
-
-  Status = gMmst->MmRegisterProtocolNotify (
-                    &gEdkiiSmmExitBootServicesProtocolGuid,
-                    SmmPerformanceLibExitBootServicesCallback,
-                    &mPerformanceLibExitBootServicesRegistration
-                    );
-  ASSERT_EFI_ERROR (Status);
-
-  return Status;
+  return RegisterExitBootServicesCallback (&gEdkiiSmmExitBootServicesProtocolGuid);
 }
 
 /**
@@ -72,17 +53,5 @@ SmmPerformanceLibDestructor (
   IN EFI_SYSTEM_TABLE  *SystemTable
   )
 {
-  EFI_STATUS  Status;
-
-  //
-  // Unregister SmmExitBootServices notification.
-  //
-  Status = gMmst->MmRegisterProtocolNotify (
-                    &gEdkiiSmmExitBootServicesProtocolGuid,
-                    NULL,
-                    &mPerformanceLibExitBootServicesRegistration
-                    );
-  ASSERT_EFI_ERROR (Status);
-
-  return Status;
+  return UnregisterExitBootServicesCallback (&gEdkiiSmmExitBootServicesProtocolGuid);
 }

--- a/MdeModulePkg/Library/SmmPerformanceLib/SmmPerformanceLib.inf
+++ b/MdeModulePkg/Library/SmmPerformanceLib/SmmPerformanceLib.inf
@@ -34,8 +34,8 @@
 #
 
 [Sources]
-  SmmPerformanceLibInternal.h   # MU_CHANGE - Standalone MM Perf Support
-  SmmPerformanceLibInternal.c   # MU_CHANGE - Standalone MM Perf Support
+  SmmPerformanceLibInternal.h
+  SmmPerformanceLibInternal.c
   SmmPerformanceLib.c
 
 
@@ -46,7 +46,7 @@
 
 [LibraryClasses]
   PcdLib
-  MmServicesTableLib            # MU_CHANGE - Standalone MM Perf Support
+  MmServicesTableLib
   DebugLib
   BaseMemoryLib
 

--- a/MdeModulePkg/Library/SmmPerformanceLib/SmmPerformanceLibInternal.c
+++ b/MdeModulePkg/Library/SmmPerformanceLib/SmmPerformanceLibInternal.c
@@ -10,7 +10,6 @@
   Copyright (c) Microsoft Corporation.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
-  MU_CHANGE [WHOLE FILE] - Standalone MM Perf Support
 **/
 
 #include <Guid/PerformanceMeasurement.h>
@@ -28,6 +27,61 @@
 EDKII_PERFORMANCE_MEASUREMENT_PROTOCOL  *mPerformanceMeasurement = NULL;
 BOOLEAN                                 mPerformanceMeasurementEnabled;
 VOID                                    *mPerformanceLibExitBootServicesRegistration;
+
+/**
+  Registers a callback to perform library actions needed at exit boot services.
+
+  @param[in] ExitBootServicesProtocolGuid  The protocol GUID to register the callback for.
+
+  @retval EFI_SUCCESS The callback was registered successfully.
+  @retval Others      An error occurred registering the callback.
+ **/
+EFI_STATUS
+RegisterExitBootServicesCallback (
+  IN  CONST EFI_GUID  *ExitBootServicesProtocolGuid
+  )
+{
+  EFI_STATUS  Status;
+
+  mPerformanceMeasurementEnabled =  (BOOLEAN)((PcdGet8 (PcdPerformanceLibraryPropertyMask) & PERFORMANCE_LIBRARY_PROPERTY_MEASUREMENT_ENABLED) != 0);
+
+  Status = gMmst->MmRegisterProtocolNotify (
+                    ExitBootServicesProtocolGuid,
+                    SmmPerformanceLibExitBootServicesCallback,
+                    &mPerformanceLibExitBootServicesRegistration
+                    );
+  ASSERT_EFI_ERROR (Status);
+
+  return Status;
+}
+
+/**
+  Unregisters a callback to perform library actions needed at exit boot services.
+
+  @param[in] ExitBootServicesProtocolGuid  The protocol GUID to unregister the callback for.
+
+  @retval EFI_SUCCESS The callback was unregistered successfully.
+  @retval Others      An error occurred unregistering the callback.
+ **/
+EFI_STATUS
+UnregisterExitBootServicesCallback (
+  IN  CONST EFI_GUID  *ExitBootServicesProtocolGuid
+  )
+{
+  EFI_STATUS  Status;
+
+  //
+  // Unregister SmmExitBootServices notification.
+  //
+  Status = gMmst->MmRegisterProtocolNotify (
+                    ExitBootServicesProtocolGuid,
+                    NULL,
+                    &mPerformanceLibExitBootServicesRegistration
+                    );
+  ASSERT_EFI_ERROR (Status);
+
+  return Status;
+}
 
 /**
   This is the Event call back function is triggered in MM to notify the Library

--- a/MdeModulePkg/Library/SmmPerformanceLib/SmmPerformanceLibInternal.h
+++ b/MdeModulePkg/Library/SmmPerformanceLib/SmmPerformanceLibInternal.h
@@ -4,11 +4,36 @@
   Copyright (c) Microsoft Corporation.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
-  MU_CHANGE [WHOLE FILE] - Standalone MM Perf Support
 **/
 
 #ifndef SMM_CORE_PERFORMANCE_LIB_INTERNAL_H_
 #define SMM_CORE_PERFORMANCE_LIB_INTERNAL_H_
+
+/**
+  Registers a callback to perform library actions needed at exit boot services.
+
+  @param[in] ExitBootServicesProtocolGuid  The protocol GUID to register the callback for.
+
+  @retval EFI_SUCCESS The callback was registered successfully.
+  @retval Others      An error occurred registering the callback.
+ **/
+EFI_STATUS
+RegisterExitBootServicesCallback (
+  IN  CONST EFI_GUID  *ExitBootServicesProtocolGuid
+  );
+
+/**
+  Unregisters a callback to perform library actions needed at exit boot services.
+
+  @param[in] ExitBootServicesProtocolGuid  The protocol GUID to unregister the callback for.
+
+  @retval EFI_SUCCESS The callback was unregistered successfully.
+  @retval Others      An error occurred unregistering the callback.
+ **/
+EFI_STATUS
+UnregisterExitBootServicesCallback (
+  IN  CONST EFI_GUID  *ExitBootServicesProtocolGuid
+  );
 
 /**
   This is the Event call back function is triggered in MM to notify the Library

--- a/MdeModulePkg/Library/SmmPerformanceLib/StandaloneMmPerformanceLib.c
+++ b/MdeModulePkg/Library/SmmPerformanceLib/StandaloneMmPerformanceLib.c
@@ -10,20 +10,11 @@
   Copyright (c) Microsoft Corporation.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
-  MU_CHANGE [WHOLE FILE] - Standalone MM Perf Support
 **/
 
-#include <Guid/PerformanceMeasurement.h>
-
-#include <Library/DebugLib.h>
-#include <Library/MmServicesTableLib.h>
-#include <Library/PcdLib.h>
-#include <Library/PerformanceLib.h>
-
+#include <PiMm.h>
+#include <Guid/EventGroup.h>
 #include "SmmPerformanceLibInternal.h"
-
-extern BOOLEAN  mPerformanceMeasurementEnabled;
-extern VOID     *mPerformanceLibExitBootServicesRegistration;
 
 /**
   The constructor function initializes the Performance Measurement Enable flag.
@@ -41,18 +32,7 @@ StandaloneMmPerformanceLibConstructor (
   IN EFI_MM_SYSTEM_TABLE  *MmSystemTable
   )
 {
-  EFI_STATUS  Status;
-
-  mPerformanceMeasurementEnabled =  (BOOLEAN)((PcdGet8 (PcdPerformanceLibraryPropertyMask) & PERFORMANCE_LIBRARY_PROPERTY_MEASUREMENT_ENABLED) != 0);
-
-  Status = gMmst->MmRegisterProtocolNotify (
-                    &gEdkiiSmmExitBootServicesProtocolGuid,
-                    SmmPerformanceLibExitBootServicesCallback,
-                    &mPerformanceLibExitBootServicesRegistration
-                    );
-  ASSERT_EFI_ERROR (Status);
-
-  return Status;
+  return RegisterExitBootServicesCallback (&gEfiEventExitBootServicesGuid);
 }
 
 /**
@@ -71,17 +51,5 @@ StandaloneMmPerformanceLibDestructor (
   IN EFI_MM_SYSTEM_TABLE  *MmSystemTable
   )
 {
-  EFI_STATUS  Status;
-
-  //
-  // Unregister SmmExitBootServices notification.
-  //
-  Status = gMmst->MmRegisterProtocolNotify (
-                    &gEdkiiSmmExitBootServicesProtocolGuid,
-                    NULL,
-                    &mPerformanceLibExitBootServicesRegistration
-                    );
-  ASSERT_EFI_ERROR (Status);
-
-  return Status;
+  return UnregisterExitBootServicesCallback (&gEfiEventExitBootServicesGuid);
 }

--- a/MdeModulePkg/Library/SmmPerformanceLib/StandaloneMmPerformanceLib.inf
+++ b/MdeModulePkg/Library/SmmPerformanceLib/StandaloneMmPerformanceLib.inf
@@ -7,10 +7,9 @@
 #  performance information.
 #
 #  Copyright (c) 2011 - 2018, Intel Corporation. All rights reserved.<BR>
-#  Copyright Microsoft Corporation. All rights reserved.
+#  Copyright Microsoft Corporation.
 #  SPDX-License-Identifier: BSD-2-Clause-Patent
 #
-#  MU_CHANGE [WHOLE FILE] - Standalone MM Perf Support
 ##
 
 [Defines]
@@ -43,9 +42,7 @@
 
 [Guids]
   gEdkiiSmmPerformanceMeasurementProtocolGuid                   ## SOMETIMES_CONSUMES   ## UNDEFINED # Locate protocol
-
-[Protocols]
-  gEdkiiSmmExitBootServicesProtocolGuid                         ## CONSUMES
+  gEfiEventExitBootServicesGuid                                 ## CONSUMES
 
 [Pcd]
   gEfiMdePkgTokenSpaceGuid.PcdPerformanceLibraryPropertyMask    ## CONSUMES

--- a/MdeModulePkg/Library/SmmPerformanceLib/StandaloneMmPerformanceLib.uni
+++ b/MdeModulePkg/Library/SmmPerformanceLib/StandaloneMmPerformanceLib.uni
@@ -7,14 +7,14 @@
 // performance information.
 //
 // Copyright (c) 2011 - 2018, Intel Corporation. All rights reserved.<BR>
+// Copyright Microsoft Corporation.
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 //
-// MU_CHANGE [WHOLE FILE] - Standalone MM Perf Support
 // **/
 
 
 #string STR_MODULE_ABSTRACT             #language en-US "Performance library instance used in the Standalone MM phase"
 
-#string STR_MODULE_DESCRIPTION          #language en-US "This library instance provides infrastructure for Standalone MM drivers to log performance data. It consumest the Standalone MM PerformanceEx or Performance Protocol to log performance data. If both Standalone MM PerformanceEx and Performance Protocol are not available, it does not log any performance information."
+#string STR_MODULE_DESCRIPTION          #language en-US "This library instance provides infrastructure for Standalone MM drivers to log performance data. It consumes the Standalone MM PerformanceEx or Performance Protocol to log performance data. If both Standalone MM PerformanceEx and Performance Protocol are not available, it does not log any performance information."
 

--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -576,7 +576,7 @@
   MdeModulePkg/Library/SmmCorePerformanceLib/SmmCorePerformanceLib.inf
   MdeModulePkg/Library/SmmCorePerformanceLib/StandaloneMmCorePerformanceLib.inf
   MdeModulePkg/Library/SmmPerformanceLib/SmmPerformanceLib.inf
-  MdeModulePkg/Library/SmmPerformanceLib/StandaloneMmPerformanceLib.inf         # MU_CHANGE - Standalone MM Perf Support
+  MdeModulePkg/Library/SmmPerformanceLib/StandaloneMmPerformanceLib.inf
   MdeModulePkg/Library/SmmLockBoxLib/SmmLockBoxPeiLib.inf
   MdeModulePkg/Library/SmmLockBoxLib/SmmLockBoxDxeLib.inf
   MdeModulePkg/Library/SmmLockBoxLib/SmmLockBoxSmmLib.inf

--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -574,7 +574,7 @@
   MdeModulePkg/Library/PiSmmCoreMemoryAllocationLib/PiSmmCoreMemoryAllocationProfileLib.inf
   MdeModulePkg/Library/PiSmmCoreMemoryAllocationLib/PiSmmCoreMemoryAllocationLib.inf
   MdeModulePkg/Library/SmmCorePerformanceLib/SmmCorePerformanceLib.inf
-  MdeModulePkg/Library/SmmCorePerformanceLib/StandaloneMmCorePerformanceLib.inf # MU_CHANGE - Standalone MM Perf Support
+  MdeModulePkg/Library/SmmCorePerformanceLib/StandaloneMmCorePerformanceLib.inf
   MdeModulePkg/Library/SmmPerformanceLib/SmmPerformanceLib.inf
   MdeModulePkg/Library/SmmPerformanceLib/StandaloneMmPerformanceLib.inf         # MU_CHANGE - Standalone MM Perf Support
   MdeModulePkg/Library/SmmLockBoxLib/SmmLockBoxPeiLib.inf


### PR DESCRIPTION
## Description

Now that the changes are upstreamed, the Mu changes are updated to reflect
the edk2 code.

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

---

Note: Not backported as the [original Mu changes](https://github.com/microsoft/mu_basecore/pull/1268) were not backported.

---

## How This Was Tested

- Traditional and Standalone MM perf build and record retrieval

## Integration Instructions

- Traditional MM should be able to continue using the same libraries.
- Standalone MM:
  - Link `MdeModulePkg/Library/SmmCorePerformanceLib/StandaloneMmCorePerformanceLib.inf`
    against a Standalone MM module that is loaded early and has MM Services available.
  - Link `MdeModulePkg/Library/SmmPerformanceLib/StandaloneMmPerformanceLib.inf` against
    all Standalone MM modules that have a `PerformanceLib` dependency and need to log
    MM performance data.