### PR TITLE
[SQUASH ON REBASE] MdePkg: BaseLib.inf Add CpuBreakAssert.c to AARCH64

### DIFF
--- a/MdePkg/Library/BaseLib/BaseLib.inf
+++ b/MdePkg/Library/BaseLib/BaseLib.inf
@@ -393,6 +393,7 @@
   AArch64/GetInterruptsState.asm    | MSFT
   AArch64/SetJumpLongJump.asm       | MSFT
   AArch64/CpuBreakpoint.asm         | MSFT
+  AArch64/CpuBreakAssert.c          | MSFT ## MU_CHANGE
   AArch64/SpeculationBarrier.asm    | MSFT
   AArch64/ArmReadIdAA64Isar0Reg.asm     | MSFT
   IntelTdxNull.c


### PR DESCRIPTION
## Description

Add CpuBreakAssert.c to AARCH64 MSVC build

Squash with this commit: ae5f2bcf81cf212dd35ec4313a610943ade1d421
The original commit only added CpuBreakAssert.S for AARCH64 GCC build

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Built locally for AARCH64

## Integration Instructions

N/A