### PR TITLE
[Cherry-pick] Fix a bug exposed in MM communicate v3

### DIFF
--- a/MdeModulePkg/Core/PiSmmCore/PiSmmIpl.c
+++ b/MdeModulePkg/Core/PiSmmCore/PiSmmIpl.c
@@ -554,13 +554,11 @@ SmmCommunicationCommunicate (
   IN OUT UINTN                             *CommSize OPTIONAL
   )
 {
-  EFI_STATUS                    Status;
-  EFI_SMM_COMMUNICATE_HEADER    *CommunicateHeader;
-  EFI_MM_COMMUNICATE_HEADER_V3  *CommunicateHeaderV3 = NULL;
-  BOOLEAN                       OldInSmm;
-  UINTN                         TempCommSize;
-  UINTN                         CommHeaderSize;
-  UINT64                        LongCommSize; // MU_CHANGE: BZ3398
+  EFI_STATUS                  Status;
+  EFI_SMM_COMMUNICATE_HEADER  *CommunicateHeader;
+  BOOLEAN                     OldInSmm;
+  UINT64                      LongCommSize; // MU_CHANGE: BZ3398
+  UINTN                       TempCommSize;
 
   //
   // Check parameters
@@ -570,39 +568,28 @@ SmmCommunicationCommunicate (
   }
 
   CommunicateHeader = (EFI_SMM_COMMUNICATE_HEADER *)CommBuffer;
-  if (CompareGuid (&CommunicateHeader->HeaderGuid, &gEfiMmCommunicateHeaderV3Guid)) {
-    CommunicateHeaderV3 = (EFI_MM_COMMUNICATE_HEADER_V3 *)CommBuffer;
-    if (CommunicateHeaderV3->BufferSize < sizeof (EFI_MM_COMMUNICATE_HEADER_V3) + CommunicateHeaderV3->MessageSize) {
+
+  if (CommSize == NULL) {
+    // MU_CHANGE Starts: BZ3398 Make MessageLength the same size in EFI_MM_COMMUNICATE_HEADER for both IA32 and X64.
+    Status = SafeUint64Add (OFFSET_OF (EFI_SMM_COMMUNICATE_HEADER, Data), CommunicateHeader->MessageLength, &LongCommSize);
+    if (EFI_ERROR (Status)) {
       return EFI_INVALID_PARAMETER;
     }
 
-    TempCommSize   = (UINTN)CommunicateHeaderV3->BufferSize;
-    CommHeaderSize = sizeof (EFI_MM_COMMUNICATE_HEADER_V3);
-  } else {
-    if (CommSize == NULL) {
-      // MU_CHANGE Starts: BZ3398 Make MessageLength the same size in EFI_MM_COMMUNICATE_HEADER for both IA32 and X64.
-      Status = SafeUint64Add (OFFSET_OF (EFI_SMM_COMMUNICATE_HEADER, Data), CommunicateHeader->MessageLength, &LongCommSize);
-      if (EFI_ERROR (Status)) {
-        return EFI_INVALID_PARAMETER;
-      }
-
-      Status = SafeUint64ToUintn (LongCommSize, &TempCommSize);
-      if (EFI_ERROR (Status)) {
-        return EFI_INVALID_PARAMETER;
-      }
-
-      // MU_CHANGE Ends: BZ3398
-    } else {
-      TempCommSize = *CommSize;
-      //
-      // CommSize must hold HeaderGuid and MessageLength
-      //
-      if (TempCommSize < OFFSET_OF (EFI_SMM_COMMUNICATE_HEADER, Data)) {
-        return EFI_INVALID_PARAMETER;
-      }
+    Status = SafeUint64ToUintn (LongCommSize, &TempCommSize);
+    if (EFI_ERROR (Status)) {
+      return EFI_INVALID_PARAMETER;
     }
 
-    CommHeaderSize = OFFSET_OF (EFI_SMM_COMMUNICATE_HEADER, Data);
+    // MU_CHANGE Ends: BZ3398
+  } else {
+    TempCommSize = *CommSize;
+    //
+    // CommSize must hold HeaderGuid and MessageLength
+    //
+    if (TempCommSize < OFFSET_OF (EFI_SMM_COMMUNICATE_HEADER, Data)) {
+      return EFI_INVALID_PARAMETER;
+    }
   }
 
   //
@@ -659,14 +646,14 @@ SmmCommunicationCommunicate (
   //
   // Before SetVirtualAddressMap(), we are in SMM or SMRAM is open and unlocked, call SmiManage() directly.
   //
-  TempCommSize -= CommHeaderSize;
+  TempCommSize -= OFFSET_OF (EFI_SMM_COMMUNICATE_HEADER, Data);
   Status        = gSmmCorePrivate->Smst->SmiManage (
                                            &CommunicateHeader->HeaderGuid,
                                            NULL,
                                            CommunicateHeader->Data,
                                            &TempCommSize
                                            );
-  TempCommSize += CommHeaderSize;
+  TempCommSize += OFFSET_OF (EFI_SMM_COMMUNICATE_HEADER, Data);
   if (CommSize != NULL) {
     *CommSize = TempCommSize;
   }
@@ -752,11 +739,98 @@ MmCommunicationMmCommunicate3 (
   IN OUT VOID                              *CommBufferVirtual
   )
 {
-  return SmmCommunicationCommunicate (
-           &mSmmCommunication,
-           CommBufferPhysical,
-           NULL
-           );
+  EFI_STATUS                    Status;
+  EFI_MM_COMMUNICATE_HEADER_V3  *CommunicateHeader;
+  BOOLEAN                       OldInSmm;
+  UINT64                        MinCommSize;
+  UINT64                        TempCommSize;
+
+  //
+  // Check parameters
+  //
+  if ((CommBufferPhysical == NULL) || (CommBufferVirtual == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  CommunicateHeader = (EFI_MM_COMMUNICATE_HEADER_V3 *)CommBufferVirtual;
+
+  Status = SafeUint64Add (sizeof (EFI_MM_COMMUNICATE_HEADER_V3), CommunicateHeader->MessageSize, &MinCommSize);
+  if (EFI_ERROR (Status)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // CommSize must hold the entire EFI_MM_COMMUNICATE_HEADER_V3
+  //
+  if (CommunicateHeader->BufferSize < MinCommSize) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // If not already in SMM, then generate a Software SMI
+  //
+  if (!gSmmCorePrivate->InSmm && gSmmCorePrivate->SmmEntryPointRegistered) {
+    //
+    // Put arguments for Software SMI in gSmmCorePrivate
+    //
+    gSmmCorePrivate->CommunicationBuffer = CommBufferPhysical;
+    gSmmCorePrivate->BufferSize          = (UINTN)CommunicateHeader->BufferSize;
+
+    //
+    // Generate Software SMI
+    //
+    Status = mSmmControl2->Trigger (mSmmControl2, NULL, NULL, FALSE, 0);
+    if (EFI_ERROR (Status)) {
+      return EFI_UNSUPPORTED;
+    }
+
+    return gSmmCorePrivate->ReturnStatus;
+  }
+
+  //
+  // If we are in SMM, then the execution mode must be physical, which means that
+  // OS established virtual addresses can not be used.  If SetVirtualAddressMap()
+  // has been called, then a direct invocation of the Software SMI is not allowed,
+  // so return EFI_INVALID_PARAMETER.
+  //
+  if (EfiGoneVirtual ()) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // If we are not in SMM, don't allow call SmiManage() directly when SMRAM is closed or locked.
+  //
+  if ((!gSmmCorePrivate->InSmm) && (!mSmmAccess->OpenState || mSmmAccess->LockState)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // Save current InSmm state and set InSmm state to TRUE
+  //
+  OldInSmm               = gSmmCorePrivate->InSmm;
+  gSmmCorePrivate->InSmm = TRUE;
+
+  //
+  // Before SetVirtualAddressMap(), we are in SMM or SMRAM is open and unlocked, call SmiManage() directly.
+  //
+  TempCommSize = CommunicateHeader->BufferSize - sizeof (EFI_MM_COMMUNICATE_HEADER_V3);
+  Status       = gSmmCorePrivate->Smst->SmiManage (
+                                          &CommunicateHeader->MessageGuid,
+                                          NULL,
+                                          CommunicateHeader->MessageData,
+                                          (UINTN *)&TempCommSize
+                                          );
+  TempCommSize += sizeof (EFI_MM_COMMUNICATE_HEADER_V3);
+
+  // Return the size of the buffer
+  CommunicateHeader->BufferSize = TempCommSize;
+
+  //
+  // Restore original InSmm state
+  //
+  gSmmCorePrivate->InSmm = OldInSmm;
+
+  return (Status == EFI_SUCCESS) ? EFI_SUCCESS : EFI_NOT_FOUND;
 }
 
 /**


### PR DESCRIPTION
## Description

With current implemenation, all 3 SmmCommunication* functions go through the same routine, which will dereference the incoming pointer to inspect whether this is a V3 buffer or not.

However, the caller always pass in the physical addresses, which could cause the system to page fault after OS take over the runtime control.

This change reverted the original common routine and added a specific v3 routine to support MM communicate v3.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

This was tested with OVMF package and booted to Windows.

## Integration Instructions

N/A