### PR TITLE
[REBASE & FF] StandaloneMmPkg: Avoid updating attributes on 0 length sections

### DIFF
--- a/StandaloneMmPkg/Library/StandaloneMmPeCoffExtraActionLib/AArch64/StandaloneMmPeCoffExtraActionLib.c
+++ b/StandaloneMmPkg/Library/StandaloneMmPeCoffExtraActionLib/AArch64/StandaloneMmPeCoffExtraActionLib.c
@@ -167,7 +167,17 @@ UpdatePeCoffPermissions (
 
     Base = TmpContext.ImageAddress + SectionHeader.VirtualAddress;
 
-    if ((SectionHeader.Characteristics & EFI_IMAGE_SCN_MEM_EXECUTE) == 0) {
+    // MU_CHANGE [BEGIN] - Skip sections with zero size
+    if (SectionHeader.Misc.VirtualSize == 0) {
+      DEBUG ((
+        DEBUG_INFO,
+        "%a: Skipping section %d of image at 0x%lx with size 0\n",
+        __func__,
+        Index,
+        Base
+        ));
+    } else if ((SectionHeader.Characteristics & EFI_IMAGE_SCN_MEM_EXECUTE) == 0) {
+      // MU_CHANGE [END] - Skip sections with zero size
       if ((SectionHeader.Characteristics & EFI_IMAGE_SCN_MEM_WRITE) == 0) {
         DEBUG ((
           DEBUG_INFO,


### PR DESCRIPTION
## Description

PE images can have a zero virtual length section for placeholders, unused relocation, or other artifacts. Some update callbacks such as Hafnium may assert or fail on such a call. This change simply skips such scenarios as no real operation is required anyways.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Tested on SBSA

## Integration Instructions

N/A
