### PR TITLE
2502 Mu DevOps Pilot Change: Use pull_request_target in PR formatting validator

### DIFF
--- a/.github/workflows/pull-request-formatting-validator.yml
+++ b/.github/workflows/pull-request-formatting-validator.yml
@@ -13,7 +13,7 @@
 name: Validate Pull Request Formatting
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - edited
       - opened


### PR DESCRIPTION
## Description

As an amendment to https://github.com/microsoft/mu_basecore/pull/1417...

`pull-request-formatting-validator.yml` needs to have a `pull_request_target` trigger type to allow secrets to be used (to derive the GitHub app token) for PRs coming from forks.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

- PR

## Integration Instructions

- N/A