### PR TITLE
[SQUASH ON REBASE] Revert basetool MU changes

### DIFF
--- a/BaseTools/Source/C/GenFw/GenFw.c
+++ b/BaseTools/Source/C/GenFw/GenFw.c
@@ -1141,7 +1141,7 @@ Returns:
   UINT32                           OutputFileLength;
   UINT8                            *InputFileBuffer;
   UINT32                           InputFileLength;
-  PD_RUNTIME_FUNCTION              *RuntimeFunction;  // MU_CHANGE: Resolve definition conflict for ARM
+  RUNTIME_FUNCTION                 *RuntimeFunction;
   UNWIND_INFO                      *UnwindInfo;
   STATUS                           Status;
   BOOLEAN                          ReplaceFlag;
@@ -2555,10 +2555,8 @@ Returns:
               //
               memset (SectionHeader->Name, 0, sizeof (SectionHeader->Name));
 
-              // MU_CHANGE Starts: Resolve definition conflict for ARM
-              RuntimeFunction = (PD_RUNTIME_FUNCTION *)(FileBuffer + SectionHeader->PointerToRawData);
-              for (Index1 = 0; Index1 < Optional64->DataDirectory[EFI_IMAGE_DIRECTORY_ENTRY_EXCEPTION].Size / sizeof (PD_RUNTIME_FUNCTION); Index1++, RuntimeFunction++) {
-              // MU_CHANGE Ends
+              RuntimeFunction = (RUNTIME_FUNCTION *)(FileBuffer + SectionHeader->PointerToRawData);
+              for (Index1 = 0; Index1 < Optional64->DataDirectory[EFI_IMAGE_DIRECTORY_ENTRY_EXCEPTION].Size / sizeof (RUNTIME_FUNCTION); Index1++, RuntimeFunction++) {
                 SectionHeader = (EFI_IMAGE_SECTION_HEADER *) ((UINT8 *) &(PeHdr->Pe32.OptionalHeader) + PeHdr->Pe32.FileHeader.SizeOfOptionalHeader);
                 for (Index2 = 0; Index2 < PeHdr->Pe32.FileHeader.NumberOfSections; Index2++, SectionHeader++) {
                   if (RuntimeFunction->UnwindInfoAddress >= SectionHeader->VirtualAddress && RuntimeFunction->UnwindInfoAddress < (SectionHeader->VirtualAddress + SectionHeader->SizeOfRawData)) {
@@ -2570,7 +2568,7 @@ Returns:
                     break;
                   }
                 }
-                memset (RuntimeFunction, 0, sizeof (PD_RUNTIME_FUNCTION)); // MU_CHANGE: Resolve definition conflict for ARM
+                memset (RuntimeFunction, 0, sizeof (RUNTIME_FUNCTION));
               }
               //
               // Zero Exception Table

--- a/BaseTools/Source/C/Makefiles/header.makefile
+++ b/BaseTools/Source/C/Makefiles/header.makefile
@@ -54,13 +54,11 @@ AS ?= $(CLANG_BIN)clang
 AR ?= $(CLANG_BIN)llvm-ar
 LD ?= $(CLANG_BIN)llvm-ld
 else ifeq ($(origin CC),default)
-# MU_CHANGE STARTs: Support GCC prefix
-CC ?= $(GCC_PREFIX)gcc
-CXX ?= $(GCC_PREFIX)g++
-AS ?= $(GCC_PREFIX)gcc
-AR ?= $(GCC_PREFIX)ar
-LD ?= $(GCC_PREFIX)ld
-# MU_CHANGE ENDs
+CC = $(GCC_PREFIX)gcc
+CXX = $(GCC_PREFIX)g++
+AS = $(GCC_PREFIX)gcc
+AR = $(GCC_PREFIX)ar
+LD = $(GCC_PREFIX)ld
 endif
 LINKER ?= $(CC)
 ifeq ($(HOST_ARCH), IA32)

--- a/BaseTools/Source/C/Makefiles/ms.common
+++ b/BaseTools/Source/C/Makefiles/ms.common
@@ -69,15 +69,6 @@ SYS_LIB_PATH = $(EDK_TOOLS_PATH)\Lib\Win64
 # Note: These are bit-width conversion related warning suppressions.
 CFLAGS = $(CFLAGS) /wd4267 /wd4244 /wd4334
 
-# MU_CHANGE Starts: Adding support to build base tools for ARM
-!ELSEIF "$(HOST_ARCH)"=="ARM"
-ARCH_INCLUDE = $(EDK2_PATH)\MdePkg\Include\Arm
-BIN_PATH     = $(BASE_TOOLS_PATH)\Bin\Win32
-LIB_PATH     = $(BASE_TOOLS_PATH)\Lib\Win32
-SYS_BIN_PATH = $(EDK_TOOLS_PATH)\Bin\Win32
-SYS_LIB_PATH = $(EDK_TOOLS_PATH)\Lib\Win32
-# MU_CHANGE Ends
-
 !ELSE
 !ERROR "Bad HOST_ARCH"
 !ENDIF

--- a/BaseTools/Source/C/Makefiles/ms.common
+++ b/BaseTools/Source/C/Makefiles/ms.common
@@ -69,23 +69,13 @@ SYS_LIB_PATH = $(EDK_TOOLS_PATH)\Lib\Win64
 # Note: These are bit-width conversion related warning suppressions.
 CFLAGS = $(CFLAGS) /wd4267 /wd4244 /wd4334
 
-# MU_CHANGE Starts: Adding support to build base tools for ARM and AARCH64
+# MU_CHANGE Starts: Adding support to build base tools for ARM
 !ELSEIF "$(HOST_ARCH)"=="ARM"
 ARCH_INCLUDE = $(EDK2_PATH)\MdePkg\Include\Arm
 BIN_PATH     = $(BASE_TOOLS_PATH)\Bin\Win32
 LIB_PATH     = $(BASE_TOOLS_PATH)\Lib\Win32
 SYS_BIN_PATH = $(EDK_TOOLS_PATH)\Bin\Win32
 SYS_LIB_PATH = $(EDK_TOOLS_PATH)\Lib\Win32
-!ELSEIF "$(HOST_ARCH)"=="AARCH64"
-ARCH_INCLUDE = $(EDK2_PATH)\MdePkg\Include\AArch64
-BIN_PATH     = $(BASE_TOOLS_PATH)\Bin\Win64
-LIB_PATH     = $(BASE_TOOLS_PATH)\Lib\Win64
-SYS_BIN_PATH = $(EDK_TOOLS_PATH)\Bin\Win64
-SYS_LIB_PATH = $(EDK_TOOLS_PATH)\Lib\Win64
-# Note: These are bit-width conversion related warning suppressions we carry to avoid much more
-#       overrides in the C code. The future plan is to replace all of these binary based tools
-#       with python scripts, when it happens in tianocore..
-CFLAGS = $(CFLAGS) /wd4267 /wd4244 /wd4334
 # MU_CHANGE Ends
 
 !ELSE

--- a/MdePkg/Include/IndustryStandard/PeImage.h
+++ b/MdePkg/Include/IndustryStandard/PeImage.h
@@ -700,7 +700,7 @@ typedef struct {
   UINT32    FunctionStartAddress;
   UINT32    FunctionEndAddress;
   UINT32    UnwindInfoAddress;
-} PD_RUNTIME_FUNCTION; // MU_CHANGE: Resolve definition conflict in winnt.h for ARM target.
+} RUNTIME_FUNCTION;
 
 typedef struct {
   UINT8    Version             : 3;


### PR DESCRIPTION
## Description

This change reverts 3 commits from last Project MU release branch because they are already upstreamed to EDK2.

The double change is causing the CC and other tools not picking up the intended compiler when doing cross compilation, producing binaries that is the same as the host system instead of target system.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

This change was tested on Linux ARM system and verified functional.

## Integration Instructions

N/A