### PR TITLE
[CHERRY-PICK] MdeModulePkg/FaultTolerantWriteDxe: Add validation for FtwWorkSpaceHeader

### DIFF
--- a/MdeModulePkg/Universal/FaultTolerantWriteDxe/FtwMisc.c
+++ b/MdeModulePkg/Universal/FaultTolerantWriteDxe/FtwMisc.c
@@ -1300,7 +1300,14 @@ InitFtwProtocol (
   // Refresh the working space data from working block
   //
   Status = WorkSpaceRefresh (FtwDevice);
-  ASSERT_EFI_ERROR (Status);
+  // MU_CHANGE [BEGIN]: Add validation for FtwWorkSpaceHeader within WorkSpaceRefresh()
+  // ASSERT_EFI_ERROR (Status);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Ftw: Init.. WorkSpaceRefresh failed: Status = %r\n", Status));
+  }
+
+  // MU_CHANGE [END]: Add validation for FtwWorkSpaceHeader within WorkSpaceRefresh()
+
   //
   // If the working block workspace is not valid, try the spare block
   //

--- a/MdeModulePkg/Universal/FaultTolerantWriteDxe/UpdateWorkingBlock.c
+++ b/MdeModulePkg/Universal/FaultTolerantWriteDxe/UpdateWorkingBlock.c
@@ -286,6 +286,13 @@ WorkSpaceRefresh (
     return EFI_ABORTED;
   }
 
+  // MU_CHANGE [BEGIN]: Add validation for FtwWorkSpaceHeader within WorkSpaceRefresh()
+  if (!IsValidWorkSpace (FtwDevice->FtwWorkSpaceHeader)) {
+    return EFI_ABORTED;
+  }
+
+  // MU_CHANGE [END]: Add validation for FtwWorkSpaceHeader within WorkSpaceRefresh()
+
   //
   // Refresh the FtwLastWriteHeader
   //


### PR DESCRIPTION
## Description

Fixes #1371

Add validation for FtwWorkSpaceHeader within the WorkSpaceRefresh() function to address an issue where the variable store cannot recover from the FTW spare block if the variable store is erased or corrupted during an FTW write or reclaim operation.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Flash UEFI with the corrupted variable store dumped from the failed device. The device should boot successfully and recover the variable store from the FTW spare block. 
No regressions observed.

## Integration Instructions

N/A

(cherry picked from mu basecore commit 7afb1e31517294fd91d6db564f87a5b0fa5a5430)