### PR TITLE
Add the functions from LocalApicLib.h to MockLocalApicLib.

### DIFF
--- a/UefiCpuPkg/Test/Mock/Include/GoogleTest/Library/MockLocalApicLib.h
+++ b/UefiCpuPkg/Test/Mock/Include/GoogleTest/Library/MockLocalApicLib.h
@@ -18,6 +18,203 @@ struct MockLocalApicLib {
   MOCK_INTERFACE_DECLARATION (MockLocalApicLib);
 
   MOCK_FUNCTION_DECLARATION (
+    UINTN,
+    GetLocalApicBaseAddress,
+    (
+    )
+    );
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    SetLocalApicBaseAddress,
+    (
+     IN UINTN  BaseAddress
+    )
+    );
+  MOCK_FUNCTION_DECLARATION (
+    UINTN,
+    GetApicMode,
+    (
+    )
+    );
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    SetApicMode,
+    (
+     IN UINTN  ApicMode
+    )
+    );
+  MOCK_FUNCTION_DECLARATION (
+    UINT32,
+    GetInitialApicId,
+    (
+    )
+    );
+  MOCK_FUNCTION_DECLARATION (
+    UINT32,
+    GetApicId,
+    (
+    )
+    );
+  MOCK_FUNCTION_DECLARATION (
+    UINT32,
+    GetApicVersion,
+    (
+    )
+    );
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    SendFixedIpi,
+    (
+     IN UINT32  ApicId,
+     IN UINT8   Vector
+    )
+    );
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    SendFixedIpiAllExcludingSelf,
+    (
+     IN UINT8  Vector
+    )
+    );
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    SendSmiIpi,
+    (
+     IN UINT32  ApicId
+    )
+    );
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    SendSmiIpiAllExcludingSelf,
+    (
+    )
+    );
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    SendInitIpi,
+    (
+     IN UINT32  ApicId
+    )
+    );
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    SendInitIpiAllExcludingSelf,
+    (
+    )
+    );
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    SendStartupIpiAllExcludingSelf,
+    (
+     IN UINT32  StartupRoutine
+    )
+    );
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    SendInitSipiSipi,
+    (
+     IN UINT32  ApicId,
+     IN UINT32  StartupRoutine
+    )
+    );
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    SendInitSipiSipiAllExcludingSelf,
+    (
+     IN UINT32  StartupRoutine
+    )
+    );
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    InitializeLocalApicSoftwareEnable,
+    (
+     IN BOOLEAN  Enable
+    )
+    );
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    ProgramVirtualWireMode,
+    (
+    )
+    );
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    DisableLvtInterrupts,
+    (
+    )
+    );
+  MOCK_FUNCTION_DECLARATION (
+    UINT32,
+    GetApicTimerInitCount,
+    (
+    )
+    );
+  MOCK_FUNCTION_DECLARATION (
+    UINT32,
+    GetApicTimerCurrentCount,
+    (
+    )
+    );
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    InitializeApicTimer,
+    (
+     IN UINTN    DivideValue,
+     IN UINT32   InitCount,
+     IN BOOLEAN  PeriodicMode,
+     IN UINT8    Vector
+    )
+    );
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    GetApicTimerState,
+    (
+     OUT UINTN    *DivideValue  OPTIONAL,
+     OUT BOOLEAN  *PeriodicMode  OPTIONAL,
+     OUT UINT8    *Vector  OPTIONAL
+    )
+    );
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    EnableApicTimerInterrupt,
+    (
+    )
+    );
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    DisableApicTimerInterrupt,
+    (
+    )
+    );
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    GetApicTimerInterruptState,
+    (
+    )
+    );
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    SendApicEoi,
+    (
+    )
+    );
+  MOCK_FUNCTION_DECLARATION (
+    UINT32,
+    GetApicMsiAddress,
+    (
+    )
+    );
+  MOCK_FUNCTION_DECLARATION (
+    UINT64,
+    GetApicMsiValue,
+    (
+     IN UINT8    Vector,
+     IN UINTN    DeliveryMode,
+     IN BOOLEAN  LevelTriggered,
+     IN BOOLEAN  AssertionLevel
+    )
+    );
+  MOCK_FUNCTION_DECLARATION (
     VOID,
     GetProcessorLocationByApicId,
     (
@@ -28,9 +225,16 @@ struct MockLocalApicLib {
     )
     );
   MOCK_FUNCTION_DECLARATION (
-    UINT32,
-    GetInitialApicId,
+    VOID,
+    GetProcessorLocation2ByApicId,
     (
+     IN  UINT32  InitialApicId,
+     OUT UINT32  *Package  OPTIONAL,
+     OUT UINT32  *Die      OPTIONAL,
+     OUT UINT32  *Tile     OPTIONAL,
+     OUT UINT32  *Module   OPTIONAL,
+     OUT UINT32  *Core     OPTIONAL,
+     OUT UINT32  *Thread   OPTIONAL
     )
     );
 };

--- a/UefiCpuPkg/Test/Mock/Include/GoogleTest/Library/MockLocalApicLib.h
+++ b/UefiCpuPkg/Test/Mock/Include/GoogleTest/Library/MockLocalApicLib.h
@@ -27,6 +27,12 @@ struct MockLocalApicLib {
      OUT UINT32  *Thread  OPTIONAL
     )
     );
+  MOCK_FUNCTION_DECLARATION (
+    UINT32,
+    GetInitialApicId,
+    (
+    )
+    );
 };
 
 #endif //MOCK_LOCAL_APIC_LIB_H_

--- a/UefiCpuPkg/Test/Mock/Library/GoogleTest/MockLocalApicLib/MockLocalApicLib.cpp
+++ b/UefiCpuPkg/Test/Mock/Library/GoogleTest/MockLocalApicLib/MockLocalApicLib.cpp
@@ -8,5 +8,34 @@
 #include <GoogleTest/Library/MockLocalApicLib.h>
 
 MOCK_INTERFACE_DEFINITION (MockLocalApicLib);
-MOCK_FUNCTION_DEFINITION (MockLocalApicLib, GetProcessorLocationByApicId, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, GetLocalApicBaseAddress, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, SetLocalApicBaseAddress, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, GetApicMode, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, SetApicMode, 1, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockLocalApicLib, GetInitialApicId, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, GetApicId, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, GetApicVersion, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, SendFixedIpi, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, SendFixedIpiAllExcludingSelf, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, SendSmiIpi, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, SendSmiIpiAllExcludingSelf, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, SendInitIpi, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, SendInitIpiAllExcludingSelf, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, SendStartupIpiAllExcludingSelf, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, SendInitSipiSipi, 2, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, SendInitSipiSipiAllExcludingSelf, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, InitializeLocalApicSoftwareEnable, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, ProgramVirtualWireMode, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, DisableLvtInterrupts, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, GetApicTimerInitCount, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, GetApicTimerCurrentCount, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, InitializeApicTimer, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, GetApicTimerState, 3, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, EnableApicTimerInterrupt, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, DisableApicTimerInterrupt, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, GetApicTimerInterruptState, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, SendApicEoi, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, GetApicMsiAddress, 0, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, GetApicMsiValue, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, GetProcessorLocationByApicId, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, GetProcessorLocation2ByApicId, 7, EFIAPI);

--- a/UefiCpuPkg/Test/Mock/Library/GoogleTest/MockLocalApicLib/MockLocalApicLib.cpp
+++ b/UefiCpuPkg/Test/Mock/Library/GoogleTest/MockLocalApicLib/MockLocalApicLib.cpp
@@ -9,3 +9,4 @@
 
 MOCK_INTERFACE_DEFINITION (MockLocalApicLib);
 MOCK_FUNCTION_DEFINITION (MockLocalApicLib, GetProcessorLocationByApicId, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockLocalApicLib, GetInitialApicId, 0, EFIAPI);


### PR DESCRIPTION
## Description

Add mock function "GetInitialApicId" for unit testing.
EDK2 PR: https://github.com/tianocore/edk2/pull/11330

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

The mock library API can be consumed successfully in unit test.

## Integration Instructions

N/A