### PR TITLE
[SQUASH ON REBASE] Fix bucket type matching as soon as the bucket is ready

### DIFF
--- a/MdeModulePkg/Core/Dxe/Mem/Page.c
+++ b/MdeModulePkg/Core/Dxe/Mem/Page.c
@@ -993,7 +993,7 @@ CoreAddMemoryDescriptor (
       gMemoryTypeInformation[Index].NumberOfPages = 0;
       CoreFreePages (
         mMemoryTypeStatistics[Type].BaseAddress,
-        mMemoryTypeStatistics[Type].NumberOfPages
+        (UINTN)mMemoryTypeStatistics[Type].NumberOfPages
         );
       // mMemoryTypeStatistics[Type].NumberOfPages   = gMemoryTypeInformation[Index].NumberOfPages;
       // gMemoryTypeInformation[Index].NumberOfPages = 0;

--- a/MdeModulePkg/Core/Dxe/Mem/Page.c
+++ b/MdeModulePkg/Core/Dxe/Mem/Page.c
@@ -406,12 +406,9 @@ CoreAddRange (
     }
 
     // MU_CHANGE STARTS: Add check to merge memory regions of the bucket type
-    if (MergeType != EfiMaxMemoryType) {
-      // We are in the midst of merging memory descriptors, so we can only merge
-      // with the same type as the merge type.
-      if (MergeType != GetBucketMemoryType (Entry->Start, Entry->End)) {
-        continue;
-      }
+    // We need to make sure we can only merge with the same type as the merge type
+    if (MergeType != GetBucketMemoryType (Entry->Start, Entry->End)) {
+      continue;
     }
 
     // MU_CHANGE ENDS
@@ -989,12 +986,18 @@ CoreAddMemoryDescriptor (
     }
 
     if (gMemoryTypeInformation[Index].NumberOfPages != 0) {
-      CoreFreePages (
-        mMemoryTypeStatistics[Type].BaseAddress,
-        gMemoryTypeInformation[Index].NumberOfPages
-        );
+      // MU_CHANGE Starts
+      // Activate the statistics so that the free page operation can be performed
+      // with valid bucket information.
       mMemoryTypeStatistics[Type].NumberOfPages   = gMemoryTypeInformation[Index].NumberOfPages;
       gMemoryTypeInformation[Index].NumberOfPages = 0;
+      CoreFreePages (
+        mMemoryTypeStatistics[Type].BaseAddress,
+        mMemoryTypeStatistics[Type].NumberOfPages
+        );
+      // mMemoryTypeStatistics[Type].NumberOfPages   = gMemoryTypeInformation[Index].NumberOfPages;
+      // gMemoryTypeInformation[Index].NumberOfPages = 0;
+      // MU_CHANGE Ends
     }
   }
 


### PR DESCRIPTION
## Description

The merging logic check could be voided if the incoming memory is non-special between 2 special buckets.

This change removes the bypass when the incoming memory is non-special. This change also moves the bucket size to be set before the bucket memory is freed.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

This is tested on proprietary hardware platforms.

## Integration Instructions

N/A