### PR TITLE
Expression.py fails to handle a zero byte PCD

### DIFF
--- a/BaseTools/Source/Python/Common/Expression.py
+++ b/BaseTools/Source/Python/Common/Expression.py
@@ -969,8 +969,8 @@ class ValueExpressionEx(ValueExpression):
                                 NewPcdValueList.append(Item)
 
                             AllPcdValueList = []
+                            Size = 0
                             for Item in NewPcdValueList:
-                                Size = 0
                                 ValueStr = ''
                                 TokenSpaceGuidName = ''
                                 if Item.startswith(TAB_GUID) and Item.endswith(')'):


### PR DESCRIPTION
## Description

The following example fails to be parsed correctly due to Size
being initialized in the inner scope but not the outer scope

```
gMsSurfaceCorePkgTokenSpaceGuid.PcdSecureBootDbxBinaryFile|{}
```

Problematic code:

```python
for Item in NewPcdValueList:
      Size = 0
      # ....
 
if Size > 0:
      PcdValue = '{' + ', '.join(AllPcdValueList) + '}'
````

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Locally, Building a zero byte DBX

## Integration Instructions

N/A