### PR TITLE
[REVERT] Revert stm header changes

### DIFF
--- a/BaseTools/Source/C/GenStm/GenStm.h
+++ b/BaseTools/Source/C/GenStm/GenStm.h
@@ -34,7 +34,6 @@
 #include <IndustryStandard/PeImage.h>
 
 #define  SIZE_2KB    0x00000800
-#define  SIZE_1KB    0x00000400
 
 #include <Register/Intel/StmApi.h>
 

--- a/MdePkg/Include/Register/Intel/StmApi.h
+++ b/MdePkg/Include/Register/Intel/StmApi.h
@@ -20,8 +20,6 @@
 
 // MU_CHANGE - Added SMM_REV_ID definition, according to STM spec
 #define STM_SMM_REV_ID  0x80010100
-// MU_CHANGE - Added signature for CPU_INFORMATION_HEADER
-#define STM_CPU_INFORMATION_HEADER_SIGNATURE  SIGNATURE_32('C', 'p', 'u', 'I')
 
 /**
   STM Header Structures
@@ -35,11 +33,6 @@ typedef struct {
 
 #define STM_SPEC_VERSION_MAJOR  1
 #define STM_SPEC_VERSION_MINOR  0
-
-// MU_CHANGE - [START]: Add new CPU information header for STM
-
-#define CPU_INFORMATION_HEADER_PADDING_SIZE  (SIZE_1KB - 2 * sizeof (UINT32))
-#define SOFTWARE_STM_HEADER_PADDING_SIZE     (SIZE_1KB - 5 * sizeof (UINT32) - 2 * sizeof (UINT8) - sizeof (UINT16) - sizeof (STM_FEAT))
 
 typedef struct {
   UINT8       StmSpecVerMajor;
@@ -57,30 +50,12 @@ typedef struct {
   ///
   /// The total STM_HEADER should be 4K.
   ///
-
-  // Pad to take up 1KB of space
-  UINT8       Reserved2[SOFTWARE_STM_HEADER_PADDING_SIZE];
 } SOFTWARE_STM_HEADER;
 
 typedef struct {
-  UINT32    Signature;
-  UINT32    NumberOfCpus;
-  /// Pad to take up 1KB of space
-  UINT8     Reserved[CPU_INFORMATION_HEADER_PADDING_SIZE];
-} CPU_INFORMATION_HEADER;
-
-typedef struct {
-  MSEG_HEADER               HwStmHdr;
-  SOFTWARE_STM_HEADER       SwStmHdr;
-  CPU_INFORMATION_HEADER    CpuInfoHdr;
+  MSEG_HEADER            HwStmHdr;
+  SOFTWARE_STM_HEADER    SwStmHdr;
 } STM_HEADER;
-
-STATIC_ASSERT (SIZE_1KB == sizeof (SOFTWARE_STM_HEADER), "SOFTWARE_STM_HEADER size isn't 1KB!");
-STATIC_ASSERT (SIZE_1KB == sizeof (CPU_INFORMATION_HEADER), "CPU_INFORMATION_HEADER size isn't 1KB!");
-STATIC_ASSERT ((SIZE_1KB - OFFSET_OF (CPU_INFORMATION_HEADER, Reserved)) == CPU_INFORMATION_HEADER_PADDING_SIZE, "CPU_INFORMATION_HEADER_PADDING_SIZE mismatch!");
-STATIC_ASSERT ((SIZE_1KB - OFFSET_OF (SOFTWARE_STM_HEADER, Reserved2)) == SOFTWARE_STM_HEADER_PADDING_SIZE, "SOFTWARE_STM_HEADER_PADDING_SIZE mismatch!");
-
-// MU_CHANGE - [END]
 
 /**
   VMCALL API Numbers

--- a/MdePkg/Include/Register/Intel/StmApi.h
+++ b/MdePkg/Include/Register/Intel/StmApi.h
@@ -38,7 +38,7 @@ typedef struct {
 
 // MU_CHANGE - [START]: Add new CPU information header for STM
 
-#define CPU_INFORMATION_HEADER_PADDING_SIZE  (SIZE_1KB - 3 * sizeof (UINT32))
+#define CPU_INFORMATION_HEADER_PADDING_SIZE  (SIZE_1KB - 2 * sizeof (UINT32))
 #define SOFTWARE_STM_HEADER_PADDING_SIZE     (SIZE_1KB - 5 * sizeof (UINT32) - 2 * sizeof (UINT8) - sizeof (UINT16) - sizeof (STM_FEAT))
 
 typedef struct {
@@ -65,7 +65,6 @@ typedef struct {
 typedef struct {
   UINT32    Signature;
   UINT32    NumberOfCpus;
-  UINT32    MsegSize;
   /// Pad to take up 1KB of space
   UINT8     Reserved[CPU_INFORMATION_HEADER_PADDING_SIZE];
 } CPU_INFORMATION_HEADER;


### PR DESCRIPTION
## Description

The changes recently introduced to the STM header allowed changes to the STM header at runtime.  We've decided that we want the STM header to be completely constructed during build time so these changes are being reverted.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Tested on an intel physical platform.  Everything works as expected.

## Integration Instructions

If you were referencing the new CpuInfoHdr you now need to remove all those references.
