### PR TITLE
Fixing a case where the incoming is not a file path

### DIFF
--- a/ShellPkg/Application/Shell/Shell.c
+++ b/ShellPkg/Application/Shell/Shell.c
@@ -1242,8 +1242,10 @@ LocateStartupScript (
   CHAR16        *TempSpot;
   CONST CHAR16  *MapName;
   UINTN         Size;
+  CHAR16        *ConvertedPath;
 
   StartupScriptPath = NULL;
+  ConvertedPath     = NULL;
   Size              = 0;
 
   //
@@ -1266,7 +1268,17 @@ LocateStartupScript (
 
     InternalEfiShellSetEnv (L"homefilesystem", StartupScriptPath, TRUE);
 
-    StartupScriptPath = StrnCatGrow (&StartupScriptPath, &Size, ((FILEPATH_DEVICE_PATH *)FileDevicePath)->PathName, 0);
+    ConvertedPath = ConvertDevicePathToText (
+      FileDevicePath,
+      FALSE,
+      TRUE
+      );
+    if (ConvertedPath == NULL) {
+      SHELL_FREE_NON_NULL (StartupScriptPath);
+      return NULL;
+    }
+
+    StartupScriptPath = StrnCatGrow (&StartupScriptPath, &Size, ConvertedPath, 0);
     PathRemoveLastItem (StartupScriptPath);
     StartupScriptPath = StrnCatGrow (&StartupScriptPath, &Size, mStartupScript, 0);
   }
@@ -1279,6 +1291,7 @@ LocateStartupScript (
     StartupScriptPath = ShellFindFilePath (mStartupScript);
   }
 
+  SHELL_FREE_NON_NULL (ConvertedPath);
   return StartupScriptPath;
 }
 


### PR DESCRIPTION
## Description

When there are file systems that do not belong to `FILEPATH_DEVICE_PATH`, the casting will be incorrect AND could potentially cause page fault. i.e. if the path belongs to a FV enumerated by FvFileSystemDxe driver, the `PathName` is actually a GUID and does not end with 0.

This change will parse out the file path using DevicePathLib and then perform the string concatenation.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

This fixed a hang in the QEMU SBSA UEFI shell when searching for the startup.nsh file.

## Integration Instructions

N/A
