### PR TITLE
[CHERRY-PICK] MdePkg/AArch64: fix AsmMacroLib signed value handling for MOV32/MOV64

### DIFF
--- a/MdePkg/Include/AArch64/AsmMacroLib.h
+++ b/MdePkg/Include/AArch64/AsmMacroLib.h
@@ -157,12 +157,12 @@ bgt    %b6                  __CR__ \
 #define ASM_FUNC_ALIGN(Name, Align)  \
   _ASM_FUNC_ALIGN(ASM_PFX(Name), .text. ## Name, Align)
 
-#define MOV32(Reg, Val)                   \
-  movz      Reg, (Val) >> 16, lsl #16   ; \
+#define MOV32(Reg, Val)                             \
+  movz      Reg, ((Val) >> 16) & 0xffff, lsl #16  ; \
   movk      Reg, (Val) & 0xffff
 
 #define MOV64(Reg, Val)                             \
-  movz      Reg, (Val) >> 48, lsl #48             ; \
+  movz      Reg, ((Val) >> 48) & 0xffff, lsl #48  ; \
   movk      Reg, ((Val) >> 32) & 0xffff, lsl #32  ; \
   movk      Reg, ((Val) >> 16) & 0xffff, lsl #16  ; \
   movk      Reg, (Val) & 0xffff


### PR DESCRIPTION
## Description

MOV32 and MOV64, defined in AsmMacrolib.h, use a combination of movz and movk instructions to fill a register with an immediate value. With each instruction supplying 16 of the bits.

CLANGPDB builds have been reported to fail on the current implementation when provided with negative values with:
  error: immediate must be an integer in range [0, 65535].

To resolve this, add a mask for the line filling the top 16 bits, like the other lines already had.

Reported-by: Michael Kubacki <mikuback@linux.microsoft.com>

(cherry picked from edk2 commit 3e7e3e2467445fe3b5931c1423a36df09cc26a80)

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

- QemuSbsaPkg CLANGPDB build

## Integration Instructions

- Include this commit if seeing this issue:

```
error: immediate must be an integer in range [0, 65535].
movz x9, (-1) >> 48, lsl #48
movk x9, ((-1) >> 32) & 0xffff, lsl #32
movk x9, ((-1) >> 16) & 0xffff, lsl #16
movk x9, (-1) & 0xffff
```

From `MOV64 (x9, ARM_FFA_RET_NOT_SUPPORTED)` in MdePkg/Include/AArch64/AsmMacroLib.h.