### PR TITLE
Update SnpDxe for alignment fault issue

### DIFF
--- a/NetworkPkg/SnpDxe/Get_status.c
+++ b/NetworkPkg/SnpDxe/Get_status.c
@@ -40,47 +40,47 @@ PxeGetStatus (
 
   Tmp             = NULL;
   Db              = Snp->Db;
-  Snp->Cdb.OpCode = PXE_OPCODE_GET_STATUS;
+  Snp->Cdb->OpCode = PXE_OPCODE_GET_STATUS;
 
-  Snp->Cdb.OpFlags = 0;
+  Snp->Cdb->OpFlags = 0;
 
   if (GetTransmittedBuf) {
-    Snp->Cdb.OpFlags |= PXE_OPFLAGS_GET_TRANSMITTED_BUFFERS;
+    Snp->Cdb->OpFlags |= PXE_OPFLAGS_GET_TRANSMITTED_BUFFERS;
     ZeroMem (Db->TxBuffer, sizeof (Db->TxBuffer));
   }
 
   if (InterruptStatusPtr != NULL) {
-    Snp->Cdb.OpFlags |= PXE_OPFLAGS_GET_INTERRUPT_STATUS;
+    Snp->Cdb->OpFlags |= PXE_OPFLAGS_GET_INTERRUPT_STATUS;
   }
 
   if (Snp->MediaStatusSupported) {
-    Snp->Cdb.OpFlags |= PXE_OPFLAGS_GET_MEDIA_STATUS;
+    Snp->Cdb->OpFlags |= PXE_OPFLAGS_GET_MEDIA_STATUS;
   }
 
-  Snp->Cdb.CPBsize = PXE_CPBSIZE_NOT_USED;
-  Snp->Cdb.CPBaddr = PXE_CPBADDR_NOT_USED;
+  Snp->Cdb->CPBsize = PXE_CPBSIZE_NOT_USED;
+  Snp->Cdb->CPBaddr = PXE_CPBADDR_NOT_USED;
 
-  Snp->Cdb.DBsize = (UINT16)sizeof (PXE_DB_GET_STATUS);
-  Snp->Cdb.DBaddr = (UINT64)(UINTN)Db;
+  Snp->Cdb->DBsize = (UINT16)sizeof (PXE_DB_GET_STATUS);
+  Snp->Cdb->DBaddr = (UINT64)(UINTN)Db;
 
-  Snp->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  Snp->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  Snp->Cdb.IFnum     = Snp->IfNum;
-  Snp->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  Snp->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  Snp->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  Snp->Cdb->IFnum     = Snp->IfNum;
+  Snp->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   //
   // Issue UNDI command and check result.
   //
   DEBUG ((DEBUG_NET, "\nSnp->undi.get_status()  "));
 
-  (*Snp->IssueUndi32Command)((UINT64)(UINTN)&Snp->Cdb);
+  (*Snp->IssueUndi32Command)((UINT64)(UINTN)Snp->Cdb);
 
-  if (Snp->Cdb.StatCode != PXE_STATCODE_SUCCESS) {
+  if (Snp->Cdb->StatCode != PXE_STATCODE_SUCCESS) {
     DEBUG (
       (DEBUG_NET,
        "\nSnp->undi.get_status()  %xh:%xh\n",
-       Snp->Cdb.StatFlags,
-       Snp->Cdb.StatCode)
+       Snp->Cdb->StatFlags,
+       Snp->Cdb->StatCode)
       );
 
     return EFI_DEVICE_ERROR;
@@ -90,7 +90,7 @@ PxeGetStatus (
   // report the values back..
   //
   if (InterruptStatusPtr != NULL) {
-    InterruptFlags = (UINT16)(Snp->Cdb.StatFlags & PXE_STATFLAGS_GET_STATUS_INTERRUPT_MASK);
+    InterruptFlags = (UINT16)(Snp->Cdb->StatFlags & PXE_STATFLAGS_GET_STATUS_INTERRUPT_MASK);
 
     *InterruptStatusPtr = 0;
 
@@ -112,7 +112,7 @@ PxeGetStatus (
   }
 
   if (GetTransmittedBuf) {
-    if ((Snp->Cdb.StatFlags & PXE_STATFLAGS_GET_STATUS_NO_TXBUFS_WRITTEN) == 0) {
+    if ((Snp->Cdb->StatFlags & PXE_STATFLAGS_GET_STATUS_NO_TXBUFS_WRITTEN) == 0) {
       //
       // UNDI has written some transmitted buffer addresses into the DB. Store them into Snp->RecycledTxBuf.
       //
@@ -150,7 +150,7 @@ PxeGetStatus (
   //
   if (Snp->MediaStatusSupported) {
     Snp->Snp.Mode->MediaPresent =
-      (BOOLEAN)(((Snp->Cdb.StatFlags & PXE_STATFLAGS_GET_STATUS_NO_MEDIA) != 0) ? FALSE : TRUE);
+      (BOOLEAN)(((Snp->Cdb->StatFlags & PXE_STATFLAGS_GET_STATUS_NO_MEDIA) != 0) ? FALSE : TRUE);
   }
 
   return EFI_SUCCESS;

--- a/NetworkPkg/SnpDxe/Initialize.c
+++ b/NetworkPkg/SnpDxe/Initialize.c
@@ -76,41 +76,41 @@ PxeInit (
 
   Cpb->LoopBackMode = LOOPBACK_NORMAL;
 
-  Snp->Cdb.OpCode  = PXE_OPCODE_INITIALIZE;
-  Snp->Cdb.OpFlags = CableDetectFlag;
+  Snp->Cdb->OpCode  = PXE_OPCODE_INITIALIZE;
+  Snp->Cdb->OpFlags = CableDetectFlag;
 
-  Snp->Cdb.CPBsize = (UINT16)sizeof (PXE_CPB_INITIALIZE);
-  Snp->Cdb.DBsize  = (UINT16)sizeof (PXE_DB_INITIALIZE);
+  Snp->Cdb->CPBsize = (UINT16)sizeof (PXE_CPB_INITIALIZE);
+  Snp->Cdb->DBsize  = (UINT16)sizeof (PXE_DB_INITIALIZE);
 
-  Snp->Cdb.CPBaddr = (UINT64)(UINTN)Snp->Cpb;
-  Snp->Cdb.DBaddr  = (UINT64)(UINTN)Snp->Db;
+  Snp->Cdb->CPBaddr = (UINT64)(UINTN)Snp->Cpb;
+  Snp->Cdb->DBaddr  = (UINT64)(UINTN)Snp->Db;
 
-  Snp->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  Snp->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  Snp->Cdb.IFnum     = Snp->IfNum;
-  Snp->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  Snp->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  Snp->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  Snp->Cdb->IFnum     = Snp->IfNum;
+  Snp->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   DEBUG ((DEBUG_NET, "\nSnp->undi.initialize()  "));
 
-  (*Snp->IssueUndi32Command)((UINT64)(UINTN)&Snp->Cdb);
+  (*Snp->IssueUndi32Command)((UINT64)(UINTN)Snp->Cdb);
 
   //
   // There are two fields need to be checked here:
-  // First is the upper two bits (14 & 15) in the CDB.StatFlags field. Until these bits change to report
+  // First is the upper two bits (14 & 15) in the Cdb->StatFlags field. Until these bits change to report
   // PXE_STATFLAGS_COMMAND_COMPLETE or PXE_STATFLAGS_COMMAND_FAILED, the command has not been executed by the UNDI.
-  // Second is the CDB.StatCode field. After command execution completes, either successfully or not,
-  // the CDB.StatCode field contains the result of the command execution.
+  // Second is the Cdb->StatCode field. After command execution completes, either successfully or not,
+  // the Cdb->StatCode field contains the result of the command execution.
   //
-  if ((((Snp->Cdb.StatFlags) & PXE_STATFLAGS_STATUS_MASK) == PXE_STATFLAGS_COMMAND_COMPLETE) &&
-      (Snp->Cdb.StatCode == PXE_STATCODE_SUCCESS))
+  if ((((Snp->Cdb->StatFlags) & PXE_STATFLAGS_STATUS_MASK) == PXE_STATFLAGS_COMMAND_COMPLETE) &&
+      (Snp->Cdb->StatCode == PXE_STATCODE_SUCCESS))
   {
     //
-    // If cable detect feature is enabled in CDB.OpFlags, check the CDB.StatFlags to see if there is an
+    // If cable detect feature is enabled in Cdb->OpFlags, check the Cdb->StatFlags to see if there is an
     // active connection to this network device. If the no media StatFlag is set, the UNDI and network
     // device are still initialized.
     //
     if (CableDetectFlag == PXE_OPFLAGS_INITIALIZE_DETECT_CABLE) {
-      if (((Snp->Cdb.StatFlags) & PXE_STATFLAGS_INITIALIZED_NO_MEDIA) != PXE_STATFLAGS_INITIALIZED_NO_MEDIA) {
+      if (((Snp->Cdb->StatFlags) & PXE_STATFLAGS_INITIALIZED_NO_MEDIA) != PXE_STATFLAGS_INITIALIZED_NO_MEDIA) {
         Snp->Mode.MediaPresent = TRUE;
       } else {
         Snp->Mode.MediaPresent = FALSE;
@@ -123,8 +123,8 @@ PxeInit (
     DEBUG (
       (DEBUG_WARN,
        "\nSnp->undi.initialize()  %xh:%xh\n",
-       Snp->Cdb.StatFlags,
-       Snp->Cdb.StatCode)
+       Snp->Cdb->StatFlags,
+       Snp->Cdb->StatCode)
       );
 
     if (Snp->TxRxBuffer != NULL) {

--- a/NetworkPkg/SnpDxe/Mcast_ip_to_mac.c
+++ b/NetworkPkg/SnpDxe/Mcast_ip_to_mac.c
@@ -37,18 +37,18 @@ PxeIp2Mac (
 
   Cpb              = Snp->Cpb;
   Db               = Snp->Db;
-  Snp->Cdb.OpCode  = PXE_OPCODE_MCAST_IP_TO_MAC;
-  Snp->Cdb.OpFlags = (UINT16)(IPv6 ? PXE_OPFLAGS_MCAST_IPV6_TO_MAC : PXE_OPFLAGS_MCAST_IPV4_TO_MAC);
-  Snp->Cdb.CPBsize = (UINT16)sizeof (PXE_CPB_MCAST_IP_TO_MAC);
-  Snp->Cdb.DBsize  = (UINT16)sizeof (PXE_DB_MCAST_IP_TO_MAC);
+  Snp->Cdb->OpCode  = PXE_OPCODE_MCAST_IP_TO_MAC;
+  Snp->Cdb->OpFlags = (UINT16)(IPv6 ? PXE_OPFLAGS_MCAST_IPV6_TO_MAC : PXE_OPFLAGS_MCAST_IPV4_TO_MAC);
+  Snp->Cdb->CPBsize = (UINT16)sizeof (PXE_CPB_MCAST_IP_TO_MAC);
+  Snp->Cdb->DBsize  = (UINT16)sizeof (PXE_DB_MCAST_IP_TO_MAC);
 
-  Snp->Cdb.CPBaddr = (UINT64)(UINTN)Cpb;
-  Snp->Cdb.DBaddr  = (UINT64)(UINTN)Db;
+  Snp->Cdb->CPBaddr = (UINT64)(UINTN)Cpb;
+  Snp->Cdb->DBaddr  = (UINT64)(UINTN)Db;
 
-  Snp->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  Snp->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  Snp->Cdb.IFnum     = Snp->IfNum;
-  Snp->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  Snp->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  Snp->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  Snp->Cdb->IFnum     = Snp->IfNum;
+  Snp->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   CopyMem (&Cpb->IP, IP, sizeof (PXE_IP_ADDR));
 
@@ -57,9 +57,9 @@ PxeIp2Mac (
   //
   DEBUG ((DEBUG_NET, "\nSnp->undi.mcast_ip_to_mac()  "));
 
-  (*Snp->IssueUndi32Command)((UINT64)(UINTN)&Snp->Cdb);
+  (*Snp->IssueUndi32Command)((UINT64)(UINTN)Snp->Cdb);
 
-  switch (Snp->Cdb.StatCode) {
+  switch (Snp->Cdb->StatCode) {
     case PXE_STATCODE_SUCCESS:
       break;
 
@@ -70,8 +70,8 @@ PxeIp2Mac (
       DEBUG (
         (DEBUG_NET,
          "\nSnp->undi.mcast_ip_to_mac()  %xh:%xh\n",
-         Snp->Cdb.StatFlags,
-         Snp->Cdb.StatCode)
+         Snp->Cdb->StatFlags,
+         Snp->Cdb->StatCode)
         );
       return EFI_UNSUPPORTED;
 
@@ -83,8 +83,8 @@ PxeIp2Mac (
       DEBUG (
         (DEBUG_NET,
          "\nSnp->undi.mcast_ip_to_mac()  %xh:%xh\n",
-         Snp->Cdb.StatFlags,
-         Snp->Cdb.StatCode)
+         Snp->Cdb->StatFlags,
+         Snp->Cdb->StatCode)
         );
 
       return EFI_DEVICE_ERROR;

--- a/NetworkPkg/SnpDxe/Nvdata.c
+++ b/NetworkPkg/SnpDxe/Nvdata.c
@@ -34,29 +34,29 @@ PxeNvDataRead (
   PXE_DB_NVDATA  *Db;
 
   Db              = Snp->Db;
-  Snp->Cdb.OpCode = PXE_OPCODE_NVDATA;
+  Snp->Cdb->OpCode = PXE_OPCODE_NVDATA;
 
-  Snp->Cdb.OpFlags = PXE_OPFLAGS_NVDATA_READ;
+  Snp->Cdb->OpFlags = PXE_OPFLAGS_NVDATA_READ;
 
-  Snp->Cdb.CPBsize = PXE_CPBSIZE_NOT_USED;
-  Snp->Cdb.CPBaddr = PXE_CPBADDR_NOT_USED;
+  Snp->Cdb->CPBsize = PXE_CPBSIZE_NOT_USED;
+  Snp->Cdb->CPBaddr = PXE_CPBADDR_NOT_USED;
 
-  Snp->Cdb.DBsize = (UINT16)sizeof (PXE_DB_NVDATA);
-  Snp->Cdb.DBaddr = (UINT64)(UINTN)Db;
+  Snp->Cdb->DBsize = (UINT16)sizeof (PXE_DB_NVDATA);
+  Snp->Cdb->DBaddr = (UINT64)(UINTN)Db;
 
-  Snp->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  Snp->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  Snp->Cdb.IFnum     = Snp->IfNum;
-  Snp->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  Snp->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  Snp->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  Snp->Cdb->IFnum     = Snp->IfNum;
+  Snp->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   //
   // Issue UNDI command and check result.
   //
   DEBUG ((DEBUG_NET, "\nsnp->undi.nvdata ()  "));
 
-  (*Snp->IssueUndi32Command)((UINT64)(UINTN)&Snp->Cdb);
+  (*Snp->IssueUndi32Command)((UINT64)(UINTN)Snp->Cdb);
 
-  switch (Snp->Cdb.StatCode) {
+  switch (Snp->Cdb->StatCode) {
     case PXE_STATCODE_SUCCESS:
       break;
 
@@ -64,8 +64,8 @@ PxeNvDataRead (
       DEBUG (
         (DEBUG_NET,
          "\nsnp->undi.nvdata()  %xh:%xh\n",
-         Snp->Cdb.StatFlags,
-         Snp->Cdb.StatCode)
+         Snp->Cdb->StatFlags,
+         Snp->Cdb->StatCode)
         );
 
       return EFI_UNSUPPORTED;
@@ -74,8 +74,8 @@ PxeNvDataRead (
       DEBUG (
         (DEBUG_NET,
          "\nsnp->undi.nvdata()  %xh:%xh\n",
-         Snp->Cdb.StatFlags,
-         Snp->Cdb.StatCode)
+         Snp->Cdb->StatFlags,
+         Snp->Cdb->StatCode)
         );
 
       return EFI_DEVICE_ERROR;

--- a/NetworkPkg/SnpDxe/Receive.c
+++ b/NetworkPkg/SnpDxe/Receive.c
@@ -58,28 +58,28 @@ PxeReceive (
 
   Cpb->reserved = 0;
 
-  Snp->Cdb.OpCode  = PXE_OPCODE_RECEIVE;
-  Snp->Cdb.OpFlags = PXE_OPFLAGS_NOT_USED;
+  Snp->Cdb->OpCode  = PXE_OPCODE_RECEIVE;
+  Snp->Cdb->OpFlags = PXE_OPFLAGS_NOT_USED;
 
-  Snp->Cdb.CPBsize = (UINT16)sizeof (PXE_CPB_RECEIVE);
-  Snp->Cdb.CPBaddr = (UINT64)(UINTN)Cpb;
+  Snp->Cdb->CPBsize = (UINT16)sizeof (PXE_CPB_RECEIVE);
+  Snp->Cdb->CPBaddr = (UINT64)(UINTN)Cpb;
 
-  Snp->Cdb.DBsize = (UINT16)sizeof (PXE_DB_RECEIVE);
-  Snp->Cdb.DBaddr = (UINT64)(UINTN)Db;
+  Snp->Cdb->DBsize = (UINT16)sizeof (PXE_DB_RECEIVE);
+  Snp->Cdb->DBaddr = (UINT64)(UINTN)Db;
 
-  Snp->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  Snp->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  Snp->Cdb.IFnum     = Snp->IfNum;
-  Snp->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  Snp->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  Snp->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  Snp->Cdb->IFnum     = Snp->IfNum;
+  Snp->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   //
   // Issue UNDI command and check result.
   //
   DEBUG ((DEBUG_NET, "\nsnp->undi.receive ()  "));
 
-  (*Snp->IssueUndi32Command)((UINT64)(UINTN)&Snp->Cdb);
+  (*Snp->IssueUndi32Command)((UINT64)(UINTN)Snp->Cdb);
 
-  switch (Snp->Cdb.StatCode) {
+  switch (Snp->Cdb->StatCode) {
     case PXE_STATCODE_SUCCESS:
       break;
 
@@ -87,8 +87,8 @@ PxeReceive (
       DEBUG (
         (DEBUG_NET,
          "\nsnp->undi.receive ()  %xh:%xh\n",
-         Snp->Cdb.StatFlags,
-         Snp->Cdb.StatCode)
+         Snp->Cdb->StatFlags,
+         Snp->Cdb->StatCode)
         );
 
       return EFI_NOT_READY;
@@ -97,8 +97,8 @@ PxeReceive (
       DEBUG (
         (DEBUG_ERROR,
          "\nsnp->undi.receive()  %xh:%xh\n",
-         Snp->Cdb.StatFlags,
-         Snp->Cdb.StatCode)
+         Snp->Cdb->StatFlags,
+         Snp->Cdb->StatCode)
         );
 
       return EFI_DEVICE_ERROR;

--- a/NetworkPkg/SnpDxe/Receive_filters.c
+++ b/NetworkPkg/SnpDxe/Receive_filters.c
@@ -32,41 +32,41 @@ PxeRecvFilterEnable (
   EFI_MAC_ADDRESS  *MCastAddressList
   )
 {
-  Snp->Cdb.OpCode    = PXE_OPCODE_RECEIVE_FILTERS;
-  Snp->Cdb.OpFlags   = PXE_OPFLAGS_RECEIVE_FILTER_ENABLE;
-  Snp->Cdb.CPBsize   = PXE_CPBSIZE_NOT_USED;
-  Snp->Cdb.DBsize    = PXE_DBSIZE_NOT_USED;
-  Snp->Cdb.CPBaddr   = PXE_CPBADDR_NOT_USED;
-  Snp->Cdb.DBaddr    = PXE_DBADDR_NOT_USED;
-  Snp->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  Snp->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  Snp->Cdb.IFnum     = Snp->IfNum;
-  Snp->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  Snp->Cdb->OpCode    = PXE_OPCODE_RECEIVE_FILTERS;
+  Snp->Cdb->OpFlags   = PXE_OPFLAGS_RECEIVE_FILTER_ENABLE;
+  Snp->Cdb->CPBsize   = PXE_CPBSIZE_NOT_USED;
+  Snp->Cdb->DBsize    = PXE_DBSIZE_NOT_USED;
+  Snp->Cdb->CPBaddr   = PXE_CPBADDR_NOT_USED;
+  Snp->Cdb->DBaddr    = PXE_DBADDR_NOT_USED;
+  Snp->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  Snp->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  Snp->Cdb->IFnum     = Snp->IfNum;
+  Snp->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   if ((EnableFlags & EFI_SIMPLE_NETWORK_RECEIVE_UNICAST) != 0) {
-    Snp->Cdb.OpFlags |= PXE_OPFLAGS_RECEIVE_FILTER_UNICAST;
+    Snp->Cdb->OpFlags |= PXE_OPFLAGS_RECEIVE_FILTER_UNICAST;
   }
 
   if ((EnableFlags & EFI_SIMPLE_NETWORK_RECEIVE_BROADCAST) != 0) {
-    Snp->Cdb.OpFlags |= PXE_OPFLAGS_RECEIVE_FILTER_BROADCAST;
+    Snp->Cdb->OpFlags |= PXE_OPFLAGS_RECEIVE_FILTER_BROADCAST;
   }
 
   if ((EnableFlags & EFI_SIMPLE_NETWORK_RECEIVE_PROMISCUOUS) != 0) {
-    Snp->Cdb.OpFlags |= PXE_OPFLAGS_RECEIVE_FILTER_PROMISCUOUS;
+    Snp->Cdb->OpFlags |= PXE_OPFLAGS_RECEIVE_FILTER_PROMISCUOUS;
   }
 
   if ((EnableFlags & EFI_SIMPLE_NETWORK_RECEIVE_PROMISCUOUS_MULTICAST) != 0) {
-    Snp->Cdb.OpFlags |= PXE_OPFLAGS_RECEIVE_FILTER_ALL_MULTICAST;
+    Snp->Cdb->OpFlags |= PXE_OPFLAGS_RECEIVE_FILTER_ALL_MULTICAST;
   }
 
   if ((EnableFlags & EFI_SIMPLE_NETWORK_RECEIVE_MULTICAST) != 0) {
-    Snp->Cdb.OpFlags |= PXE_OPFLAGS_RECEIVE_FILTER_FILTERED_MULTICAST;
+    Snp->Cdb->OpFlags |= PXE_OPFLAGS_RECEIVE_FILTER_FILTERED_MULTICAST;
   }
 
   if (MCastAddressCount != 0) {
-    Snp->Cdb.CPBsize = (UINT16)(MCastAddressCount * sizeof (EFI_MAC_ADDRESS));
-    Snp->Cdb.CPBaddr = (UINT64)(UINTN)Snp->Cpb;
-    CopyMem (Snp->Cpb, MCastAddressList, Snp->Cdb.CPBsize);
+    Snp->Cdb->CPBsize = (UINT16)(MCastAddressCount * sizeof (EFI_MAC_ADDRESS));
+    Snp->Cdb->CPBaddr = (UINT64)(UINTN)Snp->Cpb;
+    CopyMem (Snp->Cpb, MCastAddressList, Snp->Cdb->CPBsize);
   }
 
   //
@@ -74,20 +74,20 @@ PxeRecvFilterEnable (
   //
   DEBUG ((DEBUG_NET, "\nsnp->undi.receive_filters()  "));
 
-  (*Snp->IssueUndi32Command)((UINT64)(UINTN)&Snp->Cdb);
+  (*Snp->IssueUndi32Command)((UINT64)(UINTN)Snp->Cdb);
 
-  if (Snp->Cdb.StatCode != PXE_STATCODE_SUCCESS) {
+  if (Snp->Cdb->StatCode != PXE_STATCODE_SUCCESS) {
     //
     // UNDI command failed.  Return UNDI status to caller.
     //
     DEBUG (
       (DEBUG_ERROR,
        "\nsnp->undi.receive_filters()  %xh:%xh\n",
-       Snp->Cdb.StatFlags,
-       Snp->Cdb.StatCode)
+       Snp->Cdb->StatFlags,
+       Snp->Cdb->StatCode)
       );
 
-    switch (Snp->Cdb.StatCode) {
+    switch (Snp->Cdb->StatCode) {
       case PXE_STATCODE_INVALID_CDB:
       case PXE_STATCODE_INVALID_CPB:
       case PXE_STATCODE_INVALID_PARAMETER:
@@ -122,40 +122,40 @@ PxeRecvFilterDisable (
   BOOLEAN     ResetMCastList
   )
 {
-  Snp->Cdb.OpCode    = PXE_OPCODE_RECEIVE_FILTERS;
-  Snp->Cdb.CPBsize   = PXE_CPBSIZE_NOT_USED;
-  Snp->Cdb.DBsize    = PXE_DBSIZE_NOT_USED;
-  Snp->Cdb.CPBaddr   = PXE_CPBADDR_NOT_USED;
-  Snp->Cdb.DBaddr    = PXE_DBADDR_NOT_USED;
-  Snp->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  Snp->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  Snp->Cdb.IFnum     = Snp->IfNum;
-  Snp->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  Snp->Cdb->OpCode    = PXE_OPCODE_RECEIVE_FILTERS;
+  Snp->Cdb->CPBsize   = PXE_CPBSIZE_NOT_USED;
+  Snp->Cdb->DBsize    = PXE_DBSIZE_NOT_USED;
+  Snp->Cdb->CPBaddr   = PXE_CPBADDR_NOT_USED;
+  Snp->Cdb->DBaddr    = PXE_DBADDR_NOT_USED;
+  Snp->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  Snp->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  Snp->Cdb->IFnum     = Snp->IfNum;
+  Snp->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
-  Snp->Cdb.OpFlags = (UINT16)((DisableFlags != 0) ? PXE_OPFLAGS_RECEIVE_FILTER_DISABLE : PXE_OPFLAGS_NOT_USED);
+  Snp->Cdb->OpFlags = (UINT16)((DisableFlags != 0) ? PXE_OPFLAGS_RECEIVE_FILTER_DISABLE : PXE_OPFLAGS_NOT_USED);
 
   if (ResetMCastList) {
-    Snp->Cdb.OpFlags |= PXE_OPFLAGS_RECEIVE_FILTER_RESET_MCAST_LIST;
+    Snp->Cdb->OpFlags |= PXE_OPFLAGS_RECEIVE_FILTER_RESET_MCAST_LIST;
   }
 
   if ((DisableFlags & EFI_SIMPLE_NETWORK_RECEIVE_UNICAST) != 0) {
-    Snp->Cdb.OpFlags |= PXE_OPFLAGS_RECEIVE_FILTER_UNICAST;
+    Snp->Cdb->OpFlags |= PXE_OPFLAGS_RECEIVE_FILTER_UNICAST;
   }
 
   if ((DisableFlags & EFI_SIMPLE_NETWORK_RECEIVE_BROADCAST) != 0) {
-    Snp->Cdb.OpFlags |= PXE_OPFLAGS_RECEIVE_FILTER_BROADCAST;
+    Snp->Cdb->OpFlags |= PXE_OPFLAGS_RECEIVE_FILTER_BROADCAST;
   }
 
   if ((DisableFlags & EFI_SIMPLE_NETWORK_RECEIVE_PROMISCUOUS) != 0) {
-    Snp->Cdb.OpFlags |= PXE_OPFLAGS_RECEIVE_FILTER_PROMISCUOUS;
+    Snp->Cdb->OpFlags |= PXE_OPFLAGS_RECEIVE_FILTER_PROMISCUOUS;
   }
 
   if ((DisableFlags & EFI_SIMPLE_NETWORK_RECEIVE_PROMISCUOUS_MULTICAST) != 0) {
-    Snp->Cdb.OpFlags |= PXE_OPFLAGS_RECEIVE_FILTER_ALL_MULTICAST;
+    Snp->Cdb->OpFlags |= PXE_OPFLAGS_RECEIVE_FILTER_ALL_MULTICAST;
   }
 
   if ((DisableFlags & EFI_SIMPLE_NETWORK_RECEIVE_MULTICAST) != 0) {
-    Snp->Cdb.OpFlags |= PXE_OPFLAGS_RECEIVE_FILTER_FILTERED_MULTICAST;
+    Snp->Cdb->OpFlags |= PXE_OPFLAGS_RECEIVE_FILTER_FILTERED_MULTICAST;
   }
 
   //
@@ -163,17 +163,17 @@ PxeRecvFilterDisable (
   //
   DEBUG ((DEBUG_NET, "\nsnp->undi.receive_filters()  "));
 
-  (*Snp->IssueUndi32Command)((UINT64)(UINTN)&Snp->Cdb);
+  (*Snp->IssueUndi32Command)((UINT64)(UINTN)Snp->Cdb);
 
-  if (Snp->Cdb.StatCode != PXE_STATCODE_SUCCESS) {
+  if (Snp->Cdb->StatCode != PXE_STATCODE_SUCCESS) {
     //
     // UNDI command failed.  Return UNDI status to caller.
     //
     DEBUG (
       (DEBUG_ERROR,
        "\nsnp->undi.receive_filters()  %xh:%xh\n",
-       Snp->Cdb.StatFlags,
-       Snp->Cdb.StatCode)
+       Snp->Cdb->StatFlags,
+       Snp->Cdb->StatCode)
       );
 
     return EFI_DEVICE_ERROR;
@@ -196,36 +196,36 @@ PxeRecvFilterRead (
   SNP_DRIVER  *Snp
   )
 {
-  Snp->Cdb.OpCode  = PXE_OPCODE_RECEIVE_FILTERS;
-  Snp->Cdb.OpFlags = PXE_OPFLAGS_RECEIVE_FILTER_READ;
-  Snp->Cdb.CPBsize = PXE_CPBSIZE_NOT_USED;
-  Snp->Cdb.DBsize  = (UINT16)(Snp->Mode.MaxMCastFilterCount * sizeof (EFI_MAC_ADDRESS));
-  Snp->Cdb.CPBaddr = PXE_CPBADDR_NOT_USED;
-  if (Snp->Cdb.DBsize == 0) {
-    Snp->Cdb.DBaddr = (UINT64)(UINTN)NULL;
+  Snp->Cdb->OpCode  = PXE_OPCODE_RECEIVE_FILTERS;
+  Snp->Cdb->OpFlags = PXE_OPFLAGS_RECEIVE_FILTER_READ;
+  Snp->Cdb->CPBsize = PXE_CPBSIZE_NOT_USED;
+  Snp->Cdb->DBsize  = (UINT16)(Snp->Mode.MaxMCastFilterCount * sizeof (EFI_MAC_ADDRESS));
+  Snp->Cdb->CPBaddr = PXE_CPBADDR_NOT_USED;
+  if (Snp->Cdb->DBsize == 0) {
+    Snp->Cdb->DBaddr = (UINT64)(UINTN)NULL;
   } else {
-    Snp->Cdb.DBaddr = (UINT64)(UINTN)Snp->Db;
-    ZeroMem (Snp->Db, Snp->Cdb.DBsize);
+    Snp->Cdb->DBaddr = (UINT64)(UINTN)Snp->Db;
+    ZeroMem (Snp->Db, Snp->Cdb->DBsize);
   }
 
-  Snp->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  Snp->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  Snp->Cdb.IFnum     = Snp->IfNum;
-  Snp->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  Snp->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  Snp->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  Snp->Cdb->IFnum     = Snp->IfNum;
+  Snp->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   DEBUG ((DEBUG_NET, "\nsnp->undi.receive_filters()  "));
 
-  (*Snp->IssueUndi32Command)((UINT64)(UINTN)&Snp->Cdb);
+  (*Snp->IssueUndi32Command)((UINT64)(UINTN)Snp->Cdb);
 
-  if (Snp->Cdb.StatCode != PXE_STATCODE_SUCCESS) {
+  if (Snp->Cdb->StatCode != PXE_STATCODE_SUCCESS) {
     //
     // UNDI command failed.  Return UNDI status to caller.
     //
     DEBUG (
       (DEBUG_ERROR,
        "\nsnp->undi.receive_filters()  %xh:%xh\n",
-       Snp->Cdb.StatFlags,
-       Snp->Cdb.StatCode)
+       Snp->Cdb->StatFlags,
+       Snp->Cdb->StatCode)
       );
 
     return EFI_DEVICE_ERROR;
@@ -236,27 +236,27 @@ PxeRecvFilterRead (
   //
   Snp->Mode.ReceiveFilterSetting = 0;
 
-  if ((Snp->Cdb.StatFlags & PXE_STATFLAGS_RECEIVE_FILTER_UNICAST) != 0) {
+  if ((Snp->Cdb->StatFlags & PXE_STATFLAGS_RECEIVE_FILTER_UNICAST) != 0) {
     Snp->Mode.ReceiveFilterSetting |= EFI_SIMPLE_NETWORK_RECEIVE_UNICAST;
   }
 
-  if ((Snp->Cdb.StatFlags & PXE_STATFLAGS_RECEIVE_FILTER_BROADCAST) != 0) {
+  if ((Snp->Cdb->StatFlags & PXE_STATFLAGS_RECEIVE_FILTER_BROADCAST) != 0) {
     Snp->Mode.ReceiveFilterSetting |= EFI_SIMPLE_NETWORK_RECEIVE_BROADCAST;
   }
 
-  if ((Snp->Cdb.StatFlags & PXE_STATFLAGS_RECEIVE_FILTER_PROMISCUOUS) != 0) {
+  if ((Snp->Cdb->StatFlags & PXE_STATFLAGS_RECEIVE_FILTER_PROMISCUOUS) != 0) {
     Snp->Mode.ReceiveFilterSetting |= EFI_SIMPLE_NETWORK_RECEIVE_PROMISCUOUS;
   }
 
-  if ((Snp->Cdb.StatFlags & PXE_STATFLAGS_RECEIVE_FILTER_ALL_MULTICAST) != 0) {
+  if ((Snp->Cdb->StatFlags & PXE_STATFLAGS_RECEIVE_FILTER_ALL_MULTICAST) != 0) {
     Snp->Mode.ReceiveFilterSetting |= EFI_SIMPLE_NETWORK_RECEIVE_PROMISCUOUS_MULTICAST;
   }
 
-  if ((Snp->Cdb.StatFlags & PXE_STATFLAGS_RECEIVE_FILTER_FILTERED_MULTICAST) != 0) {
+  if ((Snp->Cdb->StatFlags & PXE_STATFLAGS_RECEIVE_FILTER_FILTERED_MULTICAST) != 0) {
     Snp->Mode.ReceiveFilterSetting |= EFI_SIMPLE_NETWORK_RECEIVE_MULTICAST;
   }
 
-  CopyMem (Snp->Mode.MCastFilter, Snp->Db, Snp->Cdb.DBsize);
+  CopyMem (Snp->Mode.MCastFilter, Snp->Db, Snp->Cdb->DBsize);
 
   //
   // Count number of active entries in multicast filter list.

--- a/NetworkPkg/SnpDxe/Reset.c
+++ b/NetworkPkg/SnpDxe/Reset.c
@@ -23,30 +23,30 @@ PxeReset (
   SNP_DRIVER  *Snp
   )
 {
-  Snp->Cdb.OpCode    = PXE_OPCODE_RESET;
-  Snp->Cdb.OpFlags   = PXE_OPFLAGS_NOT_USED;
-  Snp->Cdb.CPBsize   = PXE_CPBSIZE_NOT_USED;
-  Snp->Cdb.DBsize    = PXE_DBSIZE_NOT_USED;
-  Snp->Cdb.CPBaddr   = PXE_CPBADDR_NOT_USED;
-  Snp->Cdb.DBaddr    = PXE_DBADDR_NOT_USED;
-  Snp->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  Snp->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  Snp->Cdb.IFnum     = Snp->IfNum;
-  Snp->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  Snp->Cdb->OpCode    = PXE_OPCODE_RESET;
+  Snp->Cdb->OpFlags   = PXE_OPFLAGS_NOT_USED;
+  Snp->Cdb->CPBsize   = PXE_CPBSIZE_NOT_USED;
+  Snp->Cdb->DBsize    = PXE_DBSIZE_NOT_USED;
+  Snp->Cdb->CPBaddr   = PXE_CPBADDR_NOT_USED;
+  Snp->Cdb->DBaddr    = PXE_DBADDR_NOT_USED;
+  Snp->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  Snp->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  Snp->Cdb->IFnum     = Snp->IfNum;
+  Snp->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   //
   // Issue UNDI command and check result.
   //
   DEBUG ((DEBUG_NET, "\nsnp->undi.reset()  "));
 
-  (*Snp->IssueUndi32Command)((UINT64)(UINTN)&Snp->Cdb);
+  (*Snp->IssueUndi32Command)((UINT64)(UINTN)Snp->Cdb);
 
-  if (Snp->Cdb.StatCode != PXE_STATCODE_SUCCESS) {
+  if (Snp->Cdb->StatCode != PXE_STATCODE_SUCCESS) {
     DEBUG (
       (DEBUG_WARN,
        "\nsnp->undi32.reset()  %xh:%xh\n",
-       Snp->Cdb.StatFlags,
-       Snp->Cdb.StatCode)
+       Snp->Cdb->StatFlags,
+       Snp->Cdb->StatCode)
       );
 
     //

--- a/NetworkPkg/SnpDxe/Shutdown.c
+++ b/NetworkPkg/SnpDxe/Shutdown.c
@@ -22,29 +22,29 @@ PxeShutdown (
   IN SNP_DRIVER  *Snp
   )
 {
-  Snp->Cdb.OpCode    = PXE_OPCODE_SHUTDOWN;
-  Snp->Cdb.OpFlags   = PXE_OPFLAGS_NOT_USED;
-  Snp->Cdb.CPBsize   = PXE_CPBSIZE_NOT_USED;
-  Snp->Cdb.DBsize    = PXE_DBSIZE_NOT_USED;
-  Snp->Cdb.CPBaddr   = PXE_CPBADDR_NOT_USED;
-  Snp->Cdb.DBaddr    = PXE_DBADDR_NOT_USED;
-  Snp->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  Snp->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  Snp->Cdb.IFnum     = Snp->IfNum;
-  Snp->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  Snp->Cdb->OpCode    = PXE_OPCODE_SHUTDOWN;
+  Snp->Cdb->OpFlags   = PXE_OPFLAGS_NOT_USED;
+  Snp->Cdb->CPBsize   = PXE_CPBSIZE_NOT_USED;
+  Snp->Cdb->DBsize    = PXE_DBSIZE_NOT_USED;
+  Snp->Cdb->CPBaddr   = PXE_CPBADDR_NOT_USED;
+  Snp->Cdb->DBaddr    = PXE_DBADDR_NOT_USED;
+  Snp->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  Snp->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  Snp->Cdb->IFnum     = Snp->IfNum;
+  Snp->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   //
   // Issue UNDI command and check result.
   //
   DEBUG ((DEBUG_NET, "\nsnp->undi.shutdown()  "));
 
-  (*Snp->IssueUndi32Command)((UINT64)(UINTN)&Snp->Cdb);
+  (*Snp->IssueUndi32Command)((UINT64)(UINTN)Snp->Cdb);
 
-  if (Snp->Cdb.StatCode != PXE_STATCODE_SUCCESS) {
+  if (Snp->Cdb->StatCode != PXE_STATCODE_SUCCESS) {
     //
     // UNDI could not be shutdown. Return UNDI error.
     //
-    DEBUG ((DEBUG_WARN, "\nsnp->undi.shutdown()  %xh:%xh\n", Snp->Cdb.StatFlags, Snp->Cdb.StatCode));
+    DEBUG ((DEBUG_WARN, "\nsnp->undi.shutdown()  %xh:%xh\n", Snp->Cdb->StatFlags, Snp->Cdb->StatCode));
 
     return EFI_DEVICE_ERROR;
   }

--- a/NetworkPkg/SnpDxe/Snp.c
+++ b/NetworkPkg/SnpDxe/Snp.c
@@ -361,23 +361,30 @@ SimpleNetworkDriverStart (
   // OK, we like this UNDI, and we know snp is not already there on this handle
   // Allocate and initialize a new simple network protocol structure.
   //
-  Status = PciIo->AllocateBuffer (
-                    PciIo,
-                    AllocateAnyPages,
-                    EfiBootServicesData,
-                    SNP_MEM_PAGES (sizeof (SNP_DRIVER)),
-                    &Address,
-                    0
-                    );
-
-  if (Status != EFI_SUCCESS) {
+  Snp = AllocatePages (SNP_MEM_PAGES (sizeof (SNP_DRIVER)));
+  if (Snp == NULL) {
     DEBUG ((DEBUG_NET, "\nCould not allocate SNP_DRIVER structure.\n"));
     goto NiiError;
   }
 
-  Snp = (SNP_DRIVER *)(UINTN)Address;
+  Status = PciIo->AllocateBuffer (
+    PciIo,
+    AllocateAnyPages,
+    EfiBootServicesData,
+    SNP_MEM_PAGES (sizeof (PXE_CDB)),
+    &Address,
+    0
+    );
+
+  if (Status != EFI_SUCCESS) {
+    DEBUG ((DEBUG_NET, "\nCould not allocate CDB structures.\n"));
+    goto Error_DeleteSNP;
+  }
 
   ZeroMem (Snp, sizeof (SNP_DRIVER));
+
+  Snp->Cdb = (PXE_CDB *)(UINTN)Address;
+  ZeroMem (Snp->Cdb, sizeof (PXE_CDB));
 
   Snp->PciIo     = PciIo;
   Snp->Signature = SNP_DRIVER_SIGNATURE;
@@ -511,32 +518,32 @@ SimpleNetworkDriverStart (
     goto Error_DeleteSNP;
   }
 
-  Snp->Cdb.OpCode  = PXE_OPCODE_GET_INIT_INFO;
-  Snp->Cdb.OpFlags = PXE_OPFLAGS_NOT_USED;
+  Snp->Cdb->OpCode  = PXE_OPCODE_GET_INIT_INFO;
+  Snp->Cdb->OpFlags = PXE_OPFLAGS_NOT_USED;
 
-  Snp->Cdb.CPBsize = PXE_CPBSIZE_NOT_USED;
-  Snp->Cdb.CPBaddr = PXE_DBADDR_NOT_USED;
+  Snp->Cdb->CPBsize = PXE_CPBSIZE_NOT_USED;
+  Snp->Cdb->CPBaddr = PXE_DBADDR_NOT_USED;
 
-  Snp->Cdb.DBsize = (UINT16)sizeof (Snp->InitInfo);
-  Snp->Cdb.DBaddr = (UINT64)(UINTN)(&Snp->InitInfo);
+  Snp->Cdb->DBsize = (UINT16)sizeof (Snp->InitInfo);
+  Snp->Cdb->DBaddr = (UINT64)(UINTN)(&Snp->InitInfo);
 
-  Snp->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  Snp->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
+  Snp->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  Snp->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
 
-  Snp->Cdb.IFnum   = Snp->IfNum;
-  Snp->Cdb.Control = PXE_CONTROL_LAST_CDB_IN_LIST;
+  Snp->Cdb->IFnum   = Snp->IfNum;
+  Snp->Cdb->Control = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   DEBUG ((DEBUG_NET, "\nSnp->undi.get_init_info()  "));
 
-  (*Snp->IssueUndi32Command)((UINT64)(UINTN)&Snp->Cdb);
+  (*Snp->IssueUndi32Command)((UINT64)(UINTN)Snp->Cdb);
 
   //
   // Save the INIT Stat Code...
   //
-  InitStatFlags = Snp->Cdb.StatFlags;
+  InitStatFlags = Snp->Cdb->StatFlags;
 
-  if (Snp->Cdb.StatCode != PXE_STATCODE_SUCCESS) {
-    DEBUG ((DEBUG_NET, "\nSnp->undi.init_info()  %xh:%xh\n", Snp->Cdb.StatFlags, Snp->Cdb.StatCode));
+  if (Snp->Cdb->StatCode != PXE_STATCODE_SUCCESS) {
+    DEBUG ((DEBUG_NET, "\nSnp->undi.init_info()  %xh:%xh\n", Snp->Cdb->StatFlags, Snp->Cdb->StatCode));
     PxeStop (Snp);
     goto Error_DeleteSNP;
   }
@@ -686,6 +693,11 @@ SimpleNetworkDriverStart (
            SNP_MEM_PAGES (4096),
            Snp->Cpb
            );
+  PciIo->FreeBuffer (
+          PciIo,
+          SNP_MEM_PAGES (sizeof (PXE_CDB)),
+          Snp->Cdb
+          );
 
 Error_DeleteSNP:
 
@@ -693,11 +705,7 @@ Error_DeleteSNP:
     FreePool (Snp->RecycledTxBuf);
   }
 
-  PciIo->FreeBuffer (
-           PciIo,
-           SNP_MEM_PAGES (sizeof (SNP_DRIVER)),
-           Snp
-           );
+  FreePages (Snp, SNP_MEM_PAGES (sizeof (SNP_DRIVER)));
 NiiError:
   gBS->CloseProtocol (
          Controller,
@@ -811,16 +819,16 @@ SimpleNetworkDriverStop (
 
   PciIo = Snp->PciIo;
   PciIo->FreeBuffer (
-           PciIo,
-           SNP_MEM_PAGES (4096),
-           Snp->Cpb
-           );
-
+    PciIo,
+    SNP_MEM_PAGES (4096),
+    Snp->Cpb
+    );
   PciIo->FreeBuffer (
-           PciIo,
-           SNP_MEM_PAGES (sizeof (SNP_DRIVER)),
-           Snp
-           );
+    PciIo,
+    SNP_MEM_PAGES (sizeof (PXE_CDB)),
+    Snp->Cdb
+    );
+  FreePages (Snp, SNP_MEM_PAGES (sizeof (SNP_DRIVER)));
 
   return Status;
 }

--- a/NetworkPkg/SnpDxe/Snp.h
+++ b/NetworkPkg/SnpDxe/Snp.h
@@ -100,7 +100,7 @@ typedef struct {
   // Buffers for command descriptor block, command parameter block
   // and data block.
   //
-  PXE_CDB                        Cdb;
+  PXE_CDB                        *Cdb;
   VOID                           *Cpb;
   VOID                           *CpbUnmap;
   VOID                           *Db;

--- a/NetworkPkg/SnpDxe/Start.c
+++ b/NetworkPkg/SnpDxe/Start.c
@@ -28,24 +28,24 @@ PxeStart (
   //
   // Initialize UNDI Start CDB for H/W UNDI
   //
-  Snp->Cdb.OpCode    = PXE_OPCODE_START;
-  Snp->Cdb.OpFlags   = PXE_OPFLAGS_NOT_USED;
-  Snp->Cdb.CPBsize   = PXE_CPBSIZE_NOT_USED;
-  Snp->Cdb.DBsize    = PXE_DBSIZE_NOT_USED;
-  Snp->Cdb.CPBaddr   = PXE_CPBADDR_NOT_USED;
-  Snp->Cdb.DBaddr    = PXE_DBADDR_NOT_USED;
-  Snp->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  Snp->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  Snp->Cdb.IFnum     = Snp->IfNum;
-  Snp->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  Snp->Cdb->OpCode    = PXE_OPCODE_START;
+  Snp->Cdb->OpFlags   = PXE_OPFLAGS_NOT_USED;
+  Snp->Cdb->CPBsize   = PXE_CPBSIZE_NOT_USED;
+  Snp->Cdb->DBsize    = PXE_DBSIZE_NOT_USED;
+  Snp->Cdb->CPBaddr   = PXE_CPBADDR_NOT_USED;
+  Snp->Cdb->DBaddr    = PXE_DBADDR_NOT_USED;
+  Snp->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  Snp->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  Snp->Cdb->IFnum     = Snp->IfNum;
+  Snp->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   //
   // Make changes to H/W UNDI Start CDB if this is
   // a S/W UNDI.
   //
   if (Snp->IsSwUndi) {
-    Snp->Cdb.CPBsize = (UINT16)sizeof (PXE_CPB_START_31);
-    Snp->Cdb.CPBaddr = (UINT64)(UINTN)Cpb31;
+    Snp->Cdb->CPBsize = (UINT16)sizeof (PXE_CPB_START_31);
+    Snp->Cdb->CPBaddr = (UINT64)(UINTN)Cpb31;
 
     Cpb31->Delay = (UINT64)(UINTN)&SnpUndi32CallbackDelay;
     Cpb31->Block = (UINT64)(UINTN)&SnpUndi32CallbackBlock;
@@ -68,17 +68,17 @@ PxeStart (
   //
   DEBUG ((DEBUG_NET, "\nsnp->undi.start()  "));
 
-  (*Snp->IssueUndi32Command)((UINT64)(UINTN)&Snp->Cdb);
+  (*Snp->IssueUndi32Command)((UINT64)(UINTN)Snp->Cdb);
 
-  if (Snp->Cdb.StatCode != PXE_STATCODE_SUCCESS) {
+  if (Snp->Cdb->StatCode != PXE_STATCODE_SUCCESS) {
     //
     // UNDI could not be started. Return UNDI error.
     //
     DEBUG (
       (DEBUG_ERROR,
        "\nsnp->undi.start()  %xh:%xh\n",
-       Snp->Cdb.StatCode,
-       Snp->Cdb.StatFlags)
+       Snp->Cdb->StatCode,
+       Snp->Cdb->StatFlags)
       );
 
     return EFI_DEVICE_ERROR;

--- a/NetworkPkg/SnpDxe/Station_address.c
+++ b/NetworkPkg/SnpDxe/Station_address.c
@@ -26,33 +26,33 @@ PxeGetStnAddr (
   PXE_DB_STATION_ADDRESS  *Db;
 
   Db               = Snp->Db;
-  Snp->Cdb.OpCode  = PXE_OPCODE_STATION_ADDRESS;
-  Snp->Cdb.OpFlags = PXE_OPFLAGS_STATION_ADDRESS_READ;
+  Snp->Cdb->OpCode  = PXE_OPCODE_STATION_ADDRESS;
+  Snp->Cdb->OpFlags = PXE_OPFLAGS_STATION_ADDRESS_READ;
 
-  Snp->Cdb.CPBaddr = PXE_CPBADDR_NOT_USED;
-  Snp->Cdb.CPBsize = PXE_CPBSIZE_NOT_USED;
+  Snp->Cdb->CPBaddr = PXE_CPBADDR_NOT_USED;
+  Snp->Cdb->CPBsize = PXE_CPBSIZE_NOT_USED;
 
-  Snp->Cdb.DBsize = (UINT16)sizeof (PXE_DB_STATION_ADDRESS);
-  Snp->Cdb.DBaddr = (UINT64)(UINTN)Db;
+  Snp->Cdb->DBsize = (UINT16)sizeof (PXE_DB_STATION_ADDRESS);
+  Snp->Cdb->DBaddr = (UINT64)(UINTN)Db;
 
-  Snp->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  Snp->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  Snp->Cdb.IFnum     = Snp->IfNum;
-  Snp->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  Snp->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  Snp->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  Snp->Cdb->IFnum     = Snp->IfNum;
+  Snp->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   //
   // Issue UNDI command and check result.
   //
   DEBUG ((DEBUG_NET, "\nsnp->undi.station_addr()  "));
 
-  (*Snp->IssueUndi32Command)((UINT64)(UINTN)&Snp->Cdb);
+  (*Snp->IssueUndi32Command)((UINT64)(UINTN)Snp->Cdb);
 
-  if (Snp->Cdb.StatCode != PXE_STATCODE_SUCCESS) {
+  if (Snp->Cdb->StatCode != PXE_STATCODE_SUCCESS) {
     DEBUG (
       (DEBUG_ERROR,
        "\nsnp->undi.station_addr()  %xh:%xh\n",
-       Snp->Cdb.StatFlags,
-       Snp->Cdb.StatCode)
+       Snp->Cdb->StatFlags,
+       Snp->Cdb->StatCode)
       );
 
     return EFI_DEVICE_ERROR;
@@ -103,44 +103,44 @@ PxeSetStnAddr (
 
   Cpb             = Snp->Cpb;
   Db              = Snp->Db;
-  Snp->Cdb.OpCode = PXE_OPCODE_STATION_ADDRESS;
+  Snp->Cdb->OpCode = PXE_OPCODE_STATION_ADDRESS;
 
   if (NewMacAddr == NULL) {
-    Snp->Cdb.OpFlags = PXE_OPFLAGS_STATION_ADDRESS_RESET;
-    Snp->Cdb.CPBsize = PXE_CPBSIZE_NOT_USED;
-    Snp->Cdb.CPBaddr = PXE_CPBADDR_NOT_USED;
+    Snp->Cdb->OpFlags = PXE_OPFLAGS_STATION_ADDRESS_RESET;
+    Snp->Cdb->CPBsize = PXE_CPBSIZE_NOT_USED;
+    Snp->Cdb->CPBaddr = PXE_CPBADDR_NOT_USED;
   } else {
-    Snp->Cdb.OpFlags = PXE_OPFLAGS_STATION_ADDRESS_WRITE;
+    Snp->Cdb->OpFlags = PXE_OPFLAGS_STATION_ADDRESS_WRITE;
     //
     // Supplying a new address in the CPB will make undi change the mac address to the new one.
     //
     CopyMem (&Cpb->StationAddr, NewMacAddr, Snp->Mode.HwAddressSize);
 
-    Snp->Cdb.CPBsize = (UINT16)sizeof (PXE_CPB_STATION_ADDRESS);
-    Snp->Cdb.CPBaddr = (UINT64)(UINTN)Cpb;
+    Snp->Cdb->CPBsize = (UINT16)sizeof (PXE_CPB_STATION_ADDRESS);
+    Snp->Cdb->CPBaddr = (UINT64)(UINTN)Cpb;
   }
 
-  Snp->Cdb.DBsize = (UINT16)sizeof (PXE_DB_STATION_ADDRESS);
-  Snp->Cdb.DBaddr = (UINT64)(UINTN)Db;
+  Snp->Cdb->DBsize = (UINT16)sizeof (PXE_DB_STATION_ADDRESS);
+  Snp->Cdb->DBaddr = (UINT64)(UINTN)Db;
 
-  Snp->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  Snp->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  Snp->Cdb.IFnum     = Snp->IfNum;
-  Snp->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  Snp->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  Snp->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  Snp->Cdb->IFnum     = Snp->IfNum;
+  Snp->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   //
   // Issue UNDI command and check result.
   //
   DEBUG ((DEBUG_NET, "\nsnp->undi.station_addr()  "));
 
-  (*Snp->IssueUndi32Command)((UINT64)(UINTN)&Snp->Cdb);
+  (*Snp->IssueUndi32Command)((UINT64)(UINTN)Snp->Cdb);
 
-  if (Snp->Cdb.StatCode != PXE_STATCODE_SUCCESS) {
+  if (Snp->Cdb->StatCode != PXE_STATCODE_SUCCESS) {
     DEBUG (
       (DEBUG_ERROR,
        "\nsnp->undi.station_addr()  %xh:%xh\n",
-       Snp->Cdb.StatFlags,
-       Snp->Cdb.StatCode)
+       Snp->Cdb->StatFlags,
+       Snp->Cdb->StatCode)
       );
 
     //

--- a/NetworkPkg/SnpDxe/Statistics.c
+++ b/NetworkPkg/SnpDxe/Statistics.c
@@ -112,23 +112,23 @@ SnpUndi32Statistics (
   //
   // Initialize UNDI Statistics CDB
   //
-  Snp->Cdb.OpCode    = PXE_OPCODE_STATISTICS;
-  Snp->Cdb.CPBsize   = PXE_CPBSIZE_NOT_USED;
-  Snp->Cdb.CPBaddr   = PXE_CPBADDR_NOT_USED;
-  Snp->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  Snp->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  Snp->Cdb.IFnum     = Snp->IfNum;
-  Snp->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  Snp->Cdb->OpCode    = PXE_OPCODE_STATISTICS;
+  Snp->Cdb->CPBsize   = PXE_CPBSIZE_NOT_USED;
+  Snp->Cdb->CPBaddr   = PXE_CPBADDR_NOT_USED;
+  Snp->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  Snp->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  Snp->Cdb->IFnum     = Snp->IfNum;
+  Snp->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   if (Reset) {
-    Snp->Cdb.OpFlags = PXE_OPFLAGS_STATISTICS_RESET;
-    Snp->Cdb.DBsize  = PXE_DBSIZE_NOT_USED;
-    Snp->Cdb.DBaddr  = PXE_DBADDR_NOT_USED;
+    Snp->Cdb->OpFlags = PXE_OPFLAGS_STATISTICS_RESET;
+    Snp->Cdb->DBsize  = PXE_DBSIZE_NOT_USED;
+    Snp->Cdb->DBaddr  = PXE_DBADDR_NOT_USED;
     Db               = Snp->Db;
   } else {
-    Snp->Cdb.OpFlags = PXE_OPFLAGS_STATISTICS_READ;
-    Snp->Cdb.DBsize  = (UINT16)sizeof (PXE_DB_STATISTICS);
-    Snp->Cdb.DBaddr  = (UINT64)(UINTN)(Db = Snp->Db);
+    Snp->Cdb->OpFlags = PXE_OPFLAGS_STATISTICS_READ;
+    Snp->Cdb->DBsize  = (UINT16)sizeof (PXE_DB_STATISTICS);
+    Snp->Cdb->DBaddr  = (UINT64)(UINTN)(Db = Snp->Db);
   }
 
   //
@@ -136,9 +136,9 @@ SnpUndi32Statistics (
   //
   DEBUG ((DEBUG_NET, "\nsnp->undi.statistics()  "));
 
-  (*Snp->IssueUndi32Command)((UINT64)(UINTN)&Snp->Cdb);
+  (*Snp->IssueUndi32Command)((UINT64)(UINTN)Snp->Cdb);
 
-  switch (Snp->Cdb.StatCode) {
+  switch (Snp->Cdb->StatCode) {
     case PXE_STATCODE_SUCCESS:
       break;
 
@@ -146,8 +146,8 @@ SnpUndi32Statistics (
       DEBUG (
         (DEBUG_ERROR,
          "\nsnp->undi.statistics()  %xh:%xh\n",
-         Snp->Cdb.StatFlags,
-         Snp->Cdb.StatCode)
+         Snp->Cdb->StatFlags,
+         Snp->Cdb->StatCode)
         );
 
       Status = EFI_UNSUPPORTED;
@@ -157,8 +157,8 @@ SnpUndi32Statistics (
       DEBUG (
         (DEBUG_ERROR,
          "\nsnp->undi.statistics()  %xh:%xh\n",
-         Snp->Cdb.StatFlags,
-         Snp->Cdb.StatCode)
+         Snp->Cdb->StatFlags,
+         Snp->Cdb->StatCode)
         );
 
       Status = EFI_DEVICE_ERROR;

--- a/NetworkPkg/SnpDxe/Stop.c
+++ b/NetworkPkg/SnpDxe/Stop.c
@@ -22,30 +22,30 @@ PxeStop (
   SNP_DRIVER  *Snp
   )
 {
-  Snp->Cdb.OpCode    = PXE_OPCODE_STOP;
-  Snp->Cdb.OpFlags   = PXE_OPFLAGS_NOT_USED;
-  Snp->Cdb.CPBsize   = PXE_CPBSIZE_NOT_USED;
-  Snp->Cdb.DBsize    = PXE_DBSIZE_NOT_USED;
-  Snp->Cdb.CPBaddr   = PXE_CPBADDR_NOT_USED;
-  Snp->Cdb.DBaddr    = PXE_DBADDR_NOT_USED;
-  Snp->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  Snp->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  Snp->Cdb.IFnum     = Snp->IfNum;
-  Snp->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  Snp->Cdb->OpCode    = PXE_OPCODE_STOP;
+  Snp->Cdb->OpFlags   = PXE_OPFLAGS_NOT_USED;
+  Snp->Cdb->CPBsize   = PXE_CPBSIZE_NOT_USED;
+  Snp->Cdb->DBsize    = PXE_DBSIZE_NOT_USED;
+  Snp->Cdb->CPBaddr   = PXE_CPBADDR_NOT_USED;
+  Snp->Cdb->DBaddr    = PXE_DBADDR_NOT_USED;
+  Snp->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  Snp->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  Snp->Cdb->IFnum     = Snp->IfNum;
+  Snp->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   //
   // Issue UNDI command
   //
   DEBUG ((DEBUG_NET, "\nsnp->undi.stop()  "));
 
-  (*Snp->IssueUndi32Command)((UINT64)(UINTN)&Snp->Cdb);
+  (*Snp->IssueUndi32Command)((UINT64)(UINTN)Snp->Cdb);
 
-  if (Snp->Cdb.StatCode != PXE_STATCODE_SUCCESS) {
+  if (Snp->Cdb->StatCode != PXE_STATCODE_SUCCESS) {
     DEBUG (
       (DEBUG_WARN,
        "\nsnp->undi.stop()  %xh:%xh\n",
-       Snp->Cdb.StatFlags,
-       Snp->Cdb.StatCode)
+       Snp->Cdb->StatFlags,
+       Snp->Cdb->StatCode)
       );
 
     return EFI_DEVICE_ERROR;

--- a/NetworkPkg/SnpDxe/Transmit.c
+++ b/NetworkPkg/SnpDxe/Transmit.c
@@ -77,28 +77,28 @@ PxeFillHeader (
 
   Cpb->FragDesc[0].reserved = Cpb->FragDesc[1].reserved = 0;
 
-  Snp->Cdb.OpCode  = PXE_OPCODE_FILL_HEADER;
-  Snp->Cdb.OpFlags = PXE_OPFLAGS_FILL_HEADER_FRAGMENTED;
+  Snp->Cdb->OpCode  = PXE_OPCODE_FILL_HEADER;
+  Snp->Cdb->OpFlags = PXE_OPFLAGS_FILL_HEADER_FRAGMENTED;
 
-  Snp->Cdb.DBsize = PXE_DBSIZE_NOT_USED;
-  Snp->Cdb.DBaddr = PXE_DBADDR_NOT_USED;
+  Snp->Cdb->DBsize = PXE_DBSIZE_NOT_USED;
+  Snp->Cdb->DBaddr = PXE_DBADDR_NOT_USED;
 
-  Snp->Cdb.CPBsize = (UINT16)sizeof (PXE_CPB_FILL_HEADER_FRAGMENTED);
-  Snp->Cdb.CPBaddr = (UINT64)(UINTN)Cpb;
+  Snp->Cdb->CPBsize = (UINT16)sizeof (PXE_CPB_FILL_HEADER_FRAGMENTED);
+  Snp->Cdb->CPBaddr = (UINT64)(UINTN)Cpb;
 
-  Snp->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  Snp->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  Snp->Cdb.IFnum     = Snp->IfNum;
-  Snp->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  Snp->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  Snp->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  Snp->Cdb->IFnum     = Snp->IfNum;
+  Snp->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   //
   // Issue UNDI command and check result.
   //
   DEBUG ((DEBUG_NET, "\nSnp->undi.fill_header()  "));
 
-  (*Snp->IssueUndi32Command)((UINT64)(UINTN)&Snp->Cdb);
+  (*Snp->IssueUndi32Command)((UINT64)(UINTN)Snp->Cdb);
 
-  switch (Snp->Cdb.StatCode) {
+  switch (Snp->Cdb->StatCode) {
     case PXE_STATCODE_SUCCESS:
       return EFI_SUCCESS;
 
@@ -106,8 +106,8 @@ PxeFillHeader (
       DEBUG (
         (DEBUG_ERROR,
          "\nSnp->undi.fill_header()  %xh:%xh\n",
-         Snp->Cdb.StatFlags,
-         Snp->Cdb.StatCode)
+         Snp->Cdb->StatFlags,
+         Snp->Cdb->StatCode)
         );
 
       return EFI_INVALID_PARAMETER;
@@ -116,8 +116,8 @@ PxeFillHeader (
       DEBUG (
         (DEBUG_ERROR,
          "\nSnp->undi.fill_header()  %xh:%xh\n",
-         Snp->Cdb.StatFlags,
-         Snp->Cdb.StatCode)
+         Snp->Cdb->StatFlags,
+         Snp->Cdb->StatCode)
         );
 
       return EFI_DEVICE_ERROR;
@@ -152,37 +152,37 @@ PxeTransmit (
   Cpb->MediaheaderLen = 0;
   Cpb->reserved       = 0;
 
-  Snp->Cdb.OpFlags = PXE_OPFLAGS_TRANSMIT_WHOLE;
+  Snp->Cdb->OpFlags = PXE_OPFLAGS_TRANSMIT_WHOLE;
 
-  Snp->Cdb.CPBsize = (UINT16)sizeof (PXE_CPB_TRANSMIT);
-  Snp->Cdb.CPBaddr = (UINT64)(UINTN)Cpb;
+  Snp->Cdb->CPBsize = (UINT16)sizeof (PXE_CPB_TRANSMIT);
+  Snp->Cdb->CPBaddr = (UINT64)(UINTN)Cpb;
 
-  Snp->Cdb.OpCode = PXE_OPCODE_TRANSMIT;
-  Snp->Cdb.DBsize = PXE_DBSIZE_NOT_USED;
-  Snp->Cdb.DBaddr = PXE_DBADDR_NOT_USED;
+  Snp->Cdb->OpCode = PXE_OPCODE_TRANSMIT;
+  Snp->Cdb->DBsize = PXE_DBSIZE_NOT_USED;
+  Snp->Cdb->DBaddr = PXE_DBADDR_NOT_USED;
 
-  Snp->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  Snp->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  Snp->Cdb.IFnum     = Snp->IfNum;
-  Snp->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  Snp->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  Snp->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  Snp->Cdb->IFnum     = Snp->IfNum;
+  Snp->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   //
   // Issue UNDI command and check result.
   //
   DEBUG ((DEBUG_NET, "\nSnp->undi.transmit()  "));
-  DEBUG ((DEBUG_NET, "\nSnp->Cdb.OpCode  == %x", Snp->Cdb.OpCode));
-  DEBUG ((DEBUG_NET, "\nSnp->Cdb.CPBaddr == %LX", Snp->Cdb.CPBaddr));
-  DEBUG ((DEBUG_NET, "\nSnp->Cdb.DBaddr  == %LX", Snp->Cdb.DBaddr));
+  DEBUG ((DEBUG_NET, "\nSnp->Cdb->OpCode  == %x", Snp->Cdb->OpCode));
+  DEBUG ((DEBUG_NET, "\nSnp->Cdb->CPBaddr == %LX", Snp->Cdb->CPBaddr));
+  DEBUG ((DEBUG_NET, "\nSnp->Cdb->DBaddr  == %LX", Snp->Cdb->DBaddr));
   DEBUG ((DEBUG_NET, "\nCpb->FrameAddr   == %LX\n", Cpb->FrameAddr));
 
-  (*Snp->IssueUndi32Command)((UINT64)(UINTN)&Snp->Cdb);
+  (*Snp->IssueUndi32Command)((UINT64)(UINTN)Snp->Cdb);
 
   DEBUG ((DEBUG_NET, "\nexit Snp->undi.transmit()  "));
 
   //
   // we will unmap the buffers in get_status call, not here
   //
-  switch (Snp->Cdb.StatCode) {
+  switch (Snp->Cdb->StatCode) {
     case PXE_STATCODE_SUCCESS:
       return EFI_SUCCESS;
 
@@ -193,8 +193,8 @@ PxeTransmit (
       DEBUG (
         (DEBUG_NET,
          "\nSnp->undi.transmit()  %xh:%xh\n",
-         Snp->Cdb.StatFlags,
-         Snp->Cdb.StatCode)
+         Snp->Cdb->StatFlags,
+         Snp->Cdb->StatCode)
         );
       break;
 
@@ -202,8 +202,8 @@ PxeTransmit (
       DEBUG (
         (DEBUG_ERROR,
          "\nSnp->undi.transmit()  %xh:%xh\n",
-         Snp->Cdb.StatFlags,
-         Snp->Cdb.StatCode)
+         Snp->Cdb->StatFlags,
+         Snp->Cdb->StatCode)
         );
       Status = EFI_DEVICE_ERROR;
   }

--- a/NetworkPkg/SnpDxe/WaitForPacket.c
+++ b/NetworkPkg/SnpDxe/WaitForPacket.c
@@ -47,16 +47,16 @@ SnpWaitForPacketNotify (
   //
   // Fill in CDB for UNDI GetStatus().
   //
-  ((SNP_DRIVER *)SnpPtr)->Cdb.OpCode    = PXE_OPCODE_GET_STATUS;
-  ((SNP_DRIVER *)SnpPtr)->Cdb.OpFlags   = 0;
-  ((SNP_DRIVER *)SnpPtr)->Cdb.CPBsize   = PXE_CPBSIZE_NOT_USED;
-  ((SNP_DRIVER *)SnpPtr)->Cdb.CPBaddr   = PXE_CPBADDR_NOT_USED;
-  ((SNP_DRIVER *)SnpPtr)->Cdb.DBsize    = (UINT16)(sizeof (UINT32) * 2);
-  ((SNP_DRIVER *)SnpPtr)->Cdb.DBaddr    = (UINT64)(UINTN)(((SNP_DRIVER *)SnpPtr)->Db);
-  ((SNP_DRIVER *)SnpPtr)->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  ((SNP_DRIVER *)SnpPtr)->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  ((SNP_DRIVER *)SnpPtr)->Cdb.IFnum     = ((SNP_DRIVER *)SnpPtr)->IfNum;
-  ((SNP_DRIVER *)SnpPtr)->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  ((SNP_DRIVER *)SnpPtr)->Cdb->OpCode    = PXE_OPCODE_GET_STATUS;
+  ((SNP_DRIVER *)SnpPtr)->Cdb->OpFlags   = 0;
+  ((SNP_DRIVER *)SnpPtr)->Cdb->CPBsize   = PXE_CPBSIZE_NOT_USED;
+  ((SNP_DRIVER *)SnpPtr)->Cdb->CPBaddr   = PXE_CPBADDR_NOT_USED;
+  ((SNP_DRIVER *)SnpPtr)->Cdb->DBsize    = (UINT16)(sizeof (UINT32) * 2);
+  ((SNP_DRIVER *)SnpPtr)->Cdb->DBaddr    = (UINT64)(UINTN)(((SNP_DRIVER *)SnpPtr)->Db);
+  ((SNP_DRIVER *)SnpPtr)->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  ((SNP_DRIVER *)SnpPtr)->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  ((SNP_DRIVER *)SnpPtr)->Cdb->IFnum     = ((SNP_DRIVER *)SnpPtr)->IfNum;
+  ((SNP_DRIVER *)SnpPtr)->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   //
   // Clear contents of DB buffer.
@@ -66,9 +66,9 @@ SnpWaitForPacketNotify (
   //
   // Issue UNDI command and check result.
   //
-  (*((SNP_DRIVER *)SnpPtr)->IssueUndi32Command)((UINT64)(UINTN)&((SNP_DRIVER *)SnpPtr)->Cdb);
+  (*((SNP_DRIVER *)SnpPtr)->IssueUndi32Command)((UINT64)(UINTN)((SNP_DRIVER *)SnpPtr)->Cdb);
 
-  if (((SNP_DRIVER *)SnpPtr)->Cdb.StatCode != EFI_SUCCESS) {
+  if (((SNP_DRIVER *)SnpPtr)->Cdb->StatCode != EFI_SUCCESS) {
     return;
   }
 


### PR DESCRIPTION
## Description

- Updates SNP_DRIVER allocation to use AllocatePages()
- Allocates the PXE_CDB struct as a pointer instead, using PciIo->AllocateBuffer()

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

Tested on physical arm device

## Integration Instructions

N/A
