### PR TITLE
[REBASE & FF] NvmExpressDxe: Request Number of Queues from Controller

### DIFF
--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.c
@@ -979,6 +979,94 @@ Done:
   return Status;
 }
 
+// MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+
+/**
+  Unmap the queues from PciIo and free the buffers allocated.
+
+  @param[in]  Private  The pointer to the NVME_CONTROLLER_PRIVATE_DATA data structure.
+
+  @retval EFI_SUCCESS           The queues are successfully cleaned up.
+  @return Others                Some error occurs when cleaning up the queues.
+
+**/
+EFI_STATUS
+EFIAPI
+NvmExpressDriverCleanUpQueues (
+  IN NVME_CONTROLLER_PRIVATE_DATA  *Private
+  )
+{
+  EFI_STATUS  Status;
+  EFI_STATUS  ReturnStatus;
+  UINTN       QueuePairPageCount;
+
+  ReturnStatus = EFI_SUCCESS;
+
+  if (Private == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // Admin Queue Clean-up
+  //
+  if (Private->Mapping != NULL) {
+    Status = Private->PciIo->Unmap (Private->PciIo, Private->Mapping);
+    if (EFI_ERROR (Status)) {
+      ReturnStatus = Status;
+      DEBUG ((DEBUG_ERROR, "%a: Unmap Admin Queue Mapping failed %r\n", __func__, Status));
+      ASSERT_EFI_ERROR (Status);
+    }
+
+    Private->Mapping = NULL;
+  }
+
+  if (Private->Buffer != NULL) {
+    QueuePairPageCount = NVME_SQ_SIZE_IN_PAGES (Private, 0) + NVME_CQ_SIZE_IN_PAGES (Private, 0);
+    Status             = Private->PciIo->FreeBuffer (Private->PciIo, QueuePairPageCount, Private->Buffer);
+
+    if (EFI_ERROR (Status)) {
+      ReturnStatus = Status;
+      DEBUG ((DEBUG_ERROR, "%a: FreeBuffer Buffer failed %r\n", __func__, Status));
+      ASSERT_EFI_ERROR (Status);
+    }
+
+    Private->Buffer = NULL;
+  }
+
+  //
+  // I/O Queue Clean-up
+  //
+  if (Private->IoQueueMapping != NULL) {
+    Status = Private->PciIo->Unmap (Private->PciIo, Private->IoQueueMapping);
+
+    if (EFI_ERROR (Status)) {
+      ReturnStatus = Status;
+      DEBUG ((DEBUG_ERROR, "%a: Unmap IoQueueMapping failed %r\n", __func__, Status));
+      ASSERT_EFI_ERROR (Status);
+    }
+
+    Private->IoQueueMapping = NULL;
+  }
+
+  if (Private->IoQueueBuffer != NULL) {
+    // Using the first data queue size for the number of pages required for the data queues
+    QueuePairPageCount = NVME_SQ_SIZE_IN_PAGES (Private, 1) + NVME_CQ_SIZE_IN_PAGES (Private, 1);
+    Status             = Private->PciIo->FreeBuffer (Private->PciIo, QueuePairPageCount*Private->NumberOfIoQueuePairs, Private->IoQueueBuffer);
+
+    if (EFI_ERROR (Status)) {
+      ReturnStatus = Status;
+      DEBUG ((DEBUG_ERROR, "%a: FreeBuffer IoQueueBuffer failed %r\n", __func__, Status));
+      ASSERT_EFI_ERROR (Status);
+    }
+
+    Private->IoQueueBuffer = NULL;
+  }
+
+  return ReturnStatus;
+}
+
+// MU_CHANGE [END] - Allocate IO Queue Buffer
+
 /**
   Starts a device controller or a bus controller.
 
@@ -1022,13 +1110,16 @@ NvmExpressDriverBindingStart (
   IN EFI_DEVICE_PATH_PROTOCOL     *RemainingDevicePath
   )
 {
-  EFI_STATUS                          Status;
-  EFI_PCI_IO_PROTOCOL                 *PciIo;
-  NVME_CONTROLLER_PRIVATE_DATA        *Private;
-  EFI_DEVICE_PATH_PROTOCOL            *ParentDevicePath;
-  UINT32                              NamespaceId;
-  EFI_PHYSICAL_ADDRESS                MappedAddr;
-  UINTN                               Bytes;
+  EFI_STATUS                    Status;
+  EFI_PCI_IO_PROTOCOL           *PciIo;
+  NVME_CONTROLLER_PRIVATE_DATA  *Private;
+  EFI_DEVICE_PATH_PROTOCOL      *ParentDevicePath;
+  UINT32                        NamespaceId;
+  // MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+  // EFI_PHYSICAL_ADDRESS                MappedAddr;
+  // UINTN                               Bytes;
+  // MU_CHANGE [END] - Allocate IO Queue Buffer
+
   EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL  *Passthru;
 
   DEBUG ((DEBUG_INFO, "NvmExpressDriverBindingStart: start\n"));
@@ -1101,44 +1192,46 @@ NvmExpressDriverBindingStart (
       DEBUG ((DEBUG_WARN, "NvmExpressDriverBindingStart: failed to enable 64-bit DMA (%r)\n", Status));
     }
 
-    //
-    // 6 x 4kB aligned buffers will be carved out of this buffer.
-    // 1st 4kB boundary is the start of the admin submission queue.
-    // 2nd 4kB boundary is the start of the admin completion queue.
-    // 3rd 4kB boundary is the start of I/O submission queue #1.
-    // 4th 4kB boundary is the start of I/O completion queue #1.
-    // 5th 4kB boundary is the start of I/O submission queue #2.
-    // 6th 4kB boundary is the start of I/O completion queue #2.
-    //
-    // Allocate 6 pages of memory, then map it for bus master read and write.
-    //
-    Status = PciIo->AllocateBuffer (
-                      PciIo,
-                      AllocateAnyPages,
-                      EfiBootServicesData,
-                      6,
-                      (VOID **)&Private->Buffer,
-                      0
-                      );
-    if (EFI_ERROR (Status)) {
-      goto Exit;
-    }
+    // MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+    // //
+    // // 6 x 4kB aligned buffers will be carved out of this buffer.
+    // // 1st 4kB boundary is the start of the admin submission queue.
+    // // 2nd 4kB boundary is the start of the admin completion queue.
+    // // 3rd 4kB boundary is the start of I/O submission queue #1.
+    // // 4th 4kB boundary is the start of I/O completion queue #1.
+    // // 5th 4kB boundary is the start of I/O submission queue #2.
+    // // 6th 4kB boundary is the start of I/O completion queue #2.
+    // //
+    // // Allocate 6 pages of memory, then map it for bus master read and write.
+    // //
+    // Status = PciIo->AllocateBuffer (
+    //                   PciIo,
+    //                   AllocateAnyPages,
+    //                   EfiBootServicesData,
+    //                   6,
+    //                   (VOID **)&Private->Buffer,
+    //                   0
+    //                   );
+    // if (EFI_ERROR (Status)) {
+    //   goto Exit;
+    // }
 
-    Bytes  = EFI_PAGES_TO_SIZE (6);
-    Status = PciIo->Map (
-                      PciIo,
-                      EfiPciIoOperationBusMasterCommonBuffer,
-                      Private->Buffer,
-                      &Bytes,
-                      &MappedAddr,
-                      &Private->Mapping
-                      );
+    // Bytes  = EFI_PAGES_TO_SIZE (6);
+    // Status = PciIo->Map (
+    //                   PciIo,
+    //                   EfiPciIoOperationBusMasterCommonBuffer,
+    //                   Private->Buffer,
+    //                   &Bytes,
+    //                   &MappedAddr,
+    //                   &Private->Mapping
+    //                   );
 
-    if (EFI_ERROR (Status) || (Bytes != EFI_PAGES_TO_SIZE (6))) {
-      goto Exit;
-    }
+    // if (EFI_ERROR (Status) || (Bytes != EFI_PAGES_TO_SIZE (6))) {
+    //   goto Exit;
+    // }
 
-    Private->BufferPciAddr = (UINT8 *)(UINTN)MappedAddr;
+    // Private->BufferPciAddr             = (UINT8 *)(UINTN)MappedAddr;
+    // MU_CHANGE [END] - Allocate IO Queue Buffer
 
     Private->Signature                 = NVME_CONTROLLER_PRIVATE_DATA_SIGNATURE;
     Private->ControllerHandle          = Controller;
@@ -1247,13 +1340,21 @@ NvmExpressDriverBindingStart (
   return EFI_SUCCESS;
 
 Exit:
-  if ((Private != NULL) && (Private->Mapping != NULL)) {
-    PciIo->Unmap (PciIo, Private->Mapping);
+  // MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+  // if ((Private != NULL) && (Private->Mapping != NULL)) {
+  //   PciIo->Unmap (PciIo, Private->Mapping);
+  // }
+  //
+  // if ((Private != NULL) && (Private->Buffer != NULL)) {
+  //   PciIo->FreeBuffer (PciIo, 6, Private->Buffer);
+  // }
+
+  Status = NvmExpressDriverCleanUpQueues (Private);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: NvmExpressDriverCleanUpQueues failed %r\n", __func__, Status));
   }
 
-  if ((Private != NULL) && (Private->Buffer != NULL)) {
-    PciIo->FreeBuffer (PciIo, 6, Private->Buffer);
-  }
+  // MU_CHANGE [END] - Allocate IO Queue Buffer
 
   if ((Private != NULL) && (Private->ControllerData != NULL)) {
     FreePool (Private->ControllerData);
@@ -1369,13 +1470,21 @@ NvmExpressDriverBindingStop (
         gBS->CloseEvent (Private->TimerEvent);
       }
 
-      if (Private->Mapping != NULL) {
-        Private->PciIo->Unmap (Private->PciIo, Private->Mapping);
+      // MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+      // if (Private->Mapping != NULL) {
+      //   Private->PciIo->Unmap (Private->PciIo, Private->Mapping);
+      // }
+      //
+      // if (Private->Buffer != NULL) {
+      //   Private->PciIo->FreeBuffer (Private->PciIo, 6, Private->Buffer);
+      // }
+
+      Status = NvmExpressDriverCleanUpQueues (Private);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "%a: NvmExpressDriverCleanUpQueues failed %r\n", __func__, Status));
       }
 
-      if (Private->Buffer != NULL) {
-        Private->PciIo->FreeBuffer (Private->PciIo, 6, Private->Buffer);
-      }
+      // MU_CHANGE [END] - Allocate IO Queue Buffer
 
       FreePool (Private->ControllerData);
       FreePool (Private);

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.c
@@ -655,6 +655,9 @@ ProcessAsyncTaskList (
   EFI_BLOCK_IO2_TOKEN           *Token;
   BOOLEAN                       HasNewItem;
   EFI_STATUS                    Status;
+  // MU_CHANGE - Support alternative hardware queue sizes in NVME driver
+  UINT16  QueueSize = PcdGetBool (PcdSupportAlternativeQueueSize) ?
+                      NVME_ALTERNATIVE_MAX_QUEUE_SIZE : NVME_ASYNC_CCQ_SIZE;
 
   Private    = (NVME_CONTROLLER_PRIVATE_DATA *)Context;
   QueueId    = 2;
@@ -797,7 +800,8 @@ ProcessAsyncTaskList (
     }
 
     Private->CqHdbl[QueueId].Cqh++;
-    if (Private->CqHdbl[QueueId].Cqh > MIN (NVME_ASYNC_CCQ_SIZE, Private->Cap.Mqes)) {
+    // MU_CHANGE - Support alternative hardware queue sizes in NVME driver
+    if (Private->CqHdbl[QueueId].Cqh > MIN (QueueSize, Private->Cap.Mqes)) {
       Private->CqHdbl[QueueId].Cqh = 0;
       Private->Pt[QueueId]        ^= 1;
     }

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.c
@@ -172,14 +172,20 @@ EnumerateNvmeDevNamespace (
     Device->BlockIo.WriteBlocks = NvmeBlockIoWriteBlocks;
     Device->BlockIo.FlushBlocks = NvmeBlockIoFlushBlocks;
 
-    //
-    // Create BlockIo2 Protocol instance
-    //
-    Device->BlockIo2.Media         = &Device->Media;
-    Device->BlockIo2.Reset         = NvmeBlockIoResetEx;
-    Device->BlockIo2.ReadBlocksEx  = NvmeBlockIoReadBlocksEx;
-    Device->BlockIo2.WriteBlocksEx = NvmeBlockIoWriteBlocksEx;
-    Device->BlockIo2.FlushBlocksEx = NvmeBlockIoFlushBlocksEx;
+    // MU_CHANGE [BEGIN] - Request Number of Queues from Controller
+    if (NVME_SUPPORT_BLOCKIO2 (Private)) {
+      // We have multiple data queues, so we can support the BlockIo2 protocol
+
+      // Create BlockIo2 Protocol instance
+      Device->BlockIo2.Media         = &Device->Media;
+      Device->BlockIo2.Reset         = NvmeBlockIoResetEx;
+      Device->BlockIo2.ReadBlocksEx  = NvmeBlockIoReadBlocksEx;
+      Device->BlockIo2.WriteBlocksEx = NvmeBlockIoWriteBlocksEx;
+      Device->BlockIo2.FlushBlocksEx = NvmeBlockIoFlushBlocksEx;
+    }
+
+    // MU_CHANGE [END] - Request Number of Queues from Controller
+
     InitializeListHead (&Device->AsyncQueue);
 
     //
@@ -258,8 +264,8 @@ EnumerateNvmeDevNamespace (
                     Device->DevicePath,
                     &gEfiBlockIoProtocolGuid,
                     &Device->BlockIo,
-                    &gEfiBlockIo2ProtocolGuid,
-                    &Device->BlockIo2,
+                    // &gEfiBlockIo2ProtocolGuid, // MU_CHANGE - Request Number of Queues from Controller
+                    // &Device->BlockIo2, // MU_CHANGE - Request Number of Queues from Controller
                     &gEfiDiskInfoProtocolGuid,
                     &Device->DiskInfo,
                     &gMediaSanitizeProtocolGuid,
@@ -270,6 +276,36 @@ EnumerateNvmeDevNamespace (
     if (EFI_ERROR (Status)) {
       goto Exit;
     }
+
+    // MU_CHANGE [BEGIN] - Request Number of Queues from Controller
+    if (NVME_SUPPORT_BLOCKIO2 (Private)) {
+      // We have multiple data queues, so we can support the BlockIo2 protocol
+      Status = gBS->InstallMultipleProtocolInterfaces (
+                      &Device->DeviceHandle,
+                      &gEfiBlockIo2ProtocolGuid,
+                      &Device->BlockIo2,
+                      NULL
+                      );
+
+      if (EFI_ERROR (Status)) {
+        gBS->UninstallMultipleProtocolInterfaces (
+               Device->DeviceHandle,
+               &gEfiDevicePathProtocolGuid,
+               Device->DevicePath,
+               &gEfiBlockIoProtocolGuid,
+               &Device->BlockIo,
+               &gEfiDiskInfoProtocolGuid,
+               &Device->DiskInfo,
+               NULL
+               );
+
+        DEBUG ((DEBUG_ERROR, "%a: Failed to install BlockIo2 protocol. Error %r\n", __func__, Status));
+        ASSERT_EFI_ERROR (Status);
+        goto Exit;
+      }
+    }
+
+    // MU_CHANGE [END] - Request Number of Queues from Controller
 
     //
     // Check if the NVMe controller supports the Security Send and Security Receive commands
@@ -288,14 +324,28 @@ EnumerateNvmeDevNamespace (
                Device->DevicePath,
                &gEfiBlockIoProtocolGuid,
                &Device->BlockIo,
-               &gEfiBlockIo2ProtocolGuid,
-               &Device->BlockIo2,
+               // &gEfiBlockIo2ProtocolGuid, // MU_CHANGE - Request Number of Queues from Controller
+               // &Device->BlockIo2, // MU_CHANGE - Request Number of Queues from Controller
                &gEfiDiskInfoProtocolGuid,
                &Device->DiskInfo,
                &gMediaSanitizeProtocolGuid,
                &Device->MediaSanitize,
                NULL
                );
+
+        // MU_CHANGE [BEGIN] - Request Number of Queues from Controller
+        if (NVME_SUPPORT_BLOCKIO2 (Private)) {
+          // We have multiple data queues, so we need to uninstall the BlockIo2 protocol
+          gBS->UninstallMultipleProtocolInterfaces (
+                 Device->DeviceHandle,
+                 &gEfiBlockIo2ProtocolGuid,
+                 &Device->BlockIo2,
+                 NULL
+                 );
+        }
+
+        // MU_CHANGE [END] - Request Number of Queues from Controller
+
         goto Exit;
       }
     }
@@ -431,6 +481,7 @@ UnregisterNvmeNamespace (
   )
 {
   EFI_STATUS                             Status;
+  EFI_STATUS                             BlockIo2Status; // MU_CHANGE - Request Number of Queues from Controller
   EFI_BLOCK_IO_PROTOCOL                  *BlockIo;
   NVME_DEVICE_PRIVATE_DATA               *Device;
   EFI_STORAGE_SECURITY_COMMAND_PROTOCOL  *StorageSecurity;
@@ -438,7 +489,10 @@ UnregisterNvmeNamespace (
   EFI_TPL                                OldTpl;
   VOID                                   *DummyInterface;
 
-  BlockIo = NULL;
+  // MU_CHANGE [BEGIN] - Request Number of Queues from Controller
+  BlockIo        = NULL;
+  BlockIo2Status = EFI_SUCCESS;
+  // MU_CHANGE [END] - Request Number of Queues from Controller
 
   Status = gBS->OpenProtocol (
                   Handle,
@@ -479,6 +533,24 @@ UnregisterNvmeNamespace (
          Handle
          );
 
+  // MU_CHANGE [BEGIN] - Request Number of Queues from Controller
+  //
+  // If BlockIo2 is installed, uninstall it.
+  //
+  if (NVME_SUPPORT_BLOCKIO2 (Device->Controller)) {
+    BlockIo2Status = gBS->UninstallMultipleProtocolInterfaces (
+                            Handle,
+                            &gEfiBlockIo2ProtocolGuid,
+                            &Device->BlockIo2,
+                            NULL
+                            );
+
+    if (EFI_ERROR (BlockIo2Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to uninstall BlockIo2 protocol\n", __func__));
+    }
+  }
+
+  // MU_CHANGE [END] - Request Number of Queues from Controller
   //
   // The Nvm Express driver installs the BlockIo and DiskInfo in the DriverBindingStart().
   // Here should uninstall both of them.
@@ -489,8 +561,8 @@ UnregisterNvmeNamespace (
                   Device->DevicePath,
                   &gEfiBlockIoProtocolGuid,
                   &Device->BlockIo,
-                  &gEfiBlockIo2ProtocolGuid,
-                  &Device->BlockIo2,
+                  // &gEfiBlockIo2ProtocolGuid, // MU_CHANGE - Request Number of Queues from Controller
+                  // &Device->BlockIo2, // MU_CHANGE - Request Number of Queues from Controller
                   &gEfiDiskInfoProtocolGuid,
                   &Device->DiskInfo,
                   &gMediaSanitizeProtocolGuid,
@@ -498,7 +570,8 @@ UnregisterNvmeNamespace (
                   NULL
                   );
 
-  if (EFI_ERROR (Status)) {
+  if (EFI_ERROR (Status) || EFI_ERROR (BlockIo2Status)) {
+    // MU_CHANGE - Request Number of Queues from Controller
     gBS->OpenProtocol (
            Controller,
            &gEfiNvmExpressPassThruProtocolGuid,
@@ -1087,28 +1160,36 @@ NvmExpressDriverBindingStart (
       goto Exit;
     }
 
+    // MU_CHANGE [BEGIN] - Request Number of Queues from Controller
+
     //
     // Start the asynchronous I/O completion monitor
+    // The ProcessAsyncTaskList event and NVME_HC_ASYNC_TIMER timer are only used for the BlockIo2 protocol,
+    // which is only installed when the number of IO queues is greater than 1
     //
-    Status = gBS->CreateEvent (
-                    EVT_TIMER | EVT_NOTIFY_SIGNAL,
-                    TPL_NOTIFY,
-                    ProcessAsyncTaskList,
-                    Private,
-                    &Private->TimerEvent
-                    );
-    if (EFI_ERROR (Status)) {
-      goto Exit;
+    if (NVME_SUPPORT_BLOCKIO2 (Private)) {
+      Status = gBS->CreateEvent (
+                      EVT_TIMER | EVT_NOTIFY_SIGNAL,
+                      TPL_NOTIFY,
+                      ProcessAsyncTaskList,
+                      Private,
+                      &Private->TimerEvent
+                      );
+      if (EFI_ERROR (Status)) {
+        goto Exit;
+      }
+
+      Status = gBS->SetTimer (
+                      Private->TimerEvent,
+                      TimerPeriodic,
+                      NVME_HC_ASYNC_TIMER
+                      );
+      if (EFI_ERROR (Status)) {
+        goto Exit;
+      }
     }
 
-    Status = gBS->SetTimer (
-                    Private->TimerEvent,
-                    TimerPeriodic,
-                    NVME_HC_ASYNC_TIMER
-                    );
-    if (EFI_ERROR (Status)) {
-      goto Exit;
-    }
+    // MU_CHANGE [END] - Request Number of Queues from Controller
 
     Status = gBS->InstallMultipleProtocolInterfaces (
                     &Controller,

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.c
@@ -582,9 +582,6 @@ ProcessAsyncTaskList (
   EFI_BLOCK_IO2_TOKEN           *Token;
   BOOLEAN                       HasNewItem;
   EFI_STATUS                    Status;
-  // MU_CHANGE - Support alternative hardware queue sizes in NVME driver
-  UINT16  QueueSize = PcdGetBool (PcdSupportAlternativeQueueSize) ?
-                      NVME_ALTERNATIVE_MAX_QUEUE_SIZE : NVME_ASYNC_CCQ_SIZE;
 
   Private    = (NVME_CONTROLLER_PRIVATE_DATA *)Context;
   QueueId    = 2;
@@ -727,8 +724,7 @@ ProcessAsyncTaskList (
     }
 
     Private->CqHdbl[QueueId].Cqh++;
-    // MU_CHANGE - Support alternative hardware queue sizes in NVME driver
-    if (Private->CqHdbl[QueueId].Cqh > MIN (QueueSize, Private->Cap.Mqes)) {
+    if (Private->CqHdbl[QueueId].Cqh > MIN (NVME_ASYNC_CCQ_SIZE, Private->Cap.Mqes)) {
       Private->CqHdbl[QueueId].Cqh = 0;
       Private->Pt[QueueId]        ^= 1;
     }
@@ -961,9 +957,6 @@ NvmExpressDriverBindingStart (
   EFI_PHYSICAL_ADDRESS                MappedAddr;
   UINTN                               Bytes;
   EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL  *Passthru;
-  // MU_CHANGE - Support alternative hardware queue sizes in NVME driver
-  UINTN  QueuePageCount = PcdGetBool (PcdSupportAlternativeQueueSize) ?
-                          NVME_ALTERNATIVE_TOTAL_QUEUE_BUFFER_IN_PAGES : 6;
 
   DEBUG ((DEBUG_INFO, "NvmExpressDriverBindingStart: start\n"));
 
@@ -1035,13 +1028,7 @@ NvmExpressDriverBindingStart (
       DEBUG ((DEBUG_WARN, "NvmExpressDriverBindingStart: failed to enable 64-bit DMA (%r)\n", Status));
     }
 
-    // MU_CHANGE - Support alternative hardware queue sizes in NVME driver
-
     //
-    // Depending on PCD disablement, either support the default or alternative
-    // queue sizes.
-    //
-    // Default:
     // 6 x 4kB aligned buffers will be carved out of this buffer.
     // 1st 4kB boundary is the start of the admin submission queue.
     // 2nd 4kB boundary is the start of the admin completion queue.
@@ -1052,22 +1039,11 @@ NvmExpressDriverBindingStart (
     //
     // Allocate 6 pages of memory, then map it for bus master read and write.
     //
-    // Alternative:
-    // 15 x 4kB aligned buffers will be carved out of this buffer.
-    // 1st 4kB boundary is the start of the admin submission queue.
-    // 5th 4kB boundary is the start of the admin completion queue.
-    // 6th 4kB boundary is the start of I/O submission queue #1.
-    // 10th 4kB boundary is the start of I/O completion queue #1.
-    // 11th 4kB boundary is the start of I/O submission queue #2.
-    // 15th 4kB boundary is the start of I/O completion queue #2.
-    //
-    // Allocate 15 pages of memory, then map it for bus master read and write.
-    //
     Status = PciIo->AllocateBuffer (
                       PciIo,
                       AllocateAnyPages,
                       EfiBootServicesData,
-                      QueuePageCount,
+                      6,
                       (VOID **)&Private->Buffer,
                       0
                       );
@@ -1075,8 +1051,7 @@ NvmExpressDriverBindingStart (
       goto Exit;
     }
 
-    // MU_CHANGE - Support alternative hardware queue sizes in NVME driver
-    Bytes  = EFI_PAGES_TO_SIZE (QueuePageCount);
+    Bytes  = EFI_PAGES_TO_SIZE (6);
     Status = PciIo->Map (
                       PciIo,
                       EfiPciIoOperationBusMasterCommonBuffer,
@@ -1086,8 +1061,7 @@ NvmExpressDriverBindingStart (
                       &Private->Mapping
                       );
 
-    // MU_CHANGE - Support alternative hardware queue sizes in NVME driver
-    if (EFI_ERROR (Status) || (Bytes != EFI_PAGES_TO_SIZE (QueuePageCount))) {
+    if (EFI_ERROR (Status) || (Bytes != EFI_PAGES_TO_SIZE (6))) {
       goto Exit;
     }
 
@@ -1197,8 +1171,7 @@ Exit:
   }
 
   if ((Private != NULL) && (Private->Buffer != NULL)) {
-    // MU_CHANGE - Support alternative hardware queue sizes in NVME driver
-    PciIo->FreeBuffer (PciIo, QueuePageCount, Private->Buffer);
+    PciIo->FreeBuffer (PciIo, 6, Private->Buffer);
   }
 
   if ((Private != NULL) && (Private->ControllerData != NULL)) {
@@ -1274,9 +1247,6 @@ NvmExpressDriverBindingStop (
   EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL  *PassThru;
   BOOLEAN                             IsEmpty;
   EFI_TPL                             OldTpl;
-  // MU_CHANGE - Support alternative hardware queue sizes in NVME driver
-  UINT16  QueuePageCount = PcdGetBool (PcdSupportAlternativeQueueSize) ?
-                           NVME_ALTERNATIVE_TOTAL_QUEUE_BUFFER_IN_PAGES : 6;
 
   if (NumberOfChildren == 0) {
     Status = gBS->OpenProtocol (
@@ -1323,8 +1293,7 @@ NvmExpressDriverBindingStop (
       }
 
       if (Private->Buffer != NULL) {
-        // MU_CHANGE - Support alternative hardware queue sizes in NVME driver
-        Private->PciIo->FreeBuffer (Private->PciIo, QueuePageCount, Private->Buffer);
+        Private->PciIo->FreeBuffer (Private->PciIo, 6, Private->Buffer);
       }
 
       FreePool (Private->ControllerData);

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.h
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.h
@@ -78,7 +78,17 @@ extern EFI_DRIVER_SUPPORTED_EFI_VERSION_PROTOCOL  gNvmExpressDriverSupportedEfiV
 //
 #define NVME_ASYNC_CCQ_SIZE  255
 
-#define NVME_MAX_QUEUES  3                              // Number of queues supported by the driver
+// MU_CHANGE [BEGIN] - Request Number of Queues from Controller
+// Maximum number of queue pairs supported by the driver, including the admin queues.
+// Queue 0 - Admin
+// Queue 1 - Blocking I/O (BlockIo Protocol)
+// Queue 2 - Asynchronous I/O (BlockIo2 Protocol)
+#define NVME_MAX_QUEUES  3
+
+// Returns if the controller supports the BlockIo2 protocol.
+// The BlockIo2 protocol is only supported if the controller has more than 1 queue pair allocated
+#define NVME_SUPPORT_BLOCKIO2(ContollerPointer)  (((ContollerPointer)->NumberOfIoQueuePairs) > 1)
+// MU_CHANGE [END] - Request Number of Queues from Controller
 
 //
 // FormatNVM Admin Command LBA Format (LBAF) Mask
@@ -143,6 +153,16 @@ struct _NVME_CONTROLLER_PRIVATE_DATA {
   // pointer to identify controller data
   //
   NVME_ADMIN_CONTROLLER_DATA            *ControllerData;
+
+  // MU_CHANGE [BEGIN] - Request Number of Queues from Controller
+  //
+  // Number of Queues Allocated by the controller
+  // UEFI always uses a 1:1 submission:completion queue allocation so we
+  // use NumberOfIoQueuePairs to represent the number of data queue pairs allocated.
+  // NumberOfIoQueuePairs = Nsqa = Ncqa
+  //
+  UINT32    NumberOfIoQueuePairs;
+  // MU_CHANGE [END] - Request Number of Queues from Controller
 
   //
   // 6 x 4kB aligned buffers will be carved out of this buffer.

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.h
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.h
@@ -47,6 +47,7 @@
 
 typedef struct _NVME_CONTROLLER_PRIVATE_DATA  NVME_CONTROLLER_PRIVATE_DATA;
 typedef struct _NVME_DEVICE_PRIVATE_DATA      NVME_DEVICE_PRIVATE_DATA;
+typedef struct _NVME_QUEUE_SIZE_DATA          NVME_QUEUE_SIZE_DATA; // MU_CHANGE - Allocate IO Queue Buffer
 
 #include "NvmExpressBlockIo.h"
 #include "NvmExpressDiskInfo.h"
@@ -66,6 +67,14 @@ extern EFI_DRIVER_SUPPORTED_EFI_VERSION_PROTOCOL  gNvmExpressDriverSupportedEfiV
 
 #define NVME_CSQ_SIZE  1                                // Number of I/O submission queue entries, which is 0-based
 #define NVME_CCQ_SIZE  1                                // Number of I/O completion queue entries, which is 0-based
+
+// MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+// NVM Express 2.0e specification, section 5.17.1 Identify Controller Data Structure (CNS 01h)
+// The specification defines these numbers as the minimum and standard values. They are what this driver supports.
+// The values are in bytes and are reported as a power of 2.
+#define NVME_IOSQES_MIN  6                              // I/O submission queue entry size
+#define NVME_IOCQES_MIN  4                              // I/O completion queue entry size
+// MU_CHANGE [END] - Allocate IO Queue Buffer
 
 //
 // Number of asynchronous I/O submission queue entries, which is 0-based.
@@ -89,6 +98,19 @@ extern EFI_DRIVER_SUPPORTED_EFI_VERSION_PROTOCOL  gNvmExpressDriverSupportedEfiV
 // The BlockIo2 protocol is only supported if the controller has more than 1 queue pair allocated
 #define NVME_SUPPORT_BLOCKIO2(ContollerPointer)  (((ContollerPointer)->NumberOfIoQueuePairs) > 1)
 // MU_CHANGE [END] - Request Number of Queues from Controller
+
+// MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+//
+// Returns the number of pages required for a submission/completion queue
+// The Indices are the same as above, 0 for admin, 1 for blocking I/O, 2 for async I/O.
+//
+#define NVME_SQ_SIZE_IN_PAGES(ControllerPointer, Index) \
+  ((ControllerPointer)->SqData[(Index)].NumberOfEntries * (UINTN)LShiftU64 (2, (ControllerPointer)->SqData[(Index)].EntrySize))
+
+#define NVME_CQ_SIZE_IN_PAGES(ControllerPointer, Index) \
+  ((ControllerPointer)->CqData[(Index)].NumberOfEntries * (UINTN)LShiftU64 (2, (ControllerPointer)->CqData[(Index)].EntrySize))
+
+// MU_CHANGE [END] - Allocate IO Queue Buffer
 
 //
 // FormatNVM Admin Command LBA Format (LBAF) Mask
@@ -130,6 +152,18 @@ extern EFI_DRIVER_SUPPORTED_EFI_VERSION_PROTOCOL  gNvmExpressDriverSupportedEfiV
 // Unique signature for private data structure.
 //
 #define NVME_CONTROLLER_PRIVATE_DATA_SIGNATURE  SIGNATURE_32 ('N','V','M','E')
+// MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+#define NVME_INVALID_VID_DID  0xFFFF
+
+//
+// Nvme queue data
+//
+struct _NVME_QUEUE_SIZE_DATA {
+  UINT32    NumberOfEntries; // in number of entries
+  UINT8     EntrySize;       // in bytes, as a power of 2
+};
+
+// MU_CHANGE [END] - Allocate IO Queue Buffer
 
 //
 // Nvme private data structure.
@@ -161,8 +195,16 @@ struct _NVME_CONTROLLER_PRIVATE_DATA {
   // use NumberOfIoQueuePairs to represent the number of data queue pairs allocated.
   // NumberOfIoQueuePairs = Nsqa = Ncqa
   //
-  UINT32    NumberOfIoQueuePairs;
+  UINT32                  NumberOfIoQueuePairs;
   // MU_CHANGE [END] - Request Number of Queues from Controller
+
+  // MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+  //
+  // Queue Size Data
+  //
+  NVME_QUEUE_SIZE_DATA    SqData[NVME_MAX_QUEUES];
+  NVME_QUEUE_SIZE_DATA    CqData[NVME_MAX_QUEUES];
+  // MU_CHANGE [END] - Allocate IO Queue Buffer
 
   //
   // 6 x 4kB aligned buffers will be carved out of this buffer.
@@ -175,6 +217,11 @@ struct _NVME_CONTROLLER_PRIVATE_DATA {
   //
   UINT8          *Buffer;
   UINT8          *BufferPciAddr;
+
+  // MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+  UINT8          *IoQueueBuffer;
+  UINT8          *IoQueueBufferPciAddr;
+  // MU_CHANGE [END] - Allocate IO Queue Buffer
 
   //
   // Pointers to 4kB aligned submission & completion queues.
@@ -205,6 +252,7 @@ struct _NVME_CONTROLLER_PRIVATE_DATA {
   NVME_CAP       Cap;
 
   VOID           *Mapping;
+  VOID           *IoQueueMapping; // MU_CHANGE - Allocate IO Queue Buffer
 
   //
   // For Non-blocking operations.

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.h
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.h
@@ -104,21 +104,6 @@ extern EFI_DRIVER_SUPPORTED_EFI_VERSION_PROTOCOL  gNvmExpressDriverSupportedEfiV
 
 #define NVME_ALL_NAMESPACES  0xFFFFFFFF
 
-// MU_CHANGE [BEGIN] - Support alternative hardware queue sizes in NVME driver
-
-//
-// NVMe DXE to accommodate hardware which requires queue size 255.
-// Driver supports queue size up to 255 (4 page SQ buffer).
-// DXE driver creates queue size MIN(Cap.Mqes, NVME_MAX_QUEUE_SIZE) for all queues.
-// Driver allocates queue buffer to support 255 max queue size.
-// Each submission queue buffer is allocated as 64B * 256 = 4 * 4kB = 4 pages.
-// Each completion queue buffer is allocated as 16B * 256 = 4kB = 1 page.
-//
-#define NVME_ALTERNATIVE_MAX_QUEUE_SIZE               255
-#define NVME_ALTERNATIVE_TOTAL_QUEUE_BUFFER_IN_PAGES  NVME_MAX_QUEUES * 5
-
-// MU_CHANGE [END]
-
 #define NVME_CONTROLLER_ID  0
 
 //

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.h
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.h
@@ -136,6 +136,20 @@ extern EFI_DRIVER_SUPPORTED_EFI_VERSION_PROTOCOL  gNvmExpressDriverSupportedEfiV
 
 #define NVME_ALL_NAMESPACES  0xFFFFFFFF
 
+// MU_CHANGE [BEGIN] - Support alternative hardware queue sizes in NVME driver
+
+//
+// NVMe DXE to accommodate hardware which requires queue size 255.
+// Driver supports queue size up to 255 (4 page SQ buffer).
+// DXE driver creates queue size MIN(Cap.Mqes, NVME_MAX_QUEUE_SIZE) for all queues.
+// Driver allocates queue buffer to support 255 max queue size.
+// Each submission queue buffer is allocated as 64B * 256 = 4 * 4kB = 4 pages.
+// Each completion queue buffer is allocated as 16B * 256 = 4kB = 1 page.
+//
+#define NVME_ALTERNATIVE_MAX_QUEUE_SIZE  255
+
+// MU_CHANGE [END] - Support alternative hardware queue sizes in NVME driver
+
 #define NVME_CONTROLLER_ID  0
 
 //

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressBlockIo.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressBlockIo.c
@@ -992,7 +992,7 @@ NvmeBlockIoReset (
 
   Private = Device->Controller;
 
-  Status = NvmeControllerInit (Private);
+  Status = NvmeControllerReset (Private); // MU_CHANGE - Allocate IO Queue Buffer
 
   if (EFI_ERROR (Status)) {
     Status = EFI_DEVICE_ERROR;
@@ -1260,7 +1260,7 @@ NvmeBlockIoResetEx (
 
   OldTpl = gBS->RaiseTPL (TPL_CALLBACK);
 
-  Status = NvmeControllerInit (Private);
+  Status = NvmeControllerReset (Private); // MU_CHANGE - Allocate IO Queue Buffer
 
   if (EFI_ERROR (Status)) {
     Status = EFI_DEVICE_ERROR;

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressDxe.inf
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressDxe.inf
@@ -77,11 +77,6 @@
   gMediaSanitizeProtocolGuid                  ## PRODUCES
   gEfiResetNotificationProtocolGuid           ## CONSUMES
 
-[Pcd]
-  ## MU_CHANGE [BEGIN] - Support alternative hardware queue sizes in NVME driver
-  gEfiMdeModulePkgTokenSpaceGuid.PcdSupportAlternativeQueueSize ## CONSUMES
-  ## MU_CHANGE [END]
-
 # [Event]
 # EVENT_TYPE_RELATIVE_TIMER ## SOMETIMES_CONSUMES
 #

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressDxe.inf
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressDxe.inf
@@ -77,6 +77,11 @@
   gMediaSanitizeProtocolGuid                  ## PRODUCES
   gEfiResetNotificationProtocolGuid           ## CONSUMES
 
+[Pcd]
+  ## MU_CHANGE [BEGIN] - Support alternative hardware queue sizes in NVME driver
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSupportAlternativeQueueSize ## CONSUMES
+  ## MU_CHANGE [END] - Support alternative hardware queue sizes in NVME driver
+
 # [Event]
 # EVENT_TYPE_RELATIVE_TIMER ## SOMETIMES_CONSUMES
 #

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
@@ -808,12 +808,14 @@ NvmeControllerInit (
   //
   // Address of admin submission queue.
   //
-  Asq = (UINT64)(UINTN)(Private->BufferPciAddr) & ~0xFFF;
+  // MU_CHANGE - Remove the page mask since the buffer is allocated using AllocatePages
+  Asq = (UINT64)(UINTN)(Private->BufferPciAddr);
 
   //
   // Address of admin completion queue.
   //
-  Acq = (UINT64)(UINTN)(Private->BufferPciAddr + EFI_PAGE_SIZE) & ~0xFFF;
+  // MU_CHANGE - Remove the page mask since the buffer is allocated using AllocatePages
+  Acq = (UINT64)(UINTN)(Private->BufferPciAddr + EFI_PAGE_SIZE);
 
   //
   // Address of I/O submission & completion queue.

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
@@ -751,15 +751,14 @@ NvmeCreateIoCompletionQueue (
     CommandPacket.CommandTimeout = NVME_GENERIC_TIMEOUT;
     CommandPacket.QueueType      = NVME_ADMIN_QUEUE;
 
+    // MU_CHANGE [BEGIN] - Use the Mqes value from the Cap register
     if (Index == 1) {
-      QueueSize = NVME_CCQ_SIZE;
+      QueueSize = MIN (NVME_CCQ_SIZE, Private->Cap.Mqes);
     } else {
-      if (Private->Cap.Mqes > NVME_ASYNC_CCQ_SIZE) {
-        QueueSize = NVME_ASYNC_CCQ_SIZE;
-      } else {
-        QueueSize = Private->Cap.Mqes;
-      }
+      QueueSize = MIN (NVME_ASYNC_CCQ_SIZE, Private->Cap.Mqes);
     }
+
+    // MU_CHANGE [END] - Use the Mqes value from the Cap register
 
     CrIoCq.Qid   = Index;
     CrIoCq.Qsize = QueueSize;
@@ -829,15 +828,14 @@ NvmeCreateIoSubmissionQueue (
     CommandPacket.CommandTimeout = NVME_GENERIC_TIMEOUT;
     CommandPacket.QueueType      = NVME_ADMIN_QUEUE;
 
+    // MU_CHANGE [BEGIN] - Use the Mqes value from the Cap register
     if (Index == 1) {
-      QueueSize = NVME_CSQ_SIZE;
+      QueueSize = MIN (NVME_CSQ_SIZE, Private->Cap.Mqes);
     } else {
-      if (Private->Cap.Mqes > NVME_ASYNC_CSQ_SIZE) {
-        QueueSize = NVME_ASYNC_CSQ_SIZE;
-      } else {
-        QueueSize = Private->Cap.Mqes;
-      }
+      QueueSize = MIN (NVME_ASYNC_CSQ_SIZE, Private->Cap.Mqes);
     }
+
+    // MU_CHANGE [END] - Use the Mqes value from the Cap register
 
     CrIoSq.Qid   = Index;
     CrIoSq.Qsize = QueueSize;

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
@@ -180,6 +180,52 @@ ReadNvmeControllerStatus (
   return EFI_SUCCESS;
 }
 
+// MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+
+/**
+  Read Nvm Express admin queue attributes register.
+
+  @param  Private          The pointer to the NVME_CONTROLLER_PRIVATE_DATA data structure.
+  @param  Aqa              The buffer used to store the content to be read from admin queue attributes register.
+
+  @return EFI_SUCCESS      Successfully read data from the admin queue attributes register.
+  @return EFI_DEVICE_ERROR Fail to read data from the admin queue attributes register.
+
+**/
+EFI_STATUS
+ReadNvmeAdminQueueAttributes (
+  IN  NVME_CONTROLLER_PRIVATE_DATA  *Private,
+  OUT NVME_AQA                      *Aqa
+  )
+{
+  EFI_PCI_IO_PROTOCOL  *PciIo;
+  EFI_STATUS           Status;
+  UINT32               Data;
+
+  PciIo  = Private->PciIo;
+  Status = PciIo->Mem.Read (
+                        PciIo,
+                        EfiPciIoWidthUint32,
+                        NVME_BAR,
+                        NVME_AQA_OFFSET,
+                        1,
+                        &Data
+                        );
+
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  WriteUnaligned32 ((UINT32 *)Aqa, Data);
+
+  DEBUG ((DEBUG_INFO, "%a: Admin Submission Queue Size (Number of Entries): %d\n", __func__, Aqa->Asqs));
+  DEBUG ((DEBUG_INFO, "%a: Admin Completion Queue Size (Number of Entries): %d\n", __func__, Aqa->Acqs));
+
+  return EFI_SUCCESS;
+}
+
+// MU_CHANGE [END] - Allocate IO Queue Buffer
+
 /**
   Write Nvm Express admin queue attributes register.
 

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
@@ -246,6 +246,14 @@ WriteNvmeAdminQueueAttributes (
   EFI_STATUS           Status;
   UINT32               Data;
 
+  // MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+  //
+  // Save Aqa to Private data for later use.
+  //
+  Private->SqData[0].NumberOfEntries = Aqa->Asqs;
+  Private->CqData[0].NumberOfEntries = Aqa->Acqs;
+  // MU_CHANGE [END] - Allocate IO Queue Buffer
+
   PciIo  = Private->PciIo;
   Data   = ReadUnaligned32 ((UINT32 *)Aqa);
   Status = PciIo->Mem.Write (
@@ -427,10 +435,14 @@ NvmeDisableController (
   return Status;
 }
 
+// MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+
 /**
-  Enable the Nvm Express controller.
+  Enable the Nvm Express controller. Allocate and write the Controller Configuration data.
 
   @param  Private          The pointer to the NVME_CONTROLLER_PRIVATE_DATA data structure.
+  @param  IoSqEs           The I/O Submission Queue Entry Size.
+  @param  IoCqEs           The I/O Completion Queue Entry Size.
 
   @return EFI_SUCCESS      Successfully enable the controller.
   @return EFI_DEVICE_ERROR Fail to enable the controller.
@@ -439,9 +451,12 @@ NvmeDisableController (
 **/
 EFI_STATUS
 NvmeEnableController (
-  IN NVME_CONTROLLER_PRIVATE_DATA  *Private
+  IN NVME_CONTROLLER_PRIVATE_DATA  *Private,
+  IN UINT8                         IoSqEs,
+  IN UINT8                         IoCqEs
   )
 {
+  // MU_CHANGE [END] - Allocate IO Queue Buffer
   NVME_CC     Cc;
   NVME_CSTS   Csts;
   EFI_STATUS  Status;
@@ -455,9 +470,11 @@ NvmeEnableController (
   // CC.AMS, CC.MPS and CC.CSS are all set to 0.
   //
   ZeroMem (&Cc, sizeof (NVME_CC));
+  // MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
   Cc.En     = 1;
-  Cc.Iosqes = 6;
-  Cc.Iocqes = 4;
+  Cc.Iosqes = IoSqEs;
+  Cc.Iocqes = IoCqEs;
+  // MU_CHANGE [END] - Allocate IO Queue Buffer
 
   Status = WriteNvmeControllerConfiguration (Private, &Cc);
   if (EFI_ERROR (Status)) {
@@ -864,6 +881,143 @@ NvmeCreateIoSubmissionQueue (
   return Status;
 }
 
+// MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+
+/**
+  Initialize the Nvm Express controller Data (IO) Queues
+
+  @param[in] Private                 The pointer to the NVME_CONTROLLER_PRIVATE_DATA data structure.
+
+  @retval EFI_SUCCESS                The NVM Express Controller IO Queues are initialized successfully.
+  @retval Others                     A device error occurred while initializing the IO Queues.
+
+**/
+EFI_STATUS
+NvmeControllerInitIoQueues (
+  IN NVME_CONTROLLER_PRIVATE_DATA  *Private
+  )
+{
+  UINTN       SqPageCount;
+  UINTN       IoQueuePairPageCount;
+  UINT32      Index;
+  EFI_STATUS  Status;
+
+  // Offset completion queue with submission queue size
+  SqPageCount = NVME_SQ_SIZE_IN_PAGES (Private, 1);
+
+  // Calculate the number of pages required for the data queues
+  IoQueuePairPageCount = SqPageCount + NVME_CQ_SIZE_IN_PAGES (Private, 1);
+
+  //
+  // Address of Data I/O submission & completion queue(s).
+  // We are using the same table of buffer pointers that the admin queues are in, so we start the table from Index + 1, but we have a separate
+  // buffer so we start at the beginning of that buffer.
+  //
+  ZeroMem (Private->IoQueueBuffer, EFI_PAGES_TO_SIZE (IoQueuePairPageCount) * Private->NumberOfIoQueuePairs);
+  for (Index = 0; Index < Private->NumberOfIoQueuePairs; Index++) {
+    Private->SqBuffer[Index + 1]        = (NVME_SQ *)(UINTN)(Private->IoQueueBuffer + EFI_PAGES_TO_SIZE (Index * IoQueuePairPageCount));
+    Private->SqBufferPciAddr[Index + 1] = (NVME_SQ *)(UINTN)(Private->IoQueueBufferPciAddr + EFI_PAGES_TO_SIZE (Index * IoQueuePairPageCount));
+    Private->CqBuffer[Index + 1]        = (NVME_CQ *)(UINTN)(Private->IoQueueBuffer + EFI_PAGES_TO_SIZE (Index * IoQueuePairPageCount + SqPageCount));
+    Private->CqBufferPciAddr[Index + 1] = (NVME_CQ *)(UINTN)(Private->IoQueueBufferPciAddr + EFI_PAGES_TO_SIZE (Index * IoQueuePairPageCount + SqPageCount));
+
+    DEBUG ((DEBUG_INFO, "Data IO   Submission Queue (SqBuffer[%d]) = [%016X]\n", Index + 1, Private->SqBuffer[Index + 1]));
+    DEBUG ((DEBUG_INFO, "Data IO   Completion Queue (CqBuffer[%d]) = [%016X]\n", Index + 1, Private->CqBuffer[Index + 1]));
+  }
+
+  //
+  // Create I/O completion queue(s).
+  //
+  Status = NvmeCreateIoCompletionQueue (Private);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Create I/O Submission queue(s).
+  //
+  Status = NvmeCreateIoSubmissionQueue (Private);
+
+  return Status;
+}
+
+// MU_CHANGE [END] - Allocate IO Queue Buffer
+
+// MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+
+/**
+  Initialize the Nvm Express controller Admin Queues
+
+  @param[in] Private                 The pointer to the NVME_CONTROLLER_PRIVATE_DATA data structure.
+
+  @retval EFI_SUCCESS                The NVM Express Controller is initialized successfully.
+  @retval Others                     A device error occurred while initializing the controller.
+
+**/
+EFI_STATUS
+NvmeControllerInitAdminQueues (
+  IN NVME_CONTROLLER_PRIVATE_DATA  *Private
+  )
+{
+  NVME_ASQ    Asq;
+  NVME_ACQ    Acq;
+  UINTN       AsqPageCount;
+  UINTN       AsqSize;
+  UINTN       AdminQueuePairPageCount;
+  EFI_STATUS  Status;
+
+  // Offset completion queue with submission queue size
+  AsqPageCount = NVME_SQ_SIZE_IN_PAGES (Private, 0);
+  AsqSize      = EFI_PAGES_TO_SIZE (AsqPageCount);
+
+  //
+  // Address of admin submission queue.
+  //
+  // MU_CHANGE - Remove Page Mask
+  Asq = (UINT64)(UINTN)(Private->BufferPciAddr);
+
+  //
+  // Address of admin completion queue.
+  //
+  // MU_CHANGE - Remove Page Mask
+  Acq = (UINT64)(UINTN)(Private->BufferPciAddr + AsqSize);
+
+  // Calculate the number of pages required for the admin queues
+  AdminQueuePairPageCount = AsqPageCount + NVME_CQ_SIZE_IN_PAGES (Private, 0);
+
+  //
+  // Address of Admin I/O submission & completion queues.
+  //
+  ZeroMem (Private->Buffer, EFI_PAGES_TO_SIZE (AdminQueuePairPageCount));
+  Private->SqBuffer[0]        = (NVME_SQ *)(UINTN)(Private->Buffer);
+  Private->SqBufferPciAddr[0] = (NVME_SQ *)(UINTN)(Private->BufferPciAddr);
+  Private->CqBuffer[0]        = (NVME_CQ *)(UINTN)(Private->Buffer + AsqSize);
+  Private->CqBufferPciAddr[0] = (NVME_CQ *)(UINTN)(Private->BufferPciAddr + AsqSize);
+
+  DEBUG ((DEBUG_INFO, "Private->Buffer = [%016X]\n", (UINT64)(UINTN)Private->Buffer));
+  DEBUG ((DEBUG_INFO, "Admin     Submission Queue size (Number of Entries) = [%08X]\n", Private->SqData[0].NumberOfEntries));
+  DEBUG ((DEBUG_INFO, "Admin     Completion Queue size (Number of Entries) = [%08X]\n", Private->CqData[0].NumberOfEntries));
+  DEBUG ((DEBUG_INFO, "Admin     Submission Queue (SqBuffer[0]) = [%016X]\n", Private->SqBuffer[0]));
+  DEBUG ((DEBUG_INFO, "Admin     Completion Queue (CqBuffer[0]) = [%016X]\n", Private->CqBuffer[0]));
+
+  //
+  // Program admin submission queue address.
+  //
+  Status = WriteNvmeAdminSubmissionQueueBaseAddress (Private, &Asq);
+
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Program admin completion queue address.
+  //
+  Status = WriteNvmeAdminCompletionQueueBaseAddress (Private, &Acq);
+
+  return Status;
+}
+
+// MU_CHANGE [END] - Allocate IO Queue Buffer
+
 /**
   Initialize the Nvm Express controller.
 
@@ -878,14 +1032,23 @@ NvmeControllerInit (
   IN NVME_CONTROLLER_PRIVATE_DATA  *Private
   )
 {
+  // MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
   EFI_STATUS           Status;
   EFI_PCI_IO_PROTOCOL  *PciIo;
   UINT64               Supports;
-  NVME_AQA             Aqa;
-  NVME_ASQ             Asq;
-  NVME_ACQ             Acq;
-  UINT8                Sn[21];
-  UINT8                Mn[41];
+  // NVME_AQA             Aqa;
+  // NVME_ASQ             Asq;
+  // NVME_ACQ             Acq;
+  UINT8                 Sn[21];
+  UINT8                 Mn[41];
+  UINTN                 Bytes;
+  UINT32                Index;
+  EFI_PHYSICAL_ADDRESS  MappedAddr;
+  NVME_AQA              Aqa;
+  UINTN                 AdminQueuePairPageCount;
+  UINTN                 IoQueuePairPageCount;
+
+  // MU_CHANGE [END] - Allocate IO Queue Buffer
 
   //
   // Enable this controller.
@@ -931,72 +1094,135 @@ NvmeControllerInit (
   //
   ASSERT ((Private->Cap.Mpsmin + 12) <= EFI_PAGE_SHIFT);
 
-  Private->Cid[0]        = 0;
-  Private->Cid[1]        = 0;
-  Private->Cid[2]        = 0;
-  Private->Pt[0]         = 0;
-  Private->Pt[1]         = 0;
-  Private->Pt[2]         = 0;
-  Private->SqTdbl[0].Sqt = 0;
-  Private->SqTdbl[1].Sqt = 0;
-  Private->SqTdbl[2].Sqt = 0;
-  Private->CqHdbl[0].Cqh = 0;
-  Private->CqHdbl[1].Cqh = 0;
-  Private->CqHdbl[2].Cqh = 0;
-  Private->AsyncSqHead   = 0;
+  // MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
 
+  // Private->Cid[0]        = 0;
+  // Private->Cid[1]        = 0;
+  // Private->Cid[2]        = 0;
+  // Private->Pt[0]         = 0;
+  // Private->Pt[1]         = 0;
+  // Private->Pt[2]         = 0;
+  // Private->SqTdbl[0].Sqt = 0;
+  // Private->SqTdbl[1].Sqt = 0;
+  // Private->SqTdbl[2].Sqt = 0;
+  // Private->CqHdbl[0].Cqh = 0;
+  // Private->CqHdbl[1].Cqh = 0;
+  // Private->CqHdbl[2].Cqh = 0;
+  // Private->AsyncSqHead   = 0;
+
+  for (Index = 0; Index < NVME_MAX_QUEUES; Index++) {
+    Private->Cid[Index]        = 0;
+    Private->Pt[Index]         = 0;
+    Private->SqTdbl[Index].Sqt = 0;
+    Private->CqHdbl[Index].Cqh = 0;
+  }
+
+  Private->AsyncSqHead = 0;
+
+  //
+  // set number of entries admin submission & completion queues.
+  //
+  Aqa.Asqs  = MIN (NVME_ASQ_SIZE, Private->Cap.Mqes);
+  Aqa.Rsvd1 = 0;
+  Aqa.Acqs  = MIN (NVME_ACQ_SIZE, Private->Cap.Mqes);
+  Aqa.Rsvd2 = 0;
+
+  //
+  // Set admin queue entry size to default
+  // Note we are using the spec-defined minimum SQES and CQES here.
+  //
+  Private->SqData[0].EntrySize = NVME_IOSQES_MIN;
+  Private->CqData[0].EntrySize = NVME_IOCQES_MIN;
+
+  // Calculate the number of pages required for the admin queues
+  AdminQueuePairPageCount = NVME_SQ_SIZE_IN_PAGES (Private, 0) + NVME_CQ_SIZE_IN_PAGES (Private, 0);
+
+  //
+  // Default:
+  // 6 x 4kB aligned buffers will be carved out of this buffer.
+  // 1st 4kB boundary is the start of the admin submission queue.
+  // 2nd 4kB boundary is the start of the admin completion queue.
+  // 3rd 4kB boundary is the start of I/O submission queue #1.
+  // 4th 4kB boundary is the start of I/O completion queue #1.
+  // 5th 4kB boundary is the start of I/O submission queue #2.
+  // 6th 4kB boundary is the start of I/O completion queue #2.
+  //
+  // Allocate 6 pages of memory, then map it for bus master read and write.
+  //
+  Status = PciIo->AllocateBuffer (
+                    PciIo,
+                    AllocateAnyPages,
+                    EfiBootServicesData,
+                    AdminQueuePairPageCount,
+                    (VOID **)&Private->Buffer,
+                    0
+                    );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Bytes  = EFI_PAGES_TO_SIZE (AdminQueuePairPageCount);
+  Status = PciIo->Map (
+                    PciIo,
+                    EfiPciIoOperationBusMasterCommonBuffer,
+                    Private->Buffer,
+                    &Bytes,
+                    &MappedAddr,
+                    &Private->Mapping
+                    );
+  if (EFI_ERROR (Status) || (Bytes != EFI_PAGES_TO_SIZE (AdminQueuePairPageCount))) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  Private->BufferPciAddr = (UINT8 *)(UINTN)MappedAddr;
+
+  // Disable the controller to wait for CSTS.RDY to become 0
+  // NVMe Base Specification 2.0e, Section 3.5 Controller Initialization
+  // MU_CHANGE [END] - Allocate IO Queue Buffer
   Status = NvmeDisableController (Private);
 
   if (EFI_ERROR (Status)) {
     return Status;
   }
 
-  //
-  // set number of entries admin submission & completion queues.
-  //
-  Aqa.Asqs  = NVME_ASQ_SIZE;
-  Aqa.Rsvd1 = 0;
-  Aqa.Acqs  = NVME_ACQ_SIZE;
-  Aqa.Rsvd2 = 0;
-
+  // MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
   //
   // Address of admin submission queue.
   //
   // MU_CHANGE - Remove the page mask since the buffer is allocated using AllocatePages
-  Asq = (UINT64)(UINTN)(Private->BufferPciAddr);
+  // Asq = (UINT64)(UINTN)(Private->BufferPciAddr);
 
   //
   // Address of admin completion queue.
   //
   // MU_CHANGE - Remove the page mask since the buffer is allocated using AllocatePages
-  Acq = (UINT64)(UINTN)(Private->BufferPciAddr + EFI_PAGE_SIZE);
+  // Acq = (UINT64)(UINTN)(Private->BufferPciAddr + EFI_PAGE_SIZE);
 
   //
   // Address of I/O submission & completion queue.
   //
-  ZeroMem (Private->Buffer, EFI_PAGES_TO_SIZE (6));
-  Private->SqBuffer[0]        = (NVME_SQ *)(UINTN)(Private->Buffer);
-  Private->SqBufferPciAddr[0] = (NVME_SQ *)(UINTN)(Private->BufferPciAddr);
-  Private->CqBuffer[0]        = (NVME_CQ *)(UINTN)(Private->Buffer + 1 * EFI_PAGE_SIZE);
-  Private->CqBufferPciAddr[0] = (NVME_CQ *)(UINTN)(Private->BufferPciAddr + 1 * EFI_PAGE_SIZE);
-  Private->SqBuffer[1]        = (NVME_SQ *)(UINTN)(Private->Buffer + 2 * EFI_PAGE_SIZE);
-  Private->SqBufferPciAddr[1] = (NVME_SQ *)(UINTN)(Private->BufferPciAddr + 2 * EFI_PAGE_SIZE);
-  Private->CqBuffer[1]        = (NVME_CQ *)(UINTN)(Private->Buffer + 3 * EFI_PAGE_SIZE);
-  Private->CqBufferPciAddr[1] = (NVME_CQ *)(UINTN)(Private->BufferPciAddr + 3 * EFI_PAGE_SIZE);
-  Private->SqBuffer[2]        = (NVME_SQ *)(UINTN)(Private->Buffer + 4 * EFI_PAGE_SIZE);
-  Private->SqBufferPciAddr[2] = (NVME_SQ *)(UINTN)(Private->BufferPciAddr + 4 * EFI_PAGE_SIZE);
-  Private->CqBuffer[2]        = (NVME_CQ *)(UINTN)(Private->Buffer + 5 * EFI_PAGE_SIZE);
-  Private->CqBufferPciAddr[2] = (NVME_CQ *)(UINTN)(Private->BufferPciAddr + 5 * EFI_PAGE_SIZE);
+  // ZeroMem (Private->Buffer, EFI_PAGES_TO_SIZE (6));
+  // Private->SqBuffer[0]        = (NVME_SQ *)(UINTN)(Private->Buffer);
+  // Private->SqBufferPciAddr[0] = (NVME_SQ *)(UINTN)(Private->BufferPciAddr);
+  // Private->CqBuffer[0]        = (NVME_CQ *)(UINTN)(Private->Buffer + 1 * EFI_PAGE_SIZE);
+  // Private->CqBufferPciAddr[0] = (NVME_CQ *)(UINTN)(Private->BufferPciAddr + 1 * EFI_PAGE_SIZE);
+  // Private->SqBuffer[1]        = (NVME_SQ *)(UINTN)(Private->Buffer + 2 * EFI_PAGE_SIZE);
+  // Private->SqBufferPciAddr[1] = (NVME_SQ *)(UINTN)(Private->BufferPciAddr + 2 * EFI_PAGE_SIZE);
+  // Private->CqBuffer[1]        = (NVME_CQ *)(UINTN)(Private->Buffer + 3 * EFI_PAGE_SIZE);
+  // Private->CqBufferPciAddr[1] = (NVME_CQ *)(UINTN)(Private->BufferPciAddr + 3 * EFI_PAGE_SIZE);
+  // Private->SqBuffer[2]        = (NVME_SQ *)(UINTN)(Private->Buffer + 4 * EFI_PAGE_SIZE);
+  // Private->SqBufferPciAddr[2] = (NVME_SQ *)(UINTN)(Private->BufferPciAddr + 4 * EFI_PAGE_SIZE);
+  // Private->CqBuffer[2]        = (NVME_CQ *)(UINTN)(Private->Buffer + 5 * EFI_PAGE_SIZE);
+  // Private->CqBufferPciAddr[2] = (NVME_CQ *)(UINTN)(Private->BufferPciAddr + 5 * EFI_PAGE_SIZE);
 
-  DEBUG ((DEBUG_INFO, "Private->Buffer = [%016X]\n", (UINT64)(UINTN)Private->Buffer));
-  DEBUG ((DEBUG_INFO, "Admin     Submission Queue size (Aqa.Asqs) = [%08X]\n", Aqa.Asqs));
-  DEBUG ((DEBUG_INFO, "Admin     Completion Queue size (Aqa.Acqs) = [%08X]\n", Aqa.Acqs));
-  DEBUG ((DEBUG_INFO, "Admin     Submission Queue (SqBuffer[0]) = [%016X]\n", Private->SqBuffer[0]));
-  DEBUG ((DEBUG_INFO, "Admin     Completion Queue (CqBuffer[0]) = [%016X]\n", Private->CqBuffer[0]));
-  DEBUG ((DEBUG_INFO, "Sync  I/O Submission Queue (SqBuffer[1]) = [%016X]\n", Private->SqBuffer[1]));
-  DEBUG ((DEBUG_INFO, "Sync  I/O Completion Queue (CqBuffer[1]) = [%016X]\n", Private->CqBuffer[1]));
-  DEBUG ((DEBUG_INFO, "Async I/O Submission Queue (SqBuffer[2]) = [%016X]\n", Private->SqBuffer[2]));
-  DEBUG ((DEBUG_INFO, "Async I/O Completion Queue (CqBuffer[2]) = [%016X]\n", Private->CqBuffer[2]));
+  // DEBUG ((DEBUG_INFO, "Admin     Submission Queue size (Aqa.Asqs) = [%08X]\n", Aqa.Asqs));
+  // DEBUG ((DEBUG_INFO, "Admin     Completion Queue size (Aqa.Acqs) = [%08X]\n", Aqa.Acqs));
+  // DEBUG ((DEBUG_INFO, "Admin     Submission Queue (SqBuffer[0]) = [%016X]\n", Private->SqBuffer[0]));
+  // DEBUG ((DEBUG_INFO, "Admin     Completion Queue (CqBuffer[0]) = [%016X]\n", Private->CqBuffer[0]));
+  // DEBUG ((DEBUG_INFO, "Sync  I/O Submission Queue (SqBuffer[1]) = [%016X]\n", Private->SqBuffer[1]));
+  // DEBUG ((DEBUG_INFO, "Sync  I/O Completion Queue (CqBuffer[1]) = [%016X]\n", Private->CqBuffer[1]));
+  // DEBUG ((DEBUG_INFO, "Async I/O Submission Queue (SqBuffer[2]) = [%016X]\n", Private->SqBuffer[2]));
+  // DEBUG ((DEBUG_INFO, "Async I/O Completion Queue (CqBuffer[2]) = [%016X]\n", Private->CqBuffer[2]));
 
   //
   // Program admin queue attributes.
@@ -1010,25 +1236,24 @@ NvmeControllerInit (
   //
   // Program admin submission queue address.
   //
-  Status = WriteNvmeAdminSubmissionQueueBaseAddress (Private, &Asq);
-
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
+  // Status = WriteNvmeAdminSubmissionQueueBaseAddress (Private, &Asq);
 
   //
   // Program admin completion queue address.
   //
-  Status = WriteNvmeAdminCompletionQueueBaseAddress (Private, &Acq);
+  // Status = WriteNvmeAdminCompletionQueueBaseAddress (Private, &Acq);
 
+  Status = NvmeControllerInitAdminQueues (Private);
   if (EFI_ERROR (Status)) {
     return Status;
   }
 
-  Status = NvmeEnableController (Private);
+  Status = NvmeEnableController (Private, Private->SqData[0].EntrySize, Private->CqData[0].EntrySize);
   if (EFI_ERROR (Status)) {
     return Status;
   }
+
+  // MU_CHANGE [END] - Allocate IO Queue Buffer
 
   //
   // Allocate buffer for Identify Controller data
@@ -1055,6 +1280,8 @@ NvmeControllerInit (
   //
   // Dump NvmExpress Identify Controller Data
   //
+  // Serial Number and Model Number are not null-terminated strings, but will be printed as ones.
+  // So here we add a null terminator to the end of their arrays.
   CopyMem (Sn, Private->ControllerData->Sn, sizeof (Private->ControllerData->Sn));
   Sn[20] = 0;
   CopyMem (Mn, Private->ControllerData->Mn, sizeof (Private->ControllerData->Mn));
@@ -1089,23 +1316,223 @@ NvmeControllerInit (
 
   // MU_CHANGE [END] - Request Number of Queues from Controller
 
+  // MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
   //
-  // Create two I/O completion queues.
-  // One for blocking I/O, one for non-blocking I/O.
+  // Allocate Data Queues - note we are assuming the queue entry sizes are the same as the admin queue entry sizes for the sake of memory allocation.
+  // The identify controller data tells us in SQES and CQES what the controller's minimum and maximum queue entry sizes are. We haven't used this before since we
+  // use the spec-defined minimum queue entry sizes.
+  // We are also allocating based on the admin defined queue sizes in number of entries.
+  // Some scenarios may use different queue sizes, currently we only see the case where the driver needs IO queue sizes <= admin queue sizes. So this allocation should be sufficient.
+  // We may want to explore a more dynamic allocation in the future.
   //
-  Status = NvmeCreateIoCompletionQueue (Private);
+  for (Index = 1; Index <= Private->NumberOfIoQueuePairs; Index++) {
+    Private->SqData[Index].NumberOfEntries = Private->SqData[0].NumberOfEntries;
+    Private->CqData[Index].NumberOfEntries = Private->CqData[0].NumberOfEntries;
+    Private->SqData[Index].EntrySize       = Private->SqData[0].EntrySize;
+    Private->CqData[Index].EntrySize       = Private->CqData[0].EntrySize;
+  }
+
+  // Using the first data queue size for the number of pages required for the data queues
+  IoQueuePairPageCount = NVME_SQ_SIZE_IN_PAGES (Private, 1) + NVME_CQ_SIZE_IN_PAGES (Private, 1);
+
+  Status = PciIo->AllocateBuffer (
+                    PciIo,
+                    AllocateAnyPages,
+                    EfiBootServicesData,
+                    IoQueuePairPageCount * Private->NumberOfIoQueuePairs,
+                    (VOID **)&Private->IoQueueBuffer,
+                    0
+                    );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Bytes  = EFI_PAGES_TO_SIZE (IoQueuePairPageCount * Private->NumberOfIoQueuePairs);
+  Status = PciIo->Map (
+                    PciIo,
+                    EfiPciIoOperationBusMasterCommonBuffer,
+                    Private->IoQueueBuffer,
+                    &Bytes,
+                    &MappedAddr,
+                    &Private->IoQueueMapping
+                    );
+
+  if (EFI_ERROR (Status) || (Bytes != EFI_PAGES_TO_SIZE (IoQueuePairPageCount * Private->NumberOfIoQueuePairs))) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  Private->IoQueueBufferPciAddr = (UINT8 *)(UINTN)MappedAddr;
+
+  Status = NvmeControllerInitIoQueues (Private);
+  // MU_CHANGE [END] - Allocate IO Queue Buffer
+
+  return Status;
+}
+
+// MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+
+/**
+  Reset the Nvm Express controller.
+
+  @param[in] Private                 The pointer to the NVME_CONTROLLER_PRIVATE_DATA data structure.
+
+  @retval EFI_SUCCESS                The NVM Express Controller is reset successfully.
+  @retval Others                     A device error occurred while resetting the controller.
+
+**/
+EFI_STATUS
+NvmeControllerReset (
+  IN NVME_CONTROLLER_PRIVATE_DATA  *Private
+  )
+{
+  EFI_STATUS           Status;
+  EFI_PCI_IO_PROTOCOL  *PciIo;
+  UINT32               Index;
+  UINT16               VidDid[2];
+  UINT8                Sn[21];
+  UINT8                Mn[41];
+  NVME_AQA             Aqa;
+  UINT32               NdqpBeforeReset;
+
+  DEBUG ((DEBUG_INFO, "%a: Begin Controller Reset\n", __func__));
+
+  PciIo = Private->PciIo;
+
+  //
+  // Verify the controller is still accessible
+  //
+  Status = PciIo->Pci.Read (
+                        PciIo,
+                        EfiPciIoWidthUint16,
+                        PCI_VENDOR_ID_OFFSET,
+                        ARRAY_SIZE (VidDid),
+                        VidDid
+                        );
+  if (EFI_ERROR (Status)) {
+    ASSERT_EFI_ERROR (Status);
+    return EFI_DEVICE_ERROR;
+  }
+
+  if ((VidDid[0] == NVME_INVALID_VID_DID) || (VidDid[1] == NVME_INVALID_VID_DID)) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  for (Index = 0; Index < NVME_MAX_QUEUES; Index++) {
+    Private->Cid[Index]        = 0;
+    Private->Pt[Index]         = 0;
+    Private->SqTdbl[Index].Sqt = 0;
+    Private->CqHdbl[Index].Cqh = 0;
+  }
+
+  Private->AsyncSqHead = 0;
+
+  Status = NvmeDisableController (Private);
+
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = ReadNvmeAdminQueueAttributes (Private, &Aqa);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  if ((Private->SqData[0].NumberOfEntries != Aqa.Asqs) || (Private->CqData[0].NumberOfEntries != Aqa.Acqs)) {
+    // By spec these values should not change between resets, so we'll fail out here.
+    DEBUG ((DEBUG_ERROR, "%a: Admin Submission Queue Size (Number of Entries) mismatch: %d != %d\n", __func__, Private->SqData[0].NumberOfEntries, Aqa.Asqs));
+    ASSERT (FALSE);
+    return EFI_DEVICE_ERROR;
+  }
+
+  Status = NvmeControllerInitAdminQueues (Private);
+
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = NvmeEnableController (Private, Private->SqData[0].EntrySize, Private->CqData[0].EntrySize);
   if (EFI_ERROR (Status)) {
     return Status;
   }
 
   //
-  // Create two I/O Submission queues.
-  // One for blocking I/O, one for non-blocking I/O.
+  // Allocate buffer for Identify Controller data
   //
-  Status = NvmeCreateIoSubmissionQueue (Private);
+  if (Private->ControllerData == NULL) {
+    Private->ControllerData = (NVME_ADMIN_CONTROLLER_DATA *)AllocateZeroPool (sizeof (NVME_ADMIN_CONTROLLER_DATA));
+
+    if (Private->ControllerData == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+    }
+  }
+
+  //
+  // Get current Identify Controller Data
+  //
+  Status = NvmeIdentifyController (Private, Private->ControllerData);
+
+  if (EFI_ERROR (Status)) {
+    FreePool (Private->ControllerData);
+    Private->ControllerData = NULL;
+    return EFI_NOT_FOUND;
+  }
+
+  //
+  // Dump NvmExpress Identify Controller Data
+  //
+  CopyMem (Sn, Private->ControllerData->Sn, sizeof (Private->ControllerData->Sn));
+  // Serial Number and Model Number are not null-terminated strings, but will be printed as ones.
+  // So here we add a null terminator to the end of their arrays.
+  Sn[20] = 0;
+  CopyMem (Mn, Private->ControllerData->Mn, sizeof (Private->ControllerData->Mn));
+  Mn[40] = 0;
+  DEBUG ((DEBUG_INFO, " == NVME IDENTIFY CONTROLLER DATA ==\n"));
+  DEBUG ((DEBUG_INFO, "    PCI VID   : 0x%x\n", Private->ControllerData->Vid));
+  DEBUG ((DEBUG_INFO, "    PCI SSVID : 0x%x\n", Private->ControllerData->Ssvid));
+  DEBUG ((DEBUG_INFO, "    SN        : %a\n", Sn));
+  DEBUG ((DEBUG_INFO, "    MN        : %a\n", Mn));
+  DEBUG ((DEBUG_INFO, "    FR        : 0x%x\n", *((UINT64 *)Private->ControllerData->Fr)));
+  DEBUG ((DEBUG_INFO, "    TNVMCAP (high 8-byte) : 0x%lx\n", *((UINT64 *)(Private->ControllerData->Tnvmcap + 8))));
+  DEBUG ((DEBUG_INFO, "    TNVMCAP (low 8-byte)  : 0x%lx\n", *((UINT64 *)Private->ControllerData->Tnvmcap)));
+  DEBUG ((DEBUG_INFO, "    RAB       : 0x%x\n", Private->ControllerData->Rab));
+  DEBUG ((DEBUG_INFO, "    IEEE      : 0x%x\n", *(UINT32 *)Private->ControllerData->Ieee_oui));
+  DEBUG ((DEBUG_INFO, "    AERL      : 0x%x\n", Private->ControllerData->Aerl));
+  DEBUG ((DEBUG_INFO, "    SQES      : 0x%x\n", Private->ControllerData->Sqes));
+  DEBUG ((DEBUG_INFO, "    CQES      : 0x%x\n", Private->ControllerData->Cqes));
+  DEBUG ((DEBUG_INFO, "    NN        : 0x%x\n", Private->ControllerData->Nn));
+
+  //
+  // Send Set Features Command to request the maximum number of data queues.
+  // The controller is free to allocate a different number of queues from the number requested.
+  // The number of queues allocated is returned and stored in the controller private data structure
+  // using the NumberOfIoQueuePairs field.
+  //
+  NdqpBeforeReset = Private->NumberOfIoQueuePairs;
+  Status          = NvmeSetFeaturesNumberOfQueues (Private, NVME_MAX_QUEUES - 1);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  if (NdqpBeforeReset != Private->NumberOfIoQueuePairs) {
+    // This is a controller reset, so the number of data queues should not have changed.
+    // If the number of queues has changed, then the driver must be re-initialized.
+    DEBUG ((DEBUG_ERROR, "%a: Number of Data Queue Pairs mismatch: %d != %d\n", __func__, NdqpBeforeReset, Private->NumberOfIoQueuePairs));
+    ASSERT (FALSE);
+    return EFI_DEVICE_ERROR;
+  }
+
+  //
+  // Create I/O completion queue(s).
+  //
+  Status = NvmeControllerInitIoQueues (Private);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
 
   return Status;
 }
+
+// MU_CHANGE [END] - Allocate IO Queue Buffer
 
 /**
  This routine is called to properly shutdown the Nvm Express controller per NVMe spec.

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
@@ -30,10 +30,8 @@ UINTN  mNvmeControllerNumber = 0;
 **/
 EFI_STATUS
 ReadNvmeControllerCapabilities (
-  // MU_CHANGE [BEGIN] - Correct Cap parameter modifier
-  IN  NVME_CONTROLLER_PRIVATE_DATA  *Private,
-  OUT NVME_CAP                      *Cap
-  // MU_CHANGE [END] - Correct Cap parameter modifier
+  IN NVME_CONTROLLER_PRIVATE_DATA  *Private,
+  IN NVME_CAP                      *Cap
   )
 {
   EFI_PCI_IO_PROTOCOL  *PciIo;
@@ -606,18 +604,15 @@ NvmeCreateIoCompletionQueue (
     CommandPacket.CommandTimeout = NVME_GENERIC_TIMEOUT;
     CommandPacket.QueueType      = NVME_ADMIN_QUEUE;
 
-    // MU_CHANGE [BEGIN] - Support alternative hardware queue sizes in NVME driver
-    if (PcdGetBool (PcdSupportAlternativeQueueSize)) {
-      QueueSize = MIN (NVME_ALTERNATIVE_MAX_QUEUE_SIZE, Private->Cap.Mqes);
-    } else if (Index == 1) {
+    if (Index == 1) {
       QueueSize = NVME_CCQ_SIZE;
-    } else if (Private->Cap.Mqes > NVME_ASYNC_CCQ_SIZE) {
-      QueueSize = NVME_ASYNC_CCQ_SIZE;
     } else {
-      QueueSize = Private->Cap.Mqes;
+      if (Private->Cap.Mqes > NVME_ASYNC_CCQ_SIZE) {
+        QueueSize = NVME_ASYNC_CCQ_SIZE;
+      } else {
+        QueueSize = Private->Cap.Mqes;
+      }
     }
-
-    // MU_CHANGE [END]
 
     CrIoCq.Qid   = Index;
     CrIoCq.Qsize = QueueSize;
@@ -681,18 +676,15 @@ NvmeCreateIoSubmissionQueue (
     CommandPacket.CommandTimeout = NVME_GENERIC_TIMEOUT;
     CommandPacket.QueueType      = NVME_ADMIN_QUEUE;
 
-    // MU_CHANGE [BEGIN] - Support alternative hardware queue sizes in NVME driver
-    if (PcdGetBool (PcdSupportAlternativeQueueSize)) {
-      QueueSize = MIN (NVME_ALTERNATIVE_MAX_QUEUE_SIZE, Private->Cap.Mqes);
-    } else if (Index == 1) {
-      QueueSize = NVME_CCQ_SIZE;
-    } else if (Private->Cap.Mqes > NVME_ASYNC_CCQ_SIZE) {
-      QueueSize = NVME_ASYNC_CCQ_SIZE;
+    if (Index == 1) {
+      QueueSize = NVME_CSQ_SIZE;
     } else {
-      QueueSize = Private->Cap.Mqes;
+      if (Private->Cap.Mqes > NVME_ASYNC_CSQ_SIZE) {
+        QueueSize = NVME_ASYNC_CSQ_SIZE;
+      } else {
+        QueueSize = Private->Cap.Mqes;
+      }
     }
-
-    // MU_CHANGE [END]
 
     CrIoSq.Qid   = Index;
     CrIoSq.Qsize = QueueSize;
@@ -738,36 +730,13 @@ NvmeControllerInit (
   NVME_AQA             Aqa;
   NVME_ASQ             Asq;
   NVME_ACQ             Acq;
-  UINT16               VidDid[2]; // MU_CHANGE - Improve NVMe controller init robustness
   UINT8                Sn[21];
   UINT8                Mn[41];
-
-  // MU_CHANGE [BEGIN] - Improve NVMe controller init robustness
-  PciIo = Private->PciIo;
-
-  //
-  // Verify the controller is still accessible
-  //
-  Status = PciIo->Pci.Read (
-                        PciIo,
-                        EfiPciIoWidthUint16,
-                        PCI_VENDOR_ID_OFFSET,
-                        ARRAY_SIZE (VidDid),
-                        VidDid
-                        );
-  if (EFI_ERROR (Status)) {
-    ASSERT_EFI_ERROR (Status);
-    return EFI_DEVICE_ERROR;
-  }
-
-  if ((VidDid[0] == 0xFFFF) || (VidDid[1] == 0xFFFF)) {
-    return EFI_DEVICE_ERROR;
-  }
 
   //
   // Enable this controller.
   //
-  // MU_CHANGE [END] - Improve NVMe controller init robustness
+  PciIo  = Private->PciIo;
   Status = PciIo->Attributes (
                     PciIo,
                     EfiPciIoAttributeOperationSupported,
@@ -806,17 +775,7 @@ NvmeControllerInit (
   //
   // Currently the driver only supports 4k page size.
   //
-
-  // MU_CHANGE [BEGIN] - Improve NVMe controller init robustness
-
-  // Currently, this means Cap.Mpsmin must be zero for an EFI_PAGE_SHIFT size of 12.
-  // ASSERT ((Private->Cap.Mpsmin + 12) <= EFI_PAGE_SHIFT);
-  if ((Private->Cap.Mpsmin + 12) > EFI_PAGE_SHIFT) {
-    DEBUG ((DEBUG_ERROR, "NvmeControllerInit: Mpsmin is larger than expected (0x%02x).\n", Private->Cap.Mpsmin));
-    return EFI_DEVICE_ERROR;
-  }
-
-  // MU_CHANGE [END] - Improve NVMe controller init robustness
+  ASSERT ((Private->Cap.Mpsmin + 12) <= EFI_PAGE_SHIFT);
 
   Private->Cid[0]        = 0;
   Private->Cid[1]        = 0;
@@ -841,12 +800,10 @@ NvmeControllerInit (
   //
   // set number of entries admin submission & completion queues.
   //
-  // MU_CHANGE [BEGIN] - Support alternative hardware queue sizes in NVME driver
-  Aqa.Asqs  = PcdGetBool (PcdSupportAlternativeQueueSize) ? MIN (NVME_ALTERNATIVE_MAX_QUEUE_SIZE, Private->Cap.Mqes) : NVME_ASQ_SIZE;
+  Aqa.Asqs  = NVME_ASQ_SIZE;
   Aqa.Rsvd1 = 0;
-  Aqa.Acqs  = PcdGetBool (PcdSupportAlternativeQueueSize) ? MIN (NVME_ALTERNATIVE_MAX_QUEUE_SIZE, Private->Cap.Mqes) : NVME_ACQ_SIZE;
+  Aqa.Acqs  = NVME_ACQ_SIZE;
   Aqa.Rsvd2 = 0;
-  // MU_CHANGE [END]
 
   //
   // Address of admin submission queue.
@@ -856,47 +813,24 @@ NvmeControllerInit (
   //
   // Address of admin completion queue.
   //
-  // MU_CHANGE [BEGIN] - Support alternative hardware queue sizes in NVME driver
-  if (PcdGetBool (PcdSupportAlternativeQueueSize)) {
-    Acq = (UINT64)(UINTN)(Private->BufferPciAddr + 4 * EFI_PAGE_SIZE) & ~0xFFF;
-  } else {
-    Acq = (UINT64)(UINTN)(Private->BufferPciAddr + EFI_PAGE_SIZE) & ~0xFFF;
-  }
+  Acq = (UINT64)(UINTN)(Private->BufferPciAddr + EFI_PAGE_SIZE) & ~0xFFF;
 
   //
   // Address of I/O submission & completion queue.
   //
-  if (PcdGetBool (PcdSupportAlternativeQueueSize)) {
-    ZeroMem (Private->Buffer, EFI_PAGES_TO_SIZE (NVME_ALTERNATIVE_TOTAL_QUEUE_BUFFER_IN_PAGES));
-    Private->SqBuffer[0]        = (NVME_SQ *)(UINTN)(Private->Buffer);
-    Private->SqBufferPciAddr[0] = (NVME_SQ *)(UINTN)(Private->BufferPciAddr);
-    Private->CqBuffer[0]        = (NVME_CQ *)(UINTN)(Private->Buffer + 4 * EFI_PAGE_SIZE);
-    Private->CqBufferPciAddr[0] = (NVME_CQ *)(UINTN)(Private->BufferPciAddr + 4 * EFI_PAGE_SIZE);
-    Private->SqBuffer[1]        = (NVME_SQ *)(UINTN)(Private->Buffer + 5 * EFI_PAGE_SIZE);
-    Private->SqBufferPciAddr[1] = (NVME_SQ *)(UINTN)(Private->BufferPciAddr + 5 * EFI_PAGE_SIZE);
-    Private->CqBuffer[1]        = (NVME_CQ *)(UINTN)(Private->Buffer + 9 * EFI_PAGE_SIZE);
-    Private->CqBufferPciAddr[1] = (NVME_CQ *)(UINTN)(Private->BufferPciAddr + 9 * EFI_PAGE_SIZE);
-    Private->SqBuffer[2]        = (NVME_SQ *)(UINTN)(Private->Buffer + 10 * EFI_PAGE_SIZE);
-    Private->SqBufferPciAddr[2] = (NVME_SQ *)(UINTN)(Private->BufferPciAddr + 10 * EFI_PAGE_SIZE);
-    Private->CqBuffer[2]        = (NVME_CQ *)(UINTN)(Private->Buffer + 14 * EFI_PAGE_SIZE);
-    Private->CqBufferPciAddr[2] = (NVME_CQ *)(UINTN)(Private->BufferPciAddr + 14 * EFI_PAGE_SIZE);
-  } else {
-    ZeroMem (Private->Buffer, EFI_PAGES_TO_SIZE (6));
-    Private->SqBuffer[0]        = (NVME_SQ *)(UINTN)(Private->Buffer);
-    Private->SqBufferPciAddr[0] = (NVME_SQ *)(UINTN)(Private->BufferPciAddr);
-    Private->CqBuffer[0]        = (NVME_CQ *)(UINTN)(Private->Buffer + 1 * EFI_PAGE_SIZE);
-    Private->CqBufferPciAddr[0] = (NVME_CQ *)(UINTN)(Private->BufferPciAddr + 1 * EFI_PAGE_SIZE);
-    Private->SqBuffer[1]        = (NVME_SQ *)(UINTN)(Private->Buffer + 2 * EFI_PAGE_SIZE);
-    Private->SqBufferPciAddr[1] = (NVME_SQ *)(UINTN)(Private->BufferPciAddr + 2 * EFI_PAGE_SIZE);
-    Private->CqBuffer[1]        = (NVME_CQ *)(UINTN)(Private->Buffer + 3 * EFI_PAGE_SIZE);
-    Private->CqBufferPciAddr[1] = (NVME_CQ *)(UINTN)(Private->BufferPciAddr + 3 * EFI_PAGE_SIZE);
-    Private->SqBuffer[2]        = (NVME_SQ *)(UINTN)(Private->Buffer + 4 * EFI_PAGE_SIZE);
-    Private->SqBufferPciAddr[2] = (NVME_SQ *)(UINTN)(Private->BufferPciAddr + 4 * EFI_PAGE_SIZE);
-    Private->CqBuffer[2]        = (NVME_CQ *)(UINTN)(Private->Buffer + 5 * EFI_PAGE_SIZE);
-    Private->CqBufferPciAddr[2] = (NVME_CQ *)(UINTN)(Private->BufferPciAddr + 5 * EFI_PAGE_SIZE);
-  }
-
-  // MU_CHANGE [END]
+  ZeroMem (Private->Buffer, EFI_PAGES_TO_SIZE (6));
+  Private->SqBuffer[0]        = (NVME_SQ *)(UINTN)(Private->Buffer);
+  Private->SqBufferPciAddr[0] = (NVME_SQ *)(UINTN)(Private->BufferPciAddr);
+  Private->CqBuffer[0]        = (NVME_CQ *)(UINTN)(Private->Buffer + 1 * EFI_PAGE_SIZE);
+  Private->CqBufferPciAddr[0] = (NVME_CQ *)(UINTN)(Private->BufferPciAddr + 1 * EFI_PAGE_SIZE);
+  Private->SqBuffer[1]        = (NVME_SQ *)(UINTN)(Private->Buffer + 2 * EFI_PAGE_SIZE);
+  Private->SqBufferPciAddr[1] = (NVME_SQ *)(UINTN)(Private->BufferPciAddr + 2 * EFI_PAGE_SIZE);
+  Private->CqBuffer[1]        = (NVME_CQ *)(UINTN)(Private->Buffer + 3 * EFI_PAGE_SIZE);
+  Private->CqBufferPciAddr[1] = (NVME_CQ *)(UINTN)(Private->BufferPciAddr + 3 * EFI_PAGE_SIZE);
+  Private->SqBuffer[2]        = (NVME_SQ *)(UINTN)(Private->Buffer + 4 * EFI_PAGE_SIZE);
+  Private->SqBufferPciAddr[2] = (NVME_SQ *)(UINTN)(Private->BufferPciAddr + 4 * EFI_PAGE_SIZE);
+  Private->CqBuffer[2]        = (NVME_CQ *)(UINTN)(Private->Buffer + 5 * EFI_PAGE_SIZE);
+  Private->CqBufferPciAddr[2] = (NVME_CQ *)(UINTN)(Private->BufferPciAddr + 5 * EFI_PAGE_SIZE);
 
   DEBUG ((DEBUG_INFO, "Private->Buffer = [%016X]\n", (UINT64)(UINTN)Private->Buffer));
   DEBUG ((DEBUG_INFO, "Admin     Submission Queue size (Aqa.Asqs) = [%08X]\n", Aqa.Asqs));

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
@@ -769,7 +769,11 @@ NvmeCreateIoCompletionQueue (
     CommandPacket.QueueType      = NVME_ADMIN_QUEUE;
 
     // MU_CHANGE [BEGIN] - Use the Mqes value from the Cap register
-    if (Index == 1) {
+    // MU_CHANGE [BEGIN] - Support alternative hardware queue sizes in NVME driver
+    if (PcdGetBool (PcdSupportAlternativeQueueSize)) {
+      QueueSize = MIN (NVME_ALTERNATIVE_MAX_QUEUE_SIZE, Private->Cap.Mqes);
+    } else if (Index == 1) {
+      // MU_CHANGE [END] - Support alternative hardware queue sizes in NVME driver
       QueueSize = MIN (NVME_CCQ_SIZE, Private->Cap.Mqes);
     } else {
       QueueSize = MIN (NVME_ASYNC_CCQ_SIZE, Private->Cap.Mqes);
@@ -846,7 +850,11 @@ NvmeCreateIoSubmissionQueue (
     CommandPacket.QueueType      = NVME_ADMIN_QUEUE;
 
     // MU_CHANGE [BEGIN] - Use the Mqes value from the Cap register
-    if (Index == 1) {
+    // MU_CHANGE [BEGIN] - Support alternative hardware queue sizes in NVME driver
+    if (PcdGetBool (PcdSupportAlternativeQueueSize)) {
+      QueueSize = MIN (NVME_ALTERNATIVE_MAX_QUEUE_SIZE, Private->Cap.Mqes);
+    } else if (Index == 1) {
+      // MU_CHANGE [END] - Support alternative hardware queue sizes in NVME driver
       QueueSize = MIN (NVME_CSQ_SIZE, Private->Cap.Mqes);
     } else {
       QueueSize = MIN (NVME_ASYNC_CSQ_SIZE, Private->Cap.Mqes);
@@ -1036,7 +1044,7 @@ NvmeControllerInit (
   EFI_STATUS           Status;
   EFI_PCI_IO_PROTOCOL  *PciIo;
   UINT64               Supports;
-  // NVME_AQA             Aqa;
+  UINT16               VidDid[2];  // MU_CHANGE - Improve NVMe controller init robustness
   // NVME_ASQ             Asq;
   // NVME_ACQ             Acq;
   UINT8                 Sn[21];
@@ -1050,10 +1058,33 @@ NvmeControllerInit (
 
   // MU_CHANGE [END] - Allocate IO Queue Buffer
 
+  // MU_CHANGE [BEGIN] - Improve NVMe controller init robustness
+  PciIo = Private->PciIo;
+
+  //
+  // Verify the controller is still accessible
+  //
+  Status = PciIo->Pci.Read (
+                        PciIo,
+                        EfiPciIoWidthUint16,
+                        PCI_VENDOR_ID_OFFSET,
+                        ARRAY_SIZE (VidDid),
+                        VidDid
+                        );
+  if (EFI_ERROR (Status)) {
+    ASSERT_EFI_ERROR (Status);
+    return EFI_DEVICE_ERROR;
+  }
+
+  if ((VidDid[0] == NVME_INVALID_VID_DID) || (VidDid[1] == NVME_INVALID_VID_DID)) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  // MU_CHANGE [END] - Improve NVMe controller init robustness
+
   //
   // Enable this controller.
   //
-  PciIo  = Private->PciIo;
   Status = PciIo->Attributes (
                     PciIo,
                     EfiPciIoAttributeOperationSupported,
@@ -1092,7 +1123,16 @@ NvmeControllerInit (
   //
   // Currently the driver only supports 4k page size.
   //
-  ASSERT ((Private->Cap.Mpsmin + 12) <= EFI_PAGE_SHIFT);
+  // MU_CHANGE [BEGIN] - Improve NVMe controller init robustness
+
+  // Currently, this means Cap.Mpsmin must be zero for an EFI_PAGE_SHIFT size of 12.
+  // ASSERT ((Private->Cap.Mpsmin + 12) <= EFI_PAGE_SHIFT);
+  if ((Private->Cap.Mpsmin + 12) > EFI_PAGE_SHIFT) {
+    DEBUG ((DEBUG_ERROR, "NvmeControllerInit: Mpsmin is larger than expected (0x%02x).\n", Private->Cap.Mpsmin));
+    return EFI_DEVICE_ERROR;
+  }
+
+  // MU_CHANGE [END] - Improve NVMe controller init robustness
 
   // MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
 
@@ -1122,10 +1162,12 @@ NvmeControllerInit (
   //
   // set number of entries admin submission & completion queues.
   //
-  Aqa.Asqs  = MIN (NVME_ASQ_SIZE, Private->Cap.Mqes);
+  // MU_CHANGE [BEGIN] - Support alternative hardware queue sizes in NVME driver
+  Aqa.Asqs  = PcdGetBool (PcdSupportAlternativeQueueSize) ? MIN (NVME_ALTERNATIVE_MAX_QUEUE_SIZE, Private->Cap.Mqes) : MIN (NVME_ASQ_SIZE, Private->Cap.Mqes);
   Aqa.Rsvd1 = 0;
-  Aqa.Acqs  = MIN (NVME_ACQ_SIZE, Private->Cap.Mqes);
+  Aqa.Acqs  = PcdGetBool (PcdSupportAlternativeQueueSize) ? MIN (NVME_ALTERNATIVE_MAX_QUEUE_SIZE, Private->Cap.Mqes) : MIN (NVME_ACQ_SIZE, Private->Cap.Mqes);
   Aqa.Rsvd2 = 0;
+  // MU_CHANGE [END] - Support alternative hardware queue sizes in NVME driver
 
   //
   // Set admin queue entry size to default

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
@@ -30,8 +30,10 @@ UINTN  mNvmeControllerNumber = 0;
 **/
 EFI_STATUS
 ReadNvmeControllerCapabilities (
-  IN NVME_CONTROLLER_PRIVATE_DATA  *Private,
-  IN NVME_CAP                      *Cap
+  // MU_CHANGE [BEGIN] - Correct Cap parameter modifier
+  IN  NVME_CONTROLLER_PRIVATE_DATA  *Private,
+  OUT NVME_CAP                      *Cap
+  // MU_CHANGE [END] - Correct Cap parameter modifier
   )
 {
   EFI_PCI_IO_PROTOCOL  *PciIo;
@@ -564,8 +566,103 @@ NvmeIdentifyNamespace (
   return Status;
 }
 
+// MU_CHANGE [BEGIN] - Request Number of Queues from Controller
+
 /**
-  Create io completion queue.
+  Send the Set Features Command to the controller for the number of queues requested.
+  Note that the number of queues allocated may be different from the number of queues requested.
+  The number of data queue pairs allocated is returned and stored in the controller private data structure
+  using the NumberOfIoQueuePairs field.
+
+  @param  Private          The pointer to the NVME_CONTROLLER_PRIVATE_DATA data structure.
+  @param  Ndqpr            The number of data queue pairs requested.
+
+  @return EFI_SUCCESS      Successfully set the number of queues.
+  @return EFI_DEVICE_ERROR Fail to set the number of queues.
+
+**/
+EFI_STATUS
+NvmeSetFeaturesNumberOfQueues (
+  IN OUT NVME_CONTROLLER_PRIVATE_DATA  *Private,
+  IN UINT16                            Ndqpr
+  )
+{
+  EFI_NVM_EXPRESS_PASS_THRU_COMMAND_PACKET  CommandPacket;
+  EFI_NVM_EXPRESS_COMMAND                   Command;
+  EFI_NVM_EXPRESS_COMPLETION                Completion;
+  EFI_STATUS                                Status;
+  NVME_ADMIN_SET_FEATURES_CDW10             SetFeatures;
+  NVME_ADMIN_SET_FEATURES_NUM_QUEUES        NumberOfQueuesRequested;
+  NVME_ADMIN_SET_FEATURES_NUM_QUEUES        NumberOfQueuesAllocated;
+
+  Status = EFI_SUCCESS;
+
+  if (Ndqpr == 0) {
+    DEBUG ((DEBUG_ERROR, "Number of Data Queue Pairs Requested cannot be 0\n"));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ZeroMem (&CommandPacket, sizeof (EFI_NVM_EXPRESS_PASS_THRU_COMMAND_PACKET));
+  ZeroMem (&Command, sizeof (EFI_NVM_EXPRESS_COMMAND));
+  ZeroMem (&Completion, sizeof (EFI_NVM_EXPRESS_COMPLETION));
+  ZeroMem (&SetFeatures, sizeof (NVME_ADMIN_SET_FEATURES));
+  ZeroMem (&NumberOfQueuesRequested, sizeof (NVME_ADMIN_SET_FEATURES_NUM_QUEUES));
+  ZeroMem (&NumberOfQueuesAllocated, sizeof (NVME_ADMIN_SET_FEATURES_NUM_QUEUES));
+
+  CommandPacket.NvmeCmd        = &Command;
+  CommandPacket.NvmeCompletion = &Completion;
+  CommandPacket.CommandTimeout = NVME_GENERIC_TIMEOUT;
+  CommandPacket.QueueType      = NVME_ADMIN_QUEUE;
+  Command.Nsid                 = 0; // NSID must be set to 0h or FFFFFFFFh for an admin command
+  Command.Cdw0.Opcode          = NVME_ADMIN_SET_FEATURES_CMD;
+
+  // Populate the Set Features Cdw10 and Cdw11 according to Nvm Express 1.3d Spec
+  // Note we subtract 1 from the requested number of queues to get the 0-based value
+  SetFeatures.Bits.Fid             = NVME_FEATURE_NUMBER_OF_QUEUES;
+  NumberOfQueuesRequested.Bits.Ncq = Ndqpr - 1;
+  NumberOfQueuesRequested.Bits.Nsq = Ndqpr - 1;
+  CommandPacket.NvmeCmd->Cdw10     = SetFeatures.Uint32;
+  CommandPacket.NvmeCmd->Cdw11     = NumberOfQueuesRequested.Uint32;
+
+  CommandPacket.NvmeCmd->Flags = CDW10_VALID | CDW11_VALID;
+
+  DEBUG ((DEBUG_INFO, "Number of Data Queue Pairs Requested: %d\n", Ndqpr));
+
+  // Send the Set Features Command for Number of Queues
+  Status = Private->Passthru.PassThru (
+                               &Private->Passthru,
+                               0,
+                               &CommandPacket,
+                               NULL
+                               );
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Set Features Command for Number of Queues failed with Status %r\n", Status));
+    return Status;
+  }
+
+  //
+  // Save the number of queues allocated, adding 1 to account for it being a 0-based value.
+  // E.g. if 1 pair of data queues is allocated Nsq=0, Ncq=0, then NumberOfIoQueuePairs=1.
+  // These numbers do not include the admin queues.
+  //
+  NumberOfQueuesAllocated.Uint32 = CommandPacket.NvmeCompletion->DW0;
+  DEBUG ((DEBUG_INFO, "Number of Data Queue Pairs Allocated By Controller: %d, \n", (NumberOfQueuesAllocated.Bits.Nsq + 1)));
+  if ((NumberOfQueuesAllocated.Bits.Nsq + 1) > Ndqpr) {
+    // This driver at maximum supports 2 pairs of data queues. So we will take the minimum of the requested and allocated values.
+    Private->NumberOfIoQueuePairs = Ndqpr;
+  } else {
+    Private->NumberOfIoQueuePairs = NumberOfQueuesAllocated.Bits.Nsq + 1;
+  }
+
+  DEBUG ((DEBUG_INFO, "Number of Data Queue Pairs Supported By Driver: %d, \n", Private->NumberOfIoQueuePairs));
+  return Status;
+}
+
+// MU_CHANGE [END] - Request Number of Queues from Controller
+
+/**
+  Create io completion queue(s).
 
   @param  Private          The pointer to the NVME_CONTROLLER_PRIVATE_DATA data structure.
 
@@ -589,7 +686,11 @@ NvmeCreateIoCompletionQueue (
   Status                 = EFI_SUCCESS;
   Private->CreateIoQueue = TRUE;
 
-  for (Index = 1; Index < NVME_MAX_QUEUES; Index++) {
+  // MU_CHANGE [BEGIN] - Request Number of Queues from Controller
+  // Start from Index 1 because Index 0 is reserved for admin queue
+  for (Index = 1; Index <= Private->NumberOfIoQueuePairs; Index++) {
+    // MU_CHANGE [END] - Request Number of Queues from Controller
+
     ZeroMem (&CommandPacket, sizeof (EFI_NVM_EXPRESS_PASS_THRU_COMMAND_PACKET));
     ZeroMem (&Command, sizeof (EFI_NVM_EXPRESS_COMMAND));
     ZeroMem (&Completion, sizeof (EFI_NVM_EXPRESS_COMPLETION));
@@ -627,6 +728,9 @@ NvmeCreateIoCompletionQueue (
                                  NULL
                                  );
     if (EFI_ERROR (Status)) {
+      // MU_CHANGE [BEGIN] - Request Number of Queues from Controller
+      DEBUG ((DEBUG_ERROR, "%a: Create Completion Queue Command %d failed with Status %r\n", __func__, Index, Status));
+      // MU_CHANGE [END] - Request Number of Queues from Controller
       break;
     }
   }
@@ -661,7 +765,10 @@ NvmeCreateIoSubmissionQueue (
   Status                 = EFI_SUCCESS;
   Private->CreateIoQueue = TRUE;
 
-  for (Index = 1; Index < NVME_MAX_QUEUES; Index++) {
+  // MU_CHANGE [BEGIN] - Request Number of Queues from Controller
+  // Start from Index 1 because Index 0 is reserved for admin queue
+  for (Index = 1; Index <= Private->NumberOfIoQueuePairs; Index++) {
+    // MU_CHANGE [END] - Request Number of Queues from Controller
     ZeroMem (&CommandPacket, sizeof (EFI_NVM_EXPRESS_PASS_THRU_COMMAND_PACKET));
     ZeroMem (&Command, sizeof (EFI_NVM_EXPRESS_COMMAND));
     ZeroMem (&Completion, sizeof (EFI_NVM_EXPRESS_COMPLETION));
@@ -701,6 +808,9 @@ NvmeCreateIoSubmissionQueue (
                                  NULL
                                  );
     if (EFI_ERROR (Status)) {
+      // MU_CHANGE [BEGIN] - Request Number of Queues from Controller
+      DEBUG ((DEBUG_ERROR, "%a: Create Submission Queue Command %d failed with Status %r\n", __func__, Index, Status));
+      // MU_CHANGE [END] - Request Number of Queues from Controller
       break;
     }
   }
@@ -919,6 +1029,21 @@ NvmeControllerInit (
   DEBUG ((DEBUG_INFO, "    SQES      : 0x%x\n", Private->ControllerData->Sqes));
   DEBUG ((DEBUG_INFO, "    CQES      : 0x%x\n", Private->ControllerData->Cqes));
   DEBUG ((DEBUG_INFO, "    NN        : 0x%x\n", Private->ControllerData->Nn));
+
+  // MU_CHANGE [BEGIN] - Request Number of Queues from Controller
+  //
+  // Send Set Features Command to request the maximum number of data queues.
+  // The controller is free to allocate a different number of queues from the number requested.
+  // The number of queues allocated is returned and stored in the controller private data structure
+  // using the NumberOfIoQueuePairs field.
+  //
+  Status = NvmeSetFeaturesNumberOfQueues (Private, NVME_MAX_QUEUES - 1);
+
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  // MU_CHANGE [END] - Request Number of Queues from Controller
 
   //
   // Create two I/O completion queues.

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.h
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.h
@@ -18,6 +18,24 @@
 //
 #define NVME_ASQ_BUF_OFFSET  EFI_PAGE_SIZE
 
+// MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+
+/**
+  Reset the Nvm Express controller.
+
+  @param[in] Private                 The pointer to the NVME_CONTROLLER_PRIVATE_DATA data structure.
+
+  @retval EFI_SUCCESS                The NVM Express Controller is reset successfully.
+  @retval Others                     A device error occurred while resetting the controller.
+
+**/
+EFI_STATUS
+NvmeControllerReset (
+  IN NVME_CONTROLLER_PRIVATE_DATA  *Private
+  );
+
+// MU_CHANGE [END] - Allocate IO Queue Buffer
+
 /**
   Initialize the Nvm Express controller.
 

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.h
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.h
@@ -66,4 +66,24 @@ NvmeIdentifyNamespace (
   IN VOID                          *Buffer
   );
 
+// MU_CHANGE [BEGIN] - Allocate IO Queue Buffer
+
+/**
+  Read Nvm Express admin queue attributes register.
+
+  @param  Private          The pointer to the NVME_CONTROLLER_PRIVATE_DATA data structure.
+  @param  Aqa              The buffer used to store the content to be read from admin queue attributes register.
+
+  @return EFI_SUCCESS      Successfully read data from the admin queue attributes register.
+  @return EFI_DEVICE_ERROR Fail to read data from the admin queue attributes register.
+
+**/
+EFI_STATUS
+ReadNvmeAdminQueueAttributes (
+  IN  NVME_CONTROLLER_PRIVATE_DATA  *Private,
+  OUT NVME_AQA                      *Aqa
+  );
+
+// MU_CHANGE [END] - Allocate IO Queue Buffer
+
 #endif

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressPassthru.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressPassthru.c
@@ -553,7 +553,15 @@ NvmExpressPassThru (
   Prp         = NULL;
   TimerEvent  = NULL;
   Status      = EFI_SUCCESS;
-  QueueSize   = MIN (NVME_ASYNC_CSQ_SIZE, Private->Cap.Mqes) + 1;
+
+  // MU_CHANGE [BEGIN] - Support alternative hardware queue sizes in NVME driver
+  if (PcdGetBool (PcdSupportAlternativeQueueSize)) {
+    QueueSize = MIN (NVME_ALTERNATIVE_MAX_QUEUE_SIZE, Private->Cap.Mqes) + 1;
+  } else {
+    QueueSize = MIN (NVME_ASYNC_CSQ_SIZE, Private->Cap.Mqes) + 1;
+  }
+
+  // MU_CHANGE [END] - Support alternative hardware queue sizes in NVME driver
 
   if (Packet->QueueType == NVME_ADMIN_QUEUE) {
     QueueId = 0;
@@ -580,6 +588,14 @@ NvmExpressPassThru (
   if (Packet->NvmeCmd->Nsid != NamespaceId) {
     return EFI_INVALID_PARAMETER;
   }
+
+  // MU_CHANGE - Support alternative hardware queue sizes in NVME driver
+  //
+  // Nvme DXE driver polls phase bit for CQe completion.
+  // Explicitly assign phase bit with the bit before completion.
+  // A flipped phase bit will be assigned by device upon CQe completes.
+  //
+  Cq->Pt = Private->Pt[QueueId];
 
   ZeroMem (Sq, sizeof (NVME_SQ));
   Sq->Opc  = (UINT8)Packet->NvmeCmd->Cdw0.Opcode;
@@ -723,15 +739,22 @@ NvmExpressPassThru (
     Sq->Payload.Raw.Cdw15 = Packet->NvmeCmd->Cdw15;
   }
 
-  //
-  // Ring the submission queue doorbell.
-  //
-  if ((Event != NULL) && (QueueId != 0)) {
-    Private->SqTdbl[QueueId].Sqt =
-      (Private->SqTdbl[QueueId].Sqt + 1) % QueueSize;
+  // MU_CHANGE [BEGIN] - Support alternative hardware queue sizes in NVME driver
+  if (PcdGetBool (PcdSupportAlternativeQueueSize)) {
+    Private->SqTdbl[QueueId].Sqt = (Private->SqTdbl[QueueId].Sqt + 1) % QueueSize;
   } else {
-    Private->SqTdbl[QueueId].Sqt ^= 1;
+    //
+    // Ring the submission queue doorbell.
+    //
+    if ((Event != NULL) && (QueueId != 0)) {
+      Private->SqTdbl[QueueId].Sqt =
+        (Private->SqTdbl[QueueId].Sqt + 1) % QueueSize;
+    } else {
+      Private->SqTdbl[QueueId].Sqt ^= 1;
+    }
   }
+
+  // MU_CHANGE [END] - Support alternative hardware queue sizes in NVME driver
 
   Data   = ReadUnaligned32 ((UINT32 *)&Private->SqTdbl[QueueId]);
   Status = PciIo->Mem.Write (
@@ -865,9 +888,19 @@ NvmExpressPassThru (
     goto EXIT;
   }
 
-  if ((Private->CqHdbl[QueueId].Cqh ^= 1) == 0) {
-    Private->Pt[QueueId] ^= 1;
+  // MU_CHANGE [BEGIN] - Support alternative hardware queue sizes in NVME driver
+  if (PcdGetBool (PcdSupportAlternativeQueueSize)) {
+    Private->CqHdbl[QueueId].Cqh = (Private->CqHdbl[QueueId].Cqh + 1) % QueueSize;
+    if (Private->CqHdbl[QueueId].Cqh == 0) {
+      Private->Pt[QueueId] ^= 1;
+    }
+  } else {
+    if ((Private->CqHdbl[QueueId].Cqh ^= 1) == 0) {
+      Private->Pt[QueueId] ^= 1;
+    }
   }
+
+  // MU_CHANGE [END] - Support alternative hardware queue sizes in NVME driver
 
   Data           = ReadUnaligned32 ((UINT32 *)&Private->CqHdbl[QueueId]);
   PreviousStatus = Status;

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressPassthru.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressPassthru.c
@@ -553,15 +553,7 @@ NvmExpressPassThru (
   Prp         = NULL;
   TimerEvent  = NULL;
   Status      = EFI_SUCCESS;
-
-  // MU_CHANGE [BEGIN] - Support alternative hardware queue sizes in NVME driver
-  if (PcdGetBool (PcdSupportAlternativeQueueSize)) {
-    QueueSize = MIN (NVME_ALTERNATIVE_MAX_QUEUE_SIZE, Private->Cap.Mqes) + 1;
-  } else {
-    QueueSize = MIN (NVME_ASYNC_CSQ_SIZE, Private->Cap.Mqes) + 1;
-  }
-
-  // MU_CHANGE [END]
+  QueueSize   = MIN (NVME_ASYNC_CSQ_SIZE, Private->Cap.Mqes) + 1;
 
   if (Packet->QueueType == NVME_ADMIN_QUEUE) {
     QueueId = 0;
@@ -588,14 +580,6 @@ NvmExpressPassThru (
   if (Packet->NvmeCmd->Nsid != NamespaceId) {
     return EFI_INVALID_PARAMETER;
   }
-
-  // MU_CHANGE - Support alternative hardware queue sizes in NVME driver
-  //
-  // Nvme DXE driver polls phase bit for CQe completion.
-  // Explicitly assign phase bit with the bit before completion.
-  // A flipped phase bit will be assigned by device upon CQe completes.
-  //
-  Cq->Pt = Private->Pt[QueueId];
 
   ZeroMem (Sq, sizeof (NVME_SQ));
   Sq->Opc  = (UINT8)Packet->NvmeCmd->Cdw0.Opcode;
@@ -739,22 +723,15 @@ NvmExpressPassThru (
     Sq->Payload.Raw.Cdw15 = Packet->NvmeCmd->Cdw15;
   }
 
-  // MU_CHANGE [BEGIN] - Support alternative hardware queue sizes in NVME driver
-  if (PcdGetBool (PcdSupportAlternativeQueueSize)) {
-    Private->SqTdbl[QueueId].Sqt = (Private->SqTdbl[QueueId].Sqt + 1) % QueueSize;
+  //
+  // Ring the submission queue doorbell.
+  //
+  if ((Event != NULL) && (QueueId != 0)) {
+    Private->SqTdbl[QueueId].Sqt =
+      (Private->SqTdbl[QueueId].Sqt + 1) % QueueSize;
   } else {
-    //
-    // Ring the submission queue doorbell.
-    //
-    if ((Event != NULL) && (QueueId != 0)) {
-      Private->SqTdbl[QueueId].Sqt =
-        (Private->SqTdbl[QueueId].Sqt + 1) % QueueSize;
-    } else {
-      Private->SqTdbl[QueueId].Sqt ^= 1;
-    }
+    Private->SqTdbl[QueueId].Sqt ^= 1;
   }
-
-  // MU_CHANGE [END]
 
   Data   = ReadUnaligned32 ((UINT32 *)&Private->SqTdbl[QueueId]);
   Status = PciIo->Mem.Write (
@@ -888,19 +865,9 @@ NvmExpressPassThru (
     goto EXIT;
   }
 
-  // MU_CHANGE [BEGIN] - Support alternative hardware queue sizes in NVME driver
-  if (PcdGetBool (PcdSupportAlternativeQueueSize)) {
-    Private->CqHdbl[QueueId].Cqh = (Private->CqHdbl[QueueId].Cqh + 1) % QueueSize;
-    if (Private->CqHdbl[QueueId].Cqh == 0) {
-      Private->Pt[QueueId] ^= 1;
-    }
-  } else {
-    if ((Private->CqHdbl[QueueId].Cqh ^= 1) == 0) {
-      Private->Pt[QueueId] ^= 1;
-    }
+  if ((Private->CqHdbl[QueueId].Cqh ^= 1) == 0) {
+    Private->Pt[QueueId] ^= 1;
   }
-
-  // MU_CHANGE [END]
 
   Data           = ReadUnaligned32 ((UINT32 *)&Private->CqHdbl[QueueId]);
   PreviousStatus = Status;

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressPassthru.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressPassthru.c
@@ -843,7 +843,7 @@ NvmExpressPassThru (
     //
     // Reset the NVMe controller.
     //
-    Status = NvmeControllerInit (Private);
+    Status = NvmeControllerReset (Private); // MU_CHANGE - Allocate IO Queue Buffer
     if (!EFI_ERROR (Status)) {
       Status = AbortAsyncPassThruTasks (Private);
       if (!EFI_ERROR (Status)) {

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -1385,6 +1385,10 @@
   # Default is 2000, it represent delay is 2 ms.
   # @Prompt Delay access XHCI register after it issues HCRST (us)
   gEfiMdeModulePkgTokenSpaceGuid.PcdDelayXhciHCReset|2000|UINT16|0x30001060
+  
+  # MU_CHANGE [BEGIN] - Support alternative hardware queue sizes in NVME driver
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSupportAlternativeQueueSize|FALSE|BOOLEAN|0x40000151
+  # MU_CHANGE [END]
 
   ## Specifies the page count allocated for the MM communication buffer.
   # @Prompt Defines the page allocation for the MM communication buffer; default is 128 pages (512KB).

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -1385,10 +1385,6 @@
   # Default is 2000, it represent delay is 2 ms.
   # @Prompt Delay access XHCI register after it issues HCRST (us)
   gEfiMdeModulePkgTokenSpaceGuid.PcdDelayXhciHCReset|2000|UINT16|0x30001060
-  
-  # MU_CHANGE [BEGIN] - Support alternative hardware queue sizes in NVME driver
-  gEfiMdeModulePkgTokenSpaceGuid.PcdSupportAlternativeQueueSize|FALSE|BOOLEAN|0x40000151
-  # MU_CHANGE [END]
 
   ## Specifies the page count allocated for the MM communication buffer.
   # @Prompt Defines the page allocation for the MM communication buffer; default is 128 pages (512KB).

--- a/MdePkg/Include/IndustryStandard/Nvme.h
+++ b/MdePkg/Include/IndustryStandard/Nvme.h
@@ -750,6 +750,27 @@ typedef struct {
   UINT32    Sv    : 1;        /* Save */
 } NVME_ADMIN_SET_FEATURES;
 
+// MU_CHANGE [BEGIN] - Add Set Features Command - Number of Queues
+typedef union {
+  NVME_ADMIN_SET_FEATURES    Bits;
+  UINT32                     Uint32;
+} NVME_ADMIN_SET_FEATURES_CDW10;
+
+//
+// NvmExpress Admin Set Features Command - Number of Queues
+//
+typedef union {
+  struct {
+    //
+    // CDW 11 for Requested, DW0 for Allocated
+    //
+    UINT32    Nsq : 16;      /* Number of Submission Queues */
+    UINT32    Ncq : 16;      /* Number of Completion Queues */
+  } Bits;
+  UINT32    Uint32;
+} NVME_ADMIN_SET_FEATURES_NUM_QUEUES;
+
+// MU_CHANGE [END] - Add Set Features Command - Number of Queues
 //
 // NvmExpress Admin Sanitize Command
 //
@@ -971,6 +992,30 @@ typedef enum {
   SanitizeOpcode                = NVME_ADMIN_SANITIZE_CMD
 } NVME_ADMIN_COMMAND_OPCODE;
 
+// MU_CHANGE [BEGIN] - Add Nvm Express Admin Feature Identifiers
+//
+// Nvm Express Admin Feature Identifiers
+// Nvm Express Spec v1.3d Figure 129
+//
+#define NVME_FEATURE_ARBITRATION                         0x01
+#define NVME_FEATURE_POWER_MANAGEMENT                    0x02
+#define NVME_FEATURE_LBA_RANGE_TYPE                      0x03
+#define NVME_FEATURE_TEMPERATURE_THRESHOLD               0x04
+#define NVME_FEATURE_ERROR_RECOVERY                      0x05
+#define NVME_FEATURE_VOLATILE_WRITE_CACHE                0x06
+#define NVME_FEATURE_NUMBER_OF_QUEUES                    0x07
+#define NVME_FEATURE_INTERRUPT_COALESCING                0x08
+#define NVME_FEATURE_INTERRUPT_VECTOR_CONF               0x09
+#define NVME_FEATURE_WRITE_ATOMICITY                     0x0A
+#define NVME_FEATURE_ASYNC_EVENT_CONFIG                  0x0B
+#define NVME_FEATURE_AUTONOMOUS_POWER_STATE_TRANSITION   0x0C
+#define NVME_FEATURE_HOST_MEMORY_BUFFER                  0x0D
+#define NVME_FEATURE_TIMESTAMP                           0x0E
+#define NVME_FEATURE_KEEP_ALIVE_TIMER                    0x0F
+#define NVME_FEATURE_HOST_CONTROLLED_THERMAL_MANAGEMENT  0x10
+#define NVME_FEATURE_NON_OPERATIONAL_POWER_STATE_CONFIG  0x11
+
+// MU_CHANGE [END] - Add Nvm Express Admin Feature Identifiers
 //
 // Controller or Namespace Structure (CNS) field
 // (ref. spec. v1.1 figure 82).


### PR DESCRIPTION
## Description

Cherry picking the changes from dev/202405: https://github.com/microsoft/mu_basecore/pull/1260

Request Number of Queues from the Controller. If the number of queues is <2, then we only have a synchronous queue and do not support asynchronous BlockIo2 functionality.

Created issue https://github.com/microsoft/mu_basecore/issues/1335 for `PcdSupportAlternativeQueueSize `

Created issue https://github.com/microsoft/mu_basecore/issues/1358 for continuing after failing to install BlockIo2

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

CI and QEMU with NVMe virtualization with max_ioqpairs=1, 2, 64

Used `reconnect` and `connect -r` cmds in Shell on the virtualized NVMe controller handle to trigger the `NvmeControllerReset` function (saw in the run log).
Confirmed the device was reconnected using `devtree`.
Successfully wrote to file systems on the NVMe drive to test data queues. 

## Integration Instructions

N/A