### PR TITLE
[SQUASH ON REBASE] MdeModulePkg: Fix macros to convert bytes to pages

### DIFF
--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.h
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.h
@@ -105,10 +105,10 @@ extern EFI_DRIVER_SUPPORTED_EFI_VERSION_PROTOCOL  gNvmExpressDriverSupportedEfiV
 // The Indices are the same as above, 0 for admin, 1 for blocking I/O, 2 for async I/O.
 //
 #define NVME_SQ_SIZE_IN_PAGES(ControllerPointer, Index) \
-  ((ControllerPointer)->SqData[(Index)].NumberOfEntries * (UINTN)LShiftU64 (2, (ControllerPointer)->SqData[(Index)].EntrySize))
+  EFI_SIZE_TO_PAGES(((ControllerPointer)->SqData[(Index)].NumberOfEntries * (UINTN)LShiftU64 (2, (ControllerPointer)->SqData[(Index)].EntrySize)))
 
 #define NVME_CQ_SIZE_IN_PAGES(ControllerPointer, Index) \
-  ((ControllerPointer)->CqData[(Index)].NumberOfEntries * (UINTN)LShiftU64 (2, (ControllerPointer)->CqData[(Index)].EntrySize))
+  EFI_SIZE_TO_PAGES(((ControllerPointer)->CqData[(Index)].NumberOfEntries * (UINTN)LShiftU64 (2, (ControllerPointer)->CqData[(Index)].EntrySize)))
 
 // MU_CHANGE [END] - Allocate IO Queue Buffer
 


### PR DESCRIPTION
## Description

Fix a bug introduced in https://github.com/microsoft/mu_basecore/commit/1aa501c37194d2fb4d1ad627a19ab9d7093a16ae

When adding the macro for calculating queue sizes, the EFI_SIZE_TO_PAGES conversion was left out. 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Tested in 202405 CI

## Integration Instructions

N/A