### PR TITLE
MdeModulePkg SpiBus: Use correct GUID

### DIFF
--- a/MdeModulePkg/Bus/Spi/SpiBus/SpiBus.c
+++ b/MdeModulePkg/Bus/Spi/SpiBus/SpiBus.c
@@ -329,8 +329,17 @@ Transaction (
              ((SpiChip->SpiHc->Attributes & HC_SUPPORTS_WRITE_THEN_READ_OPERATIONS) != HC_SUPPORTS_WRITE_THEN_READ_OPERATIONS))
   {
     // Convert to full duplex transaction
-    DummyReadBuffer                    = AllocateZeroPool (WriteBytes);
-    DummyWriteBuffer                   = AllocateZeroPool (ReadBytes);
+    DummyReadBuffer = AllocateZeroPool (WriteBytes);
+    if (DummyReadBuffer == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    DummyWriteBuffer = AllocateZeroPool (ReadBytes);
+    if (DummyWriteBuffer == NULL) {
+      FreePool (DummyReadBuffer);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
     SpiChip->BusTransaction.ReadBuffer = DummyReadBuffer;
     SpiChip->BusTransaction.ReadBytes  = WriteBytes;
 

--- a/MdeModulePkg/Bus/Spi/SpiBus/SpiBusDxe.c
+++ b/MdeModulePkg/Bus/Spi/SpiBus/SpiBusDxe.c
@@ -108,7 +108,7 @@ SpiBusEntry (
       // Get SpiHc from the SpiHcHandles
       Status = gBS->HandleProtocol (
                       SpiHcHandles[HcIndex],
-                      &gEfiDevicePathProtocolGuid,
+                      &gEfiSpiHcProtocolGuid,
                       (VOID **)&SpiHc
                       );
 


### PR DESCRIPTION
## Description

SPI HandleProtocol failed in the incorrect guid, change to gEfiSpiHcProtocolGuid.
Add null checking for AllocateZeroPool in the spibus.c. 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Complete the AMD spi platform drivers and related libraries.

## Integration Instructions

NA
