### PR TITLE
[Squash on Rebase] Update release-basetools to use newer ubuntu.

### DIFF
--- a/.github/workflows/release-basetools.yml
+++ b/.github/workflows/release-basetools.yml
@@ -34,12 +34,12 @@ jobs:
             output_dir: "BaseTools\\Bin\\Win64"
             target: AARCH64
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             tool_chain: GCC5
             output_dir: "BaseTools/Source/C/bin"
             target: X64
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             tool_chain: GCC5
             output_dir: "BaseTools/Source/C/bin"
             target: AARCH64


### PR DESCRIPTION
## Description

Ubuntu 20.04 on github have been deprecated and
have stopped working as of 2025.04.15.

Update to use ubuntu 22.04.

https://github.com/actions/runner-images/issues/11101


- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested
CI running of pipeline

## Integration Instructions
no integration necessary.