### PR TITLE
NVME: Fix an issue with zero-sized queue allocation

### DIFF
--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressHci.c
@@ -1173,8 +1173,10 @@ NvmeControllerInit (
   // Set admin queue entry size to default
   // Note we are using the spec-defined minimum SQES and CQES here.
   //
-  Private->SqData[0].EntrySize = NVME_IOSQES_MIN;
-  Private->CqData[0].EntrySize = NVME_IOCQES_MIN;
+  Private->SqData[0].EntrySize       = NVME_IOSQES_MIN;
+  Private->SqData[0].NumberOfEntries = Aqa.Asqs;
+  Private->CqData[0].EntrySize       = NVME_IOCQES_MIN;
+  Private->CqData[0].NumberOfEntries = Aqa.Acqs;
 
   // Calculate the number of pages required for the admin queues
   AdminQueuePairPageCount = NVME_SQ_SIZE_IN_PAGES (Private, 0) + NVME_CQ_SIZE_IN_PAGES (Private, 0);


### PR DESCRIPTION
## Description

The calculation to determine `AdminQueuePairPageCount` results in a zero page count due Submission Queue and Completion Queue NumberOfEntries fields not being initialized. On some systems, this request for a zero page allocation causes the `PciIo->AllocateBuffer()` call to fail with `EFI_INVALID_PARAMETER` which results in failure to properly initialize the NVME driver and prevents NVME functioning.

This PR adds initialization of the relevant fields from the NVME Admin Queue Attributes to ensure that `AdminQueuePairPageCount` is properly initialized to a non-zero value.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Prior to the change, can reproduce `EFI_INVALID_PARAMETER` return code from NvmeControllerInit. After the change, NVME initializes as expected and storage can be used to boot the OS.

## Integration Instructions

N/A
