### PR TITLE
[CHERRY-PICK] Prevent memcpy intrinsics in VS22 (17.14.2) [Rebase & FF]

### DIFF
--- a/MdeModulePkg/Universal/DisplayEngineDxe/InputHandler.c
+++ b/MdeModulePkg/Universal/DisplayEngineDxe/InputHandler.c
@@ -229,8 +229,8 @@ ReadString (
 
       case CHAR_BACKSPACE:
         if ((StringPtr[0] != CHAR_NULL) && (CurrentCursor != 0)) {
-          for (Index = 0; Index < CurrentCursor - 1; Index++) {
-            TempString[Index] = StringPtr[Index];
+          if (CurrentCursor > 1) {
+            CopyMem (TempString, StringPtr, (CurrentCursor - 1) * sizeof (CHAR16));
           }
 
           Count = GetStringWidth (StringPtr) / 2 - 1;
@@ -261,9 +261,7 @@ ReadString (
           KeyPad[1] = CHAR_NULL;
           Count     = GetStringWidth (StringPtr) / 2 - 1;
           if (CurrentCursor < Count) {
-            for (Index = 0; Index < CurrentCursor; Index++) {
-              TempString[Index] = StringPtr[Index];
-            }
+            CopyMem (TempString, StringPtr, CurrentCursor * sizeof (CHAR16));
 
             TempString[Index] = CHAR_NULL;
             StrCatS (TempString, MaxLen, KeyPad);

--- a/MdeModulePkg/Universal/DisplayEngineDxe/InputHandler.c
+++ b/MdeModulePkg/Universal/DisplayEngineDxe/InputHandler.c
@@ -229,15 +229,9 @@ ReadString (
 
       case CHAR_BACKSPACE:
         if ((StringPtr[0] != CHAR_NULL) && (CurrentCursor != 0)) {
-          // MU_CHANGE [BEGIN]: Fix VS22 17.14 memcpy substitution
-          // for (Index = 0; Index < CurrentCursor - 1; Index++) {
-          //   TempString[Index] = StringPtr[Index];
-          // }
-          if (CurrentCursor > 1) {
-            CopyMem (TempString, StringPtr, (CurrentCursor - 1) * sizeof (CHAR16));
+          for (Index = 0; Index < CurrentCursor - 1; Index++) {
+            TempString[Index] = StringPtr[Index];
           }
-
-          // MU_CHANGE [END]: Fix VS22 17.14 memcpy substitution
 
           Count = GetStringWidth (StringPtr) / 2 - 1;
           if (Count >= CurrentCursor) {
@@ -267,12 +261,9 @@ ReadString (
           KeyPad[1] = CHAR_NULL;
           Count     = GetStringWidth (StringPtr) / 2 - 1;
           if (CurrentCursor < Count) {
-            // MU_CHANGE [BEGIN]: Fix VS22 17.14 memcpy substitution
-            // for (Index = 0; Index < CurrentCursor; Index++) {
-            //   TempString[Index] = StringPtr[Index];
-            // }
-            CopyMem (TempString, StringPtr, CurrentCursor * sizeof (CHAR16));
-            // MU_CHANGE [END]: Fix VS22 17.14 memcpy substitution
+            for (Index = 0; Index < CurrentCursor; Index++) {
+              TempString[Index] = StringPtr[Index];
+            }
 
             TempString[Index] = CHAR_NULL;
             StrCatS (TempString, MaxLen, KeyPad);

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/Edit/FileBuffer.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/Edit/FileBuffer.c
@@ -478,6 +478,7 @@ FileBufferPrintLine (
 {
   CHAR16  *Buffer;
   UINTN   Limit;
+  UINTN   PadLength;
   CHAR16  *PrintLine;
   CHAR16  *PrintLine2;
   UINTN   BufLen;
@@ -496,8 +497,9 @@ FileBufferPrintLine (
   PrintLine = AllocatePool (BufLen);
   if (PrintLine != NULL) {
     StrnCpyS (PrintLine, BufLen/sizeof (CHAR16), Buffer, MIN (Limit, MainEditor.ScreenSize.Column));
-    for (Limit = StrLen (PrintLine); Limit < MainEditor.ScreenSize.Column; Limit++) {
-      PrintLine[Limit] = L' ';
+    if (StrLen (PrintLine) < MainEditor.ScreenSize.Column) {
+      PadLength = MainEditor.ScreenSize.Column - StrLen (PrintLine);
+      SetMem16 (&PrintLine[StrLen (PrintLine)], PadLength * sizeof (CHAR16), L' ');
     }
 
     PrintLine[MainEditor.ScreenSize.Column] = CHAR_NULL;
@@ -3104,17 +3106,13 @@ FileBufferReplace (
     // set replace into it
     //
     Buffer = FileBuffer.CurrentLine->Buffer + FileBuffer.FilePosition.Column - 1;
-    for (Index = 0; Index < ReplaceLen; Index++) {
-      Buffer[Index] = Replace[Index];
-    }
+    CopyMem (Buffer, Replace, ReplaceLen * sizeof (CHAR16));
   }
 
   if (ReplaceLen < SearchLen) {
     Buffer = FileBuffer.CurrentLine->Buffer + FileBuffer.FilePosition.Column - 1;
 
-    for (Index = 0; Index < ReplaceLen; Index++) {
-      Buffer[Index] = Replace[Index];
-    }
+    CopyMem (Buffer, Replace, ReplaceLen * sizeof (CHAR16));
 
     Buffer += ReplaceLen;
     Gap     = SearchLen - ReplaceLen;
@@ -3130,9 +3128,7 @@ FileBufferReplace (
 
   if (ReplaceLen == SearchLen) {
     Buffer = FileBuffer.CurrentLine->Buffer + FileBuffer.FilePosition.Column - 1;
-    for (Index = 0; Index < ReplaceLen; Index++) {
-      Buffer[Index] = Replace[Index];
-    }
+    CopyMem (Buffer, Replace, ReplaceLen * sizeof (CHAR16));
   }
 
   FileBuffer.CurrentLine->Size += (ReplaceLen - SearchLen);
@@ -3322,9 +3318,7 @@ FileBufferReplaceAll (
       // set replace into it
       //
       Buffer = Line->Buffer + Position;
-      for (Index = 0; Index < ReplaceLen; Index++) {
-        Buffer[Index] = ReplaceStr[Index];
-      }
+      CopyMem (Buffer, ReplaceStr, ReplaceLen * sizeof (CHAR16));
 
       Line->Size += (ReplaceLen - SearchLen);
       Column     += ReplaceLen;

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/Edit/FileBuffer.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/Edit/FileBuffer.c
@@ -478,7 +478,6 @@ FileBufferPrintLine (
 {
   CHAR16  *Buffer;
   UINTN   Limit;
-  UINTN   PadLength;  // MU_CHANGE: Fix VS22 17.14 memcpy substitution
   CHAR16  *PrintLine;
   CHAR16  *PrintLine2;
   UINTN   BufLen;
@@ -497,13 +496,9 @@ FileBufferPrintLine (
   PrintLine = AllocatePool (BufLen);
   if (PrintLine != NULL) {
     StrnCpyS (PrintLine, BufLen/sizeof (CHAR16), Buffer, MIN (Limit, MainEditor.ScreenSize.Column));
-    // MU_CHANGE [BEGIN]: Fix VS22 17.14 memcpy substitution
-    if (StrLen (PrintLine) < MainEditor.ScreenSize.Column) {
-      PadLength = MainEditor.ScreenSize.Column - StrLen (PrintLine);
-      SetMem16 (&PrintLine[StrLen (PrintLine)], PadLength * sizeof (CHAR16), L' ');
+    for (Limit = StrLen (PrintLine); Limit < MainEditor.ScreenSize.Column; Limit++) {
+      PrintLine[Limit] = L' ';
     }
-
-    // MU_CHANGE [END]: Fix VS22 17.14 memcpy substitution
 
     PrintLine[MainEditor.ScreenSize.Column] = CHAR_NULL;
 
@@ -3109,23 +3104,17 @@ FileBufferReplace (
     // set replace into it
     //
     Buffer = FileBuffer.CurrentLine->Buffer + FileBuffer.FilePosition.Column - 1;
-    // MU_CHANGE [BEGIN]: Fix VS22 17.14 memcpy substitution
-    // for (Index = 0; Index < ReplaceLen; Index++) {
-    //   Buffer[Index] = Replace[Index];
-    // }
-    CopyMem (Buffer, Replace, ReplaceLen * sizeof (CHAR16));
-    // MU_CHANGE [END]: Fix VS22 17.14 memcpy substitution
+    for (Index = 0; Index < ReplaceLen; Index++) {
+      Buffer[Index] = Replace[Index];
+    }
   }
 
   if (ReplaceLen < SearchLen) {
     Buffer = FileBuffer.CurrentLine->Buffer + FileBuffer.FilePosition.Column - 1;
 
-    // MU_CHANGE [BEGIN]: Fix VS22 17.14 memcpy substitution
-    // for (Index = 0; Index < ReplaceLen; Index++) {
-    //   Buffer[Index] = Replace[Index];
-    // }
-    CopyMem (Buffer, Replace, ReplaceLen * sizeof (CHAR16));
-    // MU_CHANGE [END]: Fix VS22 17.14 memcpy substitution
+    for (Index = 0; Index < ReplaceLen; Index++) {
+      Buffer[Index] = Replace[Index];
+    }
 
     Buffer += ReplaceLen;
     Gap     = SearchLen - ReplaceLen;
@@ -3141,12 +3130,9 @@ FileBufferReplace (
 
   if (ReplaceLen == SearchLen) {
     Buffer = FileBuffer.CurrentLine->Buffer + FileBuffer.FilePosition.Column - 1;
-    // MU_CHANGE [BEGIN]: Fix VS22 17.14 memcpy substitution
-    // for (Index = 0; Index < ReplaceLen; Index++) {
-    //   Buffer[Index] = Replace[Index];
-    // }
-    CopyMem (Buffer, Replace, ReplaceLen * sizeof (CHAR16));
-    // MU_CHANGE [END]: Fix VS22 17.14 memcpy substitution
+    for (Index = 0; Index < ReplaceLen; Index++) {
+      Buffer[Index] = Replace[Index];
+    }
   }
 
   FileBuffer.CurrentLine->Size += (ReplaceLen - SearchLen);
@@ -3336,12 +3322,9 @@ FileBufferReplaceAll (
       // set replace into it
       //
       Buffer = Line->Buffer + Position;
-      // MU_CHANGE [BEGIN]: Fix VS22 17.14 memcpy substitution
-      // for (Index = 0; Index < ReplaceLen; Index++) {
-      //   Buffer[Index] = ReplaceStr[Index];
-      // }
-      CopyMem (Buffer, ReplaceStr, ReplaceLen * sizeof (CHAR16));
-      // MU_CHANGE [END]]: Fix VS22 17.14 memcpy substitution
+      for (Index = 0; Index < ReplaceLen; Index++) {
+        Buffer[Index] = ReplaceStr[Index];
+      }
 
       Line->Size += (ReplaceLen - SearchLen);
       Column     += ReplaceLen;

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/HexEdit/BufferImage.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/HexEdit/BufferImage.c
@@ -142,9 +142,8 @@ HBufferImageBackup (
   VOID
   )
 {
-  HBufferImageBackupVar.MousePosition = HBufferImage.MousePosition;
-
-  HBufferImageBackupVar.BufferPosition = HBufferImage.BufferPosition;
+  CopyMem (&HBufferImageBackupVar.MousePosition, &HBufferImage.MousePosition, sizeof (HBufferImage.MousePosition));
+  CopyMem (&HBufferImageBackupVar.BufferPosition, &HBufferImage.BufferPosition, sizeof (HBufferImage.BufferPosition));
 
   HBufferImageBackupVar.Modified = HBufferImage.Modified;
 
@@ -569,7 +568,7 @@ HBufferImageRestoreMousePosition (
       //
       // backup the old screen attributes
       //
-      Orig                  = HMainEditor.ColorAttributes;
+      CopyMem (&Orig, &HMainEditor.ColorAttributes, sizeof (Orig));
       New.Data              = 0;
       New.Colors.Foreground = Orig.Colors.Background & 0xF;
       New.Colors.Background = Orig.Colors.Foreground & 0x7;
@@ -1955,17 +1954,13 @@ HBufferImageDeleteCharacterFromBuffer (
   // pass deleted buffer out
   //
   if (DeleteBuffer != NULL) {
-    for (Index = 0; Index < Count; Index++) {
-      DeleteBuffer[Index] = BufferPtr[Pos + Index];
-    }
+    CopyMem (&DeleteBuffer[0], &BufferPtr[Pos], Count);
   }
 
   //
   // delete the part from Pos
   //
-  for (Index = Pos; Index < Size - Count; Index++) {
-    BufferPtr[Index] = BufferPtr[Index + Count];
-  }
+  CopyMem (&BufferPtr[Pos], &BufferPtr[Pos + Count], Size - Count - Pos);
 
   Size -= Count;
 
@@ -2069,16 +2064,12 @@ HBufferImageAddCharacterToBuffer (
   //
   // get a place to add
   //
-  for (Index = (INTN)(Size + Count - 1); Index >= (INTN)Pos; Index--) {
-    BufferPtr[Index] = BufferPtr[Index - Count];
-  }
+  CopyMem (&BufferPtr[Pos], &BufferPtr[Pos - Count], Size - Pos + Count);
 
   //
   // add the buffer
   //
-  for (Index = (INTN)0; Index < (INTN)Count; Index++) {
-    BufferPtr[Index + Pos] = AddBuffer[Index];
-  }
+  CopyMem (&BufferPtr[Pos], AddBuffer, Count);
 
   Size += Count;
 

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/HexEdit/BufferImage.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/HexEdit/BufferImage.c
@@ -142,13 +142,9 @@ HBufferImageBackup (
   VOID
   )
 {
-  // MU_CHANGE [BEGIN]: Fix VS22 17.14 memcpy substitution
   HBufferImageBackupVar.MousePosition = HBufferImage.MousePosition;
 
   HBufferImageBackupVar.BufferPosition = HBufferImage.BufferPosition;
-  CopyMem (&HBufferImageBackupVar.MousePosition, &HBufferImage.MousePosition, sizeof (HBufferImage.MousePosition));
-  CopyMem (&HBufferImageBackupVar.BufferPosition, &HBufferImage.BufferPosition, sizeof (HBufferImage.BufferPosition));
-  // MU_CHANGE [END]: Fix VS22 17.14 memcpy substitution
 
   HBufferImageBackupVar.Modified = HBufferImage.Modified;
 
@@ -573,10 +569,7 @@ HBufferImageRestoreMousePosition (
       //
       // backup the old screen attributes
       //
-      // MU_CHANGE [BEGIN]: Fix VS22 17.14 memcpy substitution
-      // Orig                  = HMainEditor.ColorAttributes;
-      CopyMem (&Orig, &HMainEditor.ColorAttributes, sizeof (Orig));
-      // MU_CHANGE [END]: Fix VS22 17.14 memcpy substitution
+      Orig                  = HMainEditor.ColorAttributes;
       New.Data              = 0;
       New.Colors.Foreground = Orig.Colors.Background & 0xF;
       New.Colors.Background = Orig.Colors.Foreground & 0x7;
@@ -1962,23 +1955,17 @@ HBufferImageDeleteCharacterFromBuffer (
   // pass deleted buffer out
   //
   if (DeleteBuffer != NULL) {
-    // MU_CHANGE [BEGIN]: Fix VS22 17.14 memcpy substitution
-    // for (Index = 0; Index < Count; Index++) {
-    //   DeleteBuffer[Index] = BufferPtr[Pos + Index];
-    // }
-    CopyMem (&DeleteBuffer[0], &BufferPtr[Pos], Count);
-    // MU_CHANGE [END]: Fix VS22 17.14 memcpy substitution
+    for (Index = 0; Index < Count; Index++) {
+      DeleteBuffer[Index] = BufferPtr[Pos + Index];
+    }
   }
 
   //
   // delete the part from Pos
   //
-  // MU_CHANGE [BEGIN]: Fix VS22 17.14 memcpy substitution
-  // for (Index = Pos; Index < Size - Count; Index++) {
-  //   BufferPtr[Index] = BufferPtr[Index + Count];
-  // }
-  CopyMem (&BufferPtr[Pos], &BufferPtr[Pos + Count], Size - Count - Pos);
-  // MU_CHANGE [END]: Fix VS22 17.14 memcpy substitution
+  for (Index = Pos; Index < Size - Count; Index++) {
+    BufferPtr[Index] = BufferPtr[Index + Count];
+  }
 
   Size -= Count;
 
@@ -2082,22 +2069,16 @@ HBufferImageAddCharacterToBuffer (
   //
   // get a place to add
   //
-  // MU_CHANGE [BEGIN]: Fix VS22 17.14 memcpy substitution
-  // for (Index = (INTN)(Size + Count - 1); Index >= (INTN)Pos; Index--) {
-  //   BufferPtr[Index] = BufferPtr[Index - Count];
-  // }
-  CopyMem (&BufferPtr[Pos + Count], &BufferPtr[Pos], Size - Pos);
-  // MU_CHANGE [END]: Fix VS22 17.14 memcpy substitution
+  for (Index = (INTN)(Size + Count - 1); Index >= (INTN)Pos; Index--) {
+    BufferPtr[Index] = BufferPtr[Index - Count];
+  }
 
   //
   // add the buffer
   //
-  // MU_CHANGE [BEGIN]: Fix VS22 17.14 memcpy substitution
-  // for (Index = (INTN)0; Index < (INTN)Count; Index++) {
-  //   BufferPtr[Index + Pos] = AddBuffer[Index];
-  // }
-  CopyMem (&BufferPtr[Pos], AddBuffer, Count);
-  // MU_CHANGE [END]: Fix VS22 17.14 memcpy substitution
+  for (Index = (INTN)0; Index < (INTN)Count; Index++) {
+    BufferPtr[Index + Pos] = AddBuffer[Index];
+  }
 
   Size += Count;
 

--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/HexEdit/BufferImage.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/HexEdit/BufferImage.c
@@ -143,9 +143,9 @@ HBufferImageBackup (
   )
 {
   // MU_CHANGE [BEGIN]: Fix VS22 17.14 memcpy substitution
-  // HBufferImageBackupVar.MousePosition = HBufferImage.MousePosition;
+  HBufferImageBackupVar.MousePosition = HBufferImage.MousePosition;
 
-  // HBufferImageBackupVar.BufferPosition = HBufferImage.BufferPosition;
+  HBufferImageBackupVar.BufferPosition = HBufferImage.BufferPosition;
   CopyMem (&HBufferImageBackupVar.MousePosition, &HBufferImage.MousePosition, sizeof (HBufferImage.MousePosition));
   CopyMem (&HBufferImageBackupVar.BufferPosition, &HBufferImage.BufferPosition, sizeof (HBufferImage.BufferPosition));
   // MU_CHANGE [END]: Fix VS22 17.14 memcpy substitution


### PR DESCRIPTION
## Description

Reverts Mu changes and cherry-picks edk2 changes to prevent memcpy intrinsics in VS22 (17.14.2).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

- N/A. Replace existing code with upstream cherry-pick.

## Integration Instructions

N/A