### PR TITLE
[CHERRY-PICK] NetworkPkg/HttpBootDxe: Wait for IPv6 DAD before issuing DHCPv6 requests

### DIFF
--- a/NetworkPkg/HttpBootDxe/HttpBootDhcp6.h
+++ b/NetworkPkg/HttpBootDxe/HttpBootDhcp6.h
@@ -16,6 +16,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define HTTP_BOOT_IP6_ROUTE_TABLE_TIMEOUT  10
 #define HTTP_BOOT_DEFAULT_HOPLIMIT         64
 #define HTTP_BOOT_DEFAULT_LIFETIME         50000
+#define HTTP_BOOT_DAD_ADDITIONAL_DELAY     30000000   // 3 seconds
 
 #define HTTP_BOOT_DHCP6_ENTERPRISE_NUM      343     // TODO: IANA TBD: temporarily using Intel's
 #define HTTP_BOOT_DHCP6_MAX_BOOT_FILE_SIZE  65535   //   It's a limitation of bit length, 65535*512 bytes.


### PR DESCRIPTION
## Description
This is cherry-picked from EDK2 [11f1d28bcb8553af9c689ec121c191a258e6f01a ](https://github.com/tianocore/edk2/commit/11f1d28bcb8553af9c689ec121c191a258e6f01a)

Align HTTP Boot behavior with PXE by inserting a delay to wait for IPv6 Duplicate Address Detection (DAD) to complete before issuing DHCPv6 requests. This avoids EFI_NO_MAPPING errors caused by early DHCP attempts before a valid IPv6 address is ready.

Problem:
On some platforms, HTTP boot over IPv6 fails with EFI_NO_MAPPING during initial DHCPv6 attempts. The failure is due to the system trying to send Solicit messages before IPv6 DAD finishes, resulting in no usable IP address at that time.

Solution:
Insert a retry mechanism to poll DAD completion when the initial call to Dhcp6->Start() fails with EFI_NO_MAPPING. This behavior mirrors PXE's handling, where it waits for a valid IPv6 address to be assigned before retrying the DHCPv6 flow.


For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Tested on system with HTTP IPV6 boot enabled and boot successfully.
## Integration Instructions

This is cherry-picked from EDK2 [11f1d28bcb8553af9c689ec121c191a258e6f01a ](https://github.com/tianocore/edk2/commit/11f1d28bcb8553af9c689ec121c191a258e6f01a)
