### PR TITLE
[Cherry-Pick] Apply Read only on AP Wakeup Buffers [Rebase & FF]

### DIFF
--- a/UefiCpuPkg/Library/MpInitLib/DxeMpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/DxeMpLib.c
@@ -110,57 +110,6 @@ InstallCpuMpDebugProtocol (
   DEBUG ((DEBUG_INFO, "Installed gCpuMpDebugProtocolGuid - Status: %r\n", Status));
 }
 
-// MU_CHANGE START: Enable removal of NX attribute from buffer
-
-/**
-  Remove NX attribute from Buffer and apply RO to Buffer
-
-  @param[in]  Buffer      Buffer whose attributes will be altered
-  @param[in]  Size        Size of the buffer
-
-  @retval EFI_SUCCESS             NX attribute removed, RO attribute applied
-  @retval EFI_INVALID_PARAMETER   Buffer is not page-aligned or Buffer is 0 or Size of buffer
-                                  is not page-aligned
-  @retval Other                   Return value of LocateProtocol, ClearMemoryAttributes, or SetMemoryAttributes
-**/
-EFI_STATUS
-BufferRemoveNoExecuteSetReadOnly (
-  IN EFI_PHYSICAL_ADDRESS  Buffer,
-  IN UINTN                 Size
-  )
-{
-  EFI_CPU_ARCH_PROTOCOL  *CpuProtocol = NULL;
-  EFI_STATUS             Status;
-
-  if ((Buffer == 0) || (Buffer % EFI_PAGE_SIZE != 0) || (Size % EFI_PAGE_SIZE != 0)) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  Status = gBS->LocateProtocol (&gEfiCpuArchProtocolGuid, NULL, (VOID **)&CpuProtocol);
-
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a - Unable to locate gEfiCpuArchProtocolGuid\n", __func__));
-    ASSERT_EFI_ERROR (Status);
-    return Status;
-  }
-
-  Status = CpuProtocol->SetMemoryAttributes (
-                          CpuProtocol,
-                          Buffer,
-                          Size,
-                          EFI_MEMORY_RO
-                          );
-
-  if EFI_ERROR (Status) {
-    DEBUG ((DEBUG_INFO, "%a - Unable to update buffer attributes!\n", __func__));
-    ASSERT_EFI_ERROR (Status);
-  }
-
-  return Status;
-}
-
-// MU_CHANGE END Enable removal of NX attribute from buffer
-
 /**
   Enable Debug Agent to support source debugging on AP function.
 
@@ -293,7 +242,7 @@ GetWakeupBuffer (
   @retval 0       Cannot find free memory below 4GB.
 **/
 UINTN
-AllocateCodeBuffer (
+AllocateCodePage (
   IN UINTN  BufferSize
   )
 {
@@ -550,14 +499,11 @@ AllocateApLoopCodeBuffer (
 /**
   Remove Nx protection for the range specific by BaseAddress and Length.
 
-  The PEI implementation uses CpuPageTableLib to change the attribute.
-  The DXE implementation uses gDS to change the attribute.
-
   @param[in] BaseAddress  BaseAddress of the range.
   @param[in] Length       Length of the range.
 **/
 VOID
-RemoveNxprotection (
+RemoveNxProtection (
   IN EFI_PHYSICAL_ADDRESS  BaseAddress,
   IN UINTN                 Length
   )
@@ -565,17 +511,58 @@ RemoveNxprotection (
   EFI_STATUS                       Status;
   EFI_GCD_MEMORY_SPACE_DESCRIPTOR  MemDesc;
 
-  //
-  // TODO: Check EFI_MEMORY_XP bit set or not once it's available in DXE GCD
-  //       service.
-  //
   Status = gDS->GetMemorySpaceDescriptor (BaseAddress, &MemDesc);
   if (!EFI_ERROR (Status)) {
-    gDS->SetMemorySpaceAttributes (
-           BaseAddress,
-           Length,
-           MemDesc.Attributes & (~EFI_MEMORY_XP)
-           );
+    if (((MemDesc.Capabilities & EFI_MEMORY_XP) == EFI_MEMORY_XP) && ((MemDesc.Attributes & EFI_MEMORY_XP) == EFI_MEMORY_XP)) {
+      Status = gDS->SetMemorySpaceAttributes (
+                      BaseAddress,
+                      Length,
+                      MemDesc.Attributes & (~EFI_MEMORY_XP)
+                      );
+
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "%a - Setting Nx on 0x%p returned %r\n", __func__, BaseAddress, Status));
+        ASSERT_EFI_ERROR (Status);
+      }
+    }
+  } else {
+    DEBUG ((DEBUG_ERROR, "%a - Memory Address was not found in Memory map! %lp %r\n", __func__, BaseAddress, Status));
+    ASSERT_EFI_ERROR (Status);
+  }
+}
+
+/**
+  Add ReadOnly protection to the range specified by BaseAddress and Length.
+
+  @param[in] BaseAddress  BaseAddress of the range.
+  @param[in] Length       Length of the range.
+**/
+VOID
+ApplyRoProtection (
+  IN EFI_PHYSICAL_ADDRESS  BaseAddress,
+  IN UINTN                 Length
+  )
+{
+  EFI_STATUS                       Status;
+  EFI_GCD_MEMORY_SPACE_DESCRIPTOR  MemDesc;
+
+  Status = gDS->GetMemorySpaceDescriptor (BaseAddress, &MemDesc);
+  if (!EFI_ERROR (Status)) {
+    if (((MemDesc.Capabilities & EFI_MEMORY_RO) == EFI_MEMORY_RO) && ((MemDesc.Attributes & EFI_MEMORY_RO) != EFI_MEMORY_RO)) {
+      Status = gDS->SetMemorySpaceAttributes (
+                      BaseAddress,
+                      Length,
+                      MemDesc.Attributes | EFI_MEMORY_RO
+                      );
+
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "%a - Setting Ro on 0x%p returned %r\n", __func__, BaseAddress, Status));
+        ASSERT_EFI_ERROR (Status);
+      }
+    }
+  } else {
+    DEBUG ((DEBUG_ERROR, "%a - Memory Address was not found in Memory map! %lp %r\n", __func__, BaseAddress, Status));
+    ASSERT_EFI_ERROR (Status);
   }
 }
 
@@ -601,12 +588,7 @@ MpInitChangeApLoopCallback (
   CpuMpData->Pm16CodeSegment = GetProtectedMode16CS ();
   CpuMpData->ApLoopMode      = PcdGet8 (PcdCpuApLoopMode);
   mNumberToFinish            = CpuMpData->CpuCount - 1;
-  // MU_CHANGE END Enable removal of NX attribute from buffer
-  BufferRemoveNoExecuteSetReadOnly (
-    (EFI_PHYSICAL_ADDRESS)(UINTN)mReservedApLoop.Data,
-    EFI_PAGES_TO_SIZE (EFI_SIZE_TO_PAGES (CpuMpData->AddressMap.RelocateApLoopFuncSizeAmdSev))
-    );
-  // MU_CHANGE END Enable removal of NX attribute from buffer
+
   WakeUpAP (CpuMpData, TRUE, 0, RelocateApLoop, NULL, TRUE);
   while (mNumberToFinish > 0) {
     CpuPause ();

--- a/UefiCpuPkg/Library/MpInitLib/DxeMpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/DxeMpLib.c
@@ -39,12 +39,14 @@ CPU_MP_DEBUG_PROTOCOL  mCpuMpDebugProtocol = {
 
 #define  AP_SAFE_STACK_SIZE  128
 
-CPU_MP_DATA                    *mCpuMpData                  = NULL;
-EFI_EVENT                      mCheckAllApsEvent            = NULL;
-EFI_EVENT                      mMpInitExitBootServicesEvent = NULL;
-EFI_EVENT                      mLegacyBootEvent             = NULL;
-volatile BOOLEAN               mStopCheckAllApsStatus       = TRUE;
+CPU_MP_DATA       *mCpuMpData                  = NULL;
+EFI_EVENT         mCheckAllApsEvent            = NULL;
+EFI_EVENT         mMpInitExitBootServicesEvent = NULL;
+EFI_EVENT         mLegacyBootEvent             = NULL;
+volatile BOOLEAN  mStopCheckAllApsStatus       = TRUE;
+// MU_CHANGE START: Enable removal of NX attribute from buffer
 extern RELOCATE_AP_LOOP_ENTRY  mReservedApLoop;
+// MU_CHANGE END: Enable removal of NX attribute from buffer
 
 //
 // Begin wakeup buffer allocation below 0x88000
@@ -107,6 +109,57 @@ InstallCpuMpDebugProtocol (
                   );
   DEBUG ((DEBUG_INFO, "Installed gCpuMpDebugProtocolGuid - Status: %r\n", Status));
 }
+
+// MU_CHANGE START: Enable removal of NX attribute from buffer
+
+/**
+  Remove NX attribute from Buffer and apply RO to Buffer
+
+  @param[in]  Buffer      Buffer whose attributes will be altered
+  @param[in]  Size        Size of the buffer
+
+  @retval EFI_SUCCESS             NX attribute removed, RO attribute applied
+  @retval EFI_INVALID_PARAMETER   Buffer is not page-aligned or Buffer is 0 or Size of buffer
+                                  is not page-aligned
+  @retval Other                   Return value of LocateProtocol, ClearMemoryAttributes, or SetMemoryAttributes
+**/
+EFI_STATUS
+BufferRemoveNoExecuteSetReadOnly (
+  IN EFI_PHYSICAL_ADDRESS  Buffer,
+  IN UINTN                 Size
+  )
+{
+  EFI_CPU_ARCH_PROTOCOL  *CpuProtocol = NULL;
+  EFI_STATUS             Status;
+
+  if ((Buffer == 0) || (Buffer % EFI_PAGE_SIZE != 0) || (Size % EFI_PAGE_SIZE != 0)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = gBS->LocateProtocol (&gEfiCpuArchProtocolGuid, NULL, (VOID **)&CpuProtocol);
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a - Unable to locate gEfiCpuArchProtocolGuid\n", __func__));
+    ASSERT_EFI_ERROR (Status);
+    return Status;
+  }
+
+  Status = CpuProtocol->SetMemoryAttributes (
+                          CpuProtocol,
+                          Buffer,
+                          Size,
+                          EFI_MEMORY_RO
+                          );
+
+  if EFI_ERROR (Status) {
+    DEBUG ((DEBUG_INFO, "%a - Unable to update buffer attributes!\n", __func__));
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  return Status;
+}
+
+// MU_CHANGE END Enable removal of NX attribute from buffer
 
 /**
   Enable Debug Agent to support source debugging on AP function.
@@ -497,11 +550,14 @@ AllocateApLoopCodeBuffer (
 /**
   Remove Nx protection for the range specific by BaseAddress and Length.
 
+  The PEI implementation uses CpuPageTableLib to change the attribute.
+  The DXE implementation uses gDS to change the attribute.
+
   @param[in] BaseAddress  BaseAddress of the range.
   @param[in] Length       Length of the range.
 **/
 VOID
-RemoveNxProtection (
+RemoveNxprotection (
   IN EFI_PHYSICAL_ADDRESS  BaseAddress,
   IN UINTN                 Length
   )
@@ -509,58 +565,17 @@ RemoveNxProtection (
   EFI_STATUS                       Status;
   EFI_GCD_MEMORY_SPACE_DESCRIPTOR  MemDesc;
 
+  //
+  // TODO: Check EFI_MEMORY_XP bit set or not once it's available in DXE GCD
+  //       service.
+  //
   Status = gDS->GetMemorySpaceDescriptor (BaseAddress, &MemDesc);
   if (!EFI_ERROR (Status)) {
-    if (((MemDesc.Capabilities & EFI_MEMORY_XP) == EFI_MEMORY_XP) && ((MemDesc.Attributes & EFI_MEMORY_XP) == EFI_MEMORY_XP)) {
-      Status = gDS->SetMemorySpaceAttributes (
-                      BaseAddress,
-                      Length,
-                      MemDesc.Attributes & (~EFI_MEMORY_XP)
-                      );
-
-      if (EFI_ERROR (Status)) {
-        DEBUG ((DEBUG_ERROR, "%a - Setting Ro on 0x%p returned %r\n", __func__, BaseAddress, Status));
-        ASSERT_EFI_ERROR (Status);
-      }
-    } else {
-      DEBUG ((DEBUG_ERROR, "%a - Memory Address was not found in Memory map! %lp %r\n", __func__, BaseAddress, Status));
-      ASSERT_EFI_ERROR (Status);
-    }
-  }
-}
-
-/**
-  Add ReadOnly protection to the range specified by BaseAddress and Length.
-
-  @param[in] BaseAddress  BaseAddress of the range.
-  @param[in] Length       Length of the range.
-**/
-VOID
-ApplyReadOnlyMemoryProtection (
-  IN EFI_PHYSICAL_ADDRESS  BaseAddress,
-  IN UINTN                 Length
-  )
-{
-  EFI_STATUS                       Status;
-  EFI_GCD_MEMORY_SPACE_DESCRIPTOR  MemDesc;
-
-  Status = gDS->GetMemorySpaceDescriptor (BaseAddress, &MemDesc);
-  if (!EFI_ERROR (Status)) {
-    if (((MemDesc.Capabilities & EFI_MEMORY_RO) == EFI_MEMORY_RO) && ((MemDesc.Attributes & EFI_MEMORY_RO) != EFI_MEMORY_RO)) {
-      Status = gDS->SetMemorySpaceAttributes (
-                      BaseAddress,
-                      Length,
-                      MemDesc.Attributes | EFI_MEMORY_RO
-                      );
-
-      if (EFI_ERROR (Status)) {
-        DEBUG ((DEBUG_ERROR, "%a - Setting Ro on 0x%p returned %r\n", __func__, BaseAddress, Status));
-        ASSERT_EFI_ERROR (Status);
-      }
-    } else {
-      DEBUG ((DEBUG_ERROR, "%a - Memory Address was not found in Memory map! %lp %r\n", __func__, BaseAddress, Status));
-      ASSERT_EFI_ERROR (Status);
-    }
+    gDS->SetMemorySpaceAttributes (
+           BaseAddress,
+           Length,
+           MemDesc.Attributes & (~EFI_MEMORY_XP)
+           );
   }
 }
 
@@ -586,15 +601,12 @@ MpInitChangeApLoopCallback (
   CpuMpData->Pm16CodeSegment = GetProtectedMode16CS ();
   CpuMpData->ApLoopMode      = PcdGet8 (PcdCpuApLoopMode);
   mNumberToFinish            = CpuMpData->CpuCount - 1;
-  RemoveNxProtection (
+  // MU_CHANGE END Enable removal of NX attribute from buffer
+  BufferRemoveNoExecuteSetReadOnly (
     (EFI_PHYSICAL_ADDRESS)(UINTN)mReservedApLoop.Data,
     EFI_PAGES_TO_SIZE (EFI_SIZE_TO_PAGES (CpuMpData->AddressMap.RelocateApLoopFuncSizeAmdSev))
     );
-
-  ApplyReadOnlyMemoryProtection (
-    (EFI_PHYSICAL_ADDRESS)(UINTN)mReservedApLoop.Data,
-    EFI_PAGES_TO_SIZE (EFI_SIZE_TO_PAGES (CpuMpData->AddressMap.RelocateApLoopFuncSizeAmdSev))
-    );
+  // MU_CHANGE END Enable removal of NX attribute from buffer
   WakeUpAP (CpuMpData, TRUE, 0, RelocateApLoop, NULL, TRUE);
   while (mNumberToFinish > 0) {
     CpuPause ();
@@ -679,7 +691,7 @@ InitMpGlobalData (
                       MemDesc.Attributes | EFI_MEMORY_RP
                       );
       ASSERT_EFI_ERROR (Status);
-      AppendCpuMpDebugProtocolEntry (StackBase, CpuMpData->CpuApStackSize, Index, FALSE);     // MU_CHANGE
+      AppendCpuMpDebugProtocolEntry (StackBase, CpuMpData->CpuApStackSize, Index, FALSE); // MU_CHANGE
       DEBUG ((
         DEBUG_INFO,
         "Stack Guard set at %lx [cpu%lu]!\n",
@@ -688,7 +700,7 @@ InitMpGlobalData (
         ));
     }
 
-    InstallCpuMpDebugProtocol ();     // MU_CHANGE
+    InstallCpuMpDebugProtocol (); // MU_CHANGE
   }
   // MU_CHANGE START: Add the Debug Protocol in the case that CpuStackGuard is not active
   else {

--- a/UefiCpuPkg/Library/MpInitLib/MpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/MpLib.c
@@ -2253,7 +2253,6 @@ MpInitLibInitialize (
   // EfiBootServicesCode to avoid page fault if NX memory protection is enabled.
   //
   CpuMpData->WakeupBufferHigh = AllocateCodeBuffer (ApResetVectorSizeAbove1Mb);
-  RemoveNxProtection ((EFI_PHYSICAL_ADDRESS)(UINTN)CpuMpData->WakeupBufferHigh, ALIGN_VALUE (ApResetVectorSizeAbove1Mb, EFI_PAGE_SIZE));
   CopyMem (
     (VOID *)CpuMpData->WakeupBufferHigh,
     CpuMpData->AddressMap.RendezvousFunnelAddress +
@@ -2262,7 +2261,9 @@ MpInitLibInitialize (
     );
   DEBUG ((DEBUG_INFO, "AP Vector: non-16-bit = %p/%x\n", CpuMpData->WakeupBufferHigh, ApResetVectorSizeAbove1Mb));
 
-  ApplyReadOnlyMemoryProtection ((EFI_PHYSICAL_ADDRESS)(UINTN)CpuMpData->WakeupBufferHigh, ALIGN_VALUE (ApResetVectorSizeAbove1Mb, EFI_PAGE_SIZE));
+  // MU_CHANGE START: Enable removal of NX attribute from buffer
+  BufferRemoveNoExecuteSetReadOnly (CpuMpData->WakeupBufferHigh, ALIGN_VALUE (ApResetVectorSizeAbove1Mb, EFI_PAGE_SIZE));
+  // MU_CHANGE END: Enable removal of NX attribute from buffer
 
   //
   // Save APIC mode for AP to sync
@@ -3491,7 +3492,7 @@ PrepareApLoopCode (
     // Make sure that the buffer memory is executable if NX protection is enabled
     // for EfiReservedMemoryType.
     //
-    RemoveNxProtection (Address, EFI_PAGES_TO_SIZE (FuncPages));
+    RemoveNxprotection (Address, EFI_PAGES_TO_SIZE (FuncPages));
   }
 
   mReservedTopOfApStack = (UINTN)Address + EFI_PAGES_TO_SIZE (StackPages+FuncPages);
@@ -3499,7 +3500,6 @@ PrepareApLoopCode (
   mReservedApLoop.Data = (VOID *)(UINTN)Address;
   ASSERT (mReservedApLoop.Data != NULL);
   CopyMem (mReservedApLoop.Data, ApLoopFunc, ApLoopFuncSize);
-  ApplyReadOnlyMemoryProtection (Address, EFI_PAGES_TO_SIZE (FuncPages));
   if (!CpuMpData->UseSevEsAPMethod) {
     //
     // processors without SEV-ES and paging is enabled

--- a/UefiCpuPkg/Library/MpInitLib/MpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/MpLib.c
@@ -2067,6 +2067,7 @@ MpInitLibInitialize (
   UINTN                    ApResetVectorSizeAbove1Mb;
   UINTN                    BackupBufferAddr;
   UINTN                    ApIdtBase;
+  IA32_CR0                 Cr0;
 
   FirstMpHandOff = GetNextMpHandOffHob (NULL);
   if (FirstMpHandOff != NULL) {
@@ -2252,7 +2253,13 @@ MpInitLibInitialize (
   // Copy all 32-bit code and 64-bit code into memory with type of
   // EfiBootServicesCode to avoid page fault if NX memory protection is enabled.
   //
-  CpuMpData->WakeupBufferHigh = AllocateCodeBuffer (ApResetVectorSizeAbove1Mb);
+  CpuMpData->WakeupBufferHigh = AllocateCodePage (ApResetVectorSizeAbove1Mb);
+
+  Cr0.UintN = AsmReadCr0 ();
+  if (Cr0.Bits.PG != 0) {
+    RemoveNxProtection ((EFI_PHYSICAL_ADDRESS)(UINTN)CpuMpData->WakeupBufferHigh, ALIGN_VALUE (ApResetVectorSizeAbove1Mb, EFI_PAGE_SIZE));
+  }
+
   CopyMem (
     (VOID *)CpuMpData->WakeupBufferHigh,
     CpuMpData->AddressMap.RendezvousFunnelAddress +
@@ -2260,10 +2267,9 @@ MpInitLibInitialize (
     ApResetVectorSizeAbove1Mb
     );
   DEBUG ((DEBUG_INFO, "AP Vector: non-16-bit = %p/%x\n", CpuMpData->WakeupBufferHigh, ApResetVectorSizeAbove1Mb));
-
-  // MU_CHANGE START: Enable removal of NX attribute from buffer
-  BufferRemoveNoExecuteSetReadOnly (CpuMpData->WakeupBufferHigh, ALIGN_VALUE (ApResetVectorSizeAbove1Mb, EFI_PAGE_SIZE));
-  // MU_CHANGE END: Enable removal of NX attribute from buffer
+  if (Cr0.Bits.PG != 0) {
+    ApplyRoProtection ((EFI_PHYSICAL_ADDRESS)(UINTN)CpuMpData->WakeupBufferHigh, ALIGN_VALUE (ApResetVectorSizeAbove1Mb, EFI_PAGE_SIZE));
+  }
 
   //
   // Save APIC mode for AP to sync
@@ -3492,7 +3498,7 @@ PrepareApLoopCode (
     // Make sure that the buffer memory is executable if NX protection is enabled
     // for EfiReservedMemoryType.
     //
-    RemoveNxprotection (Address, EFI_PAGES_TO_SIZE (FuncPages));
+    RemoveNxProtection (Address, EFI_PAGES_TO_SIZE (FuncPages));
   }
 
   mReservedTopOfApStack = (UINTN)Address + EFI_PAGES_TO_SIZE (StackPages+FuncPages);
@@ -3500,6 +3506,10 @@ PrepareApLoopCode (
   mReservedApLoop.Data = (VOID *)(UINTN)Address;
   ASSERT (mReservedApLoop.Data != NULL);
   CopyMem (mReservedApLoop.Data, ApLoopFunc, ApLoopFuncSize);
+  if (Cr0.Bits.PG != 0) {
+    ApplyRoProtection (Address, EFI_PAGES_TO_SIZE (FuncPages));
+  }
+
   if (!CpuMpData->UseSevEsAPMethod) {
     //
     // processors without SEV-ES and paging is enabled

--- a/UefiCpuPkg/Library/MpInitLib/MpLib.h
+++ b/UefiCpuPkg/Library/MpInitLib/MpLib.h
@@ -527,7 +527,7 @@ GetNextMpHandOffHob (
   @retval 0       Cannot find free memory below 4GB.
 **/
 UINTN
-AllocateCodeBuffer (
+AllocateCodePage (
   IN UINTN  BufferSize
   );
 
@@ -985,36 +985,25 @@ AllocateApLoopCodeBuffer (
 /**
   Remove Nx protection for the range specific by BaseAddress and Length.
 
-  The PEI implementation uses CpuPageTableLib to change the attribute.
-  The DXE implementation uses gDS to change the attribute.
-
   @param[in] BaseAddress  BaseAddress of the range.
   @param[in] Length       Length of the range.
 **/
 VOID
-RemoveNxprotection (
+RemoveNxProtection (
   IN EFI_PHYSICAL_ADDRESS  BaseAddress,
   IN UINTN                 Length
   );
 
-// MU_CHANGE START: Enable removal of NX attribute from buffer
-
 /**
-  Remove NX attribute from Buffer and apply RO to Buffer
+Add ReadOnly protection to the range specified by BaseAddress and Length.
 
-  @param[in]  Buffer      Buffer whose attributes will be altered
-  @param[in]  Size        Size of the buffer
-
-  @retval EFI_SUCCESS             NX attribute removed, RO attribute applied
-  @retval EFI_INVALID_PARAMETER   Buffer is not page-aligned or Buffer is 0 or Size of buffer
-                                  is not page-aligned
-  @retval Other                   Return value of LocateProtocol, ClearMemoryAttributes, or SetMemoryAttributes
+@param[in] BaseAddress  BaseAddress of the range.
+@param[in] Length       Length of the range.
 **/
-EFI_STATUS
-BufferRemoveNoExecuteSetReadOnly (
-  IN EFI_PHYSICAL_ADDRESS  Buffer,
-  IN UINTN                 Size
+VOID
+ApplyRoProtection (
+  IN EFI_PHYSICAL_ADDRESS  BaseAddress,
+  IN UINTN                 Length
   );
 
-// MU_CHANGE END: Enable removal of NX attribute from buffer
 #endif

--- a/UefiCpuPkg/Library/MpInitLib/MpLib.h
+++ b/UefiCpuPkg/Library/MpInitLib/MpLib.h
@@ -985,25 +985,36 @@ AllocateApLoopCodeBuffer (
 /**
   Remove Nx protection for the range specific by BaseAddress and Length.
 
+  The PEI implementation uses CpuPageTableLib to change the attribute.
+  The DXE implementation uses gDS to change the attribute.
+
   @param[in] BaseAddress  BaseAddress of the range.
   @param[in] Length       Length of the range.
 **/
 VOID
-RemoveNxProtection (
+RemoveNxprotection (
   IN EFI_PHYSICAL_ADDRESS  BaseAddress,
   IN UINTN                 Length
   );
+
+// MU_CHANGE START: Enable removal of NX attribute from buffer
 
 /**
-Add ReadOnly protection to the range specified by BaseAddress and Length.
+  Remove NX attribute from Buffer and apply RO to Buffer
 
-@param[in] BaseAddress  BaseAddress of the range.
-@param[in] Length       Length of the range.
+  @param[in]  Buffer      Buffer whose attributes will be altered
+  @param[in]  Size        Size of the buffer
+
+  @retval EFI_SUCCESS             NX attribute removed, RO attribute applied
+  @retval EFI_INVALID_PARAMETER   Buffer is not page-aligned or Buffer is 0 or Size of buffer
+                                  is not page-aligned
+  @retval Other                   Return value of LocateProtocol, ClearMemoryAttributes, or SetMemoryAttributes
 **/
-VOID
-ApplyReadOnlyMemoryProtection (
-  IN EFI_PHYSICAL_ADDRESS  BaseAddress,
-  IN UINTN                 Length
+EFI_STATUS
+BufferRemoveNoExecuteSetReadOnly (
+  IN EFI_PHYSICAL_ADDRESS  Buffer,
+  IN UINTN                 Size
   );
 
+// MU_CHANGE END: Enable removal of NX attribute from buffer
 #endif

--- a/UefiCpuPkg/Library/MpInitLib/PeiMpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/PeiMpLib.c
@@ -14,6 +14,30 @@
 
 STATIC UINT64  mSevEsPeiWakeupBuffer = BASE_1MB;
 
+// MU_CHANGE START: Enable removal of NX attribute from buffer
+
+/**
+  Remove NX attribute from Buffer and apply RO to Buffer
+
+  @param[in]  Buffer      Buffer whose attributes will be altered
+  @param[in]  Size        Size of the buffer
+
+  @retval EFI_SUCCESS             NX attribute removed, RO attribute applied
+  @retval EFI_INVALID_PARAMETER   Buffer is not page-aligned or Buffer is 0 or Size of buffer
+                                  is not page-aligned
+  @retval Other                   Return value of LocateProtocol, ClearMemoryAttributes, or SetMemoryAttributes
+**/
+EFI_STATUS
+BufferRemoveNoExecuteSetReadOnly (
+  IN EFI_PHYSICAL_ADDRESS  Buffer,
+  IN UINTN                 Size
+  )
+{
+  return EFI_SUCCESS;
+}
+
+// MU_CHANGE End: Enable removal of NX attribute from buffer
+
 /**
   Enable Debug Agent to support source debugging on AP function.
 
@@ -862,11 +886,14 @@ AllocateApLoopCodeBuffer (
 /**
   Remove Nx protection for the range specific by BaseAddress and Length.
 
+  The PEI implementation uses CpuPageTableLib to change the attribute.
+  The DXE implementation uses gDS to change the attribute.
+
   @param[in] BaseAddress  BaseAddress of the range.
   @param[in] Length       Length of the range.
 **/
 VOID
-RemoveNxProtection (
+RemoveNxprotection (
   IN EFI_PHYSICAL_ADDRESS  BaseAddress,
   IN UINTN                 Length
   )
@@ -940,22 +967,6 @@ RemoveNxProtection (
 
   ASSERT_EFI_ERROR (Status);
   AsmWriteCr3 (PageTable);
-}
-
-/**
-  Add ReadOnly protection to the range specified by BaseAddress and Length.
-
-  @param[in] BaseAddress  BaseAddress of the range.
-  @param[in] Length       Length of the range.
-**/
-VOID
-ApplyReadOnlyMemoryProtection (
-  IN EFI_PHYSICAL_ADDRESS  BaseAddress,
-  IN UINTN                 Length
-  )
-{
-  // stub for now, page tables are limited in PEI
-  return;
 }
 
 // MU_CHANGE START: Support for protocol for reporting multi-processor debug info

--- a/UefiCpuPkg/Library/MpInitLib/PeiMpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/PeiMpLib.c
@@ -14,30 +14,6 @@
 
 STATIC UINT64  mSevEsPeiWakeupBuffer = BASE_1MB;
 
-// MU_CHANGE START: Enable removal of NX attribute from buffer
-
-/**
-  Remove NX attribute from Buffer and apply RO to Buffer
-
-  @param[in]  Buffer      Buffer whose attributes will be altered
-  @param[in]  Size        Size of the buffer
-
-  @retval EFI_SUCCESS             NX attribute removed, RO attribute applied
-  @retval EFI_INVALID_PARAMETER   Buffer is not page-aligned or Buffer is 0 or Size of buffer
-                                  is not page-aligned
-  @retval Other                   Return value of LocateProtocol, ClearMemoryAttributes, or SetMemoryAttributes
-**/
-EFI_STATUS
-BufferRemoveNoExecuteSetReadOnly (
-  IN EFI_PHYSICAL_ADDRESS  Buffer,
-  IN UINTN                 Size
-  )
-{
-  return EFI_SUCCESS;
-}
-
-// MU_CHANGE End: Enable removal of NX attribute from buffer
-
 /**
   Enable Debug Agent to support source debugging on AP function.
 
@@ -323,7 +299,7 @@ GetWakeupBuffer (
   @retval 0       Cannot find free memory below 4GB.
 **/
 UINTN
-AllocateCodeBuffer (
+AllocateCodePage (
   IN UINTN  BufferSize
   )
 {
@@ -884,31 +860,21 @@ AllocateApLoopCodeBuffer (
 }
 
 /**
-  Remove Nx protection for the range specific by BaseAddress and Length.
+  Determine the Paging Mode that the system is currently
+  using.
 
-  The PEI implementation uses CpuPageTableLib to change the attribute.
-  The DXE implementation uses gDS to change the attribute.
-
-  @param[in] BaseAddress  BaseAddress of the range.
-  @param[in] Length       Length of the range.
-**/
-VOID
-RemoveNxprotection (
-  IN EFI_PHYSICAL_ADDRESS  BaseAddress,
-  IN UINTN                 Length
+  @retval PAGING_MODE
+ **/
+PAGING_MODE
+DetermineCurrentPagingMode (
+  VOID
   )
 {
-  EFI_STATUS                  Status;
-  UINTN                       PageTable;
-  EFI_PHYSICAL_ADDRESS        Buffer;
-  UINTN                       BufferSize;
-  IA32_MAP_ATTRIBUTE          MapAttribute;
-  IA32_MAP_ATTRIBUTE          MapMask;
   PAGING_MODE                 PagingMode;
   IA32_CR4                    Cr4;
   BOOLEAN                     Page5LevelSupport;
-  UINT32                      RegEax;
   BOOLEAN                     Page1GSupport;
+  UINT32                      RegEax;
   CPUID_EXTENDED_CPU_SIG_EDX  RegEdx;
 
   if (sizeof (UINTN) == sizeof (UINT64)) {
@@ -942,12 +908,36 @@ RemoveNxprotection (
     PagingMode = PagingPae;
   }
 
+  return PagingMode;
+}
+
+/**
+  Remove Nx protection for the range specific by BaseAddress and Length.
+
+  @param[in] BaseAddress  BaseAddress of the range.
+  @param[in] Length       Length of the range.
+**/
+VOID
+RemoveNxProtection (
+  IN EFI_PHYSICAL_ADDRESS  BaseAddress,
+  IN UINTN                 Length
+  )
+{
+  EFI_STATUS            Status;
+  UINTN                 PageTable;
+  EFI_PHYSICAL_ADDRESS  Buffer;
+  UINTN                 BufferSize;
+  IA32_MAP_ATTRIBUTE    MapAttribute;
+  IA32_MAP_ATTRIBUTE    MapMask;
+  PAGING_MODE           PagingMode;
+
   MapAttribute.Uint64 = 0;
   MapMask.Uint64      = 0;
   MapMask.Bits.Nx     = 1;
   PageTable           = AsmReadCr3 () & PAGING_4K_ADDRESS_MASK_64;
   BufferSize          = 0;
 
+  PagingMode = DetermineCurrentPagingMode ();
   //
   // Get required buffer size for changing the pagetable.
   //
@@ -969,26 +959,51 @@ RemoveNxprotection (
   AsmWriteCr3 (PageTable);
 }
 
-// MU_CHANGE START: Support for protocol for reporting multi-processor debug info
-
 /**
-  Add CPU_MP_DEBUG_PROTOCOL entry to the global list
+  Add ReadOnly protection to the range specified by BaseAddress and Length.
 
-  @param[in]  StackBuffer      Start of AP stack buffer
-  @param[in]  StackSize        Size of the stack
-  @param[in]  CpuNumber        AP CPU number
-  @param[in]  IsSwitchStack    If the input buffer is the CPU switch stack
+  @param[in] BaseAddress  BaseAddress of the range.
+  @param[in] Length       Length of the range.
 **/
 VOID
-EFIAPI
-AppendCpuMpDebugProtocolEntry (
-  UINTN    StackBuffer,
-  UINTN    StackSize,
-  UINTN    CpuNumber,
-  BOOLEAN  IsSwitchStack
+ApplyRoProtection (
+  IN EFI_PHYSICAL_ADDRESS  BaseAddress,
+  IN UINTN                 Length
   )
 {
+  EFI_STATUS            Status;
+  UINTN                 PageTable;
+  EFI_PHYSICAL_ADDRESS  Buffer;
+  UINTN                 BufferSize;
+  IA32_MAP_ATTRIBUTE    MapAttribute;
+  IA32_MAP_ATTRIBUTE    MapMask;
+  PAGING_MODE           PagingMode;
+
+  MapAttribute.Uint64    = 0;
+  MapMask.Uint64         = 0;
+  MapMask.Bits.ReadWrite = 1;
+  PageTable              = AsmReadCr3 () & PAGING_4K_ADDRESS_MASK_64;
+  BufferSize             = 0;
+
+  PagingMode = DetermineCurrentPagingMode ();
+  //
+  // Get required buffer size for changing the pagetable.
+  //
+  Status = PageTableMap (&PageTable, PagingMode, 0, &BufferSize, BaseAddress, Length, &MapAttribute, &MapMask, NULL);
+  if (Status == EFI_BUFFER_TOO_SMALL) {
+    //
+    // Allocate required Buffer.
+    //
+    Status = PeiServicesAllocatePages (
+               EfiBootServicesData,
+               EFI_SIZE_TO_PAGES (BufferSize),
+               &Buffer
+               );
+    ASSERT_EFI_ERROR (Status);
+    Status = PageTableMap (&PageTable, PagingMode, (VOID *)(UINTN)Buffer, &BufferSize, BaseAddress, Length, &MapAttribute, &MapMask, NULL);
+  }
+
+  ASSERT_EFI_ERROR (Status);
+  AsmWriteCr3 (PageTable);
   return;
 }
-
-// MU_CHANGE END


### PR DESCRIPTION
## Description
Revert original mu version of patch.
Cherry-Pick the up streamed version of Applying Read only on AP Wakeup buffers.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested
Booted Q35 with changes applied and verified page audit did not report AP buffers.

## Integration Instructions
No integration necessary.