### PR TITLE
Prevent memcpy intrinsics in VS22 (17.14.2) [Rebase & FF]

### DIFF
--- a/MdeModulePkg/Universal/DisplayEngineDxe/InputHandler.c
+++ b/MdeModulePkg/Universal/DisplayEngineDxe/InputHandler.c
@@ -229,9 +229,15 @@ ReadString (
 
       case CHAR_BACKSPACE:
         if ((StringPtr[0] != CHAR_NULL) && (CurrentCursor != 0)) {
-          for (Index = 0; Index < CurrentCursor - 1; Index++) {
-            TempString[Index] = StringPtr[Index];
+          // MU_CHANGE [BEGIN]: Fix VS22 17.14 memcpy substitution
+          // for (Index = 0; Index < CurrentCursor - 1; Index++) {
+          //   TempString[Index] = StringPtr[Index];
+          // }
+          if (CurrentCursor > 1) {
+            CopyMem (TempString, StringPtr, (CurrentCursor - 1) * sizeof (CHAR16));
           }
+
+          // MU_CHANGE [END]: Fix VS22 17.14 memcpy substitution
 
           Count = GetStringWidth (StringPtr) / 2 - 1;
           if (Count >= CurrentCursor) {
@@ -261,9 +267,12 @@ ReadString (
           KeyPad[1] = CHAR_NULL;
           Count     = GetStringWidth (StringPtr) / 2 - 1;
           if (CurrentCursor < Count) {
-            for (Index = 0; Index < CurrentCursor; Index++) {
-              TempString[Index] = StringPtr[Index];
-            }
+            // MU_CHANGE [BEGIN]: Fix VS22 17.14 memcpy substitution
+            // for (Index = 0; Index < CurrentCursor; Index++) {
+            //   TempString[Index] = StringPtr[Index];
+            // }
+            CopyMem (TempString, StringPtr, CurrentCursor * sizeof (CHAR16));
+            // MU_CHANGE [END]: Fix VS22 17.14 memcpy substitution
 
             TempString[Index] = CHAR_NULL;
             StrCatS (TempString, MaxLen, KeyPad);

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/Edit/FileBuffer.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/Edit/FileBuffer.c
@@ -478,6 +478,7 @@ FileBufferPrintLine (
 {
   CHAR16  *Buffer;
   UINTN   Limit;
+  UINTN   PadLength;  // MU_CHANGE: Fix VS22 17.14 memcpy substitution
   CHAR16  *PrintLine;
   CHAR16  *PrintLine2;
   UINTN   BufLen;
@@ -496,9 +497,13 @@ FileBufferPrintLine (
   PrintLine = AllocatePool (BufLen);
   if (PrintLine != NULL) {
     StrnCpyS (PrintLine, BufLen/sizeof (CHAR16), Buffer, MIN (Limit, MainEditor.ScreenSize.Column));
-    for (Limit = StrLen (PrintLine); Limit < MainEditor.ScreenSize.Column; Limit++) {
-      PrintLine[Limit] = L' ';
+    // MU_CHANGE [BEGIN]: Fix VS22 17.14 memcpy substitution
+    if (StrLen (PrintLine) < MainEditor.ScreenSize.Column) {
+      PadLength = MainEditor.ScreenSize.Column - StrLen (PrintLine);
+      SetMem16 (&PrintLine[StrLen (PrintLine)], PadLength * sizeof (CHAR16), L' ');
     }
+
+    // MU_CHANGE [END]: Fix VS22 17.14 memcpy substitution
 
     PrintLine[MainEditor.ScreenSize.Column] = CHAR_NULL;
 
@@ -3104,17 +3109,23 @@ FileBufferReplace (
     // set replace into it
     //
     Buffer = FileBuffer.CurrentLine->Buffer + FileBuffer.FilePosition.Column - 1;
-    for (Index = 0; Index < ReplaceLen; Index++) {
-      Buffer[Index] = Replace[Index];
-    }
+    // MU_CHANGE [BEGIN]: Fix VS22 17.14 memcpy substitution
+    // for (Index = 0; Index < ReplaceLen; Index++) {
+    //   Buffer[Index] = Replace[Index];
+    // }
+    CopyMem (Buffer, Replace, ReplaceLen * sizeof (CHAR16));
+    // MU_CHANGE [END]: Fix VS22 17.14 memcpy substitution
   }
 
   if (ReplaceLen < SearchLen) {
     Buffer = FileBuffer.CurrentLine->Buffer + FileBuffer.FilePosition.Column - 1;
 
-    for (Index = 0; Index < ReplaceLen; Index++) {
-      Buffer[Index] = Replace[Index];
-    }
+    // MU_CHANGE [BEGIN]: Fix VS22 17.14 memcpy substitution
+    // for (Index = 0; Index < ReplaceLen; Index++) {
+    //   Buffer[Index] = Replace[Index];
+    // }
+    CopyMem (Buffer, Replace, ReplaceLen * sizeof (CHAR16));
+    // MU_CHANGE [END]: Fix VS22 17.14 memcpy substitution
 
     Buffer += ReplaceLen;
     Gap     = SearchLen - ReplaceLen;
@@ -3130,9 +3141,12 @@ FileBufferReplace (
 
   if (ReplaceLen == SearchLen) {
     Buffer = FileBuffer.CurrentLine->Buffer + FileBuffer.FilePosition.Column - 1;
-    for (Index = 0; Index < ReplaceLen; Index++) {
-      Buffer[Index] = Replace[Index];
-    }
+    // MU_CHANGE [BEGIN]: Fix VS22 17.14 memcpy substitution
+    // for (Index = 0; Index < ReplaceLen; Index++) {
+    //   Buffer[Index] = Replace[Index];
+    // }
+    CopyMem (Buffer, Replace, ReplaceLen * sizeof (CHAR16));
+    // MU_CHANGE [END]: Fix VS22 17.14 memcpy substitution
   }
 
   FileBuffer.CurrentLine->Size += (ReplaceLen - SearchLen);
@@ -3322,9 +3336,12 @@ FileBufferReplaceAll (
       // set replace into it
       //
       Buffer = Line->Buffer + Position;
-      for (Index = 0; Index < ReplaceLen; Index++) {
-        Buffer[Index] = ReplaceStr[Index];
-      }
+      // MU_CHANGE [BEGIN]: Fix VS22 17.14 memcpy substitution
+      // for (Index = 0; Index < ReplaceLen; Index++) {
+      //   Buffer[Index] = ReplaceStr[Index];
+      // }
+      CopyMem (Buffer, ReplaceStr, ReplaceLen * sizeof (CHAR16));
+      // MU_CHANGE [END]]: Fix VS22 17.14 memcpy substitution
 
       Line->Size += (ReplaceLen - SearchLen);
       Column     += ReplaceLen;

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/HexEdit/BufferImage.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/HexEdit/BufferImage.c
@@ -142,9 +142,13 @@ HBufferImageBackup (
   VOID
   )
 {
+  // MU_CHANGE [BEGIN]: Fix VS22 17.14 memcpy substitution
   HBufferImageBackupVar.MousePosition = HBufferImage.MousePosition;
 
   HBufferImageBackupVar.BufferPosition = HBufferImage.BufferPosition;
+  CopyMem (&HBufferImageBackupVar.MousePosition, &HBufferImage.MousePosition, sizeof (HBufferImage.MousePosition));
+  CopyMem (&HBufferImageBackupVar.BufferPosition, &HBufferImage.BufferPosition, sizeof (HBufferImage.BufferPosition));
+  // MU_CHANGE [END]: Fix VS22 17.14 memcpy substitution
 
   HBufferImageBackupVar.Modified = HBufferImage.Modified;
 
@@ -569,7 +573,10 @@ HBufferImageRestoreMousePosition (
       //
       // backup the old screen attributes
       //
-      Orig                  = HMainEditor.ColorAttributes;
+      // MU_CHANGE [BEGIN]: Fix VS22 17.14 memcpy substitution
+      // Orig                  = HMainEditor.ColorAttributes;
+      CopyMem (&Orig, &HMainEditor.ColorAttributes, sizeof (Orig));
+      // MU_CHANGE [END]: Fix VS22 17.14 memcpy substitution
       New.Data              = 0;
       New.Colors.Foreground = Orig.Colors.Background & 0xF;
       New.Colors.Background = Orig.Colors.Foreground & 0x7;
@@ -1955,17 +1962,23 @@ HBufferImageDeleteCharacterFromBuffer (
   // pass deleted buffer out
   //
   if (DeleteBuffer != NULL) {
-    for (Index = 0; Index < Count; Index++) {
-      DeleteBuffer[Index] = BufferPtr[Pos + Index];
-    }
+    // MU_CHANGE [BEGIN]: Fix VS22 17.14 memcpy substitution
+    // for (Index = 0; Index < Count; Index++) {
+    //   DeleteBuffer[Index] = BufferPtr[Pos + Index];
+    // }
+    CopyMem (&DeleteBuffer[0], &BufferPtr[Pos], Count);
+    // MU_CHANGE [END]: Fix VS22 17.14 memcpy substitution
   }
 
   //
   // delete the part from Pos
   //
-  for (Index = Pos; Index < Size - Count; Index++) {
-    BufferPtr[Index] = BufferPtr[Index + Count];
-  }
+  // MU_CHANGE [BEGIN]: Fix VS22 17.14 memcpy substitution
+  // for (Index = Pos; Index < Size - Count; Index++) {
+  //   BufferPtr[Index] = BufferPtr[Index + Count];
+  // }
+  CopyMem (&BufferPtr[Pos], &BufferPtr[Pos + Count], Size - Count - Pos);
+  // MU_CHANGE [END]: Fix VS22 17.14 memcpy substitution
 
   Size -= Count;
 
@@ -2069,16 +2082,22 @@ HBufferImageAddCharacterToBuffer (
   //
   // get a place to add
   //
-  for (Index = (INTN)(Size + Count - 1); Index >= (INTN)Pos; Index--) {
-    BufferPtr[Index] = BufferPtr[Index - Count];
-  }
+  // MU_CHANGE [BEGIN]: Fix VS22 17.14 memcpy substitution
+  // for (Index = (INTN)(Size + Count - 1); Index >= (INTN)Pos; Index--) {
+  //   BufferPtr[Index] = BufferPtr[Index - Count];
+  // }
+  CopyMem (&BufferPtr[Pos + Count], &BufferPtr[Pos], Size - Pos);
+  // MU_CHANGE [END]: Fix VS22 17.14 memcpy substitution
 
   //
   // add the buffer
   //
-  for (Index = (INTN)0; Index < (INTN)Count; Index++) {
-    BufferPtr[Index + Pos] = AddBuffer[Index];
-  }
+  // MU_CHANGE [BEGIN]: Fix VS22 17.14 memcpy substitution
+  // for (Index = (INTN)0; Index < (INTN)Count; Index++) {
+  //   BufferPtr[Index + Pos] = AddBuffer[Index];
+  // }
+  CopyMem (&BufferPtr[Pos], AddBuffer, Count);
+  // MU_CHANGE [END]: Fix VS22 17.14 memcpy substitution
 
   Size += Count;
 

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/HexEdit/BufferImage.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/HexEdit/BufferImage.c
@@ -143,9 +143,9 @@ HBufferImageBackup (
   )
 {
   // MU_CHANGE [BEGIN]: Fix VS22 17.14 memcpy substitution
-  HBufferImageBackupVar.MousePosition = HBufferImage.MousePosition;
+  // HBufferImageBackupVar.MousePosition = HBufferImage.MousePosition;
 
-  HBufferImageBackupVar.BufferPosition = HBufferImage.BufferPosition;
+  // HBufferImageBackupVar.BufferPosition = HBufferImage.BufferPosition;
   CopyMem (&HBufferImageBackupVar.MousePosition, &HBufferImage.MousePosition, sizeof (HBufferImage.MousePosition));
   CopyMem (&HBufferImageBackupVar.BufferPosition, &HBufferImage.BufferPosition, sizeof (HBufferImage.BufferPosition));
   // MU_CHANGE [END]: Fix VS22 17.14 memcpy substitution


### PR DESCRIPTION
## Description

The latest VS2022 update replaces some code patterns with struct assignments with `memcpy`. This change convert the code to explicitly use `CopyMem`.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

- VS22 17.14.2 build before and after the changes

## Integration Instructions

N/A