### PR TITLE
[CHERRY-PICK] Add resource descriptor hob v2 for memory attributes usage

### DIFF
--- a/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
+++ b/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
@@ -2350,7 +2350,7 @@ CoreInitializeMemoryServices (
       //
       Count = 0;
       for (Hob.Raw = *HobStart; !END_OF_HOB_LIST (Hob); Hob.Raw = GET_NEXT_HOB (Hob)) {
-        if (GET_HOB_TYPE (Hob) != EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+        if ((GET_HOB_TYPE (Hob) != EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) && (GET_HOB_TYPE (Hob) != EFI_HOB_TYPE_RESOURCE_DESCRIPTOR2)) {
           continue;
         }
 
@@ -2392,7 +2392,7 @@ CoreInitializeMemoryServices (
     //
     // Skip all HOBs except Resource Descriptor HOBs
     //
-    if (GET_HOB_TYPE (Hob) != EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+    if ((GET_HOB_TYPE (Hob) != EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) && (GET_HOB_TYPE (Hob) != EFI_HOB_TYPE_RESOURCE_DESCRIPTOR2)) {
       continue;
     }
 
@@ -2500,7 +2500,7 @@ CoreInitializeMemoryServices (
       //
       // Skip all HOBs except Resource Descriptor HOBs
       //
-      if (GET_HOB_TYPE (Hob) != EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+      if ((GET_HOB_TYPE (Hob) != EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) && (GET_HOB_TYPE (Hob) != EFI_HOB_TYPE_RESOURCE_DESCRIPTOR2)) {
         continue;
       }
 
@@ -2698,7 +2698,7 @@ CoreInitializeGcdServices (
     GcdMemoryType = EfiGcdMemoryTypeNonExistent;
     GcdIoType     = EfiGcdIoTypeNonExistent;
 
-    if (GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) {
+    if ((GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR) || (GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_RESOURCE_DESCRIPTOR2)) {
       ResourceHob = Hob.ResourceDescriptor;
 
       switch (ResourceHob->ResourceType) {

--- a/MdeModulePkg/Library/BaseHobLibNull/BaseHobLibNull.c
+++ b/MdeModulePkg/Library/BaseHobLibNull/BaseHobLibNull.c
@@ -231,6 +231,38 @@ BuildResourceDescriptorWithOwnerHob (
   ASSERT (FALSE);
 }
 
+// MU_CHANGE Start: Add BuildResourceDescriptorV2 function
+
+/**
+  Builds a HOB that describes a chunk of system memory with memory attributes.
+
+  This function builds a HOB that describes a chunk of system memory.
+  If there is no additional space for HOB creation, then ASSERT().
+
+  @param  ResourceType          The type of resource described by this HOB.
+  @param  ResourceAttribute     The resource attributes of the memory described by this HOB.
+  @param  PhysicalStart         The 64 bit physical address of memory described by this HOB.
+  @param  NumberOfBytes         The length of the memory described by this HOB in bytes.
+  @param  EfiMemoryAttributes   The memory attribute for the memory described by this HOB.
+  @param  OwnerGUID             GUID for the owner of this resource.
+
+**/
+VOID
+EFIAPI
+BuildResourceDescriptorV2 (
+  IN EFI_RESOURCE_TYPE            ResourceType,
+  IN EFI_RESOURCE_ATTRIBUTE_TYPE  ResourceAttribute,
+  IN EFI_PHYSICAL_ADDRESS         PhysicalStart,
+  IN UINT64                       NumberOfBytes,
+  IN UINT64                       EfiMemoryAttributes,
+  IN EFI_GUID                     *OwnerGUID OPTIONAL
+  )
+{
+  ASSERT (FALSE);
+}
+
+// MU_CHANGE End
+
 /**
   Builds a HOB that describes a chunk of system memory.
 

--- a/MdeModulePkg/Library/HobPrintLib/HobPrintLib.c
+++ b/MdeModulePkg/Library/HobPrintLib/HobPrintLib.c
@@ -215,6 +215,35 @@ PrintResourceDiscriptorHob (
 }
 
 /**
+  Print the information in Resource Discriptor Hob.
+  @param[in]  HobStart       A pointer to HOB of type EFI_HOB_TYPE_RESOURCE_DESCRIPTOR2.
+  @param[in]  HobLength      The Length in bytes of HOB of type EFI_HOB_TYPE_RESOURCE_DESCRIPTOR2.
+  @retval EFI_SUCCESS        If it completed successfully.
+**/
+EFI_STATUS
+PrintResourceDiscriptor2Hob (
+  IN  VOID    *HobStart,
+  IN  UINT16  HobLength
+  )
+{
+  EFI_PEI_HOB_POINTERS  Hob;
+
+  Hob.Raw = (UINT8 *)HobStart;
+  ASSERT (HobLength >= sizeof (*Hob.ResourceDescriptorV2));
+
+  DEBUG ((DEBUG_INFO, "   ResourceType      = %a\n", mResource_Type_List[Hob.ResourceDescriptorV2->V1.ResourceType]));
+  if (!IsZeroGuid (&Hob.ResourceDescriptorV2->V1.Owner)) {
+    DEBUG ((DEBUG_INFO, "   Owner             = %g\n", &Hob.ResourceDescriptorV2->V1.Owner));
+  }
+
+  DEBUG ((DEBUG_INFO, "   ResourceAttribute = 0x%x\n", Hob.ResourceDescriptorV2->V1.ResourceAttribute));
+  DEBUG ((DEBUG_INFO, "   PhysicalStart     = 0x%lx\n", Hob.ResourceDescriptorV2->V1.PhysicalStart));
+  DEBUG ((DEBUG_INFO, "   ResourceLength    = 0x%lx\n", Hob.ResourceDescriptorV2->V1.ResourceLength));
+  DEBUG ((DEBUG_INFO, "   Attributes         = 0x%x\n", Hob.ResourceDescriptorV2->Attributes));
+  return EFI_SUCCESS;
+}
+
+/**
   Print the Guid Hob using related print handle function.
   @param[in] HobStart        A pointer to the HOB of type EFI_HOB_TYPE_GUID_EXTENSION.
   @param[in] HobLength       The length in bytes of the HOB of type EFI_HOB_TYPE_GUID_EXTENSION.
@@ -386,16 +415,17 @@ PrintFv3Hob (
 // Mapping table from Hob type to Hob print function.
 //
 HOB_PRINT_HANDLER_TABLE  mHobHandles[] = {
-  { EFI_HOB_TYPE_HANDOFF,             "EFI_HOB_TYPE_HANDOFF",             PrintHandOffHob            },
-  { EFI_HOB_TYPE_MEMORY_ALLOCATION,   "EFI_HOB_TYPE_MEMORY_ALLOCATION",   PrintMemoryAllocationHob   },
-  { EFI_HOB_TYPE_RESOURCE_DESCRIPTOR, "EFI_HOB_TYPE_RESOURCE_DESCRIPTOR", PrintResourceDiscriptorHob },
-  { EFI_HOB_TYPE_GUID_EXTENSION,      "EFI_HOB_TYPE_GUID_EXTENSION",      PrintGuidHob               },
-  { EFI_HOB_TYPE_FV,                  "EFI_HOB_TYPE_FV",                  PrintFvHob                 },
-  { EFI_HOB_TYPE_CPU,                 "EFI_HOB_TYPE_CPU",                 PrintCpuHob                },
-  { EFI_HOB_TYPE_MEMORY_POOL,         "EFI_HOB_TYPE_MEMORY_POOL",         PrintMemoryPoolHob         },
-  { EFI_HOB_TYPE_FV2,                 "EFI_HOB_TYPE_FV2",                 PrintFv2Hob                },
-  { EFI_HOB_TYPE_UEFI_CAPSULE,        "EFI_HOB_TYPE_UEFI_CAPSULE",        PrintCapsuleHob            },
-  { EFI_HOB_TYPE_FV3,                 "EFI_HOB_TYPE_FV3",                 PrintFv3Hob                }
+  { EFI_HOB_TYPE_HANDOFF,              "EFI_HOB_TYPE_HANDOFF",              PrintHandOffHob             },
+  { EFI_HOB_TYPE_MEMORY_ALLOCATION,    "EFI_HOB_TYPE_MEMORY_ALLOCATION",    PrintMemoryAllocationHob    },
+  { EFI_HOB_TYPE_RESOURCE_DESCRIPTOR,  "EFI_HOB_TYPE_RESOURCE_DESCRIPTOR",  PrintResourceDiscriptorHob  },
+  { EFI_HOB_TYPE_GUID_EXTENSION,       "EFI_HOB_TYPE_GUID_EXTENSION",       PrintGuidHob                },
+  { EFI_HOB_TYPE_FV,                   "EFI_HOB_TYPE_FV",                   PrintFvHob                  },
+  { EFI_HOB_TYPE_CPU,                  "EFI_HOB_TYPE_CPU",                  PrintCpuHob                 },
+  { EFI_HOB_TYPE_MEMORY_POOL,          "EFI_HOB_TYPE_MEMORY_POOL",          PrintMemoryPoolHob          },
+  { EFI_HOB_TYPE_FV2,                  "EFI_HOB_TYPE_FV2",                  PrintFv2Hob                 },
+  { EFI_HOB_TYPE_UEFI_CAPSULE,         "EFI_HOB_TYPE_UEFI_CAPSULE",         PrintCapsuleHob             },
+  { EFI_HOB_TYPE_FV3,                  "EFI_HOB_TYPE_FV3",                  PrintFv3Hob                 },
+  { EFI_HOB_TYPE_RESOURCE_DESCRIPTOR2, "EFI_HOB_TYPE_RESOURCE_DESCRIPTOR2", PrintResourceDiscriptor2Hob }
 };
 
 /**

--- a/MdePkg/Include/Library/HobLib.h
+++ b/MdePkg/Include/Library/HobLib.h
@@ -204,6 +204,38 @@ BuildResourceDescriptorWithOwnerHob (
   IN EFI_GUID                     *OwnerGUID
   );
 
+// MU_CHANGE Start: Add BuildResourceDescriptorV2 function
+
+/**
+  Builds a HOB that describes a chunk of system memory with memory attributes.
+
+  This function builds a HOB that describes a chunk of system memory.
+  It can only be invoked during PEI phase;
+  for DXE phase, it will ASSERT() since PEI HOB is read-only for DXE phase.
+
+  If there is no additional space for HOB creation, then ASSERT().
+
+  @param  ResourceType          The type of resource described by this HOB.
+  @param  ResourceAttribute     The resource attributes of the memory described by this HOB.
+  @param  PhysicalStart         The 64 bit physical address of memory described by this HOB.
+  @param  NumberOfBytes         The length of the memory described by this HOB in bytes.
+  @param  EfiMemoryAttributes   The memory attribute for the memory described by this HOB.
+  @param  OwnerGUID             GUID for the owner of this resource.
+
+**/
+VOID
+EFIAPI
+BuildResourceDescriptorV2 (
+  IN EFI_RESOURCE_TYPE            ResourceType,
+  IN EFI_RESOURCE_ATTRIBUTE_TYPE  ResourceAttribute,
+  IN EFI_PHYSICAL_ADDRESS         PhysicalStart,
+  IN UINT64                       NumberOfBytes,
+  IN UINT64                       EfiMemoryAttributes,
+  IN EFI_GUID                     *OwnerGUID OPTIONAL
+  );
+
+// MU_CHANGE End
+
 /**
   Builds a HOB that describes a chunk of system memory.
 

--- a/MdePkg/Include/Pi/PiHob.h
+++ b/MdePkg/Include/Pi/PiHob.h
@@ -15,19 +15,20 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 //
 // HobType of EFI_HOB_GENERIC_HEADER.
 //
-#define EFI_HOB_TYPE_HANDOFF              0x0001
-#define EFI_HOB_TYPE_MEMORY_ALLOCATION    0x0002
-#define EFI_HOB_TYPE_RESOURCE_DESCRIPTOR  0x0003
-#define EFI_HOB_TYPE_GUID_EXTENSION       0x0004
-#define EFI_HOB_TYPE_FV                   0x0005
-#define EFI_HOB_TYPE_CPU                  0x0006
-#define EFI_HOB_TYPE_MEMORY_POOL          0x0007
-#define EFI_HOB_TYPE_FV2                  0x0009
-#define EFI_HOB_TYPE_LOAD_PEIM_UNUSED     0x000A
-#define EFI_HOB_TYPE_UEFI_CAPSULE         0x000B
-#define EFI_HOB_TYPE_FV3                  0x000C
-#define EFI_HOB_TYPE_UNUSED               0xFFFE
-#define EFI_HOB_TYPE_END_OF_HOB_LIST      0xFFFF
+#define EFI_HOB_TYPE_HANDOFF               0x0001
+#define EFI_HOB_TYPE_MEMORY_ALLOCATION     0x0002
+#define EFI_HOB_TYPE_RESOURCE_DESCRIPTOR   0x0003
+#define EFI_HOB_TYPE_GUID_EXTENSION        0x0004
+#define EFI_HOB_TYPE_FV                    0x0005
+#define EFI_HOB_TYPE_CPU                   0x0006
+#define EFI_HOB_TYPE_MEMORY_POOL           0x0007
+#define EFI_HOB_TYPE_FV2                   0x0009
+#define EFI_HOB_TYPE_LOAD_PEIM_UNUSED      0x000A
+#define EFI_HOB_TYPE_UEFI_CAPSULE          0x000B
+#define EFI_HOB_TYPE_FV3                   0x000C
+#define EFI_HOB_TYPE_RESOURCE_DESCRIPTOR2  0x000D
+#define EFI_HOB_TYPE_UNUSED                0xFFFE
+#define EFI_HOB_TYPE_END_OF_HOB_LIST       0xFFFF
 
 ///
 /// Describes the format and size of the data inside the HOB.
@@ -332,6 +333,25 @@ typedef struct {
   UINT64                         ResourceLength;
 } EFI_HOB_RESOURCE_DESCRIPTOR;
 
+/// PI Spec Status: Pending.
+/// This change is checked in as a code first approach. The PI spec will be updated
+/// to reflect this change in the future.
+///
+/// Describes the resource properties and memory attributes
+/// of all fixed, nonrelocatable resource ranges found on the
+/// processor host bus during the HOB producer phase.
+///
+typedef struct {
+  ///
+  /// The HOB generic header. Header.HobType = EFI_HOB_TYPE_RESOURCE_DESCRIPTOR.
+  ///
+  EFI_HOB_RESOURCE_DESCRIPTOR    V1;
+  ///
+  /// The memory attributes (paging and caching) of the resource region.
+  ///
+  UINT64                         Attributes;
+} EFI_HOB_RESOURCE_DESCRIPTOR_V2;
+
 ///
 /// Allows writers of executable content in the HOB producer phase to
 /// maintain and manage HOBs with specific GUID.
@@ -505,6 +525,7 @@ typedef union {
   EFI_HOB_CPU                            *Cpu;
   EFI_HOB_MEMORY_POOL                    *Pool;
   EFI_HOB_UEFI_CAPSULE                   *Capsule;
+  EFI_HOB_RESOURCE_DESCRIPTOR_V2         *ResourceDescriptorV2;
   UINT8                                  *Raw;
 } EFI_PEI_HOB_POINTERS;
 

--- a/MdePkg/Library/DxeCoreHobLib/HobLib.c
+++ b/MdePkg/Library/DxeCoreHobLib/HobLib.c
@@ -269,6 +269,38 @@ BuildResourceDescriptorWithOwnerHob (
   ASSERT (FALSE);
 }
 
+// MU_CHANGE Start: Add BuildResourceDescriptorV2 function
+
+/**
+  Builds a HOB that describes a chunk of system memory with memory attributes.
+
+  This function builds a HOB that describes a chunk of system memory.
+  If there is no additional space for HOB creation, then ASSERT().
+
+  @param  ResourceType          The type of resource described by this HOB.
+  @param  ResourceAttribute     The resource attributes of the memory described by this HOB.
+  @param  PhysicalStart         The 64 bit physical address of memory described by this HOB.
+  @param  NumberOfBytes         The length of the memory described by this HOB in bytes.
+  @param  EfiMemoryAttributes   The memory attribute for the memory described by this HOB.
+  @param  OwnerGUID             GUID for the owner of this resource.
+
+**/
+VOID
+EFIAPI
+BuildResourceDescriptorV2 (
+  IN EFI_RESOURCE_TYPE            ResourceType,
+  IN EFI_RESOURCE_ATTRIBUTE_TYPE  ResourceAttribute,
+  IN EFI_PHYSICAL_ADDRESS         PhysicalStart,
+  IN UINT64                       NumberOfBytes,
+  IN UINT64                       EfiMemoryAttributes,
+  IN EFI_GUID                     *OwnerGUID OPTIONAL
+  )
+{
+  ASSERT (FALSE);
+}
+
+// MU_CHANGE End
+
 /**
   Builds a HOB that describes a chunk of system memory.
 

--- a/MdePkg/Library/DxeHobLib/HobLib.c
+++ b/MdePkg/Library/DxeHobLib/HobLib.c
@@ -304,6 +304,38 @@ BuildResourceDescriptorWithOwnerHob (
   ASSERT (FALSE);
 }
 
+// MU_CHANGE Start: Add BuildResourceDescriptorV2 function
+
+/**
+  Builds a HOB that describes a chunk of system memory with memory attributes.
+
+  This function builds a HOB that describes a chunk of system memory.
+  If there is no additional space for HOB creation, then ASSERT().
+
+  @param  ResourceType          The type of resource described by this HOB.
+  @param  ResourceAttribute     The resource attributes of the memory described by this HOB.
+  @param  PhysicalStart         The 64 bit physical address of memory described by this HOB.
+  @param  NumberOfBytes         The length of the memory described by this HOB in bytes.
+  @param  EfiMemoryAttributes   The memory attribute for the memory described by this HOB.
+  @param  OwnerGUID             GUID for the owner of this resource.
+
+**/
+VOID
+EFIAPI
+BuildResourceDescriptorV2 (
+  IN EFI_RESOURCE_TYPE            ResourceType,
+  IN EFI_RESOURCE_ATTRIBUTE_TYPE  ResourceAttribute,
+  IN EFI_PHYSICAL_ADDRESS         PhysicalStart,
+  IN UINT64                       NumberOfBytes,
+  IN UINT64                       EfiMemoryAttributes,
+  IN EFI_GUID                     *OwnerGUID OPTIONAL
+  )
+{
+  ASSERT (FALSE);
+}
+
+// MU_CHANGE End
+
 /**
   Builds a HOB that describes a chunk of system memory.
 

--- a/MdePkg/Library/PeiHobLib/HobLib.c
+++ b/MdePkg/Library/PeiHobLib/HobLib.c
@@ -7,6 +7,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 **/
 
 #include <PiPei.h>
+#include <Uefi/UefiSpec.h>
 
 #include <Guid/MemoryAllocationHob.h>
 
@@ -341,6 +342,58 @@ BuildResourceDescriptorWithOwnerHob (
 
   CopyGuid (&Hob->Owner, OwnerGUID);
 }
+
+// MU_CHANGE Start: Add BuildResourceDescriptorV2 function
+
+/**
+  Builds a HOB that describes a chunk of system memory with memory attributes.
+
+  This function builds a HOB that describes a chunk of system memory.
+  It can only be invoked during PEI phase;
+  for DXE phase, it will ASSERT() since PEI HOB is read-only for DXE phase.
+
+  If there is no additional space for HOB creation, then ASSERT().
+
+  @param  ResourceType          The type of resource described by this HOB.
+  @param  ResourceAttribute     The resource attributes of the memory described by this HOB.
+  @param  PhysicalStart         The 64 bit physical address of memory described by this HOB.
+  @param  NumberOfBytes         The length of the memory described by this HOB in bytes.
+  @param  EfiMemoryAttributes   The memory attribute for the memory described by this HOB.
+  @param  OwnerGUID             GUID for the owner of this resource.
+
+**/
+VOID
+EFIAPI
+BuildResourceDescriptorV2 (
+  IN EFI_RESOURCE_TYPE            ResourceType,
+  IN EFI_RESOURCE_ATTRIBUTE_TYPE  ResourceAttribute,
+  IN EFI_PHYSICAL_ADDRESS         PhysicalStart,
+  IN UINT64                       NumberOfBytes,
+  IN UINT64                       EfiMemoryAttributes,
+  IN EFI_GUID                     *OwnerGUID OPTIONAL
+  )
+{
+  EFI_HOB_RESOURCE_DESCRIPTOR_V2  *Hob;
+
+  Hob = InternalPeiCreateHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR2, (UINT16)sizeof (EFI_HOB_RESOURCE_DESCRIPTOR_V2));
+  if (Hob == NULL) {
+    return;
+  }
+
+  Hob->V1.ResourceType      = ResourceType;
+  Hob->V1.ResourceAttribute = ResourceAttribute;
+  Hob->V1.PhysicalStart     = PhysicalStart;
+  Hob->V1.ResourceLength    = NumberOfBytes;
+  Hob->Attributes           = EfiMemoryAttributes;
+
+  if (OwnerGUID != NULL) {
+    CopyGuid (&Hob->V1.Owner, OwnerGUID);
+  } else {
+    ZeroMem (&(Hob->V1.Owner), sizeof (EFI_GUID));
+  }
+}
+
+// MU_CHANGE End
 
 /**
   Builds a HOB that describes a chunk of system memory.

--- a/MdePkg/Test/Mock/Library/Stub/StubHobLib/StubHobLib.c
+++ b/MdePkg/Test/Mock/Library/Stub/StubHobLib/StubHobLib.c
@@ -229,6 +229,38 @@ BuildResourceDescriptorWithOwnerHob (
   ASSERT (FALSE);
 }
 
+// MU_CHANGE Start: Add BuildResourceDescriptorV2 function
+
+/**
+  Builds a HOB that describes a chunk of system memory with memory attributes.
+
+  This function builds a HOB that describes a chunk of system memory.
+  If there is no additional space for HOB creation, then ASSERT().
+
+  @param  ResourceType          The type of resource described by this HOB.
+  @param  ResourceAttribute     The resource attributes of the memory described by this HOB.
+  @param  PhysicalStart         The 64 bit physical address of memory described by this HOB.
+  @param  NumberOfBytes         The length of the memory described by this HOB in bytes.
+  @param  EfiMemoryAttributes   The memory attribute for the memory described by this HOB.
+  @param  OwnerGUID             GUID for the owner of this resource.
+
+**/
+VOID
+EFIAPI
+BuildResourceDescriptorV2 (
+  IN EFI_RESOURCE_TYPE            ResourceType,
+  IN EFI_RESOURCE_ATTRIBUTE_TYPE  ResourceAttribute,
+  IN EFI_PHYSICAL_ADDRESS         PhysicalStart,
+  IN UINT64                       NumberOfBytes,
+  IN UINT64                       EfiMemoryAttributes,
+  IN EFI_GUID                     *OwnerGUID OPTIONAL
+  )
+{
+  ASSERT (FALSE);
+}
+
+// MU_CHANGE End
+
 /**
   Builds a HOB that describes a chunk of system memory.
 

--- a/StandaloneMmPkg/Library/StandaloneMmCoreHobLib/Common.c
+++ b/StandaloneMmPkg/Library/StandaloneMmCoreHobLib/Common.c
@@ -229,6 +229,38 @@ BuildResourceDescriptorWithOwnerHob (
   ASSERT (FALSE);
 }
 
+// MU_CHANGE Start: Add BuildResourceDescriptorV2 function
+
+/**
+  Builds a HOB that describes a chunk of system memory with memory attributes.
+
+  This function builds a HOB that describes a chunk of system memory.
+  If there is no additional space for HOB creation, then ASSERT().
+
+  @param  ResourceType          The type of resource described by this HOB.
+  @param  ResourceAttribute     The resource attributes of the memory described by this HOB.
+  @param  PhysicalStart         The 64 bit physical address of memory described by this HOB.
+  @param  NumberOfBytes         The length of the memory described by this HOB in bytes.
+  @param  EfiMemoryAttributes   The memory attribute for the memory described by this HOB.
+  @param  OwnerGUID             GUID for the owner of this resource.
+
+**/
+VOID
+EFIAPI
+BuildResourceDescriptorV2 (
+  IN EFI_RESOURCE_TYPE            ResourceType,
+  IN EFI_RESOURCE_ATTRIBUTE_TYPE  ResourceAttribute,
+  IN EFI_PHYSICAL_ADDRESS         PhysicalStart,
+  IN UINT64                       NumberOfBytes,
+  IN UINT64                       EfiMemoryAttributes,
+  IN EFI_GUID                     *OwnerGUID OPTIONAL
+  )
+{
+  ASSERT (FALSE);
+}
+
+// MU_CHANGE End
+
 /**
   Builds a Capsule Volume HOB.
 

--- a/StandaloneMmPkg/Library/StandaloneMmHobLib/StandaloneMmHobLib.c
+++ b/StandaloneMmPkg/Library/StandaloneMmHobLib/StandaloneMmHobLib.c
@@ -516,6 +516,38 @@ BuildResourceDescriptorWithOwnerHob (
   ASSERT (FALSE);
 }
 
+// MU_CHANGE Start: Add BuildResourceDescriptorV2 function
+
+/**
+  Builds a HOB that describes a chunk of system memory with memory attributes.
+
+  This function builds a HOB that describes a chunk of system memory.
+  If there is no additional space for HOB creation, then ASSERT().
+
+  @param  ResourceType          The type of resource described by this HOB.
+  @param  ResourceAttribute     The resource attributes of the memory described by this HOB.
+  @param  PhysicalStart         The 64 bit physical address of memory described by this HOB.
+  @param  NumberOfBytes         The length of the memory described by this HOB in bytes.
+  @param  EfiMemoryAttributes   The memory attribute for the memory described by this HOB.
+  @param  OwnerGUID             GUID for the owner of this resource.
+
+**/
+VOID
+EFIAPI
+BuildResourceDescriptorV2 (
+  IN EFI_RESOURCE_TYPE            ResourceType,
+  IN EFI_RESOURCE_ATTRIBUTE_TYPE  ResourceAttribute,
+  IN EFI_PHYSICAL_ADDRESS         PhysicalStart,
+  IN UINT64                       NumberOfBytes,
+  IN UINT64                       EfiMemoryAttributes,
+  IN EFI_GUID                     *OwnerGUID OPTIONAL
+  )
+{
+  ASSERT (FALSE);
+}
+
+// MU_CHANGE End
+
 /**
   Builds a Capsule Volume HOB.
 


### PR DESCRIPTION
## Description

This change adds the implementation of supporting "resource descriptor hob type 2", which will extends the existing definition of resource descriptor hob with an attribute field.

This field can be used to provide the actual attributes needs to be set for the memory region, instead of relying on the state of the system.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

This change was tested on QEMU Q35 and SBSA systems and booted to Windows.

## Integration Instructions

For platforms needing to propagate specific memory attributes (especially the cache attributes) to the DXE phase, `BuildResourceDescriptorWithCacheHob` should be used to produce resource descriptors (v2).