### PR TITLE
MdeModulePkg: Null pointer dereference in SpiNorFlashJedecSfdp

### DIFF
--- a/MdeModulePkg/Bus/Spi/SpiNorFlashJedecSfdp/SpiNorFlash.c
+++ b/MdeModulePkg/Bus/Spi/SpiNorFlashJedecSfdp/SpiNorFlash.c
@@ -48,7 +48,11 @@ FillWriteBuffer (
   UINT32  Index;
   UINT8   SfdpAddressBytes;
 
-  SfdpAddressBytes = (UINT8)Instance->SfdpBasicFlash->AddressBytes;
+  if (Instance != NULL && Instance->SfdpBasicFlash != NULL) {
+     SfdpAddressBytes = (UINT8)Instance->SfdpBasicFlash->AddressBytes;
+  } else {
+     SfdpAddressBytes = 0;
+  }
 
   // Copy Opcode into Write Buffer
   Instance->SpiTransactionWriteBuffer[0] = Opcode;


### PR DESCRIPTION
## Description

The pointer `Instance->SfdpBasicFlash` can be used before initializing.

Example code flow:
- CreateSpiNorFlashSfdpInstance: Allocate pool for `Instance`
    - InitialSpiNorFlashSfdpInstance - ReadSfdp - ReadSfdpHeader - FillWriteBuffer: Dereferencing `Instance->SfdpBasicFlash` - ReadSfdpBasicParameterTable: Allocate pool for `Instance->SfdpBasicFlash`

Check both `Instance` and `Instance->SfdpBasicFlash` should have a non null value before dereferencing it. Otherwise use the defaut value 0.

The same code change has been requested to merge into edk2: tianocore/edk2#10924

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Test in Amd SimNow simlulator. After applying this code change, an exception spotted by Mu Memory protections was fixed.

## Integration Instructions

N/A