### PR TITLE
[Cherry-Pick] MdeModulePkg/Spi: Allow NULL WriteBuffer in FillWriteBuffer()

### DIFF
--- a/MdeModulePkg/Bus/Spi/SpiNorFlashJedecSfdp/SpiNorFlash.c
+++ b/MdeModulePkg/Bus/Spi/SpiNorFlashJedecSfdp/SpiNorFlash.c
@@ -48,9 +48,9 @@ FillWriteBuffer (
   UINT32  Index;
   UINT8   SfdpAddressBytes;
 
-  if ((Instance == NULL) || (WriteBuffer == NULL)) {
+  if ((Instance == NULL) || ((WriteBytes != 0) && (WriteBuffer == NULL))) {
     ASSERT (Instance != NULL);
-    ASSERT (WriteBuffer != NULL);
+    ASSERT (WriteBytes == 0 || WriteBuffer != NULL);
     return 0;
   }
 


### PR DESCRIPTION


## Description

MdeModulePkg/Spi: Allow NULL WriteBuffer in FillWriteBuffer()

Fix false positive assert added in #10924
Functon `FillWriteBuffer()` should able to accept NULL WriteBuffer when WriteBytes equals 0.

Use case:
```
  // Read Status register
  TransactionBufferLength = FillWriteBuffer (
                              Instance,
                              SPI_FLASH_RDSR,
                              SPI_FLASH_RDSR_DUMMY,
                              SPI_FLASH_RDSR_ADDR_BYTES,
                              FALSE,
                              0,
                              0, // WriteBytes = 0
                              NULL // WriteBuffer can be NULL
                              );

```


(cherry picked from commit 93aeaa0812b75abb8637ec1a8f9883657f818a22)

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested
Tested on physical platform that uses SpiNorFlashJedecSfdp driver.


## Integration Instructions
no integration necessary