### PR TITLE
FileSync: bring githhub app backport to 202405

### DIFF
--- a/.github/workflows/backport-to-release-branch.yml
+++ b/.github/workflows/backport-to-release-branch.yml
@@ -1,5 +1,12 @@
 # This workflow moves marked commits from a development branch to a release branch.
 #
+# This workflow requires a GitHub App with the following permissions:
+# - Read and write access to repository contents
+# - Read and write access to pull requests
+#
+# The GitHub App ID and private key should be stored in the repository as a variable named `MU_ACCESS_APP_ID` and a
+# secret named `MU_ACCESS_APP_PRIVATE_KEY` respectively.
+#
 # Each commit in the development branch is cherry-picked to the release branch if the commit originates from a merged
 # PR that is marked for backport.
 #
@@ -33,11 +40,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Generate Token
+      id: app-token
+      uses: actions/create-github-app-token@v2
+      with:
+        app-id: ${{ vars.MU_ACCESS_APP_ID }}
+        private-key: ${{ secrets.MU_ACCESS_APP_PRIVATE_KEY }}
+
     - name: Checkout code
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        token: ${{ secrets.CHERRY_PICK_TOKEN }}
+        token: ${{ steps.app-token.outputs.token }}
 
     - name: Determine Contribution Info
       id: backport_info
@@ -229,5 +243,5 @@ jobs:
         -H "Content-Type: application/json" \
         -d "{\"title\":\"$PR_TITLE\",\"body\":\"$PR_BODY\",\"head\":\"$PR_BRANCH\",\"base\":\"$BASE_BRANCH\",\"labels\":[\"type:release-merge-conflict\"]}"
       env:
-        CHERRY_PICK_TOKEN: ${{ secrets.CHERRY_PICK_TOKEN }}
+        CHERRY_PICK_TOKEN: ${{ steps.app-token.outputs.token }}
 

--- a/.github/workflows/release-basetools.yml
+++ b/.github/workflows/release-basetools.yml
@@ -34,12 +34,12 @@ jobs:
             output_dir: "BaseTools\\Bin\\Win64"
             target: AARCH64
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             tool_chain: GCC5
             output_dir: "BaseTools/Source/C/bin"
             target: X64
 
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             tool_chain: GCC5
             output_dir: "BaseTools/Source/C/bin"
             target: AARCH64


### PR DESCRIPTION
## Description

Bring the necessary changes into 202405 to use the github bot to backport fixes from dev/202405 to release/202405

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested
Testing on private github repo

## Integration Instructions
No integration necesary. 