### PR TITLE
[Cherry-Pick] ShellPkg: Shell Validate parameter before use.

### DIFF
--- a/ShellPkg/Application/Shell/Shell.c
+++ b/ShellPkg/Application/Shell/Shell.c
@@ -1266,9 +1266,11 @@ LocateStartupScript (
 
     InternalEfiShellSetEnv (L"homefilesystem", StartupScriptPath, TRUE);
 
-    StartupScriptPath = StrnCatGrow (&StartupScriptPath, &Size, ((FILEPATH_DEVICE_PATH *)FileDevicePath)->PathName, 0);
-    PathRemoveLastItem (StartupScriptPath);
-    StartupScriptPath = StrnCatGrow (&StartupScriptPath, &Size, mStartupScript, 0);
+    if ((DevicePathType (FileDevicePath) == MEDIA_DEVICE_PATH) && (DevicePathSubType (FileDevicePath) == MEDIA_FILEPATH_DP)) {
+      StartupScriptPath = StrnCatGrow (&StartupScriptPath, &Size, ((FILEPATH_DEVICE_PATH *)FileDevicePath)->PathName, 0);
+      PathRemoveLastItem (StartupScriptPath);
+      StartupScriptPath = StrnCatGrow (&StartupScriptPath, &Size, mStartupScript, 0);
+    }
   }
 
   //


### PR DESCRIPTION
## Description

When FvSimpleFileSystem is included in a firmware image, the FV is accessible as a simple file system.

Shell contained a bad assumption that the FileDevicepath, the path where the efi shell was loaded from, was always a Media device path/media vendor device path. It would make a blind cast of the device path node.

Add a check to verify device path type/subtype before casting the node to a FILEPATH_DEVICE_PATH.


(cherry picked from commit c27552f3431df4580cdd56410b125a579b7201f1)

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Booted Q35 with FvSimpleFileSystem added to observe error.
After fix, test with custom startup.nsh included (EMPTY_DRIVE=TRUE) and without startup.nsh
`FILE FREEFORM = gPcBdsPkgTokenSpaceGuid {
    SECTION RAW = startup.nsh
    SECTION UI = "startup.nsh"
  }`


## Integration Instructions
No integration necessary. 