### PR TITLE
[Cherry-Pick] MdePkg: Add _CSD and _STA Acpi definitions. [Rebase & FF]

### DIFF
--- a/MdePkg/Include/IndustryStandard/Acpi30.h
+++ b/MdePkg/Include/IndustryStandard/Acpi30.h
@@ -2,6 +2,7 @@
   ACPI 3.0 definitions from the ACPI Specification Revision 3.0b October 10, 2006
 
   Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -9,6 +10,16 @@
 #define _ACPI_3_0_H_
 
 #include <IndustryStandard/Acpi20.h>
+
+///
+/// _CSD Revision for ACPI 3.0
+///
+#define EFI_ACPI_3_0_AML_CSD_REVISION  0
+
+///
+/// _CSD NumEntries for ACPI 3.0
+///
+#define EFI_ACPI_3_0_AML_CSD_NUM_ENTRIES  6
 
 //
 // Define for Descriptor

--- a/MdePkg/Include/IndustryStandard/Acpi40.h
+++ b/MdePkg/Include/IndustryStandard/Acpi40.h
@@ -2,6 +2,7 @@
   ACPI 4.0 definitions from the ACPI Specification Revision 4.0a April 5, 2010
 
   Copyright (c) 2010 - 2022, Intel Corporation. All rights reserved.<BR>
+  Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -9,6 +10,16 @@
 #define _ACPI_4_0_H_
 
 #include <IndustryStandard/Acpi30.h>
+
+///
+/// _CSD Revision for ACPI 4.0
+///
+#define EFI_ACPI_4_0_AML_CSD_REVISION  0
+
+///
+/// _CSD NumEntries for ACPI 4.0
+///
+#define EFI_ACPI_4_0_AML_CSD_NUM_ENTRIES  6
 
 ///
 /// _PSD Revision for ACPI 4.0

--- a/MdePkg/Include/IndustryStandard/Acpi50.h
+++ b/MdePkg/Include/IndustryStandard/Acpi50.h
@@ -4,6 +4,7 @@
   Copyright (c) 2014 Hewlett-Packard Development Company, L.P.<BR>
   Copyright (c) 2011 - 2022, Intel Corporation. All rights reserved.<BR>
   Copyright (c) 2020, ARM Ltd. All rights reserved.<BR>
+  Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -11,6 +12,16 @@
 #define _ACPI_5_0_H_
 
 #include <IndustryStandard/Acpi40.h>
+
+///
+/// _CSD Revision for ACPI 5.0
+///
+#define EFI_ACPI_5_0_AML_CSD_REVISION  0
+
+///
+/// _CSD NumEntries for ACPI 5.0
+///
+#define EFI_ACPI_5_0_AML_CSD_NUM_ENTRIES  6
 
 //
 // Define for Descriptor

--- a/MdePkg/Include/IndustryStandard/Acpi51.h
+++ b/MdePkg/Include/IndustryStandard/Acpi51.h
@@ -5,6 +5,7 @@
   Copyright (c) 2014 - 2022, Intel Corporation. All rights reserved.<BR>
   (C) Copyright 2015 Hewlett Packard Enterprise Development LP<BR>
   Copyright (c) 2020, ARM Ltd. All rights reserved.<BR>
+  Copyright (C) 2024, Advanced Micro Devices, Inc. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -12,6 +13,16 @@
 #define _ACPI_5_1_H_
 
 #include <IndustryStandard/Acpi50.h>
+
+///
+/// _CSD Revision for ACPI 5.1
+///
+#define EFI_ACPI_5_1_AML_CSD_REVISION  0
+
+///
+/// _CSD NumEntries for ACPI 5.1
+///
+#define EFI_ACPI_5_1_AML_CSD_NUM_ENTRIES  6
 
 ///
 /// _PSD Revision for ACPI 5.1

--- a/MdePkg/Include/IndustryStandard/Acpi60.h
+++ b/MdePkg/Include/IndustryStandard/Acpi60.h
@@ -4,6 +4,7 @@
   Copyright (c) 2015 - 2022, Intel Corporation. All rights reserved.<BR>
   (C) Copyright 2015-2016 Hewlett Packard Enterprise Development LP<BR>
   Copyright (c) 2020, ARM Ltd. All rights reserved.<BR>
+  Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -11,6 +12,16 @@
 #define _ACPI_6_0_H_
 
 #include <IndustryStandard/Acpi51.h>
+
+///
+/// _CSD Revision for ACPI 6.0
+///
+#define EFI_ACPI_6_0_AML_CSD_REVISION  0
+
+///
+/// _CSD NumEntries for ACPI 6.0
+///
+#define EFI_ACPI_6_0_AML_CSD_NUM_ENTRIES  6
 
 ///
 /// _PSD Revision for ACPI 6.0

--- a/MdePkg/Include/IndustryStandard/Acpi61.h
+++ b/MdePkg/Include/IndustryStandard/Acpi61.h
@@ -4,6 +4,7 @@
   Copyright (c) 2016 - 2022, Intel Corporation. All rights reserved.<BR>
  (C) Copyright 2016 Hewlett Packard Enterprise Development LP<BR>
   Copyright (c) 2020, ARM Ltd. All rights reserved.<BR>
+  Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -11,6 +12,16 @@
 #define _ACPI_6_1_H_
 
 #include <IndustryStandard/Acpi60.h>
+
+///
+/// _CSD Revision for ACPI 6.1
+///
+#define EFI_ACPI_6_1_AML_CSD_REVISION  0
+
+///
+/// _CSD NumEntries for ACPI 6.1
+///
+#define EFI_ACPI_6_1_AML_CSD_NUM_ENTRIES  6
 
 ///
 /// _PSD Revision for ACPI 6.1

--- a/MdePkg/Include/IndustryStandard/Acpi62.h
+++ b/MdePkg/Include/IndustryStandard/Acpi62.h
@@ -3,6 +3,7 @@
 
   Copyright (c) 2017 - 2022, Intel Corporation. All rights reserved.<BR>
   Copyright (c) 2020, ARM Ltd. All rights reserved.<BR>
+  Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
@@ -10,6 +11,16 @@
 #define _ACPI_6_2_H_
 
 #include <IndustryStandard/Acpi61.h>
+
+///
+/// _CSD Revision for ACPI 6.2
+///
+#define EFI_ACPI_6_2_AML_CSD_REVISION  0
+
+///
+/// _CSD NumEntries for ACPI 6.2
+///
+#define EFI_ACPI_6_2_AML_CSD_NUM_ENTRIES  6
 
 //
 // Large Item Descriptor Name

--- a/MdePkg/Include/IndustryStandard/Acpi63.h
+++ b/MdePkg/Include/IndustryStandard/Acpi63.h
@@ -3,6 +3,7 @@
 
   Copyright (c) 2017 - 2022, Intel Corporation. All rights reserved.<BR>
   Copyright (c) 2019 - 2020, ARM Ltd. All rights reserved.<BR>
+  Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
@@ -11,6 +12,16 @@
 #define _ACPI_6_3_H_
 
 #include <IndustryStandard/Acpi62.h>
+
+///
+/// _CSD Revision for ACPI 6.3
+///
+#define EFI_ACPI_6_3_AML_CSD_REVISION  0
+
+///
+/// _CSD NumEntries for ACPI 6.3
+///
+#define EFI_ACPI_6_3_AML_CSD_NUM_ENTRIES  6
 
 ///
 /// _PSD Revision for ACPI 6.3

--- a/MdePkg/Include/IndustryStandard/Acpi64.h
+++ b/MdePkg/Include/IndustryStandard/Acpi64.h
@@ -3,6 +3,7 @@
 
   Copyright (c) 2017 - 2022, Intel Corporation. All rights reserved.<BR>
   Copyright (c) 2019 - 2021, ARM Ltd. All rights reserved.<BR>
+  Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
@@ -11,6 +12,16 @@
 #define ACPI_6_4_H_
 
 #include <IndustryStandard/Acpi63.h>
+
+///
+/// _CSD Revision for ACPI 6.4
+///
+#define EFI_ACPI_6_4_AML_CSD_REVISION  0
+
+///
+/// _CSD NumEntries for ACPI 6.4
+///
+#define EFI_ACPI_6_4_AML_CSD_NUM_ENTRIES  6
 
 ///
 /// _PSD Revision for ACPI 6.4

--- a/MdePkg/Include/IndustryStandard/Acpi65.h
+++ b/MdePkg/Include/IndustryStandard/Acpi65.h
@@ -4,6 +4,7 @@
   Copyright (c) 2017 - 2022, Intel Corporation. All rights reserved.<BR>
   Copyright (c) 2019 - 2024, ARM Ltd. All rights reserved.<BR>
   Copyright (c) 2023, Loongson Technology Corporation Limited. All rights reserved.<BR>
+  Copyright (C) 2025, Advanced Micro Devices, Inc. All rights reserved.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
@@ -17,6 +18,16 @@
 // Ensure proper structure formats
 //
 #pragma pack(1)
+
+///
+/// _CSD Revision for ACPI 6.5
+///
+#define EFI_ACPI_6_5_AML_CSD_REVISION  0
+
+///
+/// _CSD NumEntries for ACPI 6.5
+///
+#define EFI_ACPI_6_5_AML_CSD_NUM_ENTRIES  6
 
 ///
 /// _PSD Revision for ACPI 6.5

--- a/MdePkg/Include/IndustryStandard/Acpi65.h
+++ b/MdePkg/Include/IndustryStandard/Acpi65.h
@@ -20,6 +20,15 @@
 #pragma pack(1)
 
 ///
+/// _STA bit definitions ACPI 6.5 s6.3.7
+///
+#define ACPI_AML_STA_DEVICE_STATUS_PRESET       0x1
+#define ACPI_AML_STA_DEVICE_STATUS_ENABLED      0x2
+#define ACPI_AML_STA_DEVICE_STATUS_UI           0x4
+#define ACPI_AML_STA_DEVICE_STATUS_FUNCTIONING  0x8
+#define ACPI_AML_STA_DEVICE_STATUS_BATTERY      0x10
+
+///
 /// _CSD Revision for ACPI 6.5
 ///
 #define EFI_ACPI_6_5_AML_CSD_REVISION  0


### PR DESCRIPTION
## Description

    Add _CSD version and number of entries definition.
    These were introduced in the ACPI 3.0 specification.
    Reference: ACPI 6.5 specification, section 8.4.1.2,
    Table 8.3: C-State Dependency Package Values.

    Adds _STA device status bit definitions.
    Reference: ACPI 6.5 specification, section 6.3.7

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested
Local CI only: these are just additional definitions used by silicon vendor code.

## Integration Instructions
No integration necessary.