### PR TITLE
[REBASE & FF] MdeModulePkg: Create IoMmuLib and add support to - PciBusDxe, PciHostBridgeDxe, NonDiscoverablePciDeviceDxe

### DIFF
--- a/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceDxe.inf
+++ b/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceDxe.inf
@@ -33,6 +33,7 @@
   UefiBootServicesTableLib
   UefiDriverEntryPoint
   UefiLib
+  IoMmuLib                                      ## MU_CHANGE
 
 [Protocols]
   gEfiPciIoProtocolGuid                         ## BY_START

--- a/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceIo.c
+++ b/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceIo.c
@@ -15,11 +15,14 @@
 
 #include <Protocol/PciRootBridgeIo.h>
 
+#include <Library/IoMmuLib.h> // MU_CHANGE
+
 typedef struct {
   EFI_PHYSICAL_ADDRESS             AllocAddress;
   VOID                             *HostAddress;
   EFI_PCI_IO_PROTOCOL_OPERATION    Operation;
   UINTN                            NumberOfBytes;
+  VOID                             *IoMmuContext; // MU_CHANGE
 } NON_DISCOVERABLE_PCI_DEVICE_MAP_INFO;
 
 /**
@@ -731,6 +734,13 @@ CoherentPciIoMap (
   EFI_STATUS                            Status;
   NON_DISCOVERABLE_PCI_DEVICE_MAP_INFO  *MapInfo;
 
+  // MU_CHANGE [BEGIN]
+  VOID                   *IoMmuHostAddress;
+  EDKII_IOMMU_OPERATION  IoMmuOperation;
+  UINT64                 IoMmuAttribute;
+
+  // MU_CHANGE [END]
+
   if ((Operation != EfiPciIoOperationBusMasterRead) &&
       (Operation != EfiPciIoOperationBusMasterWrite) &&
       (Operation != EfiPciIoOperationBusMasterCommonBuffer))
@@ -745,6 +755,19 @@ CoherentPciIoMap (
   {
     return EFI_INVALID_PARAMETER;
   }
+
+  // MU_CHANGE [BEGIN]
+  MapInfo = AllocatePool (sizeof *MapInfo);
+  if (MapInfo == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  MapInfo->AllocAddress  = MAX_UINT32;
+  MapInfo->HostAddress   = HostAddress;
+  MapInfo->Operation     = Operation;
+  MapInfo->NumberOfBytes = *NumberOfBytes;
+  MapInfo->IoMmuContext  = NULL;
+  // MU_CHANGE [END]
 
   //
   // If HostAddress exceeds 4 GB, and this device does not support 64-bit DMA
@@ -761,16 +784,6 @@ CoherentPciIoMap (
       return EFI_UNSUPPORTED;
     }
 
-    MapInfo = AllocatePool (sizeof *MapInfo);
-    if (MapInfo == NULL) {
-      return EFI_OUT_OF_RESOURCES;
-    }
-
-    MapInfo->AllocAddress  = MAX_UINT32;
-    MapInfo->HostAddress   = HostAddress;
-    MapInfo->Operation     = Operation;
-    MapInfo->NumberOfBytes = *NumberOfBytes;
-
     Status = gBS->AllocatePages (
                     AllocateMaxAddress,
                     EfiBootServicesData,
@@ -783,8 +796,8 @@ CoherentPciIoMap (
       // 4 GB to begin with. There is not much we can do about that other than
       // fail the map request.
       //
-      FreePool (MapInfo);
-      return EFI_DEVICE_ERROR;
+      Status = EFI_DEVICE_ERROR; // MU_CHANGE
+      goto FreeMapInfo;          // MU_CHANGE
     }
 
     if (Operation == EfiPciIoOperationBusMasterRead) {
@@ -795,14 +808,76 @@ CoherentPciIoMap (
              );
     }
 
-    *DeviceAddress = MapInfo->AllocAddress;
-    *Mapping       = MapInfo;
+    *DeviceAddress   = MapInfo->AllocAddress;
+    IoMmuHostAddress = (VOID *)(UINTN)MapInfo->AllocAddress; // MU_CHANGE
   } else {
-    *DeviceAddress = (EFI_PHYSICAL_ADDRESS)(UINTN)HostAddress;
-    *Mapping       = NULL;
+    *DeviceAddress   = (EFI_PHYSICAL_ADDRESS)(UINTN)HostAddress;
+    IoMmuHostAddress = HostAddress;      // MU_CHANGE
+  }
+
+  // MU_CHANGE [BEGIN]
+  *Mapping = MapInfo;
+
+  switch (Operation) {
+    case EfiPciIoOperationBusMasterRead:
+      IoMmuOperation = EdkiiIoMmuOperationBusMasterRead;
+      IoMmuAttribute = EDKII_IOMMU_ACCESS_READ;
+      break;
+
+    case EfiPciIoOperationBusMasterWrite:
+      IoMmuOperation = EdkiiIoMmuOperationBusMasterWrite;
+      IoMmuAttribute = EDKII_IOMMU_ACCESS_WRITE;
+      break;
+
+    case EfiPciIoOperationBusMasterCommonBuffer:
+      IoMmuOperation = EdkiiIoMmuOperationBusMasterCommonBuffer;
+      IoMmuAttribute = EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE;
+      break;
+
+    default:
+      DEBUG ((DEBUG_ERROR, "%a - Invalid operation %d\n", __func__, Operation));
+      ASSERT (FALSE);
+      return EFI_INVALID_PARAMETER;
+  }
+
+  Status = IoMmuMap (
+             IoMmuOperation,
+             IoMmuHostAddress,
+             NumberOfBytes,
+             DeviceAddress,
+             &MapInfo->IoMmuContext
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuMap failed.\n", __func__));
+    ASSERT (FALSE);
+    goto FreeMapInfo;
+  }
+
+  Status = IoMmuSetAttribute (
+             NULL,
+             MapInfo->IoMmuContext,
+             IoMmuAttribute
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttribute failed.\n", __func__));
+    ASSERT (FALSE);
+    goto Unmap;
   }
 
   return EFI_SUCCESS;
+
+Unmap:
+  Status = IoMmuUnmap (MapInfo->IoMmuContext);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuUnmap failed.\n", __func__));
+    ASSERT (FALSE);
+  }
+
+FreeMapInfo:
+  FreePool (MapInfo);
+  return Status;
+
+  // MU_CHANGE [END]
 }
 
 /**
@@ -823,23 +898,43 @@ CoherentPciIoUnmap (
   )
 {
   NON_DISCOVERABLE_PCI_DEVICE_MAP_INFO  *MapInfo;
+  // MU_CHANGE [BEGIN]
+  EFI_STATUS  Status;
+
+  if (Mapping == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
 
   MapInfo = Mapping;
-  if (MapInfo != NULL) {
-    if (MapInfo->Operation == EfiPciIoOperationBusMasterWrite) {
-      gBS->CopyMem (
-             MapInfo->HostAddress,
-             (VOID *)(UINTN)MapInfo->AllocAddress,
-             MapInfo->NumberOfBytes
-             );
-    }
 
-    gBS->FreePages (
-           MapInfo->AllocAddress,
-           EFI_SIZE_TO_PAGES (MapInfo->NumberOfBytes)
-           );
-    FreePool (MapInfo);
+  Status = IoMmuSetAttribute (NULL, MapInfo->IoMmuContext, 0);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttribute failed.\n", __func__));
+    ASSERT (FALSE);
+    return Status;
   }
+
+  Status = IoMmuUnmap (MapInfo->IoMmuContext);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuUnmap failed.\n", __func__));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  if (MapInfo->Operation == EfiPciIoOperationBusMasterWrite) {
+    gBS->CopyMem (
+           MapInfo->HostAddress,
+           (VOID *)(UINTN)MapInfo->AllocAddress,
+           MapInfo->NumberOfBytes
+           );
+  }
+
+  gBS->FreePages (
+         MapInfo->AllocAddress,
+         EFI_SIZE_TO_PAGES (MapInfo->NumberOfBytes)
+         );
+  FreePool (MapInfo);
+  // MU_CHANGE [END]
 
   return EFI_SUCCESS;
 }
@@ -1278,6 +1373,13 @@ NonCoherentPciIoMap (
   EFI_GCD_MEMORY_SPACE_DESCRIPTOR       GcdDescriptor;
   BOOLEAN                               Bounce;
 
+  // MU_CHANGE [BEGIN]
+  VOID                   *IoMmuHostAddress;
+  EDKII_IOMMU_OPERATION  IoMmuOperation;
+  UINT64                 IoMmuAttribute;
+
+  // MU_CHANGE [END]
+
   AllocAddress = NULL; // MS_CHANGE for vs2017
 
   if ((HostAddress   == NULL) ||
@@ -1303,6 +1405,7 @@ NonCoherentPciIoMap (
   MapInfo->HostAddress   = HostAddress;
   MapInfo->Operation     = Operation;
   MapInfo->NumberOfBytes = *NumberOfBytes;
+  MapInfo->IoMmuContext  = NULL; // MU_CHANGE
 
   Dev = NON_DISCOVERABLE_PCI_DEVICE_FROM_PCI_IO (This);
 
@@ -1372,10 +1475,12 @@ NonCoherentPciIoMap (
       gBS->CopyMem (AllocAddress, HostAddress, *NumberOfBytes);
     }
 
-    *DeviceAddress = MapInfo->AllocAddress;
+    *DeviceAddress   = MapInfo->AllocAddress;
+    IoMmuHostAddress = (VOID *)(UINTN)MapInfo->AllocAddress; // MU_CHANGE
   } else {
     MapInfo->AllocAddress = 0;
     *DeviceAddress        = (EFI_PHYSICAL_ADDRESS)(UINTN)HostAddress;
+    IoMmuHostAddress      = HostAddress; // MU_CHANGE
 
     //
     // We are not using a bounce buffer: the mapping is sufficiently
@@ -1396,7 +1501,64 @@ NonCoherentPciIoMap (
   }
 
   *Mapping = MapInfo;
+
+  // MU_CHANGE [BEGIN]
+  switch (Operation) {
+    case EfiPciIoOperationBusMasterRead:
+      IoMmuOperation = EdkiiIoMmuOperationBusMasterRead;
+      IoMmuAttribute = EDKII_IOMMU_ACCESS_READ;
+      break;
+
+    case EfiPciIoOperationBusMasterWrite:
+      IoMmuOperation = EdkiiIoMmuOperationBusMasterWrite;
+      IoMmuAttribute = EDKII_IOMMU_ACCESS_WRITE;
+      break;
+
+    case EfiPciIoOperationBusMasterCommonBuffer:
+      IoMmuOperation = EdkiiIoMmuOperationBusMasterCommonBuffer;
+      IoMmuAttribute = EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE;
+      break;
+
+    default:
+      DEBUG ((DEBUG_ERROR, "%a - Invalid operation %d\n", __func__, Operation));
+      ASSERT (FALSE);
+      return EFI_INVALID_PARAMETER;
+  }
+
+  Status = IoMmuMap (
+             IoMmuOperation,
+             IoMmuHostAddress,
+             NumberOfBytes,
+             DeviceAddress,
+             &MapInfo->IoMmuContext
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuMap failed.\n", __func__));
+    ASSERT (FALSE);
+    goto FreeMapInfo;
+  }
+
+  Status = IoMmuSetAttribute (
+             NULL,
+             MapInfo->IoMmuContext,
+             IoMmuAttribute
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttribute failed.\n", __func__));
+    ASSERT (FALSE);
+    goto Unmap;
+  }
+
   return EFI_SUCCESS;
+
+Unmap:
+  Status = IoMmuUnmap (MapInfo->IoMmuContext);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuUnmap failed.\n", __func__));
+    ASSERT (FALSE);
+  }
+
+  // MU_CHANGE [END]
 
 FreeMapInfo:
   FreePool (MapInfo);
@@ -1422,12 +1584,31 @@ NonCoherentPciIoUnmap (
   )
 {
   NON_DISCOVERABLE_PCI_DEVICE_MAP_INFO  *MapInfo;
+  EFI_STATUS                            Status; // MU_CHANGE
 
   if (Mapping == NULL) {
     return EFI_DEVICE_ERROR;
   }
 
   MapInfo = Mapping;
+
+  // MU_CHANGE [BEGIN]
+  Status = IoMmuSetAttribute (NULL, MapInfo->IoMmuContext, 0);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttribute failed.\n", __func__));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  Status = IoMmuUnmap (MapInfo->IoMmuContext);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuUnmap failed.\n", __func__));
+    ASSERT (FALSE);
+    return Status;
+  }
+
+  // MU_CHANGE [END]
+
   if (MapInfo->AllocAddress != 0) {
     //
     // We are using a bounce buffer: copy back the data if necessary,

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciBus.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciBus.c
@@ -34,9 +34,9 @@ BOOLEAN                                       gFullEnumeration               = T
 UINT64                                        gAllOne                        = 0xFFFFFFFFFFFFFFFFULL;
 UINT64                                        gAllZero                       = 0;
 
-EFI_PCI_PLATFORM_PROTOCOL       *gPciPlatformProtocol;
-EFI_PCI_OVERRIDE_PROTOCOL       *gPciOverrideProtocol;
-EDKII_IOMMU_PROTOCOL            *mIoMmuProtocol;
+EFI_PCI_PLATFORM_PROTOCOL  *gPciPlatformProtocol;
+EFI_PCI_OVERRIDE_PROTOCOL  *gPciOverrideProtocol;
+// EDKII_IOMMU_PROTOCOL            *mIoMmuProtocol; // MU_CHANGE
 EDKII_DEVICE_SECURITY_PROTOCOL  *mDeviceSecurityProtocol;
 
 GLOBAL_REMOVE_IF_UNREFERENCED EFI_PCI_HOTPLUG_REQUEST_PROTOCOL  mPciHotPlugRequest = {
@@ -286,13 +286,15 @@ PciBusDriverBindingStart (
            );
   }
 
-  if (mIoMmuProtocol == NULL) {
-    gBS->LocateProtocol (
-           &gEdkiiIoMmuProtocolGuid,
-           NULL,
-           (VOID **)&mIoMmuProtocol
-           );
-  }
+  // MU_CHANGE [BEGIN]
+  // if (mIoMmuProtocol == NULL) {
+  //   gBS->LocateProtocol (
+  //          &gEdkiiIoMmuProtocolGuid,
+  //          NULL,
+  //          (VOID **)&mIoMmuProtocol
+  //          );
+  // }
+  // MU_CHANGE [END]
 
   if (mDeviceSecurityProtocol == NULL) {
     gBS->LocateProtocol (

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciBus.h
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciBus.h
@@ -40,6 +40,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/DevicePathLib.h>
 #include <Library/PcdLib.h>
+#include <Library/IoMmuLib.h> // MU_CHANGE
 
 #include <IndustryStandard/Pci.h>
 #include <IndustryStandard/PeImage.h>

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciBusDxe.inf
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciBusDxe.inf
@@ -73,6 +73,7 @@
   BaseLib
   UefiDriverEntryPoint
   DebugLib
+  IoMmuLib                                        ## MU_CHANGE
 
 [Protocols]
   gEfiPciHotPlugRequestProtocolGuid               ## SOMETIMES_PRODUCES
@@ -89,7 +90,7 @@
   gEfiPciRootBridgeIoProtocolGuid                 ## TO_START
   gEfiIncompatiblePciDeviceSupportProtocolGuid    ## SOMETIMES_CONSUMES
   gEfiLoadFile2ProtocolGuid                       ## SOMETIMES_PRODUCES
-  gEdkiiIoMmuProtocolGuid                         ## SOMETIMES_CONSUMES
+  # gEdkiiIoMmuProtocolGuid                         ## SOMETIMES_CONSUMES   ## MU_CHANGE
   gEdkiiDeviceSecurityProtocolGuid                ## SOMETIMES_CONSUMES
   gEdkiiDeviceIdentifierTypePciGuid               ## SOMETIMES_CONSUMES
   gEfiLoadedImageDevicePathProtocolGuid           ## CONSUMES

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciIo.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciIo.c
@@ -8,7 +8,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include "PciBus.h"
 
-extern EDKII_IOMMU_PROTOCOL  *mIoMmuProtocol;
+// extern EDKII_IOMMU_PROTOCOL  *mIoMmuProtocol; // MU_CHANGE
 
 //
 // Pci Io Protocol Interface
@@ -1007,30 +1007,62 @@ PciIoMap (
       );
   }
 
-  if (mIoMmuProtocol != NULL) {
-    if (!EFI_ERROR (Status)) {
-      switch (Operation) {
-        case EfiPciIoOperationBusMasterRead:
-          IoMmuAttribute = EDKII_IOMMU_ACCESS_READ;
-          break;
-        case EfiPciIoOperationBusMasterWrite:
-          IoMmuAttribute = EDKII_IOMMU_ACCESS_WRITE;
-          break;
-        case EfiPciIoOperationBusMasterCommonBuffer:
-          IoMmuAttribute = EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE;
-          break;
-        default:
-          ASSERT (FALSE);
-          return EFI_INVALID_PARAMETER;
-      }
+  // MU_CHANGE [BEGIN]
+  // if (mIoMmuProtocol != NULL) {
+  //   if (!EFI_ERROR (Status)) {
+  //     switch (Operation) {
+  //       case EfiPciIoOperationBusMasterRead:
+  //         IoMmuAttribute = EDKII_IOMMU_ACCESS_READ;
+  //         break;
+  //       case EfiPciIoOperationBusMasterWrite:
+  //         IoMmuAttribute = EDKII_IOMMU_ACCESS_WRITE;
+  //         break;
+  //       case EfiPciIoOperationBusMasterCommonBuffer:
+  //         IoMmuAttribute = EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE;
+  //         break;
+  //       default:
+  //         ASSERT (FALSE);
+  //         return EFI_INVALID_PARAMETER;
+  //     }
+  // MU_CHANGE [END]
 
-      Status = mIoMmuProtocol->SetAttribute (
-                                 mIoMmuProtocol,
-                                 PciIoDevice->Handle,
-                                 *Mapping,
-                                 IoMmuAttribute
-                                 );
+  if (!EFI_ERROR (Status)) {
+    switch (Operation) {
+      case EfiPciIoOperationBusMasterRead:
+        IoMmuAttribute = EDKII_IOMMU_ACCESS_READ;
+        break;
+      case EfiPciIoOperationBusMasterWrite:
+        IoMmuAttribute = EDKII_IOMMU_ACCESS_WRITE;
+        break;
+      case EfiPciIoOperationBusMasterCommonBuffer:
+        IoMmuAttribute = EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE;
+        break;
+      default:
+        ASSERT (FALSE);
+        return EFI_INVALID_PARAMETER;
     }
+
+    // MU_CHANGE [BEGIN]
+    // Status = mIoMmuProtocol->SetAttribute (
+    //                            mIoMmuProtocol,
+    //                            PciIoDevice->Handle,
+    //                            *Mapping,
+    //                            IoMmuAttribute
+    //                            );
+    // MU_CHANGE [END]
+
+    // MU_CHANGE [BEGIN] - Use IoMmuLib
+    Status = IoMmuSetAttribute (
+               PciIoDevice->Handle,
+               *Mapping,
+               IoMmuAttribute
+               );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttribute failed.\n", __func__));
+      ASSERT (FALSE);
+    }
+
+    // MU_CHANGE [END]
   }
 
   return Status;
@@ -1057,15 +1089,29 @@ PciIoUnmap (
   PCI_IO_DEVICE  *PciIoDevice;
 
   PciIoDevice = PCI_IO_DEVICE_FROM_PCI_IO_THIS (This);
+  // MU_CHANGE [BEGIN]
+  // if (mIoMmuProtocol != NULL) {
+  //   mIoMmuProtocol->SetAttribute (
+  //                     mIoMmuProtocol,
+  //                     PciIoDevice->Handle,
+  //                     Mapping,
+  //                     0
+  //                     );
+  // MU_CHANGE [END]
 
-  if (mIoMmuProtocol != NULL) {
-    mIoMmuProtocol->SetAttribute (
-                      mIoMmuProtocol,
-                      PciIoDevice->Handle,
-                      Mapping,
-                      0
-                      );
+  // MU_CHANGE [BEGIN] - Use IoMmuLib
+  Status = IoMmuSetAttribute (
+             PciIoDevice->Handle,
+             Mapping,
+             0
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttribute failed.\n", __func__));
+    ASSERT (FALSE);
+    return Status;
   }
+
+  // MU_CHANGE [END]
 
   Status = PciIoDevice->PciRootBridgeIo->Unmap (
                                            PciIoDevice->PciRootBridgeIo,

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciIo.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciIo.c
@@ -1007,17 +1007,6 @@ PciIoMap (
       );
   }
 
-  // MU_CHANGE [BEGIN] - Re-attempt to locate IoMmu protocol, if missing.
-  if (mIoMmuProtocol == NULL) {
-    gBS->LocateProtocol (
-           &gEdkiiIoMmuProtocolGuid,
-           NULL,
-           (VOID **)&mIoMmuProtocol
-           );
-  }
-
-  // MU_CHANGE [END]
-
   if (mIoMmuProtocol != NULL) {
     if (!EFI_ERROR (Status)) {
       switch (Operation) {
@@ -1068,17 +1057,6 @@ PciIoUnmap (
   PCI_IO_DEVICE  *PciIoDevice;
 
   PciIoDevice = PCI_IO_DEVICE_FROM_PCI_IO_THIS (This);
-
-  // MU_CHANGE [BEGIN] - Re-attempt to locate IoMmu protocol, if missing.
-  if (mIoMmuProtocol == NULL) {
-    gBS->LocateProtocol (
-           &gEdkiiIoMmuProtocolGuid,
-           NULL,
-           (VOID **)&mIoMmuProtocol
-           );
-  }
-
-  // MU_CHANGE [END]
 
   if (mIoMmuProtocol != NULL) {
     mIoMmuProtocol->SetAttribute (

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.c
@@ -21,9 +21,11 @@ GLOBAL_REMOVE_IF_UNREFERENCED CHAR16  *mPciResourceTypeStr[] = {
   L"I/O", L"Mem", L"PMem", L"Mem64", L"PMem64", L"Bus"
 };
 
-EDKII_IOMMU_PROTOCOL  *mIoMmu;
-EFI_EVENT             mIoMmuEvent;
-VOID                  *mIoMmuRegistration;
+// MU_CHANGE [BEGIN]
+// EDKII_IOMMU_PROTOCOL  *mIoMmu;
+// EFI_EVENT             mIoMmuEvent;
+// VOID                  *mIoMmuRegistration;
+// MU_CHANGE [END]
 
 /**
   This routine gets translation offset from a root bridge instance by resource type.
@@ -400,27 +402,29 @@ FreeMemorySpaceMap:
   return Status;
 }
 
-/**
-  Event notification that is fired when IOMMU protocol is installed.
-
-  @param  Event                 The Event that is being processed.
-  @param  Context               Event Context.
-
-**/
-VOID
-EFIAPI
-IoMmuProtocolCallback (
-  IN  EFI_EVENT  Event,
-  IN  VOID       *Context
-  )
-{
-  EFI_STATUS  Status;
-
-  Status = gBS->LocateProtocol (&gEdkiiIoMmuProtocolGuid, NULL, (VOID **)&mIoMmu);
-  if (!EFI_ERROR (Status)) {
-    gBS->CloseEvent (mIoMmuEvent);
-  }
-}
+// MU_CHANGE [BEGIN]
+// /**
+//   Event notification that is fired when IOMMU protocol is installed.
+//
+//   @param  Event                 The Event that is being processed.
+//   @param  Context               Event Context.
+//
+// **/
+// VOID
+// EFIAPI
+// IoMmuProtocolCallback (
+//   IN  EFI_EVENT  Event,
+//   IN  VOID       *Context
+//   )
+// {
+//   EFI_STATUS  Status;
+//
+//   Status = gBS->LocateProtocol (&gEdkiiIoMmuProtocolGuid, NULL, (VOID **)&mIoMmu);
+//   if (!EFI_ERROR (Status)) {
+//     gBS->CloseEvent (mIoMmuEvent);
+//   }
+// }
+// MU_CHANGE [END]
 
 /**
 
@@ -635,15 +639,17 @@ InitializePciHostBridge (
 
   PciHostBridgeFreeRootBridges (RootBridges, RootBridgeCount);
 
-  if (!EFI_ERROR (Status)) {
-    mIoMmuEvent = EfiCreateProtocolNotifyEvent (
-                    &gEdkiiIoMmuProtocolGuid,
-                    TPL_CALLBACK,
-                    IoMmuProtocolCallback,
-                    NULL,
-                    &mIoMmuRegistration
-                    );
-  }
+  // MU_CHANGE [BEGIN]
+  // if (!EFI_ERROR (Status)) {
+  //   mIoMmuEvent = EfiCreateProtocolNotifyEvent (
+  //                   &gEdkiiIoMmuProtocolGuid,
+  //                   TPL_CALLBACK,
+  //                   IoMmuProtocolCallback,
+  //                   NULL,
+  //                   &mIoMmuRegistration
+  //                   );
+  // }
+  // MU_CHANGE [END]
 
   return Status;
 }

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.h
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridge.h
@@ -265,6 +265,6 @@ GetTranslationByResourceType (
   );
 
 extern EFI_CPU_IO2_PROTOCOL  *mCpuIo;
-extern EDKII_IOMMU_PROTOCOL  *mIoMmu;
+// extern EDKII_IOMMU_PROTOCOL  *mIoMmu; // MU_CHANGE
 
 #endif

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridgeDxe.inf
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridgeDxe.inf
@@ -39,12 +39,7 @@
   UefiLib
   PciHostBridgeLib
   TimerLib
-  PcdLib                                          ## MU_CHANGE
-  ReportStatusCodeLib                             ## MU_CHANGE
   DxeMemoryProtectionHobLib                       ## MU_CHANGE
-
-[FeaturePcd]
-  gEfiMdeModulePkgTokenSpaceGuid.PcdRequireIommu  ## MU_CHANGE
 
 [Protocols]
   gEfiCpuIo2ProtocolGuid                          ## CONSUMES

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridgeDxe.inf
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciHostBridgeDxe.inf
@@ -40,13 +40,14 @@
   PciHostBridgeLib
   TimerLib
   DxeMemoryProtectionHobLib                       ## MU_CHANGE
+  IoMmuLib                                        ## MU_CHANGE
 
 [Protocols]
   gEfiCpuIo2ProtocolGuid                          ## CONSUMES
   gEfiDevicePathProtocolGuid                      ## BY_START
   gEfiPciRootBridgeIoProtocolGuid                 ## BY_START
   gEfiPciHostBridgeResourceAllocationProtocolGuid ## BY_START
-  gEdkiiIoMmuProtocolGuid                         ## SOMETIMES_CONSUMES
+  # gEdkiiIoMmuProtocolGuid                         ## SOMETIMES_CONSUMES  ## MU_CHANGE
 
 [Depex]
   gEfiCpuIo2ProtocolGuid AND

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
@@ -10,6 +10,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include "PciHostBridge.h"
 #include "PciRootBridge.h"
 #include "PciHostResource.h"
+#include <Library/IoMmuLib.h> // MU_CHANGE
 
 #define NO_MAPPING  (VOID *) (UINTN) -1
 
@@ -1342,6 +1343,7 @@ RootBridgeIoMap (
   PCI_ROOT_BRIDGE_INSTANCE  *RootBridge;
   EFI_PHYSICAL_ADDRESS      PhysicalAddress;
   MAP_INFO                  *MapInfo;
+  EDKII_IOMMU_OPERATION     IoMmuOperation; // MU_CHANGE
 
   if ((HostAddress == NULL) || (NumberOfBytes == NULL) || (DeviceAddress == NULL) ||
       (Mapping == NULL))
@@ -1358,26 +1360,51 @@ RootBridgeIoMap (
 
   RootBridge = ROOT_BRIDGE_FROM_THIS (This);
 
-  if (mIoMmu != NULL) {
-    if (!RootBridge->DmaAbove4G) {
-      //
-      // Clear 64bit support
-      //
-      if (Operation > EfiPciOperationBusMasterCommonBuffer) {
-        Operation = (EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL_OPERATION)(Operation - EfiPciOperationBusMasterRead64);
-      }
+  // MU_CHANGE [BEGIN] - Use IoMmuLib
+  // if (mIoMmu != NULL) {
+  //   if (!RootBridge->DmaAbove4G) {
+  //     //
+  //     // Clear 64bit support
+  //     //
+  //     if (Operation > EfiPciOperationBusMasterCommonBuffer) {
+  //       Operation = (EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL_OPERATION)(Operation - EfiPciOperationBusMasterRead64);
+  //     }
+  IoMmuOperation = (EDKII_IOMMU_OPERATION)Operation;
+
+  if (!RootBridge->DmaAbove4G) {
+    //
+    // Clear 64bit support
+    //
+    if (Operation > EfiPciOperationBusMasterCommonBuffer) {
+      IoMmuOperation = (EDKII_IOMMU_OPERATION)(EFI_PCI_ROOT_BRIDGE_IO_PROTOCOL_OPERATION)(Operation - EfiPciOperationBusMasterRead64);
+    }
+  }
+
+  if (IoMmuIsPresent ()) {
+    Status = IoMmuMap (
+               (EDKII_IOMMU_OPERATION)IoMmuOperation,
+               HostAddress,
+               NumberOfBytes,
+               DeviceAddress,
+               Mapping
+               );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a - IoMmuMap failed.\n", __func__));
+      ASSERT (FALSE);
     }
 
-    Status = mIoMmu->Map (
-                       mIoMmu,
-                       (EDKII_IOMMU_OPERATION)Operation,
-                       HostAddress,
-                       NumberOfBytes,
-                       DeviceAddress,
-                       Mapping
-                       );
+    // Status = mIoMmu->Map (
+    //                    mIoMmu,
+    //                    (EDKII_IOMMU_OPERATION)Operation,
+    //                    HostAddress,
+    //                    NumberOfBytes,
+    //                    DeviceAddress,
+    //                    Mapping
+    //                    );
     return Status;
   }
+
+  // MU_CHANGE [END]
 
   PhysicalAddress = (EFI_PHYSICAL_ADDRESS)(UINTN)HostAddress;
   if ((!RootBridge->DmaAbove4G ||
@@ -1505,13 +1532,23 @@ RootBridgeIoUnmap (
   PCI_ROOT_BRIDGE_INSTANCE  *RootBridge;
   EFI_STATUS                Status;
 
-  if (mIoMmu != NULL) {
-    Status = mIoMmu->Unmap (
-                       mIoMmu,
-                       Mapping
-                       );
+  // MU_CHANGE [BEGIN] - Use IoMmuLib
+  // if (mIoMmu != NULL) {
+  //   Status = mIoMmu->Unmap (
+  //                      mIoMmu,
+  //                      Mapping
+  //                      );
+  if (IoMmuIsPresent ()) {
+    Status = IoMmuUnmap (Mapping);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a - IoMmuUnmap failed.\n", __func__));
+      ASSERT (FALSE);
+    }
+
     return Status;
   }
+
+  // MU_CHANGE [END]
 
   RootBridge = ROOT_BRIDGE_FROM_THIS (This);
 
@@ -1609,6 +1646,7 @@ RootBridgeIoAllocateBuffer (
   EFI_PHYSICAL_ADDRESS      PhysicalAddress;
   PCI_ROOT_BRIDGE_INSTANCE  *RootBridge;
   EFI_ALLOCATE_TYPE         AllocateType;
+  UINT64                    IoMmuAttributes; // MU_CHANGE
 
   //
   // Validate Attributes
@@ -1636,24 +1674,48 @@ RootBridgeIoAllocateBuffer (
 
   RootBridge = ROOT_BRIDGE_FROM_THIS (This);
 
-  if (mIoMmu != NULL) {
-    if (!RootBridge->DmaAbove4G) {
-      //
-      // Clear DUAL_ADDRESS_CYCLE
-      //
-      Attributes &= ~((UINT64)EFI_PCI_ATTRIBUTE_DUAL_ADDRESS_CYCLE);
+  // MU_CHANGE [BEGIN] - Use IoMmuLib
+  // if (mIoMmu != NULL) {
+  //   if (!RootBridge->DmaAbove4G) {
+  //     //
+  //     // Clear DUAL_ADDRESS_CYCLE
+  //     //
+  //     Attributes &= ~((UINT64)EFI_PCI_ATTRIBUTE_DUAL_ADDRESS_CYCLE);
+
+  IoMmuAttributes = Attributes;
+
+  if (!RootBridge->DmaAbove4G) {
+    //
+    // Clear DUAL_ADDRESS_CYCLE
+    //
+    IoMmuAttributes &= ~((UINT64)EFI_PCI_ATTRIBUTE_DUAL_ADDRESS_CYCLE);
+  }
+
+  if (IoMmuIsPresent ()) {
+    Status = IoMmuAllocateBuffer (
+               Type,
+               MemoryType,
+               Pages,
+               HostAddress,
+               IoMmuAttributes
+               );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a - IoMmuAllocateBuffer failed.\n", __func__));
+      ASSERT (FALSE);
     }
 
-    Status = mIoMmu->AllocateBuffer (
-                       mIoMmu,
-                       Type,
-                       MemoryType,
-                       Pages,
-                       HostAddress,
-                       Attributes
-                       );
+    // Status = mIoMmu->AllocateBuffer (
+    //                    mIoMmu,
+    //                    Type,
+    //                    MemoryType,
+    //                    Pages,
+    //                    HostAddress,
+    //                    Attributes
+    //                    );
     return Status;
   }
+
+  // MU_CHANGE [END]
 
   AllocateType = AllocateAnyPages;
   if (!RootBridge->DmaAbove4G ||
@@ -1703,14 +1765,24 @@ RootBridgeIoFreeBuffer (
 {
   EFI_STATUS  Status;
 
-  if (mIoMmu != NULL) {
-    Status = mIoMmu->FreeBuffer (
-                       mIoMmu,
-                       Pages,
-                       HostAddress
-                       );
+  // MU_CHANGE [BEGIN] - Use IoMmuLib
+  // if (mIoMmu != NULL) {
+  //   Status = mIoMmu->FreeBuffer (
+  //                      mIoMmu,
+  //                      Pages,
+  //                      HostAddress
+  //                      );
+  if (IoMmuIsPresent ()) {
+    Status = IoMmuFreeBuffer (Pages, HostAddress);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a - IoMmuFreeBuffer failed.\n", __func__));
+      ASSERT (FALSE);
+    }
+
     return Status;
   }
+
+  // MU_CHANGE [END]
 
   return gBS->FreePages ((EFI_PHYSICAL_ADDRESS)(UINTN)HostAddress, Pages);
 }

--- a/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
+++ b/MdeModulePkg/Bus/Pci/PciHostBridgeDxe/PciRootBridgeIo.c
@@ -11,16 +11,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include "PciRootBridge.h"
 #include "PciHostResource.h"
 
-// MU_CHANGE - Allow platform to disallow unprotected DMA access when done before IOMMU install.
-#include <Library/ReportStatusCodeLib.h>
-
 #define NO_MAPPING  (VOID *) (UINTN) -1
 
 #define RESOURCE_VALID(Resource)  ((Resource)->Base <= (Resource)->Limit)
-
-// MU_CHANGE - Allow platform to disallow unprotected DMA access when done before IOMMU install.
-#define PCI_DMA_ORDERING_ERROR_STATUS_TYPE  (EFI_ERROR_MAJOR | EFI_ERROR_CODE)
-#define PCI_DMA_ORDERING_ERROR_CODE         (EFI_IO_BUS_PCI | EFI_IOB_EC_NOT_CONFIGURED)
 
 //
 // Lookup table for increment values based on transfer widths
@@ -1333,7 +1326,6 @@ RootBridgeIoPciWrite (
   @retval EFI_UNSUPPORTED        The HostAddress cannot be mapped as a common buffer.
   @retval EFI_DEVICE_ERROR       The System hardware could not map the requested address.
   @retval EFI_OUT_OF_RESOURCES   The request could not be completed due to lack of resources.
-  @retval EFI_NOT_READY          Require IOMMU PCD has been set and request happens before IOMMU protocol install.    MU_CHANGE
 **/
 EFI_STATUS
 EFIAPI
@@ -1365,16 +1357,6 @@ RootBridgeIoMap (
   }
 
   RootBridge = ROOT_BRIDGE_FROM_THIS (This);
-
-  // MU_CHANGE [BEGIN] - Allow platform to disallow unprotected DMA access when done before IOMMU install.
-  if (FeaturePcdGet (PcdRequireIommu) && (mIoMmu == NULL)) {
-    DEBUG ((DEBUG_ERROR, "%a - mIoMmuProtocol is NULL!\n", __func__));
-    ASSERT (mIoMmu != NULL);
-    ReportStatusCode (PCI_DMA_ORDERING_ERROR_STATUS_TYPE, PCI_DMA_ORDERING_ERROR_CODE);
-    return EFI_NOT_READY;
-  }
-
-  // MU_CHANGE [END]
 
   if (mIoMmu != NULL) {
     if (!RootBridge->DmaAbove4G) {
@@ -1510,7 +1492,6 @@ RootBridgeIoMap (
   @retval EFI_SUCCESS            The range was unmapped.
   @retval EFI_INVALID_PARAMETER  Mapping is not a value that was returned by Map().
   @retval EFI_DEVICE_ERROR       The data was not committed to the target system memory.
-  @retval EFI_NOT_READY          Require IOMMU PCD has been set and request happens before IOMMU protocol install.    MU_CHANGE
 **/
 EFI_STATUS
 EFIAPI
@@ -1523,16 +1504,6 @@ RootBridgeIoUnmap (
   LIST_ENTRY                *Link;
   PCI_ROOT_BRIDGE_INSTANCE  *RootBridge;
   EFI_STATUS                Status;
-
-  // MU_CHANGE [BEGIN] - Allow platform to disallow unprotected DMA access when done before IOMMU install.
-  if (FeaturePcdGet (PcdRequireIommu) && (mIoMmu == NULL)) {
-    DEBUG ((DEBUG_ERROR, "%a - mIoMmuProtocol is NULL!\n", __func__));
-    ASSERT (mIoMmu != NULL);
-    ReportStatusCode (PCI_DMA_ORDERING_ERROR_STATUS_TYPE, PCI_DMA_ORDERING_ERROR_CODE);
-    return EFI_NOT_READY;
-  }
-
-  // MU_CHANGE [END]
 
   if (mIoMmu != NULL) {
     Status = mIoMmu->Unmap (
@@ -1622,7 +1593,6 @@ RootBridgeIoUnmap (
                                  attribute bits are MEMORY_WRITE_COMBINE,
                                  MEMORY_CACHED, and DUAL_ADDRESS_CYCLE.
   @retval EFI_OUT_OF_RESOURCES   The memory pages could not be allocated.
-  @retval EFI_NOT_READY          Require IOMMU PCD has been set and request happens before IOMMU protocol install.    MU_CHANGE
 **/
 EFI_STATUS
 EFIAPI
@@ -1665,16 +1635,6 @@ RootBridgeIoAllocateBuffer (
   }
 
   RootBridge = ROOT_BRIDGE_FROM_THIS (This);
-
-  // MU_CHANGE [BEGIN] - Allow platform to disallow unprotected DMA access when done before IOMMU install.
-  if (FeaturePcdGet (PcdRequireIommu) && (mIoMmu == NULL)) {
-    DEBUG ((DEBUG_ERROR, "%a - mIoMmuProtocol is NULL!\n", __func__));
-    ASSERT (mIoMmu != NULL);
-    ReportStatusCode (PCI_DMA_ORDERING_ERROR_STATUS_TYPE, PCI_DMA_ORDERING_ERROR_CODE);
-    return EFI_NOT_READY;
-  }
-
-  // MU_CHANGE [END]
 
   if (mIoMmu != NULL) {
     if (!RootBridge->DmaAbove4G) {
@@ -1732,7 +1692,6 @@ RootBridgeIoAllocateBuffer (
   @retval EFI_SUCCESS            The requested memory pages were freed.
   @retval EFI_INVALID_PARAMETER  The memory range specified by HostAddress and
                                  Pages was not allocated with AllocateBuffer().
-  @retval EFI_NOT_READY          Require IOMMU PCD has been set and request happens before IOMMU protocol install.    MU_CHANGE
 **/
 EFI_STATUS
 EFIAPI
@@ -1743,16 +1702,6 @@ RootBridgeIoFreeBuffer (
   )
 {
   EFI_STATUS  Status;
-
-  // MU_CHANGE [BEGIN] - Allow platform to disallow unprotected DMA access when done before IOMMU install.
-  if (FeaturePcdGet (PcdRequireIommu) && (mIoMmu == NULL)) {
-    DEBUG ((DEBUG_ERROR, "%a - mIoMmuProtocol is NULL!\n", __func__));
-    ASSERT (mIoMmu != NULL);
-    ReportStatusCode (PCI_DMA_ORDERING_ERROR_STATUS_TYPE, PCI_DMA_ORDERING_ERROR_CODE);
-    return EFI_NOT_READY;
-  }
-
-  // MU_CHANGE [END]
 
   if (mIoMmu != NULL) {
     Status = mIoMmu->FreeBuffer (

--- a/MdeModulePkg/Include/Library/IoMmuLib.h
+++ b/MdeModulePkg/Include/Library/IoMmuLib.h
@@ -1,0 +1,130 @@
+/** @file IoMmuLib.h
+
+    This file is the IoMmuLib header file for the IoMmu lib:
+
+    Copyright (c) Microsoft Corporation.
+    SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef IOMMU_LIB_H_
+#define IOMMU_LIB_H_
+
+#include <Uefi.h>
+#include <Protocol/IoMmu.h>
+
+/**
+  Returns True if the IoMmu protocol is available, otherwise returns False.
+
+  @retval BOOLEAN    TRUE if the IoMmu protocol is available, FALSE otherwise.
+**/
+BOOLEAN
+EFIAPI
+IoMmuIsPresent (
+  VOID
+  );
+
+/**
+  Map a host address to a device address using the Page Table.
+  Currently, this function only supports identity mapping.
+
+  @param [in]      Operation       The type of IOMMU operation.
+  @param [in]      HostAddress     The host address to map.
+  @param [in, out] NumberOfBytes   On input, the number of bytes to map. On output, the number of bytes mapped.
+  @param [out]     DeviceAddress   The resulting device address.
+  @param [out]     Mapping         A handle to the mapping. Used by IoMmuUnmap to unmap the address and IoMmuSetAttribute to set attributes.
+                                   IoMmuMap allocates this memory, and it is be freed by IoMmuUnmap.
+
+  @retval EFI_SUCCESS              Success.
+  @retval EFI_NOT_READY            The IoMmu protocol is not ready.
+  @retval Other                    Other errors as defined by the IoMmu protocol.
+
+**/
+EFI_STATUS
+EFIAPI
+IoMmuMap (
+  IN     EDKII_IOMMU_OPERATION  Operation,
+  IN     VOID                   *HostAddress,
+  IN OUT UINTN                  *NumberOfBytes,
+  OUT    EFI_PHYSICAL_ADDRESS   *DeviceAddress,
+  OUT    VOID                   **Mapping
+  );
+
+/**
+  Unmap a device address in the Page Table, also invaldidates the TLB by VA.
+
+  @param [in]  Mapping   The mapping to unmap. This is the mapping that is returned from IoMmuMap.
+
+  @retval EFI_SUCCESS            Success.
+  @retval EFI_NOT_READY          The IoMmu protocol is not ready.
+  @retval Other                  Other errors as defined by the IoMmu protocol.
+
+**/
+EFI_STATUS
+EFIAPI
+IoMmuUnmap (
+  IN  VOID  *Mapping
+  );
+
+/**
+  Free a buffer allocated by IoMmuAllocateBuffer.
+
+  @param [in]  Pages         The number of pages to free.
+  @param [in]  HostAddress   The host address to free.
+
+  @retval EFI_SUCCESS            Success.
+  @retval EFI_NOT_READY          The IoMmu protocol is not ready.
+  @retval Other                  Other errors as defined by the IoMmu protocol.
+**/
+EFI_STATUS
+EFIAPI
+IoMmuFreeBuffer (
+  IN  UINTN  Pages,
+  IN  VOID   *HostAddress
+  );
+
+/**
+  Allocate a buffer for DMA use with the IoMmu.
+
+  @param [in]      Type          The type of allocation to perform.
+  @param [in]      MemoryType    The type of memory to allocate.
+  @param [in]      Pages         The number of pages to allocate.
+  @param [in, out] HostAddress   On input, the desired host address. On output, the allocated host address.
+  @param [in]      Attributes    The memory attributes to use for the allocation.
+
+  @retval EFI_SUCCESS           The requested pages were allocated.
+  @retval EFI_NOT_READY         The IoMmu protocol is not ready.
+  @retval Other                 Other errors as defined by the IoMmu protocol.
+
+**/
+EFI_STATUS
+EFIAPI
+IoMmuAllocateBuffer (
+  IN     EFI_ALLOCATE_TYPE  Type,
+  IN     EFI_MEMORY_TYPE    MemoryType,
+  IN     UINTN              Pages,
+  IN OUT VOID               **HostAddress,
+  IN     UINT64             Attributes
+  );
+
+/**
+  Set the R/W access attributes for Mapping in the Page Table.
+
+  @param [in]  DeviceHandle  The device handle to set attributes for.
+  @param [in]  Mapping       The mapping to set attributes for. This is the mapping that is returned from IoMmuMap.
+  @param [in]  IoMmuAccess   The IOMMU access attributes.
+
+  @retval EFI_SUCCESS            Success.
+  @retval EFI_NOT_READY          The IoMmu protocol is not ready.
+  @retval Other                  Other errors as defined by the IoMmu protocol.
+
+**/
+EFI_STATUS
+EFIAPI
+IoMmuSetAttribute (
+  IN EFI_HANDLE  DeviceHandle,
+  IN VOID        *Mapping,
+  IN UINT64      IoMmuAccess
+  );
+
+#endif // IOMMU_LIB_H_

--- a/MdeModulePkg/Library/IoMmuLib/IoMmuLib.c
+++ b/MdeModulePkg/Library/IoMmuLib/IoMmuLib.c
@@ -1,0 +1,256 @@
+/** @file IoMmuLib.c
+
+    This file contains all the IoMmu library functions.
+    Wraps the IoMmu protocol functions to provide a generic interface for mapping host memory to device memory.
+
+    Copyright (c) Microsoft Corporation.
+    SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+#include <Library/IoMmuLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/UefiLib.h>
+#include <Protocol/IoMmu.h>
+
+EFI_EVENT             mIoMmuEvent;
+VOID                  *mIoMmuRegistration;
+EDKII_IOMMU_PROTOCOL  *mIoMmuProtocol = NULL;
+
+/**
+  Returns True if the IoMmu protocol is available, otherwise returns False.
+
+  @retval BOOLEAN    TRUE if the IoMmu protocol is available, FALSE otherwise.
+**/
+BOOLEAN
+EFIAPI
+IoMmuIsPresent (
+  VOID
+  )
+{
+  return (mIoMmuProtocol != NULL);
+}
+
+/**
+  Map a host address to a device address using the Page Table.
+  Currently, this function only supports identity mapping.
+
+  @param [in]      Operation       The type of IOMMU operation.
+  @param [in]      HostAddress     The host address to map.
+  @param [in, out] NumberOfBytes   On input, the number of bytes to map. On output, the number of bytes mapped.
+  @param [out]     DeviceAddress   The resulting device address.
+  @param [out]     Mapping         A handle to the mapping. Used by IoMmuUnmap to unmap the address and IoMmuSetAttribute to set attributes.
+                                   IoMmuMap allocates this memory, and it is be freed by IoMmuUnmap.
+
+  @retval EFI_SUCCESS              Success.
+  @retval EFI_NOT_READY            The IoMmu protocol is not ready.
+  @retval Other                    Other errors as defined by the IoMmu protocol.
+
+**/
+EFI_STATUS
+EFIAPI
+IoMmuMap (
+  IN     EDKII_IOMMU_OPERATION  Operation,
+  IN     VOID                   *HostAddress,
+  IN OUT UINTN                  *NumberOfBytes,
+  OUT    EFI_PHYSICAL_ADDRESS   *DeviceAddress,
+  OUT    VOID                   **Mapping
+  )
+{
+  if (mIoMmuProtocol == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: IoMmuProtocol is NULL\n", __func__));
+    ASSERT (FALSE);
+    return EFI_NOT_READY;
+  }
+
+  return mIoMmuProtocol->Map (mIoMmuProtocol, Operation, HostAddress, NumberOfBytes, DeviceAddress, Mapping);
+}
+
+/**
+  Unmap a device address in the Page Table, also invaldidates the TLB by VA.
+
+  @param [in]  Mapping   The mapping to unmap. This is the mapping that is returned from IoMmuMap.
+
+  @retval EFI_SUCCESS            Success.
+  @retval EFI_NOT_READY          The IoMmu protocol is not ready.
+  @retval Other                  Other errors as defined by the IoMmu protocol.
+
+**/
+EFI_STATUS
+EFIAPI
+IoMmuUnmap (
+  IN  VOID  *Mapping
+  )
+{
+  if (mIoMmuProtocol == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: IoMmuProtocol is NULL\n", __func__));
+    ASSERT (FALSE);
+    return EFI_NOT_READY;
+  }
+
+  return mIoMmuProtocol->Unmap (mIoMmuProtocol, Mapping);
+}
+
+/**
+  Free a buffer allocated by IoMmuAllocateBuffer.
+
+  @param [in]  Pages         The number of pages to free.
+  @param [in]  HostAddress   The host address to free.
+
+  @retval EFI_SUCCESS            Success.
+  @retval EFI_NOT_READY          The IoMmu protocol is not ready.
+  @retval Other                  Other errors as defined by the IoMmu protocol.
+**/
+EFI_STATUS
+EFIAPI
+IoMmuFreeBuffer (
+  IN  UINTN  Pages,
+  IN  VOID   *HostAddress
+  )
+{
+  if (mIoMmuProtocol == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: IoMmuProtocol is NULL\n", __func__));
+    ASSERT (FALSE);
+    return EFI_NOT_READY;
+  }
+
+  return mIoMmuProtocol->FreeBuffer (mIoMmuProtocol, Pages, HostAddress);
+}
+
+/**
+  Allocate a buffer for DMA use with the IoMmu.
+
+  @param [in]      Type          The type of allocation to perform.
+  @param [in]      MemoryType    The type of memory to allocate.
+  @param [in]      Pages         The number of pages to allocate.
+  @param [in, out] HostAddress   On input, the desired host address. On output, the allocated host address.
+  @param [in]      Attributes    The memory attributes to use for the allocation.
+
+  @retval EFI_SUCCESS           The requested pages were allocated.
+  @retval EFI_NOT_READY         The IoMmu protocol is not ready.
+  @retval Other                 Other errors as defined by the IoMmu protocol.
+
+**/
+EFI_STATUS
+EFIAPI
+IoMmuAllocateBuffer (
+  IN     EFI_ALLOCATE_TYPE  Type,
+  IN     EFI_MEMORY_TYPE    MemoryType,
+  IN     UINTN              Pages,
+  IN OUT VOID               **HostAddress,
+  IN     UINT64             Attributes
+  )
+{
+  if (mIoMmuProtocol == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: IoMmuProtocol is NULL\n", __func__));
+    ASSERT (FALSE);
+    return EFI_NOT_READY;
+  }
+
+  return mIoMmuProtocol->AllocateBuffer (mIoMmuProtocol, Type, MemoryType, Pages, HostAddress, Attributes);
+}
+
+/**
+  Set the R/W access attributes for Mapping in the Page Table.
+
+  @param [in]  DeviceHandle  The device handle to set attributes for.
+  @param [in]  Mapping       The mapping to set attributes for. This is the mapping that is returned from IoMmuMap.
+  @param [in]  IoMmuAccess   The IOMMU access attributes.
+
+  @retval EFI_SUCCESS            Success.
+  @retval EFI_NOT_READY          The IoMmu protocol is not ready.
+  @retval Other                  Other errors as defined by the IoMmu protocol.
+
+**/
+EFI_STATUS
+EFIAPI
+IoMmuSetAttribute (
+  IN EFI_HANDLE  DeviceHandle,
+  IN VOID        *Mapping,
+  IN UINT64      IoMmuAccess
+  )
+{
+  if (mIoMmuProtocol == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: IoMmuProtocol is NULL\n", __func__));
+    ASSERT (FALSE);
+    return EFI_NOT_READY;
+  }
+
+  return mIoMmuProtocol->SetAttribute (mIoMmuProtocol, DeviceHandle, Mapping, IoMmuAccess);
+}
+
+/**
+  Event notification that is fired when IOMMU protocol is installed.
+
+  @param [in] Event               The Event that is being processed.
+  @param [in] Context             Event Context.
+
+**/
+VOID
+IoMmuProtocolCallback (
+  IN  EFI_EVENT  Event,
+  IN  VOID       *Context
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = gBS->LocateProtocol (&gEdkiiIoMmuProtocolGuid, NULL, (VOID **)&mIoMmuProtocol);
+  if (!EFI_ERROR (Status)) {
+    gBS->CloseEvent (mIoMmuEvent);
+  }
+}
+
+/**
+ * IoMmuLibInit Constructor
+ * Locates the IoMmu protocol and initializes the library.
+ * If the IoMmu protocol is not found, it sets up a notification event to be called when the protocol is installed.
+ *
+ * @retval EFI_SUCCESS           A protocol instance matching Protocol was found and returned in
+ *                               Interface.
+ * @retval EFI_NOT_FOUND         No protocol instances were found that match Protocol and
+ *                               Registration.
+ * @retval EFI_INVALID_PARAMETER Interface is NULL.
+ *                               Protocol is NULL.
+ **/
+EFI_STATUS
+EFIAPI
+IoMmuLibInit (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = gBS->LocateProtocol (&gEdkiiIoMmuProtocolGuid, NULL, (VOID **)&mIoMmuProtocol);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: IoMmuProtocol not found, setting IoMmuProtocolCallback\n", __func__));
+
+    Status = gBS->CreateEvent (
+                    EVT_NOTIFY_SIGNAL,
+                    (EFI_TPL)TPL_CALLBACK,
+                    (EFI_EVENT_NOTIFY)IoMmuProtocolCallback,
+                    NULL,
+                    &mIoMmuEvent
+                    );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to create IoMmuProtocolCallback event\n", __func__));
+      ASSERT_EFI_ERROR (Status);
+      return Status;
+    }
+
+    // Register for gEdkiiIoMmuProtocolGuid notifications on this event
+    Status = gBS->RegisterProtocolNotify (
+                    &gEdkiiIoMmuProtocolGuid,
+                    mIoMmuEvent,
+                    &mIoMmuRegistration
+                    );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: Failed to register IoMmuProtocol notify\n", __func__));
+      ASSERT_EFI_ERROR (Status);
+      gBS->CloseEvent (mIoMmuEvent);
+    }
+  }
+
+  return Status;
+}

--- a/MdeModulePkg/Library/IoMmuLib/IoMmuLib.inf
+++ b/MdeModulePkg/Library/IoMmuLib/IoMmuLib.inf
@@ -1,0 +1,27 @@
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = IoMmuLib
+  FILE_GUID                      = 55af180d-a4ee-47fa-84d5-01071643ad35
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = IoMmuLib
+  CONSTRUCTOR                    = IoMmuLibInit
+
+[Sources]
+  IoMmuLib.c
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  UefiBootServicesTableLib
+  UefiLib
+
+[Packages]
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+
+[Protocols]
+  gEdkiiIoMmuProtocolGuid             ## CONSUMES
+
+[Depex.AARCH64]
+  gEdkiiIoMmuProtocolGuid             ## CONSUMES

--- a/MdeModulePkg/Library/IoMmuLib/README.md
+++ b/MdeModulePkg/Library/IoMmuLib/README.md
@@ -1,0 +1,240 @@
+# IoMmuLib
+
+IoMmuLib is a library that provides a simplified interface for IOMMU (Input/Output Memory Management Unit) operations.
+This library abstracts the complexity of directly interfacing with the IOMMU protocol.
+It eliminates the need for PCD (Platform Configuration Database) dependencies and removes the requirement for manual
+protocol location within driver code.
+
+## Overview
+
+The library wraps the EDK II IOMMU protocol dependency (depex) and provides a clean,
+consistent API for IOMMU operations across different platforms. By using IoMmuLib,
+drivers no longer need to:
+
+- Manually locate the gEdkiiIoMmuProtocolGuid IOMMU protocol using `gBS->LocateProtocol()`
+- Handle PCD configurations for IOMMU settings
+- Manage protocol availability checks
+
+## Architecture
+
+IoMmuLib consists of two implementation files:
+
+- **IoMmuLib.c**: The functional implementation that interfaces with the actual IOMMU protocol. IoMmuIsPresent == TRUE.
+- **IoMmuLibNull.c**: A null implementation that returns `EFI_SUCCESS` for all operations. IoMmuIsPresent == FALSE.
+
+The appropriate implementation is selected during the build process based on platform requirements.
+Callers of the IoMmuLib library functions can handle for if the IoMmu is present with the IoMmuisPresent() function.
+
+## Functions
+
+### IoMmuIsPresent
+
+```c
+BOOLEAN
+EFIAPI
+IoMmuIsPresent (
+  VOID
+  );
+```
+
+Returns True if IoMmu is found, False otherwise.
+
+### IoMmuMap
+
+```c
+EFI_STATUS
+EFIAPI
+IoMmuMap (
+  IN     EDKII_IOMMU_OPERATION  Operation,
+  IN     VOID                   *HostAddress,
+  IN OUT UINTN                  *NumberOfBytes,
+  OUT    EFI_PHYSICAL_ADDRESS   *DeviceAddress,
+  OUT    VOID                   **Mapping
+  );
+```
+
+Maps a host address to a device address using the IOMMU page table. Currently supports identity mapping operations.
+
+**Parameters:**
+
+- `Operation`: The type of IOMMU operation to perform
+- `HostAddress`: The host memory address to map
+- `NumberOfBytes`: Input - bytes to map; Output - bytes actually mapped
+- `DeviceAddress`: Returns the resulting device-accessible address
+- `Mapping`: Returns a handle for the mapping (used by unmap and set attribute operations)
+
+**Returns:**
+
+- `EFI_SUCCESS`: Mapping completed successfully
+- `EFI_NOT_READY`: The IoMmu protocol is not ready.
+- Other status codes as defined by the underlying IOMMU protocol
+
+### IoMmuUnmap
+
+```c
+EFI_STATUS
+EFIAPI
+IoMmuUnmap (
+  IN  VOID  *Mapping
+  );
+```
+
+Unmaps a previously mapped device address and invalidates the corresponding TLB entries.
+
+**Parameters:**
+
+- `Mapping`: The mapping handle returned by `IoMmuMap()`
+
+**Returns:**
+
+- `EFI_SUCCESS`: Unmapping completed successfully
+- `EFI_NOT_READY`: The IoMmu protocol is not ready.
+- Other status codes as defined by the underlying IOMMU protocol
+
+### IoMmuAllocateBuffer
+
+```c
+EFI_STATUS
+EFIAPI
+IoMmuAllocateBuffer (
+  IN     EFI_ALLOCATE_TYPE  Type,
+  IN     EFI_MEMORY_TYPE    MemoryType,
+  IN     UINTN              Pages,
+  IN OUT VOID               **HostAddress,
+  IN     UINT64             Attributes
+  );
+```
+
+Allocates a buffer suitable for IOMMU operations with specified memory attributes.
+
+**Parameters:**
+
+- `Type`: The allocation type (AllocateAnyPages, AllocateMaxAddress, AllocateAddress)
+- `MemoryType`: The type of memory to allocate
+- `Pages`: Number of 4KB pages to allocate
+- `HostAddress`: Input - desired address (if Type is AllocateAddress); Output - allocated address
+- `Attributes`: Memory attributes for the allocation
+
+**Returns:**
+
+- `EFI_SUCCESS`: Buffer allocated successfully
+- `EFI_NOT_READY`: The IoMmu protocol is not ready.
+- Other status codes as defined by the underlying IOMMU protocol
+
+### IoMmuFreeBuffer
+
+```c
+EFI_STATUS
+EFIAPI
+IoMmuFreeBuffer (
+  IN  UINTN  Pages,
+  IN  VOID   *HostAddress
+  );
+```
+
+Frees a buffer that was previously allocated by `IoMmuAllocateBuffer()`.
+
+**Parameters:**
+
+- `Pages`: Number of pages to free (must match the original allocation)
+- `HostAddress`: The host address to free
+
+**Returns:**
+
+- `EFI_SUCCESS`: Buffer freed successfully
+- `EFI_NOT_READY`: The IoMmu protocol is not ready.
+- Other status codes as defined by the underlying IOMMU protocol
+
+### IoMmuSetAttribute
+
+```c
+EFI_STATUS
+EFIAPI
+IoMmuSetAttribute (
+  IN EFI_HANDLE  DeviceHandle,
+  IN VOID        *Mapping,
+  IN UINT64      IoMmuAccess
+  );
+```
+
+Sets read/write access attributes for a mapped region in the IOMMU page table.
+
+**Parameters:**
+
+- `DeviceHandle`: The device handle associated with the mapping
+- `Mapping`: The mapping handle returned by `IoMmuMap()`
+- `IoMmuAccess`: The desired IOMMU access attributes
+
+**Returns:**
+
+- `EFI_SUCCESS`: Attributes set successfully
+- `EFI_NOT_READY`: The IoMmu protocol is not ready.
+- Other status codes as defined by the underlying IOMMU protocol
+
+## Usage Guidelines
+
+### Example Usage Pattern
+
+Many other usage cases could occur and the caller must handle the return status appropriatley.
+Caller must handle for cases where IOMMU is available/not available with proper error handling.
+
+```c
+// Initialize all inputs to the IoMmuLib functions appropriatley. The below is just an example.
+EFI_STATUS Status;
+VOID *Mapping;
+EFI_PHYSICAL_ADDRESS DeviceAddress;
+UINTN NumberOfBytes;
+UINT64 IoMmuAccess;
+
+// Map host buffer for device access
+Status = IoMmuMap (
+           EdkiiIoMmuOperationBusMasterRead,
+           HostBuffer,
+           &NumberOfBytes,
+           &DeviceAddress,
+           &Mapping
+           );
+
+if (EFI_ERROR (Status)) {
+  DEBUG ((DEBUG_ERROR, "%a - IoMmuMap failed.\n", __func__));
+  ASSERT (FALSE);
+}
+
+Status = IoMmuSetAttribute (
+            NULL,
+            Mapping,
+            IoMmuAccess
+            );
+
+// Perform device operation using DeviceAddress
+
+// Unmap when done
+Status = IoMmuUnmap (Mapping);
+
+```
+
+## Benefits
+
+- **Simplified Integration**: No need to manually locate the IOMMU protocol
+- **Reduced Dependencies**: Eliminates PCD requirements in driver code
+- **Platform Abstraction**: Consistent API regardless of IOMMU support
+- **Build-time Selection**: Appropriate implementation chosen automatically
+- **Error Handling**: Clear indication when IOMMU operations are unsupported
+
+## Platform Integration
+
+The library automatically adapts to platform capabilities. On platforms without IOMMU support, use IoMmuLibNull.
+On platforms with IOMMU support, use IoMmuLib.
+
+For integrating with a platform, in the top level DSC, you can do the following for example:
+
+```text
+  # Enable IoMmu/Smmu support
+  DEFINE REQUIRE_IOMMU             = TRUE
+
+!if $(REQUIRE_IOMMU) == TRUE
+  IoMmuLib|MdeModulePkg/Library/IoMmuLib/IoMmuLib.inf
+!else
+  IoMmuLib|MdeModulePkg/Library/IoMmuLibNull/IoMmuLibNull.inf
+!endif
+```

--- a/MdeModulePkg/Library/IoMmuLibNull/IoMmuLibNull.c
+++ b/MdeModulePkg/Library/IoMmuLibNull/IoMmuLibNull.c
@@ -1,0 +1,133 @@
+/** @file IoMmuLib.c
+
+    This file contains all the NULL implementation of the IoMmu protocol library functions.
+
+    Copyright (c) Microsoft Corporation.
+    SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#include <Library/BaseLib.h>
+#include <Library/IoMmuLib.h>
+
+/**
+  Returns True if the IoMmu protocol is available, otherwise returns False.
+  This is a NULL implementation, so it always returns FALSE.
+
+  @retval BOOLEAN    False, as this is a NULL implementation.
+**/
+BOOLEAN
+EFIAPI
+IoMmuIsPresent (
+  VOID
+  )
+{
+  return FALSE;
+}
+
+/**
+  NULL implementation of IoMmuMap.
+
+  @param [in]      Operation       The type of IOMMU operation.
+  @param [in]      HostAddress     The host address to map.
+  @param [in, out] NumberOfBytes   On input, the number of bytes to map. On output, the number of bytes mapped.
+  @param [out]     DeviceAddress   The resulting device address.
+  @param [out]     Mapping         A handle to the mapping. Used by IoMmuUnmap to unmap the address and IoMmuSetAttribute to set attributes.
+                                   IoMmuMap allocates this memory, and it is be freed by IoMmuUnmap.
+
+  @retval EFI_SUCCESS          NULL implementation, this function always succeeds.
+
+**/
+EFI_STATUS
+EFIAPI
+IoMmuMap (
+  IN     EDKII_IOMMU_OPERATION  Operation,
+  IN     VOID                   *HostAddress,
+  IN OUT UINTN                  *NumberOfBytes,
+  OUT    EFI_PHYSICAL_ADDRESS   *DeviceAddress,
+  OUT    VOID                   **Mapping
+  )
+{
+  return EFI_SUCCESS;
+}
+
+/**
+  NULL implementation of IoMmuUnmap.
+
+  @param [in]  Mapping   The mapping to unmap. This is the mapping that is returned from IoMmuMap.
+
+  @retval EFI_SUCCESS          NULL implementation, this function always succeeds.
+
+**/
+EFI_STATUS
+EFIAPI
+IoMmuUnmap (
+  IN  VOID  *Mapping
+  )
+{
+  return EFI_SUCCESS;
+}
+
+/**
+  NULL implementation of IoMmuFreeBuffer.
+
+  @param [in]  Pages         The number of pages to free.
+  @param [in]  HostAddress   The host address to free.
+
+  @retval EFI_SUCCESS          NULL implementation, this function always succeeds.
+
+**/
+EFI_STATUS
+EFIAPI
+IoMmuFreeBuffer (
+  IN  UINTN  Pages,
+  IN  VOID   *HostAddress
+  )
+{
+  return EFI_SUCCESS;
+}
+
+/**
+  NULL implementation of IoMmuAllocateBuffer.
+
+  @param [in]      Type          The type of allocation to perform.
+  @param [in]      MemoryType    The type of memory to allocate.
+  @param [in]      Pages         The number of pages to allocate.
+  @param [in, out] HostAddress   On input, the desired host address. On output, the allocated host address.
+  @param [in]      Attributes    The memory attributes to use for the allocation.
+
+  @retval EFI_SUCCESS          NULL implementation, this function always succeeds.
+
+**/
+EFI_STATUS
+EFIAPI
+IoMmuAllocateBuffer (
+  IN     EFI_ALLOCATE_TYPE  Type,
+  IN     EFI_MEMORY_TYPE    MemoryType,
+  IN     UINTN              Pages,
+  IN OUT VOID               **HostAddress,
+  IN     UINT64             Attributes
+  )
+{
+  return EFI_SUCCESS;
+}
+
+/**
+  NULL implementation of IoMmuSetAttribute.
+
+  @param [in]  DeviceHandle  The device handle to set attributes for.
+  @param [in]  Mapping       The mapping to set attributes for. This is the mapping that is returned from IoMmuMap.
+  @param [in]  IoMmuAccess   The IOMMU access attributes.
+
+  @retval EFI_SUCCESS          NULL implementation, this function always succeeds.
+
+**/
+EFI_STATUS
+EFIAPI
+IoMmuSetAttribute (
+  IN EFI_HANDLE  DeviceHandle,
+  IN VOID        *Mapping,
+  IN UINT64      IoMmuAccess
+  )
+{
+  return EFI_SUCCESS;
+}

--- a/MdeModulePkg/Library/IoMmuLibNull/IoMmuLibNull.inf
+++ b/MdeModulePkg/Library/IoMmuLibNull/IoMmuLibNull.inf
@@ -1,0 +1,17 @@
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = IoMmuLibNull
+  FILE_GUID                      = 743616a1-4fe5-41c2-9534-e222f6f61081
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = IoMmuLib
+
+[Sources]
+  IoMmuLibNull.c
+
+[LibraryClasses]
+  BaseLib
+
+[Packages]
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec

--- a/MdeModulePkg/Library/IoMmuLibNull/README.md
+++ b/MdeModulePkg/Library/IoMmuLibNull/README.md
@@ -1,0 +1,11 @@
+# IoMmuLibNull
+
+IoMmuLib is a library that provides a simplified interface for IOMMU (Input/Output Memory Management Unit) operations.
+This library abstracts the complexity of directly interfacing with the IOMMU protocol.
+Eliminates the need for PCD (Platform Configuration Database) dependencies and manual protocol location.
+On NULL implementations such as this one, all functions return `EFI_SUCCESS` with no depex on the IOMMU protocol.
+
+## Overview
+
+The library is a NULL implementation of the IoMmuLib. All library functions return `EFI_SUCCESS`.
+This can be used on platforms where IOMMU is not supported. For more details see readme in IoMmuLib.

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -37,6 +37,11 @@
   NULL|Include/Library/VariablePolicyLockingExLib.h
   # MU_CHANGE [END] - Isolate the VariablePolicy locking event into its own code.
 
+  # MU_CHANGE [BEGIN] - Add IoMmuLib to wrap gEdkiiIoMmuProtocolGuid
+  ## @libraryclass IoMmu library that can be used for IoMmu Protocol functions.
+  IoMmuLib|Include/Library/IoMmuLib.h
+  # MU_CHANGE [END] - Add IoMmuLib to wrap gEdkiiIoMmuProtocolGuid
+
   ##  @libraryclass  Defines a set of methods to reset whole system.
   ResetSystemLib|Include/Library/ResetSystemLib.h
 

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -1122,14 +1122,6 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdDeferBME|TRUE|BOOLEAN|0x30002050
 
   ## MU_CHANGE
-  ## Indicates if DMA is allowed before IOMMU protocol install
-  #  If enabled, device wil assert and return EFI_DEVICE_ERROR on any DMA access before IOMMU Protocol Install.<BR><BR>
-  #   TRUE  - IOMMU protocol required for DMA access.<BR>
-  #   FALSE - DMA Access can happen before IOMMU protocol install.<BR>
-  # @Prompt Enable DMA before IOMMU protocol.
-  gEfiMdeModulePkgTokenSpaceGuid.PcdRequireIommu|TRUE|BOOLEAN|0x30001090
-
-  ## MU_CHANGE
   ## Indicates if the InternalEventServices protocol is published to gBS. This protocol provides access to the
   #  internal event functions that do not require TPL_APPLICATION.
   #    TRUE  - Publish the InternalEventServices protocol

--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -78,6 +78,7 @@
   PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
   CustomizedDisplayLib|MdeModulePkg/Library/CustomizedDisplayLib/CustomizedDisplayLib.inf
   FrameBufferBltLib|MdeModulePkg/Library/FrameBufferBltLib/FrameBufferBltLib.inf
+  IoMmuLib|MdeModulePkg/Library/IoMmuLibNull/IoMmuLibNull.inf                                         ## MU_CHANGE
   #
   # Misc
   #
@@ -393,6 +394,8 @@
   MdeModulePkg/Library/BaseRngLibTimerLib/BaseRngLibTimerLib.inf
   MdeModulePkg/Library/HobPrintLib/HobPrintLib.inf
   MdeModulePkg/Library/AdvLoggerAccessLibNull/AdvLoggerAccessLib.inf              # MU_CHANGE
+  MdeModulePkg/Library/IoMmuLib/IoMmuLib.inf                                      # MU_CHANGE
+  MdeModulePkg/Library/IoMmuLibNull/IoMmuLibNull.inf                              # MU_CHANGE
 
   MdeModulePkg/Universal/BdsDxe/BdsDxe.inf
   MdeModulePkg/Application/BootManagerMenuApp/BootManagerMenuApp.inf


### PR DESCRIPTION
## Description

Reverts PcdRequireIommu change, removes PcdRequireIommu.
Create IoMmuLib
Create IoMmuLibNull
Wrapper library for IoMmu Protocol functions.

Add IoMmuLib support to NonDiscoverablePciDeviceDxe
Modify IoMmu protocol usage and add IoMmuLib support to PciBusDxe and PciHostBridgeDxe

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [x] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Tested on QEMU SBSA, physical arm device, physical x64 device.

## Integration Instructions

### Platform Integration

The library automatically adapts to platform capabilities. On platforms without IOMMU support, use IoMmuLibNull.
On platforms with IOMMU support, use IoMmuLib.

For integrating with a platform, in the top level DSC, you can do the following for example:

```text
  # Enable IoMmu/Smmu support
  DEFINE REQUIRE_IOMMU             = TRUE

!if $(REQUIRE_IOMMU) == TRUE
  IoMmuLib|MdeModulePkg/Library/IoMmuLib/IoMmuLib.inf
!else
  IoMmuLib|MdeModulePkg/Library/IoMmuLibNull/IoMmuLibNull.inf
!endif
```
