### PR TITLE
[CHERRY-PICK] MdePkg: Add DEBUG_SECURITY Bit in PcdDebugPrintErrorLevel

### DIFF
--- a/MdePkg/Include/Library/DebugLib.h
+++ b/MdePkg/Include/Library/DebugLib.h
@@ -59,7 +59,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
                                          // significantly impact boot performance
 #define DEBUG_MANAGEABILITY  0x00800000  // Detailed debug and payload manageability messages
                                          // related to modules such as Redfish, IPMI, MCTP etc.
-#define DEBUG_ERROR  0x80000000          // Error
+#define DEBUG_SECURITY  0x01000000       // Security and security HW related messages, such as TPM
+#define DEBUG_ERROR     0x80000000       // Error
 
 //
 // Aliases of debug message mask bits

--- a/MdePkg/MdePkg.dec
+++ b/MdePkg/MdePkg.dec
@@ -2333,6 +2333,7 @@
   #  BIT21 - Memory range cachability changes message.<BR>
   #  BIT22 - Detailed debug message.<BR>
   #  BIT23 - Manageability debug message.<BR>
+  #  BIT24 - Security debug message.<BR>
   #  BIT31 - Error message.<BR>
   # @Prompt Fixed Debug Message Print Level.
   gEfiMdePkgTokenSpaceGuid.PcdFixedDebugPrintErrorLevel|0xFFFFFFFF|UINT32|0x30001016
@@ -2440,6 +2441,7 @@
   #  BIT21 - Memory range cachability changes message.<BR>
   #  BIT22 - Detailed debug message.<BR>
   #  BIT23 - Manageability messages.<BR>
+  #  BIT24 - Security debug message.<BR>
   #  BIT31 - Error message.<BR>
   # @Prompt Debug Message Print Level.
   # @Expression  0x80000002 | (gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel & 0x7F84AA00) == 0


### PR DESCRIPTION
## Description

Tcg2Dxe and its libraries are currently the noisiest modules in edk2. For a sample platform printing at INFO level, Tcg2Dxe printed 4,000 lines out of 5,700 total lines printed.

This commit defines a DEBUG_SECURITY bit to control the debug output of Tcg2Dxe and other security related components. Most of the output is not useful except for deep debugging of TPM transactions, so it is appropriate to only print when the DEBUG_SECURITY bit is present.

(cherry picked from commit dbf45a870b89fb9e307c41c66949288518c24440)

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

edk2 cherry-pick

## Integration Instructions

N/A
