### PR TITLE
MdeModulePkg: Refactor MM Services Tables linked in MM Core Perf Lib

### DIFF
--- a/MdeModulePkg/Library/SmmCorePerformanceLib/MmCorePerformanceLib.c
+++ b/MdeModulePkg/Library/SmmCorePerformanceLib/MmCorePerformanceLib.c
@@ -42,12 +42,14 @@ UINT32     mCachedLength   = 0;
 UINT32     mBootRecordSize = 0;
 BOOLEAN    mPerformanceMeasurementEnabled;
 
-//
-// Interfaces for SMM PerformanceMeasurement Protocol.
-//
-EDKII_PERFORMANCE_MEASUREMENT_PROTOCOL  mPerformanceMeasurementInterface = {
-  CreatePerformanceMeasurement,
-};
+// MU_CHANGE [BEGIN] - Split MM Services Table dependencies
+// //
+// // Interfaces for SMM PerformanceMeasurement Protocol.
+// //
+// EDKII_PERFORMANCE_MEASUREMENT_PROTOCOL  mPerformanceMeasurementInterface = {
+//   CreatePerformanceMeasurement,
+// };
+// MU_CHANGE [END] - Split MM Services Table dependencies
 
 /**
   Return the module name and optionally module GUID for a given handle.
@@ -932,61 +934,63 @@ SmmCorePerformanceLibExitBootServicesCallback (
   return EFI_SUCCESS;
 }
 
-/**
-  Common initialization code for the MM Core Performance Library.
+// MU_CHANGE [BEGIN] - Split MM Services Table dependencies
+// /**
+//   Common initialization code for the MM Core Performance Library.
 
-  @param[in] ExitBootServicesProtocolGuid  The GUID of the ExitBootServices protocol.
+//   @param[in] ExitBootServicesProtocolGuid  The GUID of the ExitBootServices protocol.
 
-  @retval     EFI_SUCCESS           The MM Core Performance Library was initialized successfully.
-  @retval     Others                The MM Core Performance Library was not initialized successfully.
- **/
-EFI_STATUS
-InitializeMmCorePerformanceLibCommon (
-  IN CONST EFI_GUID  *ExitBootServicesProtocolGuid
-  )
-{
-  EFI_STATUS  Status;
-  EFI_HANDLE  Handle;
-  EFI_HANDLE  MmiHandle;
-  VOID        *Registration;
+//   @retval     EFI_SUCCESS           The MM Core Performance Library was initialized successfully.
+//   @retval     Others                The MM Core Performance Library was not initialized successfully.
+//  **/
+// EFI_STATUS
+// InitializeMmCorePerformanceLibCommon (
+//   IN CONST EFI_GUID  *ExitBootServicesProtocolGuid
+//   )
+// {
+//   EFI_STATUS  Status;
+//   EFI_HANDLE  Handle;
+//   EFI_HANDLE  MmiHandle;
+//   VOID        *Registration;
 
-  //
-  // Initialize spin lock
-  //
-  InitializeSpinLock (&mSmmFpdtLock);
+//   //
+//   // Initialize spin lock
+//   //
+//   InitializeSpinLock (&mSmmFpdtLock);
 
-  //
-  // Install the protocol interfaces for MM performance library instance.
-  //
-  Handle = NULL;
-  Status = gMmst->MmInstallProtocolInterface (
-                    &Handle,
-                    &gEdkiiSmmPerformanceMeasurementProtocolGuid,
-                    EFI_NATIVE_INTERFACE,
-                    &mPerformanceMeasurementInterface
-                    );
-  ASSERT_EFI_ERROR (Status);
+//   //
+//   // Install the protocol interfaces for MM performance library instance.
+//   //
+//   Handle = NULL;
+//   Status = gMmst->MmInstallProtocolInterface (
+//                     &Handle,
+//                     &gEdkiiSmmPerformanceMeasurementProtocolGuid,
+//                     EFI_NATIVE_INTERFACE,
+//                     &mPerformanceMeasurementInterface
+//                     );
+//   ASSERT_EFI_ERROR (Status);
 
-  //
-  // Register MMI handler.
-  //
-  MmiHandle = NULL;
-  Status    = gMmst->MmiHandlerRegister (FpdtSmiHandler, &gEfiFirmwarePerformanceGuid, &MmiHandle);
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
+//   //
+//   // Register MMI handler.
+//   //
+//   MmiHandle = NULL;
+//   Status    = gMmst->MmiHandlerRegister (FpdtSmiHandler, &gEfiFirmwarePerformanceGuid, &MmiHandle);
+//   if (EFI_ERROR (Status)) {
+//     return Status;
+//   }
 
-  //
-  // Register callback function for ExitBootServices event.
-  //
-  Status = gMmst->MmRegisterProtocolNotify (
-                    ExitBootServicesProtocolGuid,
-                    SmmCorePerformanceLibExitBootServicesCallback,
-                    &Registration
-                    );
+//   //
+//   // Register callback function for ExitBootServices event.
+//   //
+//   Status = gMmst->MmRegisterProtocolNotify (
+//                     ExitBootServicesProtocolGuid,
+//                     SmmCorePerformanceLibExitBootServicesCallback,
+//                     &Registration
+//                     );
 
-  return Status;
-}
+//   return Status;
+// }
+// MU_CHANGE [END] - Split MM Services Table dependencies
 
 /**
   Create performance record with event description and a timestamp.

--- a/MdeModulePkg/Library/SmmCorePerformanceLib/SmmCorePerformanceLib.c
+++ b/MdeModulePkg/Library/SmmCorePerformanceLib/SmmCorePerformanceLib.c
@@ -28,12 +28,21 @@ MU_CHANGE [WHOLE FILE] - Standalone MM Perf Support
 
 #include <Library/DxeServicesLib.h>
 #include <Library/SmmMemLib.h>
+#include <Library/SmmServicesTableLib.h>        // MU_CHANGE - Split MM Services Table dependencies
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiLib.h>
 #include <Protocol/SmmBase2.h>
 #include <Protocol/SmmExitBootServices.h>
 
 PERFORMANCE_PROPERTY  mPerformanceProperty;
+
+// MU_CHANGE [BEGIN] - Split MM Services Table dependencies
+extern SPIN_LOCK  mSmmFpdtLock;
+
+EDKII_PERFORMANCE_MEASUREMENT_PROTOCOL  mPerformanceMeasurementInterface = {
+  CreatePerformanceMeasurement,
+};
+// MU_CHANGE [END] - Split MM Services Table dependencies
 
 /**
   A library internal MM-instance specific implementation to check if a buffer outside MM is valid.
@@ -194,9 +203,44 @@ InitializeSmmCorePerformanceLib (
 {
   EFI_STATUS            Status;
   PERFORMANCE_PROPERTY  *PerformanceProperty;
+  // MU_CHANGE [BEGIN] - Split MM Services Table dependencies
+  EFI_HANDLE  Handle;
+  EFI_HANDLE  MmiHandle;
+  VOID        *Registration;
 
-  Status = InitializeMmCorePerformanceLibCommon (&gEdkiiSmmExitBootServicesProtocolGuid);
+  //
+  // Initialize spin lock
+  //
+  InitializeSpinLock (&mSmmFpdtLock);
+
+  //
+  // Install the protocol interfaces for MM performance library instance.
+  //
+  Handle = NULL;
+  Status = gSmst->SmmInstallProtocolInterface (
+                    &Handle,
+                    &gEdkiiSmmPerformanceMeasurementProtocolGuid,
+                    EFI_NATIVE_INTERFACE,
+                    &mPerformanceMeasurementInterface
+                    );
   ASSERT_EFI_ERROR (Status);
+
+  //
+  // Register MMI handler.
+  //
+  MmiHandle = NULL;
+  Status    = gSmst->SmiHandlerRegister (FpdtSmiHandler, &gEfiFirmwarePerformanceGuid, &MmiHandle);
+  ASSERT_EFI_ERROR (Status);
+
+  //
+  // Register callback function for ExitBootServices event.
+  //
+  Status = gSmst->SmmRegisterProtocolNotify (
+                    &gEdkiiSmmExitBootServicesProtocolGuid,
+                    SmmCorePerformanceLibExitBootServicesCallback,
+                    &Registration
+                    );
+  // MU_CHANGE [END] - Split MM Services Table dependencies
 
   Status = EfiGetSystemConfigurationTable (&gPerformanceProtocolGuid, (VOID **)&PerformanceProperty);
   if (EFI_ERROR (Status)) {

--- a/MdeModulePkg/Library/SmmCorePerformanceLib/SmmCorePerformanceLib.inf
+++ b/MdeModulePkg/Library/SmmCorePerformanceLib/SmmCorePerformanceLib.inf
@@ -46,10 +46,11 @@
   DebugLib
   DxeServicesLib
   MemoryAllocationLib
-  MmServicesTableLib
+  # MmServicesTableLib  # MU_CHANGE - Split SMM Services Table libs
   PcdLib
   PeCoffGetEntryPointLib
   SmmMemLib
+  SmmServicesTableLib  # MU_CHANGE - Split SMM Services Table libs
   SynchronizationLib
   TimerLib
   UefiBootServicesTableLib

--- a/MdeModulePkg/Library/SmmCorePerformanceLib/SmmCorePerformanceLibInternal.h
+++ b/MdeModulePkg/Library/SmmCorePerformanceLib/SmmCorePerformanceLibInternal.h
@@ -24,7 +24,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
 #include <Library/MemoryAllocationLib.h>
-#include <Library/MmServicesTableLib.h>
+// include <Library/MmServicesTableLib.h> // MU_CHANGE - Split MM Services Table dependencies
 #include <Library/PcdLib.h>
 #include <Library/PeCoffGetEntryPointLib.h>
 #include <Library/PerformanceLib.h>
@@ -44,6 +44,61 @@ extern BOOLEAN  mPerformanceMeasurementEnabled;
 //
 // Library internal function declarations
 //
+
+// MU_CHANGE [BEGIN] - Split MM Services Table dependencies
+
+/**
+  Communication service SMI Handler entry.
+
+  This SMI handler provides services for report MM boot records.
+
+  Caution: This function may receive untrusted input.
+  Communicate buffer and buffer size are external input, so this function will do basic validation.
+
+  @param[in]     DispatchHandle  The unique handle assigned to this handler by SmiHandlerRegister().
+  @param[in]     RegisterContext Points to an optional handler context which was specified when the
+                                 handler was registered.
+  @param[in, out] CommBuffer     A pointer to a collection of data in memory that will
+                                 be conveyed from a non-MM environment into an MM environment.
+  @param[in, out] CommBufferSize The size of the CommBuffer.
+
+  @retval EFI_SUCCESS                         The interrupt was handled and quiesced. No other handlers
+                                              should still be called.
+  @retval EFI_WARN_INTERRUPT_SOURCE_QUIESCED  The interrupt has been quiesced but other handlers should
+                                              still be called.
+  @retval EFI_WARN_INTERRUPT_SOURCE_PENDING   The interrupt is still pending and other handlers should still
+                                              be called.
+  @retval EFI_INTERRUPT_PENDING               The interrupt could not be quiesced.
+
+**/
+EFI_STATUS
+EFIAPI
+FpdtSmiHandler (
+  IN     EFI_HANDLE  DispatchHandle,
+  IN     CONST VOID  *RegisterContext,
+  IN OUT VOID        *CommBuffer,
+  IN OUT UINTN       *CommBufferSize
+  );
+
+/**
+  This is the Event call back function is triggered in SMM to notify the Library
+  the system is entering runtime phase.
+
+  @param[in] Protocol   Points to the protocol's unique identifier
+  @param[in] Interface  Points to the interface instance
+  @param[in] Handle     The handle on which the interface was installed
+
+  @retval EFI_SUCCESS SmmAtRuntimeCallBack runs successfully
+ **/
+EFI_STATUS
+EFIAPI
+SmmCorePerformanceLibExitBootServicesCallback (
+  IN CONST EFI_GUID  *Protocol,
+  IN VOID            *Interface,
+  IN EFI_HANDLE      Handle
+  );
+
+// MU_CHANGE [END] - Split MM Services Table dependencies
 
 /**
   Return a pointer to the loaded image protocol for the given handle.

--- a/MdeModulePkg/Library/SmmCorePerformanceLib/StandaloneMmCorePerformanceLib.c
+++ b/MdeModulePkg/Library/SmmCorePerformanceLib/StandaloneMmCorePerformanceLib.c
@@ -17,7 +17,16 @@
 #include "SmmCorePerformanceLibInternal.h"
 
 #include <Guid/EventGroup.h>
+#include <Library/MmServicesTableLib.h> // MU_CHANGE - Split MM Services Table dependencies
 #include <Library/StandaloneMmMemLib.h>
+
+// MU_CHANGE [BEGIN] - Split MM Services Table dependencies
+extern SPIN_LOCK  mSmmFpdtLock;
+
+EDKII_PERFORMANCE_MEASUREMENT_PROTOCOL  mPerformanceMeasurementInterface = {
+  CreatePerformanceMeasurement,
+};
+// MU_CHANGE [END] - Split MM Services Table dependencies
 
 /**
   A library internal MM-instance specific implementation to check if a buffer outside MM is valid.
@@ -109,6 +118,64 @@ GetNameFromUiSection (
   return EFI_NOT_FOUND;
 }
 
+// MU_CHANGE [BEGIN] - Split MM Services Table dependencies
+
+/**
+  Initializes the MM Core Performance library.
+
+  @retval EFI_SUCCESS     The performance library was initialized successfully.
+  @retval Other           An error occurred during initialization.
+**/
+EFI_STATUS
+EFIAPI
+InitializeStandaloneMmCorePerformanceLib (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+  EFI_HANDLE  Handle;
+  EFI_HANDLE  MmiHandle;
+  VOID        *Registration;
+
+  //
+  // Initialize spin lock
+  //
+  InitializeSpinLock (&mSmmFpdtLock);
+  //
+  // Install the protocol interfaces for MM performance library instance.
+  //
+  Handle = NULL;
+  Status = gMmst->MmInstallProtocolInterface (
+                    &Handle,
+                    &gEdkiiSmmPerformanceMeasurementProtocolGuid,
+                    EFI_NATIVE_INTERFACE,
+                    &mPerformanceMeasurementInterface
+                    );
+  ASSERT_EFI_ERROR (Status);
+
+  //
+  // Register MMI handler.
+  //
+  MmiHandle = NULL;
+  Status    = gMmst->MmiHandlerRegister (FpdtSmiHandler, &gEfiFirmwarePerformanceGuid, &MmiHandle);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Register callback function for ExitBootServices event.
+  //
+  Status = gMmst->MmRegisterProtocolNotify (
+                    &gEfiEventExitBootServicesGuid,
+                    SmmCorePerformanceLibExitBootServicesCallback,
+                    &Registration
+                    );
+
+  return Status;
+}
+
+// MU_CHANGE [END] - Split MM Services Table dependencies
+
 /**
   The constructor function initializes the Standalone MM Core performance library.
 
@@ -140,7 +207,7 @@ StandaloneMmCorePerformanceLibConstructor (
     return EFI_SUCCESS;
   }
 
-  Status = InitializeMmCorePerformanceLibCommon (&gEfiEventExitBootServicesGuid);
+  Status = InitializeStandaloneMmCorePerformanceLib (); // MU_CHANGE - Split MM Services Table dependencies
   ASSERT_EFI_ERROR (Status);
 
   return EFI_SUCCESS;


### PR DESCRIPTION
## Description

The code used a `MmServicesTableLib` dependency for both the Standalone MM and Traditional MM instances and shared code between those. There is not a readily available `MmServicesTable` lib instance for Traditional SMM (that can link to `PiSmmCore`). To ease integration and prevent creating an instance just for this case, this change uses `SmmServicesTableLib` in the Traditional SMM instance and `MmServicesTableLib` in the Standalone MM instance and moves code as necessary to accommodate this.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

- Tested Standalone MM on Qemu Q35 and Traditional MM on OvmfPkg X64.

## Integration Instructions

N/A