### PR TITLE
[CHERRY-PICK] NetworkPkg: Update to make IPv6 prefix length 128 will not be excluded

### DIFF
--- a/NetworkPkg/Ip6Dxe/Ip6Icmp.c
+++ b/NetworkPkg/Ip6Dxe/Ip6Icmp.c
@@ -467,14 +467,14 @@ Ip6GetPrefix (
   UINT8  Mask;
   UINT8  Value;
 
-  ASSERT ((Prefix != NULL) && (PrefixLength < IP6_PREFIX_MAX));
+  ASSERT ((Prefix != NULL) && (PrefixLength <= IP6_PREFIX_MAX));
 
   if (PrefixLength == 0) {
     ZeroMem (Prefix, sizeof (EFI_IPv6_ADDRESS));
     return;
   }
 
-  if (PrefixLength >= IP6_PREFIX_MAX) {
+  if (PrefixLength > IP6_PREFIX_MAX) {
     return;
   }
 

--- a/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
+++ b/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
@@ -838,7 +838,7 @@ NetIp6IsNetEqual (
   UINT8  Bit;
   UINT8  Mask;
 
-  ASSERT ((Ip1 != NULL) && (Ip2 != NULL) && (PrefixLength < IP6_PREFIX_MAX));
+  ASSERT ((Ip1 != NULL) && (Ip2 != NULL) && (PrefixLength <= IP6_PREFIX_MAX));
 
   if (PrefixLength == 0) {
     return TRUE;


### PR DESCRIPTION
## Description

When the length of IPv6 prefix is 128, the if and ASSERT statement incorrectly exclude the case when it equals 128. This value should be included.

Update to make sure the length of IPv6 prefix is 128 will not be excluded.
- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Setup IPv6 PXE server and connect with DUT, IPv6 PXE boot of DUT should not be blocked if IPv6 prefix length is 128.

## Integration Instructions

N/A
(cherry picked from commit a80e7c061e7b731587a08436a51b9416f9c87888)
