### PR TITLE
Add MsegSize to the CPU_INFORMATION_HEADER struct

### DIFF
--- a/MdePkg/Include/Register/Intel/StmApi.h
+++ b/MdePkg/Include/Register/Intel/StmApi.h
@@ -38,7 +38,7 @@ typedef struct {
 
 // MU_CHANGE - [START]: Add new CPU information header for STM
 
-#define CPU_INFORMATION_HEADER_PADDING_SIZE  (SIZE_1KB - 2 * sizeof (UINT32))
+#define CPU_INFORMATION_HEADER_PADDING_SIZE  (SIZE_1KB - 3 * sizeof (UINT32))
 #define SOFTWARE_STM_HEADER_PADDING_SIZE     (SIZE_1KB - 5 * sizeof (UINT32) - 2 * sizeof (UINT8) - sizeof (UINT16) - sizeof (STM_FEAT))
 
 typedef struct {
@@ -65,6 +65,7 @@ typedef struct {
 typedef struct {
   UINT32    Signature;
   UINT32    NumberOfCpus;
+  UINT32    MsegSize;
   /// Pad to take up 1KB of space
   UINT8     Reserved[CPU_INFORMATION_HEADER_PADDING_SIZE];
 } CPU_INFORMATION_HEADER;


### PR DESCRIPTION
## Description

Add MsegSize to the CPU_INFORMATION_HEADER struct so it can be referenced by the STM.  Currently we calculate the MsegSize using the CPU core count and the different Memory Sizes.  However, there is a minimum MsegSize and if that's larger than the calculated MsegSize we can have a mismatch.  Directly including the MsegSize avoids this issue.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Tested on Intel Physical platforms.

## Integration Instructions

N/A