### PR TITLE
[REBASE & FF] Integrate edk2 Memory Protection Fixes and Fix the Ensuing Chaos

### DIFF
--- a/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
+++ b/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
@@ -156,6 +156,13 @@ CoreDumpGcdMemorySpaceMap (
   EFI_GCD_MEMORY_SPACE_DESCRIPTOR  *MemorySpaceMap;
   UINTN                            Index;
 
+  // The compiler is not smart enough to compile out the whole function if DEBUG_GCD is not enabled, so we end up
+  // looping through the GCD every time it gets updated, which wastes a lot of needless cycles if we aren't going to
+  // print it. So shortcircuit and jump out if we don't need to print it.
+  if (!DebugPrintLevelEnabled (DEBUG_GCD)) {
+    return;
+  }
+
   Status = CoreGetMemorySpaceMap (&NumberOfDescriptors, &MemorySpaceMap);
   // MU_CHANGE Start - CodeQL Change
   if (!((Status == EFI_SUCCESS) && (MemorySpaceMap != NULL))) {
@@ -207,6 +214,13 @@ CoreDumpGcdIoSpaceMap (
   UINTN                        NumberOfDescriptors;
   EFI_GCD_IO_SPACE_DESCRIPTOR  *IoSpaceMap;
   UINTN                        Index;
+
+  // The compiler is not smart enough to compile out the whole function if DEBUG_GCD is not enabled, so we end up
+  // looping through the GCD every time it gets updated, which wastes a lot of needless cycles if we aren't going to
+  // print it. So shortcircuit and jump out if we don't need to print it.
+  if (!DebugPrintLevelEnabled (DEBUG_GCD)) {
+    return;
+  }
 
   Status = CoreGetIoSpaceMap (&NumberOfDescriptors, &IoSpaceMap);
   // MU_CHANGE Start - CodeQL Change

--- a/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
+++ b/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
@@ -999,7 +999,7 @@ CoreConvertSpace (
       // Set attributes operation
       //
       case GCD_SET_ATTRIBUTES_MEMORY_OPERATION:
-        if (CpuArchAttributes == 0) {
+        if ((CpuArchAttributes == 0) && (Attributes != 0)) {
           //
           // Keep original CPU arch attributes when caller just calls
           // SetMemorySpaceAttributes() with none CPU arch attributes (for example, RUNTIME).

--- a/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
+++ b/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
@@ -156,12 +156,6 @@ CoreDumpGcdMemorySpaceMap (
   EFI_GCD_MEMORY_SPACE_DESCRIPTOR  *MemorySpaceMap;
   UINTN                            Index;
 
-  // MU_CHANGE START: Skip this code if DEBUG_GCD is disabled for performance improvement
-  if (!DebugPrintLevelEnabled (DEBUG_GCD)) {
-    return;
-  }
-
-  // MU_CHANGE END
   Status = CoreGetMemorySpaceMap (&NumberOfDescriptors, &MemorySpaceMap);
   // MU_CHANGE Start - CodeQL Change
   if (!((Status == EFI_SUCCESS) && (MemorySpaceMap != NULL))) {

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
@@ -265,7 +265,7 @@ SetUefiImageMemoryAttributes (
 
   FinalAttributes = (Descriptor.Attributes & EFI_CACHE_ATTRIBUTE_MASK) | (Attributes & EFI_MEMORY_ATTRIBUTE_MASK);
 
-  DEBUG ((DEBUG_INFO, "SetUefiImageMemoryAttributes - 0x%016lx - 0x%016lx (0x%016lx)\n", BaseAddress, Length, FinalAttributes));
+  DEBUG ((DEBUG_VERBOSE, "SetUefiImageMemoryAttributes - 0x%016lx - 0x%016lx (0x%016lx)\n", BaseAddress, Length, FinalAttributes));
 
   ASSERT (gCpu != NULL);
   gCpu->SetMemoryAttributes (gCpu, BaseAddress, Length, FinalAttributes);

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
@@ -696,6 +696,15 @@ UnprotectUefiImage (
 
     if (ImageRecord->ImageBase == (EFI_PHYSICAL_ADDRESS)(UINTN)LoadedImage->ImageBase) {
       mImagePropertiesPrivate.ImageRecordCount--;
+      // this image was protected, so we need to unprotect it
+      if (gCpu != NULL) {
+        SetUefiImageMemoryAttributes (
+          ImageRecord->ImageBase,
+          ImageRecord->ImageSize,
+          0
+          );
+      }
+
       goto Free;
     }
   }
@@ -713,6 +722,8 @@ UnprotectUefiImage (
 
     if (ImageRecord->ImageBase == (EFI_PHYSICAL_ADDRESS)(UINTN)LoadedImage->ImageBase) {
       mNonProtectedImageRangesPrivate.NonProtectedImageCount--;
+      // this image was unprotected, so we don't unprotect it. Trying to do so can cause an assert because the
+      // image may not be page aligned
       goto Free;
     }
   }
@@ -720,14 +731,6 @@ UnprotectUefiImage (
   return;
 
 Free:
-  if (gCpu != NULL) {
-    SetUefiImageMemoryAttributes (
-      ImageRecord->ImageBase,
-      ImageRecord->ImageSize,
-      0
-      );
-  }
-
   // DeleteImagePropertiesRecord() will remove the record from the global list
   DeleteImagePropertiesRecord (ImageRecord);
   return;

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
@@ -574,7 +574,7 @@ Finish:
   switch (ProtectionPolicy) {
     case DO_NOT_PROTECT:
       ClearAccessAttributesFromMemoryRange (
-        (EFI_PHYSICAL_ADDRESS)(UINTN)LoadedImage->ImageBase,
+        (EFI_PHYSICAL_ADDRESS)(UINTN)LoadedImage->ImageBase & ~EFI_PAGE_MASK,
         ALIGN_VALUE ((UINTN)LoadedImage->ImageSize, EFI_PAGE_SIZE)
         );
       CreateNonProtectedImagePropertiesRecord ((EFI_PHYSICAL_ADDRESS)(UINTN)LoadedImage->ImageBase, LoadedImage->ImageSize);
@@ -632,7 +632,7 @@ Finish:
 
   if ((ProtectionPolicy == PROTECT_IF_ALIGNED_ELSE_ALLOW)) {
     ClearAccessAttributesFromMemoryRange (
-      (EFI_PHYSICAL_ADDRESS)(UINTN)LoadedImage->ImageBase,
+      (EFI_PHYSICAL_ADDRESS)(UINTN)LoadedImage->ImageBase & ~EFI_PAGE_MASK,
       ALIGN_VALUE ((UINTN)LoadedImage->ImageSize, EFI_PAGE_SIZE)
       );
     CreateNonProtectedImagePropertiesRecord ((EFI_PHYSICAL_ADDRESS)(UINTN)LoadedImage->ImageBase, LoadedImage->ImageSize);

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
@@ -264,18 +264,11 @@ SetUefiImageMemoryAttributes (
   ASSERT_EFI_ERROR (Status);
 
   FinalAttributes = (Descriptor.Attributes & EFI_CACHE_ATTRIBUTE_MASK) | (Attributes & EFI_MEMORY_ATTRIBUTE_MASK);
-  // MU_CHANGE START: Update verbosity to reduce excessive debug output
-  // DEBUG ((DEBUG_INFO, "SetUefiImageMemoryAttributes - 0x%016lx - 0x%016lx (0x%016lx)\n", BaseAddress, Length, FinalAttributes));
-  DEBUG ((DEBUG_VERBOSE, "SetUefiImageMemoryAttributes - 0x%016lx - 0x%016lx (0x%016lx)\n", BaseAddress, Length, FinalAttributes));
-  // MU_CHANGE END
+
+  DEBUG ((DEBUG_INFO, "SetUefiImageMemoryAttributes - 0x%016lx - 0x%016lx (0x%016lx)\n", BaseAddress, Length, FinalAttributes));
 
   ASSERT (gCpu != NULL);
-  // MU_CHANGE START: Don't dereference if gCpu is NULL
-  if (gCpu != NULL) {
-    gCpu->SetMemoryAttributes (gCpu, BaseAddress, Length, FinalAttributes);
-  }
-
-  // MU_CHANGE END
+  gCpu->SetMemoryAttributes (gCpu, BaseAddress, Length, FinalAttributes);
 }
 
 /**

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
@@ -261,8 +261,11 @@ SetUefiImageMemoryAttributes (
   UINT64                           FinalAttributes;
   UINT64                           CurrentAddress;
   UINT64                           CurrentLength;
+  UINT64                           ImageEnd;
+  UINT64                           DescEnd;
 
   CurrentAddress = BaseAddress;
+  ImageEnd       = BaseAddress + Length;
 
   // we loop here because we may have multiple memory space descriptors that overlap the requested range
   // this will definitely be the case for unprotecting an image, because that calls this function for the entire image,
@@ -281,11 +284,14 @@ SetUefiImageMemoryAttributes (
       return;
     }
 
-    // ensure that we only change the attributes for the range that we are interested in, not the entire descriptor
-    if (BaseAddress + Length > CurrentAddress + Descriptor.Length) {
-      CurrentLength = Descriptor.Length;
+    DescEnd = Descriptor.BaseAddress + Descriptor.Length;
+
+    // ensure that we only change the attributes for the range that we are interested in, not the entire descriptor, we
+    // may also be in the middle of a descriptor, so ensure our length is not larger than the descriptor length
+    if (ImageEnd > DescEnd) {
+      CurrentLength = DescEnd - CurrentAddress;
     } else {
-      CurrentLength = BaseAddress + Length - CurrentAddress;
+      CurrentLength = ImageEnd - CurrentAddress;
     }
 
     // Preserve the existing caching and virtual attributes, but remove the hardware access bits
@@ -356,10 +362,9 @@ SetUefiImageMemoryAttributes (
       }
     }
 
-    // we have CurrentLength, also, but that is just to handle the final descriptor case where we might take only
-    // part of a descriptor, so we can use Descriptor.Length here to move to the next descriptor, which for the final
-    // descriptor will exit the loop, regardless of whether we truncated or not
-    CurrentAddress += Descriptor.Length;
+    // we may have started in the middle of a descriptor, so we need to move to the beginning of the next descriptor,
+    // or the end of the image, whichever is smaller
+    CurrentAddress += CurrentLength;
   }
 }
 

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
@@ -259,16 +259,108 @@ SetUefiImageMemoryAttributes (
   EFI_STATUS                       Status;
   EFI_GCD_MEMORY_SPACE_DESCRIPTOR  Descriptor;
   UINT64                           FinalAttributes;
+  UINT64                           CurrentAddress;
+  UINT64                           CurrentLength;
 
-  Status = CoreGetMemorySpaceDescriptor (BaseAddress, &Descriptor);
-  ASSERT_EFI_ERROR (Status);
+  CurrentAddress = BaseAddress;
 
-  FinalAttributes = (Descriptor.Attributes & EFI_CACHE_ATTRIBUTE_MASK) | (Attributes & EFI_MEMORY_ATTRIBUTE_MASK);
+  // we loop here because we may have multiple memory space descriptors that overlap the requested range
+  // this will definitely be the case for unprotecting an image, because that calls this function for the entire image,
+  // which we split into different GCD descriptors when we protected it.
+  while (CurrentAddress < BaseAddress + Length) {
+    Status = CoreGetMemorySpaceDescriptor (CurrentAddress, &Descriptor);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a - Failed to get memory space descriptor for address %llx with status %r. Cannot protect image.\n",
+        __func__,
+        CurrentAddress,
+        Status
+        ));
+      ASSERT_EFI_ERROR (Status);
+      return;
+    }
 
-  DEBUG ((DEBUG_VERBOSE, "SetUefiImageMemoryAttributes - 0x%016lx - 0x%016lx (0x%016lx)\n", BaseAddress, Length, FinalAttributes));
+    // ensure that we only change the attributes for the range that we are interested in, not the entire descriptor
+    if (BaseAddress + Length > CurrentAddress + Descriptor.Length) {
+      CurrentLength = Descriptor.Length;
+    } else {
+      CurrentLength = BaseAddress + Length - CurrentAddress;
+    }
 
-  ASSERT (gCpu != NULL);
-  gCpu->SetMemoryAttributes (gCpu, BaseAddress, Length, FinalAttributes);
+    // Preserve the existing caching and virtual attributes, but remove the hardware access bits
+    FinalAttributes = (Descriptor.Attributes & ~EFI_MEMORY_ACCESS_MASK) | (Attributes & EFI_MEMORY_ATTRIBUTE_MASK);
+
+    DEBUG ((DEBUG_VERBOSE, "SetUefiImageMemoryAttributes - 0x%016lx - 0x%016lx (0x%016lx)\n", CurrentAddress, CurrentLength, FinalAttributes));
+
+    // check to see if the capabilities support the attributes we want to set. If not, set the capabilities appropriately
+    if ((Descriptor.Capabilities & FinalAttributes) != FinalAttributes) {
+      Status = CoreSetMemorySpaceCapabilities (
+                 CurrentAddress,
+                 CurrentLength,
+                 Descriptor.Capabilities | FinalAttributes
+                 );
+
+      // if we failed to set the capabilities, we should try to continue, it is possible we could succeed
+      if (EFI_ERROR (Status)) {
+        DEBUG ((
+          DEBUG_ERROR,
+          "%a failed setting capabilities on %llx of length %llx with capabilities %llx - %r\n",
+          __func__,
+          CurrentAddress,
+          CurrentLength,
+          Descriptor.Capabilities | FinalAttributes,
+          Status
+          ));
+        ASSERT_EFI_ERROR (Status);
+      }
+    }
+
+    // Call into the GCD to update the attributes there. It will call into the CPU Arch protocol to update the
+    // page table attributes
+    Status = CoreSetMemorySpaceAttributes (
+               CurrentAddress,
+               CurrentLength,
+               FinalAttributes
+               );
+
+    if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a failed on %llx of length %llx with attributes %llx - %r\n",
+        __func__,
+        CurrentAddress,
+        CurrentLength,
+        FinalAttributes,
+        Status
+        ));
+      ASSERT_EFI_ERROR (Status);
+    }
+
+    if (((FinalAttributes & (EFI_MEMORY_ATTRIBUTE_MASK | EFI_CACHE_ATTRIBUTE_MASK)) == 0) && (gCpu != NULL)) {
+      // if the passed hardware attributes are 0, CoreSetMemorySpaceAttributes() will not call into the CPU Arch protocol
+      // to set the attributes, so we need to do it manually here. This can be the case when we are unprotecting an
+      // image if no caching attributes are set. If gCpu has not been populated yet, we'll still have updated the GCD
+      // descriptor and we should sync the attributes with the CPU Arch protocol when it is available.
+      Status = gCpu->SetMemoryAttributes (gCpu, CurrentAddress, CurrentLength, 0);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((
+          DEBUG_ERROR,
+          "%a failed to update page table for %llx of length %llx with attributes 0 - %r\n",
+          __func__,
+          CurrentAddress,
+          CurrentLength,
+          Status
+          ));
+        ASSERT_EFI_ERROR (Status);
+      }
+    }
+
+    // we have CurrentLength, also, but that is just to handle the final descriptor case where we might take only
+    // part of a descriptor, so we can use Descriptor.Length here to move to the next descriptor, which for the final
+    // descriptor will exit the loop, regardless of whether we truncated or not
+    CurrentAddress += Descriptor.Length;
+  }
 }
 
 /**
@@ -440,6 +532,19 @@ ProtectUefiImage (
 
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a failed to create image properties record\n", __func__));
+
+    // if we failed to create the image properties record, this may mean that the image is not aligned properly
+    // the GCD will believe that this memory is non-executable, because the NX initialization routine doesn't know what
+    // memory is image memory or not, even though the page table has the correct attributes, so we need to set the
+    // attributes here to RWX so that future updates to the GCD do not apply the NX attributes to this memory in the
+    // page table (as can happen when applying virtual attributes). This may have the side effect of marking other
+    // memory as RWX, since this image may not be page aligned, but that is safe to do, it may just remove some
+    // page protections, but it already has to to execute this image.
+    SetUefiImageMemoryAttributes (
+      (UINT64)(UINTN)LoadedImage->ImageBase & ~EFI_PAGE_MASK,
+      (LoadedImage->ImageSize + EFI_PAGE_MASK) & ~EFI_PAGE_MASK,
+      0
+      );
     FreePool (ImageRecord);
     goto Finish;
   }

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -2421,7 +2421,9 @@ InitializePageAttributesForMemoryProtectionPolicy (
   MemoryMapEntry = MemoryMap;
   MemoryMapEnd   = (EFI_MEMORY_DESCRIPTOR *)((UINT8 *)MemoryMap + MemoryMapSize);
   while ((UINTN)MemoryMapEntry < (UINTN)MemoryMapEnd) {
-    if (MemoryMapEntry->Attribute != 0) {
+    // Only set the attributes for page aligned memory regions. Unaligned regions could be unaligned images
+    // so we cannot set the attributes for them.
+    if ((MemoryMapEntry->Attribute != 0) && ((MemoryMapEntry->PhysicalStart & EFI_PAGE_MASK) == 0)) {
       SetUefiImageMemoryAttributes (
         MemoryMapEntry->PhysicalStart,
         LShiftU64 (MemoryMapEntry->NumberOfPages, EFI_PAGE_SHIFT),

--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -1694,7 +1694,9 @@ SetAccessAttributesInMemoryMap (
 
   while (MemoryMapEntry < MemoryMapEnd) {
     if (!IS_BITMAP_INDEX_SET (Bitmap, Index)) {
-      MemoryMapEntry->Attribute = GetPermissionAttributeForMemoryType (MemoryMapEntry->Type);
+      // We don't apply RP in the GCD because we can't easily unset it when allocating due to recursive call issues,
+      // so we only set it in the page table.
+      MemoryMapEntry->Attribute = GetPermissionAttributeForMemoryType (MemoryMapEntry->Type) & (~EFI_MEMORY_RP);
       SET_BITMAP_INDEX (Bitmap, Index);
     }
 

--- a/UefiCpuPkg/CpuDxe/CpuPageTable.c
+++ b/UefiCpuPkg/CpuDxe/CpuPageTable.c
@@ -1075,7 +1075,7 @@ RefreshGcdMemoryAttributesFromPaging (
                          EFI_MEMORY_ATTRIBUTE_MASK))
       {
         NewAttributes = (MemorySpaceMap[Index].Attributes &
-                         ~EFI_MEMORY_ATTRIBUTE_MASK) | Attributes;
+                         ~EFI_MEMORY_ATTRIBUTE_MASK) | (Attributes & ~EFI_MEMORY_RP); // MU_CHANGE: Don't report RP to GCD
         Status = gDS->SetMemorySpaceAttributes (
                         BaseAddress,
                         Length,


### PR DESCRIPTION
## Description

This PR reverts a Mu commit that was upstreamed to edk2 as well as cherry-picking some new edk2 functionality. Changing the behavior in edk2 exposed a number of Mu bugs in memory protections that are now fixed.

Revert "MdeModulePkg: Update Memory Logging"
--
This reverts commit 7006e33619f04ba7d1b8da97ccbb933f47c03504 as it has been upstreamed to edk2 in commits d6101acb083eb0b79e3ca35c18ea87003850e3c4, 5ccb5fff02a66b21898bd57f48bbd7c3cd6f4e8d, and 6c6d6f42db3f5c3dc2b8d86ce32e1ce2c7fd85d1.

Four edk2 Cherry-Picks
--
These cherry-picks cover the commit that was reverted and better align image memory protections with the GCD, to keep it in sync, enabling a use case to apply CPU_CRYPTO to all memory near the end of boot.

[SQUASH ON REBASE]MdeModulePkg: Don't Set EFI_MEMORY_RP in the GCD
--
EFI_MEMORY_RP is set on free memory when the corresponding bit in the memory protection HOB is enabled. It is directly set in the page table using the CPU arch protocol because it cannot go through the GCD; it is not feasible with the current locking structure for the paging code to unset it in the GCD, as that may require new pages to be allocated, etc.

This commit fixes the memory protection code to not apply RP in the GCD on accident when trying to apply NX protections. This
causes issues as RP is never cleared and if a driver tries to get attributes from the GCD and update a caching attribute, say, it can end up marking the page RP and then fault trying to acces it.

This also prevents UefiCpuPkg's CpuDxe from applying RP to the GCD when refreshing the GCD from paging, for the same reason.

This should be squashed with ea5dd587ba7713eb267e4b26eb304bd9bf81f19f on rebase.

[SQUASH ON REBASE] MdeModulePkg: Page Align Access Attr Removal
--
Currently, when the image loading code decides not to protect an image, it will attempt to remove any protection attributes from the image region to remove NX. However, it does not take into account that the primary reason we do not protect images is if they are not page aligned. This causes asserts when trying to unset these attributes through the GCD.

This patch aligns the access attribute removal to page boundaries.

It should be squashed on rebase with b95a42dd1ac0cdce3a94db96a4a37856b84c5e16.

[SQUASH ON REBASE] MdeModulePkg: Remove Image Access Attributes Correctly
--
We support loading non-page aligned images, however, in order to do so, we must remove any protection attributes set on them, for example NX protections applied early in DXE Core.

However, when we encounter non-page aligned images, we attempt to take their image base (which is not page aligned) and set attributes on it, which causes an assert to be hit that page attributes are only set on page aligned memory.

This commit removes the protection attributes for the entire page(s) containing the non-aligned image.

It should be squashed with e7e74b9cfc61a126bfd3519b6cb3673492147e74 on rebase.

[SQUASH ON REBASE] MdeModulePkg: Don't Unset Memory Attrs to Unprotected Images
--
Currently, UnprotectUefiImage will attempt to unset memory attributes on any image record it finds for the given image, protected or unprotected. However, this is both a waste of time for unprotected images and can cause asserts when the image is unprotected because it does not have page aligned sections.

This patch fixes that behavior and does not attempt to unset the memory protections that were never applied.

It should be squashed with b95a42dd1ac0cdce3a94db96a4a37856b84c5e16 on rebase.

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Tested on an Intel server with aligned and unaligned images booting to shell.

## Integration Instructions

N/A.
