### PR TITLE
MdePkg: Add MockSynchronizationLib and MockSmmSxDispatch2

### DIFF
--- a/MdePkg/Test/MdePkgHostTest.dsc
+++ b/MdePkg/Test/MdePkgHostTest.dsc
@@ -73,4 +73,5 @@
   MdePkg/Test/Mock/Library/GoogleTest/MockPostCodeLib/MockPostCodeLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockSafeIntLib/MockSafeIntLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockSmmMemLib/MockSmmMemLib.inf
+  MdePkg/Test/Mock/Library/GoogleTest/MockSynchronizationLib/MockSynchronizationLib.inf
   # MU_CHANGE [END]

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockSynchronizationLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockSynchronizationLib.h
@@ -1,0 +1,118 @@
+/** @file MockSynchronizationLib.h
+  Google Test mocks for the synchronization Library
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_SYNCHRONIZATION_LIB_H_
+#define MOCK_SYNCHRONIZATION_LIB_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Library/SynchronizationLib.h>
+}
+
+struct MockSynchronizationLib {
+  MOCK_INTERFACE_DECLARATION (MockSynchronizationLib);
+
+  MOCK_FUNCTION_DECLARATION (
+    UINTN,
+    GetSpinLockProperties,
+    (
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    SPIN_LOCK *,
+    InitializeSpinLock,
+    (
+     OUT SPIN_LOCK  *SpinLock
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    SPIN_LOCK *,
+    AcquireSpinLock,
+    (
+     IN OUT SPIN_LOCK  *SpinLock
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    AcquireSpinLockOrFail,
+    (
+     IN OUT SPIN_LOCK  *SpinLock
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    SPIN_LOCK *,
+    ReleaseSpinLock,
+    (
+     IN OUT SPIN_LOCK  *SpinLock
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT32,
+    InterlockedIncrement,
+    (
+     IN volatile UINT32  *Value
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT32,
+    InterlockedDecrement,
+    (
+     IN volatile UINT32  *Value
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT16,
+    InterlockedCompareExchange16,
+    (
+     IN OUT volatile UINT16  *Value,
+     IN UINT16           CompareValue,
+     IN UINT16           ExchangeValue
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT32,
+    InterlockedCompareExchange32,
+    (
+     IN OUT  volatile UINT32  *Value,
+     IN      UINT32           CompareValue,
+     IN      UINT32           ExchangeValue
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    UINT64,
+    InterlockedCompareExchange64,
+    (
+     IN OUT  volatile UINT64  *Value,
+     IN      UINT64           CompareValue,
+     IN      UINT64           ExchangeValue
+    )
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID *,
+    InterlockedCompareExchangePointer,
+    (
+     IN OUT  VOID            *volatile  *Value,
+     IN      VOID            *CompareValue,
+     IN      VOID            *ExchangeValue
+    )
+    );
+};
+
+#endif //MOCK_SYNCHRONIZATION_LIB_H_

--- a/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockSmmSxDispatch2.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Protocol/MockSmmSxDispatch2.h
@@ -1,0 +1,52 @@
+/** @file MockSmmSxDispatch2.h
+  This file declares a mock of SMM Software Dispatch Protocol
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef MOCK_SMM_SX_DISPATCH2_H_
+#define MOCK_SMM_SX_DISPATCH2_H_
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Protocol/SmmSxDispatch2.h>
+}
+
+// Declarations to handle usage of the EFI_SMM_SX_DISPATCH2_PROTOCOL
+struct MockEfiSmmSxDispatch2Protocol {
+  MOCK_INTERFACE_DECLARATION (MockEfiSmmSxDispatch2Protocol);
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    Register,
+    (
+     IN  CONST EFI_MM_SX_DISPATCH_PROTOCOL  *This,
+     IN        EFI_MM_HANDLER_ENTRY_POINT   DispatchFunction,
+     IN  CONST EFI_MM_SX_REGISTER_CONTEXT   *RegisterContext,
+     OUT       EFI_HANDLE                   *DispatchHandle)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    UnRegister,
+    (
+     IN CONST EFI_MM_SX_DISPATCH_PROTOCOL  *This,
+     IN       EFI_HANDLE                   DispatchHandle)
+    );
+};
+
+MOCK_INTERFACE_DEFINITION (MockEfiSmmSxDispatch2Protocol);
+MOCK_FUNCTION_DEFINITION (MockEfiSmmSxDispatch2Protocol, Register, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockEfiSmmSxDispatch2Protocol, UnRegister, 2, EFIAPI);
+
+#define MOCK_EFI_SMM_SX_DISPATCH2_PROTOCOL_INSTANCE(NAME)  \
+ EFI_SMM_SX_DISPATCH2_PROTOCOL NAME##_INSTANCE = {          \
+  Register,                                            \
+  UnRegister };                                        \
+ EFI_SMM_SX_DISPATCH2_PROTOCOL  *NAME = &NAME##_INSTANCE;
+
+#endif // MOCK_SMM_SW_DISPATCH2_H_

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockSynchronizationLib/MockSynchronizationLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockSynchronizationLib/MockSynchronizationLib.cpp
@@ -1,0 +1,22 @@
+/** @file MockSynchronizationLib.cpp
+  Google Test mocks for SynchronizationLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <GoogleTest/Library/MockSynchronizationLib.h>
+
+MOCK_INTERFACE_DEFINITION (MockSynchronizationLib);
+
+MOCK_FUNCTION_DEFINITION (MockSynchronizationLib, GetSpinLockProperties, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockSynchronizationLib, InitializeSpinLock, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockSynchronizationLib, AcquireSpinLock, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockSynchronizationLib, AcquireSpinLockOrFail, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockSynchronizationLib, ReleaseSpinLock, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockSynchronizationLib, InterlockedIncrement, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockSynchronizationLib, InterlockedDecrement, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockSynchronizationLib, InterlockedCompareExchange16, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockSynchronizationLib, InterlockedCompareExchange32, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockSynchronizationLib, InterlockedCompareExchange64, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockSynchronizationLib, InterlockedCompareExchangePointer, 3, EFIAPI);

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockSynchronizationLib/MockSynchronizationLib.inf
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockSynchronizationLib/MockSynchronizationLib.inf
@@ -1,0 +1,33 @@
+## @file MockSynchronizationLib.inf
+# Google Test mocks for SynchronizationLib
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MockSynchronizationLib
+  FILE_GUID                      = C041130D-BEFC-41C7-AD8A-438EEE14AE3F
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = SynchronizationLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  MockSynchronizationLib.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHsc


### PR DESCRIPTION
## Description

MdePkg: Add MockSynchronizationLib and MockSmmSxDispatch2

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

The mock library and protocol can be consumed success in a Unit test.

## Integration Instructions

N/A
