### PR TITLE
[Cherry-Pick] Update ArmFfaLib to support SEC and STMM phase

### DIFF
--- a/MdeModulePkg/Include/Guid/ArmFfaRxTxBufferInfo.h
+++ b/MdeModulePkg/Include/Guid/ArmFfaRxTxBufferInfo.h
@@ -9,27 +9,29 @@
 #ifndef ARM_FFA_RX_TX_BUFFER_INFO_H_
 #define ARM_FFA_RX_TX_BUFFER_INFO_H_
 
+#include <Uefi/UefiBaseType.h>
+
 /**
  * Guid Hob Data for gArmFfaRxTxBufferInfoGuid Guid Hob.
  */
 typedef struct ArmFfaRxTxBuffersInfo {
   /// Tx Buffer Address.
-  VOID       *TxBufferAddr;
+  EFI_PHYSICAL_ADDRESS    TxBufferAddr;
 
   /// Tx Buffer Size.
-  UINT64     TxBufferSize;
+  UINT64                  TxBufferSize;
 
   /// Rx Buffer Address.
-  VOID       *RxBufferAddr;
+  EFI_PHYSICAL_ADDRESS    RxBufferAddr;
 
   /// Rx Buffer Size.
-  UINT64     RxBufferSize;
+  UINT64                  RxBufferSize;
 
   /// Rx/Tx buffer should be remapped to permanent memory.
-  BOOLEAN    RemapRequired;
+  BOOLEAN                 RemapRequired;
 
   /// Rx/Tx buffer offset from its allocation base.
-  UINT64     RemapOffset;
+  UINT64                  RemapOffset;
 } ARM_FFA_RX_TX_BUFFER_INFO;
 
 extern EFI_GUID  gArmFfaRxTxBufferInfoGuid;

--- a/MdeModulePkg/Include/Guid/ArmFfaRxTxBufferInfo.h
+++ b/MdeModulePkg/Include/Guid/ArmFfaRxTxBufferInfo.h
@@ -14,16 +14,22 @@
  */
 typedef struct ArmFfaRxTxBuffersInfo {
   /// Tx Buffer Address.
-  VOID      *TxBufferAddr;
+  VOID       *TxBufferAddr;
 
   /// Tx Buffer Size.
-  UINT64    TxBufferSize;
+  UINT64     TxBufferSize;
 
   /// Rx Buffer Address.
-  VOID      *RxBufferAddr;
+  VOID       *RxBufferAddr;
 
   /// Rx Buffer Size.
-  UINT64    RxBufferSize;
+  UINT64     RxBufferSize;
+
+  /// Rx/Tx buffer should be remapped to permanent memory.
+  BOOLEAN    RemapRequired;
+
+  /// Rx/Tx buffer offset from its allocation base.
+  UINT64     RemapOffset;
 } ARM_FFA_RX_TX_BUFFER_INFO;
 
 extern EFI_GUID  gArmFfaRxTxBufferInfoGuid;

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
@@ -21,11 +21,14 @@
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
+#include <Library/HobLib.h>
 #include <Library/PcdLib.h>
 
 #include <IndustryStandard/ArmFfaSvc.h>
 #include <IndustryStandard/ArmFfaPartInfo.h>
 #include <IndustryStandard/ArmStdSmc.h>
+
+#include <Guid/ArmFfaRxTxBufferInfo.h>
 
 #include "ArmFfaCommon.h"
 
@@ -749,6 +752,149 @@ ArmFfaLibCommonInit (
   }
 
   gFfaSupported = TRUE;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Get first Rx/Tx Buffer allocation hob.
+  If UseGuid is TRUE, BufferAddr and BufferSize parameters are ignored.
+
+  @param[in]  BufferAddr       Buffer address
+  @param[in]  BufferSize       Buffer Size
+  @param[in]  UseGuid          Find MemoryAllocationHob using gArmFfaRxTxBufferInfoGuid.
+
+  @retval     NULL             Not found
+  @retval     Other            MemoryAllocationHob related to Rx/Tx buffer
+
+**/
+EFI_HOB_MEMORY_ALLOCATION *
+EFIAPI
+GetRxTxBufferAllocationHob (
+  IN EFI_PHYSICAL_ADDRESS  BufferAddr,
+  IN UINT64                BufferSize,
+  IN BOOLEAN               UseGuid
+  )
+{
+  EFI_PEI_HOB_POINTERS       Hob;
+  EFI_HOB_MEMORY_ALLOCATION  *MemoryAllocationHob;
+  EFI_PHYSICAL_ADDRESS       MemoryBase;
+  UINT64                     MemorySize;
+
+  if (!UseGuid && (BufferAddr == 0x00)) {
+    return NULL;
+  }
+
+  MemoryAllocationHob = NULL;
+  Hob.Raw             = GetFirstHob (EFI_HOB_TYPE_MEMORY_ALLOCATION);
+
+  while (Hob.Raw != NULL) {
+    if (Hob.MemoryAllocation->AllocDescriptor.MemoryType == EfiConventionalMemory) {
+      continue;
+    }
+
+    MemoryBase = Hob.MemoryAllocation->AllocDescriptor.MemoryBaseAddress;
+    MemorySize = Hob.MemoryAllocation->AllocDescriptor.MemoryLength;
+
+    if ((!UseGuid && (BufferAddr >= MemoryBase) &&
+         ((BufferAddr + BufferSize) <= (MemoryBase + MemorySize))) ||
+        (UseGuid && CompareGuid (
+                      &gArmFfaRxTxBufferInfoGuid,
+                      &Hob.MemoryAllocation->AllocDescriptor.Name
+                      )))
+    {
+      MemoryAllocationHob = (EFI_HOB_MEMORY_ALLOCATION *)Hob.Raw;
+      break;
+    }
+
+    Hob.Raw = GET_NEXT_HOB (Hob);
+    Hob.Raw = GetNextHob (EFI_HOB_TYPE_MEMORY_ALLOCATION, Hob.Raw);
+  }
+
+  return MemoryAllocationHob;
+}
+
+/**
+  Get Rx/Tx buffer MinSizeAndAign and MaxSize
+
+  @param[out] MinSizeAndAlign  Minimum size of Buffer.
+
+  @retval EFI_SUCCESS
+  @retval EFI_UNSUPPORTED          Wrong min size received from SPMC
+  @retval EFI_INVALID_PARAMETER    Wrong buffer size
+  @retval Others                   Failure of ArmFfaLibGetFeatures()
+
+**/
+EFI_STATUS
+EFIAPI
+GetRxTxBufferMinSizeAndAlign (
+  OUT UINTN  *MinSizeAndAlign
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       MinAndAlign;
+  UINTN       MaxSize;
+  UINTN       Property1;
+  UINTN       Property2;
+
+  Status = ArmFfaLibGetFeatures (
+             ARM_FID_FFA_RXTX_MAP,
+             FFA_RXTX_MAP_INPUT_PROPERTY_DEFAULT,
+             &Property1,
+             &Property2
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to get RX/TX buffer property... Status: %r\n",
+      __func__,
+      Status
+      ));
+    return Status;
+  }
+
+  MinAndAlign =
+    ((Property1 >>
+      ARM_FFA_BUFFER_MINSIZE_AND_ALIGN_SHIFT) &
+     ARM_FFA_BUFFER_MINSIZE_AND_ALIGN_MASK);
+
+  switch (MinAndAlign) {
+    case ARM_FFA_BUFFER_MINSIZE_AND_ALIGN_4K:
+      MinAndAlign = SIZE_4KB;
+      break;
+    case ARM_FFA_BUFFER_MINSIZE_AND_ALIGN_16K:
+      MinAndAlign = SIZE_16KB;
+      break;
+    case ARM_FFA_BUFFER_MINSIZE_AND_ALIGN_64K:
+      MinAndAlign = SIZE_64KB;
+      break;
+    default:
+      DEBUG ((DEBUG_ERROR, "%a: Invalid MinSizeAndAlign: 0x%x\n", __func__, MinAndAlign));
+      return EFI_UNSUPPORTED;
+  }
+
+  MaxSize =
+    (((Property1 >>
+       ARM_FFA_BUFFER_MAXSIZE_PAGE_COUNT_SHIFT) &
+      ARM_FFA_BUFFER_MAXSIZE_PAGE_COUNT_MASK));
+
+  MaxSize = ((MaxSize == 0) ? MAX_UINTN : (MaxSize * MinAndAlign));
+
+  if ((MinAndAlign > (PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE)) ||
+      (MaxSize < (PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE)))
+  {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Buffer is too small! MinSize: 0x%x, MaxSize: 0x%x, PageCount: %d\n",
+      __func__,
+      MinAndAlign,
+      MaxSize,
+      PcdGet64 (PcdFfaTxRxPageCount)
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *MinSizeAndAlign = MinAndAlign;
 
   return EFI_SUCCESS;
 }

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.h
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.h
@@ -49,4 +49,41 @@ ArmFfaLibCommonInit (
   IN VOID
   );
 
+/**
+  Get first Rx/Tx Buffer allocation hob.
+  If UseGuid is TRUE, BufferAddr and BufferSize parameters are ignored.
+
+  @param[in]  BufferAddr       Buffer address
+  @param[in]  BufferSize       Buffer Size
+  @param[in]  UseGuid          Find MemoryAllocationHob using gArmFfaRxTxBufferInfoGuid.
+
+  @retval     NULL             Not found
+  @retval     Other            MemoryAllocationHob related to Rx/Tx buffer
+
+**/
+EFI_HOB_MEMORY_ALLOCATION *
+EFIAPI
+GetRxTxBufferAllocationHob (
+  IN EFI_PHYSICAL_ADDRESS  BufferAddr,
+  IN UINT64                BufferSize,
+  IN BOOLEAN               UseGuid
+  );
+
+/**
+  Get Rx/Tx buffer MinSizeAndAign and MaxSize
+
+  @param[out] MinSizeAndAlign  Minimum size of Buffer.
+
+  @retval EFI_SUCCESS
+  @retval EFI_UNSUPPORTED          Wrong min size received from SPMC
+  @retval EFI_INVALID_PARAMETER    Wrong buffer size
+  @retval Others                   Failure of ArmFfaLibGetFeatures()
+
+**/
+EFI_STATUS
+EFIAPI
+GetRxTxBufferMinSizeAndAlign (
+  OUT UINTN  *MinSizeAndAlign
+  );
+
 #endif

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.h
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.h
@@ -17,29 +17,7 @@
 #ifndef ARM_FFA_COMMON_LIB_H_
 #define ARM_FFA_COMMON_LIB_H_
 
-/**
- * Arguments to call FF-A request via SMC/SVC.
- */
-typedef struct ArmFfaArgs {
-  UINTN    Arg0;
-  UINTN    Arg1;
-  UINTN    Arg2;
-  UINTN    Arg3;
-  UINTN    Arg4;
-  UINTN    Arg5;
-  UINTN    Arg6;
-  UINTN    Arg7;
-  UINTN    Arg8;
-  UINTN    Arg9;
-  UINTN    Arg10;
-  UINTN    Arg11;
-  UINTN    Arg12;
-  UINTN    Arg13;
-  UINTN    Arg14;
-  UINTN    Arg15;
-  UINTN    Arg16;
-  UINTN    Arg17;
-} ARM_FFA_ARGS;
+#include <Library/ArmFfaLib.h>
 
 extern BOOLEAN  gFfaSupported;
 extern UINT16   gPartId;
@@ -56,18 +34,6 @@ EFI_STATUS
 EFIAPI
 FfaArgsToEfiStatus (
   IN ARM_FFA_ARGS  *FfaArgs
-  );
-
-/**
-  Trigger FF-A ABI call according to PcdFfaLibConduitSmc.
-
-  @param [in out]  FfaArgs        Ffa arguments
-
-**/
-VOID
-EFIAPI
-ArmCallFfa (
-  IN OUT ARM_FFA_ARGS  *FfaArgs
   );
 
 /**

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.c
@@ -169,7 +169,7 @@ ArmFfaPeiLibConstructor (
       RxTxBufferAllocationHob = FindRxTxBufferAllocationHob (FALSE);
       ASSERT (RxTxBufferAllocationHob != NULL);
       BufferInfo->RemapOffset =
-        (UINTN)((EFI_PHYSICAL_ADDRESS)((UINTN)BufferInfo->TxBufferAddr) -
+        (UINTN)(BufferInfo->TxBufferAddr -
                 RxTxBufferAllocationHob->AllocDescriptor.MemoryBaseAddress);
 
       CopyGuid (

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.c
@@ -35,25 +35,6 @@
 #include "ArmFfaRxTxMap.h"
 
 /**
-  Update Rx/TX buffer information.
-
-  @param  BufferInfo            Rx/Tx buffer information.
-
-**/
-STATIC
-VOID
-EFIAPI
-UpdateRxTxBufferInfo (
-  OUT ARM_FFA_RX_TX_BUFFER_INFO  *BufferInfo
-  )
-{
-  BufferInfo->TxBufferAddr = (VOID *)(UINTN)PcdGet64 (PcdFfaTxBuffer);
-  BufferInfo->TxBufferSize = PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE;
-  BufferInfo->RxBufferAddr = (VOID *)(UINTN)PcdGet64 (PcdFfaRxBuffer);
-  BufferInfo->RxBufferSize = PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE;
-}
-
-/**
   Notification service to be called when gEfiPeiMemoryDiscoveredPpiGuid is installed.
   This function change reamp Rx/Tx buffer with permanent memory from
   temporary Rx/Tx buffer.
@@ -81,7 +62,6 @@ PeiServicesMemoryDiscoveredNotifyCallback (
   IN VOID                       *Ppi
   )
 {
-  EFI_STATUS                 Status;
   EFI_HOB_GUID_TYPE          *RxTxBufferHob;
   ARM_FFA_RX_TX_BUFFER_INFO  *BufferInfo;
 
@@ -89,26 +69,7 @@ PeiServicesMemoryDiscoveredNotifyCallback (
   ASSERT (RxTxBufferHob != NULL);
   BufferInfo = GET_GUID_HOB_DATA (RxTxBufferHob);
 
-  /*
-   * Temporary memory doesn't need to be free.
-   * otherwise PEI memory manager using permanent memory will be confused.
-   */
-  PcdSet64S (PcdFfaTxBuffer, 0x00);
-  PcdSet64S (PcdFfaRxBuffer, 0x00);
-
-  Status = ArmFfaLibRxTxUnmap ();
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
-
-  Status = ArmFfaLibRxTxMap ();
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
-
-  UpdateRxTxBufferInfo (BufferInfo);
-
-  return EFI_SUCCESS;
+  return RemapFfaRxTxBuffer (BufferInfo);
 }
 
 STATIC EFI_PEI_NOTIFY_DESCRIPTOR  mNotifyOnPeiMemoryDiscovered = {
@@ -138,6 +99,7 @@ ArmFfaPeiLibConstructor (
   EFI_HOB_GUID_TYPE          *RxTxBufferHob;
   ARM_FFA_RX_TX_BUFFER_INFO  *BufferInfo;
   VOID                       *Dummy;
+  EFI_HOB_MEMORY_ALLOCATION  *RxTxBufferAllocationHob;
 
   Status = ArmFfaLibCommonInit ();
   if (EFI_ERROR (Status)) {
@@ -176,6 +138,11 @@ ArmFfaPeiLibConstructor (
 
     UpdateRxTxBufferInfo (BufferInfo);
 
+    /*
+     * When permanent memory is used, gEfiPeiMemoryDiscoveredPpiGuid
+     * is installed. If gEfiPeiMemoryDiscoveredPpiGuid is found,
+     * It doesn't need to remap Rx/Tx buffer.
+     */
     Status = (*PeiServices)->LocatePpi (
                                PeiServices,
                                &gEfiPeiMemoryDiscoveredPpiGuid,
@@ -183,10 +150,50 @@ ArmFfaPeiLibConstructor (
                                NULL,
                                &Dummy
                                );
-    if (EFI_ERROR (Status)) {
-      Status = (*PeiServices)->NotifyPpi (PeiServices, &mNotifyOnPeiMemoryDiscovered);
-      ASSERT_EFI_ERROR (Status);
+    BufferInfo->RemapRequired = EFI_ERROR (Status);
+  } else {
+    BufferInfo = GET_GUID_HOB_DATA (RxTxBufferHob);
+  }
+
+  if (BufferInfo->RemapRequired) {
+    /*
+     * If RxTxBufferAllocationHob can be found with gArmFfaRxTxBufferInfoGuid,
+     * This Rx/Tx buffer is mapped by ArmFfaSecLib.
+     */
+    RxTxBufferAllocationHob = FindRxTxBufferAllocationHob (TRUE);
+
+    /*
+     * Below case Rx/Tx buffer mapped by ArmPeiLib but in temporary memory.
+     */
+    if (RxTxBufferAllocationHob == NULL) {
+      RxTxBufferAllocationHob = FindRxTxBufferAllocationHob (FALSE);
+      ASSERT (RxTxBufferAllocationHob != NULL);
+      BufferInfo->RemapOffset =
+        (UINTN)((EFI_PHYSICAL_ADDRESS)((UINTN)BufferInfo->TxBufferAddr) -
+                RxTxBufferAllocationHob->AllocDescriptor.MemoryBaseAddress);
+
+      CopyGuid (
+        &RxTxBufferAllocationHob->AllocDescriptor.Name,
+        &gArmFfaRxTxBufferInfoGuid
+        );
     }
+
+    Status = (*PeiServices)->NotifyPpi (PeiServices, &mNotifyOnPeiMemoryDiscovered);
+
+    /*
+     * Failed to register NotifyPpi.
+     * In this case, return ERROR to make failure of load for PPI
+     * and postpone to remap to other PEIM.
+     */
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    /*
+     * Change RemapRequired to FALSE here to prevent other PEIM from
+     * registering notification again.
+     */
+    BufferInfo->RemapRequired = FALSE;
   }
 
   return EFI_SUCCESS;

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.inf
@@ -43,3 +43,6 @@
 
 [Guids]
   gArmFfaRxTxBufferInfoGuid
+
+[Ppis]
+  gEfiPeiMemoryDiscoveredPpiGuid

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaRxTxMap.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaRxTxMap.c
@@ -230,9 +230,9 @@ UpdateRxTxBufferInfo (
   OUT ARM_FFA_RX_TX_BUFFER_INFO  *BufferInfo
   )
 {
-  BufferInfo->TxBufferAddr = (VOID *)(UINTN)PcdGet64 (PcdFfaTxBuffer);
+  BufferInfo->TxBufferAddr = PcdGet64 (PcdFfaTxBuffer);
   BufferInfo->TxBufferSize = PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE;
-  BufferInfo->RxBufferAddr = (VOID *)(UINTN)PcdGet64 (PcdFfaRxBuffer);
+  BufferInfo->RxBufferAddr = PcdGet64 (PcdFfaRxBuffer);
   BufferInfo->RxBufferSize = PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE;
 }
 

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaRxTxMap.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaRxTxMap.c
@@ -19,11 +19,14 @@
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
+#include <Library/HobLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/PcdLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 
 #include <IndustryStandard/ArmFfaSvc.h>
+
+#include <Guid/ArmFfaRxTxBufferInfo.h>
 
 #include "ArmFfaCommon.h"
 #include "ArmFfaRxTxMap.h"
@@ -267,6 +270,200 @@ ArmFfaLibRxTxUnmap (
 
   PcdSet64S (PcdFfaTxBuffer, 0x00);
   PcdSet64S (PcdFfaRxBuffer, 0x00);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Update Rx/TX buffer information.
+
+  @param  BufferInfo            Rx/Tx buffer information.
+
+**/
+VOID
+EFIAPI
+UpdateRxTxBufferInfo (
+  OUT ARM_FFA_RX_TX_BUFFER_INFO  *BufferInfo
+  )
+{
+  BufferInfo->TxBufferAddr = (VOID *)(UINTN)PcdGet64 (PcdFfaTxBuffer);
+  BufferInfo->TxBufferSize = PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE;
+  BufferInfo->RxBufferAddr = (VOID *)(UINTN)PcdGet64 (PcdFfaRxBuffer);
+  BufferInfo->RxBufferSize = PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE;
+}
+
+/**
+  Find Rx/TX buffer memory allocation hob.
+
+  @param  UseGuid             Find MemoryAllocationHob using gArmFfaRxTxBufferInfoGuid.
+
+  @retval MemoryAllocationHob
+  @retval NULL                No memory allocation hob related to Rx/Tx buffer
+
+**/
+EFI_HOB_MEMORY_ALLOCATION *
+EFIAPI
+FindRxTxBufferAllocationHob (
+  IN BOOLEAN  UseGuid
+  )
+{
+  EFI_PEI_HOB_POINTERS       Hob;
+  EFI_HOB_MEMORY_ALLOCATION  *MemoryAllocationHob;
+  EFI_PHYSICAL_ADDRESS       BufferBase;
+  UINT64                     BufferSize;
+  EFI_PHYSICAL_ADDRESS       MemoryBase;
+  UINT64                     MemorySize;
+
+  BufferBase = (EFI_PHYSICAL_ADDRESS)PcdGet64 (PcdFfaTxBuffer);
+  BufferSize = PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE * 2;
+
+  if (!UseGuid && (BufferBase == 0x00)) {
+    return NULL;
+  }
+
+  MemoryAllocationHob = NULL;
+  Hob.Raw             = GetFirstHob (EFI_HOB_TYPE_MEMORY_ALLOCATION);
+
+  while (Hob.Raw != NULL) {
+    if (Hob.MemoryAllocation->AllocDescriptor.MemoryType == EfiConventionalMemory) {
+      continue;
+    }
+
+    MemoryBase = Hob.MemoryAllocation->AllocDescriptor.MemoryBaseAddress;
+    MemorySize = Hob.MemoryAllocation->AllocDescriptor.MemoryLength;
+
+    if ((!UseGuid && (BufferBase >= MemoryBase) &&
+         ((BufferBase + BufferSize) <= (MemoryBase + MemorySize))) ||
+        (UseGuid && CompareGuid (
+                      &gArmFfaRxTxBufferInfoGuid,
+                      &Hob.MemoryAllocation->AllocDescriptor.Name
+                      )))
+    {
+      MemoryAllocationHob = (EFI_HOB_MEMORY_ALLOCATION *)Hob.Raw;
+      break;
+    }
+
+    Hob.Raw = GET_NEXT_HOB (Hob);
+    Hob.Raw = GetNextHob (EFI_HOB_TYPE_MEMORY_ALLOCATION, Hob.Raw);
+  } // while
+
+  return MemoryAllocationHob;
+}
+
+/**
+  Remap Rx/TX buffer with converted Rx/Tx Buffer address after
+  using permanent memory.
+
+  @param[out] BufferInfo    BufferInfo
+
+  @retval EFI_SUCCESS       Success
+  @retval EFI_NOT_FOUND     No memory allocation hob related to Rx/Tx buffer
+
+**/
+EFI_STATUS
+EFIAPI
+RemapFfaRxTxBuffer (
+  OUT ARM_FFA_RX_TX_BUFFER_INFO  *BufferInfo
+  )
+{
+  EFI_STATUS                 Status;
+  ARM_FFA_ARGS               FfaArgs;
+  UINTN                      NewBufferBase;
+  UINTN                      NewTxBuffer;
+  UINTN                      NewRxBuffer;
+  UINTN                      Property1;
+  UINTN                      Property2;
+  UINTN                      MinSizeAndAlign;
+  EFI_HOB_MEMORY_ALLOCATION  *RxTxBufferAllocationHob;
+
+  RxTxBufferAllocationHob = FindRxTxBufferAllocationHob (TRUE);
+  if (RxTxBufferAllocationHob == NULL) {
+    return EFI_NOT_FOUND;
+  }
+
+  Status = ArmFfaLibGetFeatures (
+             ARM_FID_FFA_RXTX_MAP,
+             FFA_RXTX_MAP_INPUT_PROPERTY_DEFAULT,
+             &Property1,
+             &Property2
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to get RX/TX buffer property... Status: %r\n",
+      __func__,
+      Status
+      ));
+    return Status;
+  }
+
+  MinSizeAndAlign =
+    ((Property1 >>
+      ARM_FFA_BUFFER_MINSIZE_AND_ALIGN_SHIFT) &
+     ARM_FFA_BUFFER_MINSIZE_AND_ALIGN_MASK);
+
+  switch (MinSizeAndAlign) {
+    case ARM_FFA_BUFFER_MINSIZE_AND_ALIGN_4K:
+      MinSizeAndAlign = SIZE_4KB;
+      break;
+    case ARM_FFA_BUFFER_MINSIZE_AND_ALIGN_16K:
+      MinSizeAndAlign = SIZE_16KB;
+      break;
+    case ARM_FFA_BUFFER_MINSIZE_AND_ALIGN_64K:
+      MinSizeAndAlign = SIZE_64KB;
+      break;
+    default:
+      DEBUG ((DEBUG_ERROR, "%a: Invalid MinSizeAndAlign: 0x%x\n", __func__, MinSizeAndAlign));
+      return EFI_UNSUPPORTED;
+  }
+
+  ZeroMem (&FfaArgs, sizeof (ARM_FFA_ARGS));
+  FfaArgs.Arg0 = ARM_FID_FFA_RXTX_UNMAP;
+  FfaArgs.Arg1 = (gPartId << ARM_FFA_SOURCE_EP_SHIFT);
+
+  ArmCallFfa (&FfaArgs);
+  Status = FfaArgsToEfiStatus (&FfaArgs);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to unmap Rx/Tx buffer. Status: %r\n", __func__, Status));
+    return Status;
+  }
+
+  PcdSet64S (PcdFfaTxBuffer, 0x00);
+  PcdSet64S (PcdFfaRxBuffer, 0x00);
+
+  NewBufferBase = (UINTN)RxTxBufferAllocationHob->AllocDescriptor.MemoryBaseAddress + BufferInfo->RemapOffset;
+  NewTxBuffer   = NewBufferBase;
+  NewRxBuffer   = NewTxBuffer + (PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE);
+
+  ZeroMem (&FfaArgs, sizeof (ARM_FFA_ARGS));
+  FfaArgs.Arg0 = ARM_FID_FFA_RXTX_MAP;
+  FfaArgs.Arg1 = NewTxBuffer;
+  FfaArgs.Arg2 = NewRxBuffer;
+
+  /*
+   * PcdFfaTxRxPageCount sets with count of EFI_PAGE_SIZE granularity
+   * But, PageCounts for Tx/Rx buffer should set with
+   * count of Tx/Rx Buffer's MinSizeAndAlign. granularity.
+   */
+  FfaArgs.Arg3 = PcdGet64 (PcdFfaTxRxPageCount) / EFI_SIZE_TO_PAGES (MinSizeAndAlign);
+
+  ArmCallFfa (&FfaArgs);
+  Status = FfaArgsToEfiStatus (&FfaArgs);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to map with new Rx/Tx buffer. Status: %r\n", __func__, Status));
+    return Status;
+  }
+
+  PcdSet64S (PcdFfaTxBuffer, NewTxBuffer);
+  PcdSet64S (PcdFfaRxBuffer, NewRxBuffer);
+
+  UpdateRxTxBufferInfo (BufferInfo);
+
+  /*
+   * Remap is done. clear to AllocDesciptor.Name
+   * so that unnecessary remap happen again.
+   */
+  ZeroMem (&RxTxBufferAllocationHob->AllocDescriptor.Name, sizeof (EFI_GUID));
 
   return EFI_SUCCESS;
 }

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaRxTxMap.h
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaRxTxMap.h
@@ -17,6 +17,8 @@
 #ifndef ARM_FFA_RX_TX_MAP_LIB_H_
 #define ARM_FFA_RX_TX_MAP_LIB_H_
 
+#include <Guid/ArmFfaRxTxBufferInfo.h>
+
 /**
   Mapping Rx/Tx buffers.
   This function is only called in ArmFfaLibConstructor because
@@ -49,6 +51,49 @@ EFI_STATUS
 EFIAPI
 ArmFfaLibRxTxUnmap (
   IN VOID
+  );
+
+/**
+  Update Rx/TX buffer information.
+
+  @param  BufferInfo            Rx/Tx buffer information.
+
+**/
+VOID
+EFIAPI
+UpdateRxTxBufferInfo (
+  OUT ARM_FFA_RX_TX_BUFFER_INFO  *BufferInfo
+  );
+
+/**
+  Find Rx/TX buffer memory allocation hob.
+
+  @param  UseGuid             Find MemoryAllocationHob using Guid.
+
+  @retval MemoryAllocationHob
+  @retval NULL                No memory allocation hob related to Rx/Tx buffer
+
+**/
+EFI_HOB_MEMORY_ALLOCATION *
+EFIAPI
+FindRxTxBufferAllocationHob (
+  IN BOOLEAN  UseGuid
+  );
+
+/**
+  Remap Rx/TX buffer with converted Rx/Tx Buffer address after
+  using permanent memory.
+
+  @param[out] BufferInfo    BufferInfo
+
+  @retval EFI_SUCCESS       Success
+  @retval EFI_NOT_FOUND     No memory allocation hob related to Rx/Tx buffer
+
+**/
+EFI_STATUS
+EFIAPI
+RemapFfaRxTxBuffer (
+  IN OUT ARM_FFA_RX_TX_BUFFER_INFO  *BufferInfo
   );
 
 #endif

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaRxTxMapStmm.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaRxTxMapStmm.c
@@ -1,0 +1,321 @@
+/** @file
+  Arm Ffa library common code.
+
+  Copyright (c) 2024, Arm Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+   @par Glossary:
+     - FF-A - Firmware Framework for Arm A-profile
+
+   @par Reference(s):
+     - Arm Firmware Framework for Arm A-Profile v1.3 ALP1: [https://developer.arm.com/documentation/den0077/l]
+
+**/
+#include <Uefi.h>
+#include <Pi/PiMultiPhase.h>
+
+#include <Library/ArmLib.h>
+#include <Library/ArmFfaLib.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/PcdLib.h>
+#include <Library/MmServicesTableLib.h>
+
+#include <IndustryStandard/ArmFfaSvc.h>
+#include <Guid/ArmFfaRxTxBufferInfo.h>
+
+#include "ArmFfaCommon.h"
+#include "ArmFfaRxTxMap.h"
+
+EFI_HANDLE                 mArmFfaRxTxBufferStmmInfoHandle = NULL;
+ARM_FFA_RX_TX_BUFFER_INFO  *mArmFfaRxTxBufferStmmInfo      = NULL;
+
+/**
+  Get mapped Rx/Tx buffers.
+
+  @param [out]   TxBuffer         Address of TxBuffer
+  @param [out]   TxBufferSize     Size of TxBuffer
+  @param [out]   RxBuffer         Address of RxBuffer
+  @param [out]   RxBufferSize     Size of RxBuffer
+
+  @retval EFI_SUCCESS
+  @retval Others             Error.
+
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaLibGetRxTxBuffers (
+  OUT VOID    **TxBuffer OPTIONAL,
+  OUT UINT64  *TxBufferSize OPTIONAL,
+  OUT VOID    **RxBuffer OPTIONAL,
+  OUT UINT64  *RxBufferSize OPTIONAL
+  )
+{
+  UINTN  TxBufferAddr;
+  UINTN  RxBufferAddr;
+
+  EFI_STATUS  Status = gMmst->MmLocateProtocol (
+                                &gArmFfaRxTxBufferInfoGuid,
+                                NULL,
+                                (VOID **)&mArmFfaRxTxBufferStmmInfo
+                                );
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to locate Rx/Tx buffer protocol... Status: %r\n", __func__, Status));
+    return Status;
+  }
+
+  TxBufferAddr = (UINTN)mArmFfaRxTxBufferStmmInfo->TxBufferAddr;
+  RxBufferAddr = (UINTN)mArmFfaRxTxBufferStmmInfo->RxBufferAddr;
+
+  if ((TxBufferAddr == 0x00) || (RxBufferAddr == 0x00)) {
+    return EFI_NOT_READY;
+  }
+
+  if (TxBuffer != NULL) {
+    *TxBuffer = (VOID *)TxBufferAddr;
+  }
+
+  if (TxBufferSize != NULL) {
+    *TxBufferSize = mArmFfaRxTxBufferStmmInfo->TxBufferSize;
+  }
+
+  if (RxBuffer != NULL) {
+    *RxBuffer = (VOID *)RxBufferAddr;
+  }
+
+  if (RxBufferSize != NULL) {
+    *RxBufferSize = mArmFfaRxTxBufferStmmInfo->RxBufferSize;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Mapping Rx/Tx buffers.
+  This function is only called in ArmFfaLibConstructor because
+  Rx/Tx buffer is registered only once per partition.
+
+  @retval EFI_SUCCESS
+  @retval EFI_ALREADY_STARTED     Rx/Tx buffer already mapped.
+  @retval EFI_OUT_OF_RESOURCE     Out of memory
+  @retval EFI_INVALID_PARAMETER   Invalid alignment of Rx/Tx buffer
+  @retval Others                  Error
+
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaLibRxTxMap (
+  IN VOID
+  )
+{
+  EFI_STATUS    Status;
+  ARM_FFA_ARGS  FfaArgs;
+  UINTN         Property1;
+  UINTN         Property2;
+  UINTN         MinSizeAndAlign;
+  UINTN         MaxSize;
+  VOID          *Buffers;
+  VOID          *TxBuffer;
+  VOID          *RxBuffer;
+  UINT64        BufferSize;
+
+  Status = gMmst->MmLocateProtocol (
+                    &gArmFfaRxTxBufferInfoGuid,
+                    NULL,
+                    (VOID **)&mArmFfaRxTxBufferStmmInfo
+                    );
+  if (!EFI_ERROR (Status)) {
+    // Great, we got what we need.
+    return EFI_ALREADY_STARTED;
+  }
+
+  Status = ArmFfaLibGetFeatures (
+             ARM_FID_FFA_RXTX_MAP,
+             FFA_RXTX_MAP_INPUT_PROPERTY_DEFAULT,
+             &Property1,
+             &Property2
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to get RX/TX buffer property... Status: %r\n",
+      __func__,
+      Status
+      ));
+    return Status;
+  }
+
+  ZeroMem (&FfaArgs, sizeof (ARM_FFA_ARGS));
+
+  MinSizeAndAlign =
+    ((Property1 >>
+      ARM_FFA_BUFFER_MINSIZE_AND_ALIGN_SHIFT) &
+     ARM_FFA_BUFFER_MINSIZE_AND_ALIGN_MASK);
+
+  switch (MinSizeAndAlign) {
+    case ARM_FFA_BUFFER_MINSIZE_AND_ALIGN_4K:
+      MinSizeAndAlign = SIZE_4KB;
+      break;
+    case ARM_FFA_BUFFER_MINSIZE_AND_ALIGN_16K:
+      MinSizeAndAlign = SIZE_16KB;
+      break;
+    case ARM_FFA_BUFFER_MINSIZE_AND_ALIGN_64K:
+      MinSizeAndAlign = SIZE_64KB;
+      break;
+    default:
+      DEBUG ((DEBUG_ERROR, "%a: Invalid MinSizeAndAlign: 0x%x\n", __func__, MinSizeAndAlign));
+      return EFI_UNSUPPORTED;
+  }
+
+  MaxSize = (Property1 >> ARM_FFA_BUFFER_MAXSIZE_PAGE_COUNT_SHIFT) &
+            ARM_FFA_BUFFER_MAXSIZE_PAGE_COUNT_MASK;
+
+  MaxSize = ((MaxSize == 0) ? MAX_UINTN : (MaxSize * MinSizeAndAlign));
+
+  if ((MinSizeAndAlign > (PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE)) ||
+      (MaxSize < (PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE)))
+  {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Buffer is too small! MinSize: 0x%x, MaxSize: 0x%x, PageCount: %d\n",
+      __func__,
+      MinSizeAndAlign,
+      MaxSize,
+      PcdGet64 (PcdFfaTxRxPageCount)
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Buffers = AllocateAlignedPages ((PcdGet64 (PcdFfaTxRxPageCount) * 2), MinSizeAndAlign);
+  if (Buffers == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  BufferSize = PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE;
+  TxBuffer   = Buffers;
+  RxBuffer   = Buffers + BufferSize;
+
+  FfaArgs.Arg0 = ARM_FID_FFA_RXTX_MAP;
+  FfaArgs.Arg1 = (UINTN)TxBuffer;
+  FfaArgs.Arg2 = (UINTN)RxBuffer;
+
+  /*
+   * PcdFfaTxRxPageCount sets with count of EFI_PAGE_SIZE granularity
+   * But, PageCounts for Tx/Rx buffer should set with
+   * count of Tx/Rx Buffer's MinSizeAndAlign. granularity.
+   */
+  FfaArgs.Arg3 = PcdGet64 (PcdFfaTxRxPageCount) / EFI_SIZE_TO_PAGES (MinSizeAndAlign);
+
+  ArmCallFfa (&FfaArgs);
+
+  Status = FfaArgsToEfiStatus (&FfaArgs);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to map Rx/Tx buffer. Status: %r\n",
+      __func__,
+      Status
+      ));
+    goto ErrorHandler;
+  }
+
+  mArmFfaRxTxBufferStmmInfo = AllocateZeroPool (sizeof (ARM_FFA_RX_TX_BUFFER_INFO));
+  if (mArmFfaRxTxBufferStmmInfo == NULL) {
+    Status = EFI_OUT_OF_RESOURCES;
+    goto ErrorHandler;
+  }
+
+  mArmFfaRxTxBufferStmmInfo->TxBufferAddr = TxBuffer;
+  mArmFfaRxTxBufferStmmInfo->RxBufferAddr = RxBuffer;
+  mArmFfaRxTxBufferStmmInfo->TxBufferSize = BufferSize;
+  mArmFfaRxTxBufferStmmInfo->RxBufferSize = BufferSize;
+
+  Status = gMmst->MmInstallProtocolInterface (
+                    &mArmFfaRxTxBufferStmmInfoHandle,
+                    &gArmFfaRxTxBufferInfoGuid,
+                    EFI_NATIVE_INTERFACE,
+                    mArmFfaRxTxBufferStmmInfo
+                    );
+
+  return Status;
+
+ErrorHandler:
+  FreeAlignedPages (Buffers, (PcdGet64 (PcdFfaTxRxPageCount) * 2));
+  TxBuffer = NULL;
+  RxBuffer = NULL;
+
+  return Status;
+}
+
+/**
+  Unmap Rx/Tx buffer.
+  This function is only called in Exit boot service because
+  Rx/Tx buffer is registered only once per partition.
+
+  @retval EFI_SUCCESS
+  @retval EFI_INVALID_PARAMETERS               Already unregistered
+  @retval EFI_UNSUPPORTED                      Not supported
+
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaLibRxTxUnmap (
+  IN VOID
+  )
+{
+  EFI_STATUS    Status;
+  ARM_FFA_ARGS  FfaArgs;
+  VOID          *Buffers;
+
+  if (mArmFfaRxTxBufferStmmInfoHandle == NULL) {
+    // This means that the agent tried to unmap the buffers before even know them.
+    // Let's be a nice player...
+    return EFI_UNSUPPORTED;
+  }
+
+  ZeroMem (&FfaArgs, sizeof (ARM_FFA_ARGS));
+
+  FfaArgs.Arg0 = ARM_FID_FFA_RXTX_UNMAP;
+  FfaArgs.Arg1 = (gPartId << ARM_FFA_SOURCE_EP_SHIFT);
+
+  ArmCallFfa (&FfaArgs);
+
+  Status = FfaArgsToEfiStatus (&FfaArgs);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  /*
+   * Rx/Tx Buffer are allocated with continuous pages.
+   * and start address of these pages is set on PcdFfaTxBuffer.
+   * See ArmFfaLibRxTxMap().
+   */
+  Buffers = (VOID *)(UINTN)mArmFfaRxTxBufferStmmInfo->TxBufferAddr;
+  if (Buffers != NULL) {
+    FreeAlignedPages (Buffers, (EFI_SIZE_TO_PAGES (mArmFfaRxTxBufferStmmInfo->TxBufferSize) * 2));
+  }
+
+  Status = gMmst->MmUninstallProtocolInterface (
+                    mArmFfaRxTxBufferStmmInfoHandle,
+                    &gArmFfaRxTxBufferInfoGuid,
+                    mArmFfaRxTxBufferStmmInfo
+                    );
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to uninstall Rx/Tx buffer protocol... Status: %r\n",
+      __func__,
+      Status
+      ));
+    return Status;
+  }
+
+  FreePool (mArmFfaRxTxBufferStmmInfo);
+  mArmFfaRxTxBufferStmmInfo = NULL;
+
+  return EFI_SUCCESS;
+}

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecLib.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecLib.c
@@ -1,0 +1,107 @@
+/** @file
+  Arm Ffa library code for PeilessSec
+
+  Copyright (c) 2025, Arm Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+   @par Glossary:
+     - FF-A - Firmware Framework for Arm A-profile
+
+   @par Reference(s):
+     - Arm Firmware Framework for Arm A-Profile [https://developer.arm.com/documentation/den0077/latest]
+
+**/
+
+#include <Uefi.h>
+#include <Pi/PiMultiPhase.h>
+
+#include <Library/ArmLib.h>
+#include <Library/ArmSmcLib.h>
+#include <Library/ArmFfaLib.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/HobLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/PcdLib.h>
+
+#include <IndustryStandard/ArmFfaSvc.h>
+
+#include <Guid/ArmFfaRxTxBufferInfo.h>
+
+#include "ArmFfaCommon.h"
+#include "ArmFfaRxTxMap.h"
+
+/**
+  ArmFfaLib Constructor.
+
+  @param [in]   FileHandle        File Handle
+  @param [in]   PeiServices       Pei Service Table
+
+  @retval EFI_SUCCESS            Success
+  @retval Others                 Error
+
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaSecLibConstructor (
+  IN VOID
+  )
+{
+  EFI_STATUS                 Status;
+  ARM_FFA_RX_TX_BUFFER_INFO  *BufferInfo;
+  EFI_HOB_MEMORY_ALLOCATION  *RxTxBufferAllocationHob;
+
+  Status = ArmFfaLibCommonInit ();
+  if (EFI_ERROR (Status)) {
+    if (Status == EFI_UNSUPPORTED) {
+      /*
+       * EFI_UNSUPPORTED return from ArmFfaLibCommonInit() means
+       * FF-A interface doesn't support.
+       * However, It doesn't make failure of loading driver/library instance
+       * (i.e) ArmPkg's MmCommunication Dxe/PEI Driver uses as well as SpmMm.
+       * So If FF-A is not supported the the MmCommunication Dxe/PEI falls
+       * back to SpmMm.
+       * For this case, return EFI_SUCCESS.
+       */
+      return EFI_SUCCESS;
+    }
+
+    return Status;
+  }
+
+  Status = ArmFfaLibRxTxMap ();
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  BufferInfo = BuildGuidHob (
+                 &gArmFfaRxTxBufferInfoGuid,
+                 sizeof (ARM_FFA_RX_TX_BUFFER_INFO)
+                 );
+  if (BufferInfo == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to create Rx/Tx Buffer Info Hob\n", __func__));
+    ArmFfaLibRxTxUnmap ();
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  RxTxBufferAllocationHob = FindRxTxBufferAllocationHob (FALSE);
+  ASSERT (RxTxBufferAllocationHob != NULL);
+
+  /*
+   * Set then Name with gArmFfaRxTxBufferInfoGuid, so that ArmFfaPeiLib or
+   * ArmFfaDxeLib can find the Rx/Tx buffer allocation area.
+   */
+  CopyGuid (
+    &RxTxBufferAllocationHob->AllocDescriptor.Name,
+    &gArmFfaRxTxBufferInfoGuid
+    );
+
+  UpdateRxTxBufferInfo (BufferInfo);
+  BufferInfo->RemapOffset =
+    (UINTN)((EFI_PHYSICAL_ADDRESS)((UINTN)BufferInfo->TxBufferAddr) -
+            RxTxBufferAllocationHob->AllocDescriptor.MemoryBaseAddress);
+  BufferInfo->RemapRequired = TRUE;
+
+  return EFI_SUCCESS;
+}

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecLib.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecLib.c
@@ -99,7 +99,7 @@ ArmFfaSecLibConstructor (
 
   UpdateRxTxBufferInfo (BufferInfo);
   BufferInfo->RemapOffset =
-    (UINTN)((EFI_PHYSICAL_ADDRESS)((UINTN)BufferInfo->TxBufferAddr) -
+    (UINTN)(BufferInfo->TxBufferAddr -
             RxTxBufferAllocationHob->AllocDescriptor.MemoryBaseAddress);
   BufferInfo->RemapRequired = TRUE;
 

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecLib.inf
@@ -1,0 +1,42 @@
+## @file
+#  Provides FF-A ABI Library used in PeilessSec
+#
+#  Copyright (c) 2025, Arm Limited. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = ArmFfaSecLib
+  FILE_GUID                      = 7b2c2aa6-3e20-11f0-a8b6-db774bafa249
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = ArmFfaLib|SEC
+  CONSTRUCTOR                    = ArmFfaSecLibConstructor
+
+[Sources]
+  ArmFfaCommon.h
+  ArmFfaCommon.c
+  ArmFfaRxTxMap.h
+  ArmFfaSecRxTxMap.c
+  ArmFfaSecLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[LibraryClasses]
+  ArmSmcLib
+  ArmSvcLib
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  HobLib
+
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFfaTxRxPageCount
+
+[Guids]
+  gArmFfaRxTxBufferInfoGuid

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecRxTxMap.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecRxTxMap.c
@@ -297,47 +297,13 @@ FindRxTxBufferAllocationHob (
   IN BOOLEAN  UseGuid
   )
 {
-  EFI_PEI_HOB_POINTERS       Hob;
-  EFI_HOB_MEMORY_ALLOCATION  *MemoryAllocationHob;
-  EFI_PHYSICAL_ADDRESS       BufferBase;
-  UINT64                     BufferSize;
-  EFI_PHYSICAL_ADDRESS       MemoryBase;
-  UINT64                     MemorySize;
+  EFI_PHYSICAL_ADDRESS  BufferBase;
+  UINT64                BufferSize;
 
   BufferBase = (EFI_PHYSICAL_ADDRESS)((UINTN)mTxBuffer);
   BufferSize = PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE * 2;
 
-  if (!UseGuid && (BufferBase == 0x00)) {
-    return NULL;
-  }
-
-  MemoryAllocationHob = NULL;
-  Hob.Raw             = GetFirstHob (EFI_HOB_TYPE_MEMORY_ALLOCATION);
-
-  while (Hob.Raw != NULL) {
-    if (Hob.MemoryAllocation->AllocDescriptor.MemoryType == EfiConventionalMemory) {
-      continue;
-    }
-
-    MemoryBase = Hob.MemoryAllocation->AllocDescriptor.MemoryBaseAddress;
-    MemorySize = Hob.MemoryAllocation->AllocDescriptor.MemoryLength;
-
-    if ((!UseGuid && (BufferBase >= MemoryBase) &&
-         ((BufferBase + BufferSize) <= (MemoryBase + MemorySize))) ||
-        (UseGuid && CompareGuid (
-                      &gArmFfaRxTxBufferInfoGuid,
-                      &Hob.MemoryAllocation->AllocDescriptor.Name
-                      )))
-    {
-      MemoryAllocationHob = (EFI_HOB_MEMORY_ALLOCATION *)Hob.Raw;
-      break;
-    }
-
-    Hob.Raw = GET_NEXT_HOB (Hob);
-    Hob.Raw = GetNextHob (EFI_HOB_TYPE_MEMORY_ALLOCATION, Hob.Raw);
-  }
-
-  return MemoryAllocationHob;
+  return GetRxTxBufferAllocationHob (BufferBase, BufferSize, UseGuid);
 }
 
 /**

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecRxTxMap.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecRxTxMap.c
@@ -1,0 +1,363 @@
+/** @file
+  Arm Ffa library common code.
+
+  Copyright (c) 2025, Arm Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+   @par Glossary:
+     - FF-A - Firmware Framework for Arm A-profile
+
+   @par Reference(s):
+     - Arm Firmware Framework for Arm A-Profile [https://developer.arm.com/documentation/den0077/latest]
+
+**/
+#include <Uefi.h>
+#include <Pi/PiMultiPhase.h>
+
+#include <Library/ArmLib.h>
+#include <Library/ArmFfaLib.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/HobLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/PcdLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+
+#include <IndustryStandard/ArmFfaSvc.h>
+
+#include <Guid/ArmFfaRxTxBufferInfo.h>
+
+#include "ArmFfaCommon.h"
+#include "ArmFfaRxTxMap.h"
+
+STATIC VOID  *mTxBuffer;
+STATIC VOID  *mRxBuffer;
+
+/**
+  Get mapped Rx/Tx buffers.
+
+  @param [out]   TxBuffer         Address of TxBuffer
+  @param [out]   TxBufferSize     Size of TxBuffer
+  @param [out]   RxBuffer         Address of RxBuffer
+  @param [out]   RxBufferSize     Size of RxBuffer
+
+  @retval EFI_SUCCESS
+  @retval Others             Error.
+
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaLibGetRxTxBuffers (
+  OUT VOID    **TxBuffer OPTIONAL,
+  OUT UINT64  *TxBufferSize OPTIONAL,
+  OUT VOID    **RxBuffer OPTIONAL,
+  OUT UINT64  *RxBufferSize OPTIONAL
+  )
+{
+  if ((mTxBuffer == NULL) || (mRxBuffer == NULL)) {
+    return EFI_NOT_READY;
+  }
+
+  if (TxBuffer != NULL) {
+    *TxBuffer = mTxBuffer;
+  }
+
+  if (TxBufferSize != NULL) {
+    *TxBufferSize = PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE;
+  }
+
+  if (RxBuffer != NULL) {
+    *RxBuffer = mRxBuffer;
+  }
+
+  if (RxBufferSize != NULL) {
+    *RxBufferSize = PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Mapping Rx/Tx buffers.
+  This function is only called in ArmFfaLibConstructor because
+  Rx/Tx buffer is registered only once per partition.
+
+  @retval EFI_SUCCESS
+  @retval EFI_ALREADY_STARTED     Rx/Tx buffer already mapped.
+  @retval EFI_OUT_OF_RESOURCE     Out of memory
+  @retval EFI_INVALID_PARAMETER   Invalid alignment of Rx/Tx buffer
+  @retval Others                  Error
+
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaLibRxTxMap (
+  IN VOID
+  )
+{
+  EFI_STATUS    Status;
+  ARM_FFA_ARGS  FfaArgs;
+  UINTN         Property1;
+  UINTN         Property2;
+  UINTN         MinSizeAndAlign;
+  UINTN         MaxSize;
+  VOID          *Buffers;
+  VOID          *TxBuffer;
+  VOID          *RxBuffer;
+
+  /*
+   * If someone already mapped Rx/Tx Buffers, return EFI_ALREADY_STARTED.
+   * return EFI_ALREADY_STARTED.
+   */
+  if ((mTxBuffer != NULL) && (mRxBuffer != NULL)) {
+    return EFI_ALREADY_STARTED;
+  }
+
+  Status = ArmFfaLibGetFeatures (
+             ARM_FID_FFA_RXTX_MAP,
+             FFA_RXTX_MAP_INPUT_PROPERTY_DEFAULT,
+             &Property1,
+             &Property2
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to get RX/TX buffer property... Status: %r\n",
+      __func__,
+      Status
+      ));
+    return Status;
+  }
+
+  ZeroMem (&FfaArgs, sizeof (ARM_FFA_ARGS));
+
+  MinSizeAndAlign =
+    ((Property1 >>
+      ARM_FFA_BUFFER_MINSIZE_AND_ALIGN_SHIFT) &
+     ARM_FFA_BUFFER_MINSIZE_AND_ALIGN_MASK);
+
+  switch (MinSizeAndAlign) {
+    case ARM_FFA_BUFFER_MINSIZE_AND_ALIGN_4K:
+      MinSizeAndAlign = SIZE_4KB;
+      break;
+    case ARM_FFA_BUFFER_MINSIZE_AND_ALIGN_16K:
+      MinSizeAndAlign = SIZE_16KB;
+      break;
+    case ARM_FFA_BUFFER_MINSIZE_AND_ALIGN_64K:
+      MinSizeAndAlign = SIZE_64KB;
+      break;
+    default:
+      DEBUG ((DEBUG_ERROR, "%a: Invalid MinSizeAndAlign: 0x%x\n", __func__, MinSizeAndAlign));
+      return EFI_UNSUPPORTED;
+  }
+
+  MaxSize =
+    (((Property1 >>
+       ARM_FFA_BUFFER_MAXSIZE_PAGE_COUNT_SHIFT) &
+      ARM_FFA_BUFFER_MAXSIZE_PAGE_COUNT_MASK));
+
+  MaxSize = ((MaxSize == 0) ? MAX_UINTN : (MaxSize * MinSizeAndAlign));
+
+  if ((MinSizeAndAlign > (PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE)) ||
+      (MaxSize < (PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE)))
+  {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Buffer is too small! MinSize: 0x%x, MaxSize: 0x%x, PageCount: %d\n",
+      __func__,
+      MinSizeAndAlign,
+      MaxSize,
+      PcdGet64 (PcdFfaTxRxPageCount)
+      ));
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Buffers = AllocateAlignedPages ((PcdGet64 (PcdFfaTxRxPageCount) * 2), MinSizeAndAlign);
+  if (Buffers == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  TxBuffer = Buffers;
+  RxBuffer = Buffers + (PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE);
+
+  FfaArgs.Arg0 = ARM_FID_FFA_RXTX_MAP;
+  FfaArgs.Arg1 = (UINTN)TxBuffer;
+  FfaArgs.Arg2 = (UINTN)RxBuffer;
+
+  /*
+   * PcdFfaTxRxPageCount sets with count of EFI_PAGE_SIZE granularity
+   * But, PageCounts for Tx/Rx buffer should set with
+   * count of Tx/Rx Buffer's MinSizeAndAlign. granularity.
+   */
+  FfaArgs.Arg3 = PcdGet64 (PcdFfaTxRxPageCount) / EFI_SIZE_TO_PAGES (MinSizeAndAlign);
+
+  ArmCallFfa (&FfaArgs);
+
+  Status = FfaArgsToEfiStatus (&FfaArgs);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to map Rx/Tx buffer. Status: %r\n",
+      __func__,
+      Status
+      ));
+    goto ErrorHandler;
+  }
+
+  mTxBuffer = TxBuffer;
+  mRxBuffer = RxBuffer;
+
+  return EFI_SUCCESS;
+
+ErrorHandler:
+  FreePages (Buffers, (PcdGet64 (PcdFfaTxRxPageCount) * 2));
+
+  return Status;
+}
+
+/**
+  Unmap Rx/Tx buffer.
+  This function is only called in Exit boot service because
+  Rx/Tx buffer is registered only once per partition.
+
+  @retval EFI_SUCCESS
+  @retval EFI_INVALID_PARAMETERS               Already unregistered
+  @retval EFI_UNSUPPORTED                      Not supported
+
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaLibRxTxUnmap (
+  IN VOID
+  )
+{
+  EFI_STATUS    Status;
+  ARM_FFA_ARGS  FfaArgs;
+  VOID          *Buffers;
+
+  ZeroMem (&FfaArgs, sizeof (ARM_FFA_ARGS));
+
+  FfaArgs.Arg0 = ARM_FID_FFA_RXTX_UNMAP;
+  FfaArgs.Arg1 = (gPartId << ARM_FFA_SOURCE_EP_SHIFT);
+
+  ArmCallFfa (&FfaArgs);
+
+  Status = FfaArgsToEfiStatus (&FfaArgs);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  /*
+   * Rx/Tx Buffer are allocated with continuous pages.
+   * and start address of these pages is set on PcdFfaTxBuffer.
+   * See ArmFfaLibRxTxMap().
+   */
+  Buffers = mTxBuffer;
+  if (Buffers != NULL) {
+    FreePages (Buffers, (PcdGet64 (PcdFfaTxRxPageCount) * 2));
+  }
+
+  mTxBuffer = NULL;
+  mRxBuffer = NULL;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Update Rx/TX buffer information.
+
+  @param  BufferInfo            Rx/Tx buffer information.
+
+**/
+VOID
+EFIAPI
+UpdateRxTxBufferInfo (
+  OUT ARM_FFA_RX_TX_BUFFER_INFO  *BufferInfo
+  )
+{
+  BufferInfo->TxBufferAddr = mTxBuffer;
+  BufferInfo->TxBufferSize = PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE;
+  BufferInfo->RxBufferAddr = mRxBuffer;
+  BufferInfo->RxBufferSize = PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE;
+}
+
+/**
+  Find Rx/TX buffer memory allocation hob.
+
+  @param  UseGuid             Find MemoryAllocationHob using Guid.
+
+  @retval MemoryAllocationHob
+  @retval NULL                No memory allocation hob related to Rx/Tx buffer
+
+**/
+EFI_HOB_MEMORY_ALLOCATION *
+EFIAPI
+FindRxTxBufferAllocationHob (
+  IN BOOLEAN  UseGuid
+  )
+{
+  EFI_PEI_HOB_POINTERS       Hob;
+  EFI_HOB_MEMORY_ALLOCATION  *MemoryAllocationHob;
+  EFI_PHYSICAL_ADDRESS       BufferBase;
+  UINT64                     BufferSize;
+  EFI_PHYSICAL_ADDRESS       MemoryBase;
+  UINT64                     MemorySize;
+
+  BufferBase = (EFI_PHYSICAL_ADDRESS)((UINTN)mTxBuffer);
+  BufferSize = PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE * 2;
+
+  if (!UseGuid && (BufferBase == 0x00)) {
+    return NULL;
+  }
+
+  MemoryAllocationHob = NULL;
+  Hob.Raw             = GetFirstHob (EFI_HOB_TYPE_MEMORY_ALLOCATION);
+
+  while (Hob.Raw != NULL) {
+    if (Hob.MemoryAllocation->AllocDescriptor.MemoryType == EfiConventionalMemory) {
+      continue;
+    }
+
+    MemoryBase = Hob.MemoryAllocation->AllocDescriptor.MemoryBaseAddress;
+    MemorySize = Hob.MemoryAllocation->AllocDescriptor.MemoryLength;
+
+    if ((!UseGuid && (BufferBase >= MemoryBase) &&
+         ((BufferBase + BufferSize) <= (MemoryBase + MemorySize))) ||
+        (UseGuid && CompareGuid (
+                      &gArmFfaRxTxBufferInfoGuid,
+                      &Hob.MemoryAllocation->AllocDescriptor.Name
+                      )))
+    {
+      MemoryAllocationHob = (EFI_HOB_MEMORY_ALLOCATION *)Hob.Raw;
+      break;
+    }
+
+    Hob.Raw = GET_NEXT_HOB (Hob);
+    Hob.Raw = GetNextHob (EFI_HOB_TYPE_MEMORY_ALLOCATION, Hob.Raw);
+  }
+
+  return MemoryAllocationHob;
+}
+
+/**
+  Remap Rx/TX buffer with converted Rx/Tx Buffer address after
+  using permanent memory.
+
+  @param[out] BufferInfo    BufferInfo
+
+  @retval EFI_SUCCESS       Success
+  @retval EFI_NOT_FOUND     No memory allocation hob related to Rx/Tx buffer
+
+**/
+EFI_STATUS
+EFIAPI
+RemapFfaRxTxBuffer (
+  OUT ARM_FFA_RX_TX_BUFFER_INFO  *BufferInfo
+  )
+{
+  /*
+   * SEC binary shouldn't remap the Rx/Tx Buffer.
+   */
+  return EFI_UNSUPPORTED;
+}

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecRxTxMap.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecRxTxMap.c
@@ -276,9 +276,9 @@ UpdateRxTxBufferInfo (
   OUT ARM_FFA_RX_TX_BUFFER_INFO  *BufferInfo
   )
 {
-  BufferInfo->TxBufferAddr = mTxBuffer;
+  BufferInfo->TxBufferAddr = (UINTN)mTxBuffer;
   BufferInfo->TxBufferSize = PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE;
-  BufferInfo->RxBufferAddr = mRxBuffer;
+  BufferInfo->RxBufferAddr = (UINTN)mRxBuffer;
   BufferInfo->RxBufferSize = PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE;
 }
 

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf
@@ -19,9 +19,9 @@
 [Sources]
   ArmFfaCommon.h
   ArmFfaCommon.c
-  ArmFfaStandaloneMmLib.c
   ArmFfaRxTxMap.h
-  ArmFfaRxTxMapStmm.c
+  ArmFfaStandaloneMmRxTxMap.c
+  ArmFfaStandaloneMmLib.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf
@@ -20,6 +20,8 @@
   ArmFfaCommon.h
   ArmFfaCommon.c
   ArmFfaStandaloneMmLib.c
+  ArmFfaRxTxMap.h
+  ArmFfaRxTxMapStmm.c
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -31,6 +33,11 @@
   BaseLib
   BaseMemoryLib
   DebugLib
+  MmServicesTableLib
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFfaTxRxPageCount
+
+[Guids]
+  gArmFfaRxTxBufferInfoGuid

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.inf
@@ -19,9 +19,9 @@
 [Sources]
   ArmFfaCommon.h
   ArmFfaCommon.c
-  ArmFfaStandaloneMmLib.c
   ArmFfaRxTxMap.h
-  ArmFfaRxTxMapStmm.c
+  ArmFfaStandaloneMmRxTxMap.c
+  ArmFfaStandaloneMmLib.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.inf
@@ -20,6 +20,8 @@
   ArmFfaCommon.h
   ArmFfaCommon.c
   ArmFfaStandaloneMmLib.c
+  ArmFfaRxTxMap.h
+  ArmFfaRxTxMapStmm.c
 
 [Packages]
   MdePkg/MdePkg.dec
@@ -31,7 +33,12 @@
   BaseLib
   BaseMemoryLib
   DebugLib
+  MmServicesTableLib
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFfaTxRxPageCount
+
+[Guids]
+  gArmFfaRxTxBufferInfoGuid
 

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmRxTxMap.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmRxTxMap.c
@@ -173,8 +173,8 @@ ArmFfaLibRxTxMap (
     goto ErrorHandler;
   }
 
-  mArmFfaRxTxBufferStmmInfo->TxBufferAddr = TxBuffer;
-  mArmFfaRxTxBufferStmmInfo->RxBufferAddr = RxBuffer;
+  mArmFfaRxTxBufferStmmInfo->TxBufferAddr = (UINTN)TxBuffer;
+  mArmFfaRxTxBufferStmmInfo->RxBufferAddr = (UINTN)RxBuffer;
   mArmFfaRxTxBufferStmmInfo->TxBufferSize = BufferSize;
   mArmFfaRxTxBufferStmmInfo->RxBufferSize = BufferSize;
 

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmRxTxMap.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmRxTxMap.c
@@ -1,7 +1,7 @@
 /** @file
   Arm Ffa library common code.
 
-  Copyright (c) 2024, Arm Limited. All rights reserved.<BR>
+  Copyright (c) 2024-2025, Arm Limited. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
    @par Glossary:
@@ -11,8 +11,7 @@
      - Arm Firmware Framework for Arm A-Profile v1.3 ALP1: [https://developer.arm.com/documentation/den0077/l]
 
 **/
-#include <Uefi.h>
-#include <Pi/PiMultiPhase.h>
+#include <PiMm.h>
 
 #include <Library/ArmLib.h>
 #include <Library/ArmFfaLib.h>
@@ -318,4 +317,66 @@ ArmFfaLibRxTxUnmap (
   mArmFfaRxTxBufferStmmInfo = NULL;
 
   return EFI_SUCCESS;
+}
+
+/**
+  Update Rx/TX buffer information.
+
+  @param  BufferInfo            Rx/Tx buffer information.
+
+**/
+VOID
+EFIAPI
+UpdateRxTxBufferInfo (
+  OUT ARM_FFA_RX_TX_BUFFER_INFO  *BufferInfo
+  )
+{
+  /*
+   * StandaloneMm doesn't use Rx/Tx buffer.
+   */
+  return;
+}
+
+/**
+  Find Rx/TX buffer memory allocation hob.
+
+  @param  UseGuid           Find MemoryAllocationHob using Guid.
+
+  @retval MemoryAllocationHob
+  @retval NULL                No memory allocation hob related to Rx/Tx buffer
+
+**/
+EFI_HOB_MEMORY_ALLOCATION *
+EFIAPI
+FindRxTxBufferAllocationHob (
+  IN BOOLEAN  UseGuid
+  )
+{
+  /*
+   * StandaloneMm doesn't use Rx/Tx buffer.
+   */
+  return NULL;
+}
+
+/**
+  Remap Rx/TX buffer with converted Rx/Tx Buffer address after
+  using permanent memory.
+
+  @param[out] BufferInfo    BufferInfo
+
+  @retval EFI_SUCCESS       Success
+  @retval EFI_NOT_FOUND     No memory allocation hob related to Rx/Tx buffer
+
+**/
+EFI_STATUS
+EFIAPI
+RemapFfaRxTxBuffer (
+  OUT ARM_FFA_RX_TX_BUFFER_INFO  *BufferInfo
+  )
+{
+  /*
+   * StandaloneMm doesn't use Rx/Tx buffer.
+   * So, return EFI_UNSUPPORTED.
+   */
+  return EFI_UNSUPPORTED;
 }

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -1394,6 +1394,10 @@
   # @Prompt Defines the page allocation for the MM communication buffer; default is 128 pages (512KB).
   gEfiMdeModulePkgTokenSpaceGuid.PcdMmCommBufferPages|128|UINT32|0x30001061
 
+  ## This PCD holds the number of pages for the FFA TX/RX buffer.
+  # @Prompt FFA TX/RX Buffer Page Count
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFfaTxRxPageCount|1|UINT64|0x30001062
+
   # MU_CHANGE [BEGIN] - Support indefinite boot retries
   # # Some platforms require that all EfiLoadOptions are retried until one of the options 
   # # succeeds. When True, this Pcd will force Bds to retry all the valid EfiLoadOptions 
@@ -2614,10 +2618,6 @@
   ## This dynamic PCD holds the address of the FFA RX buffer.
   # @Prompt FFA RX Buffer Address
   gEfiMdeModulePkgTokenSpaceGuid.PcdFfaRxBuffer|0x00|UINT64|0x0003000A
-
-  ## This dynamic PCD holds the number of pages for the FFA TX/RX buffer.
-  # @Prompt FFA TX/RX Buffer Page Count
-  gEfiMdeModulePkgTokenSpaceGuid.PcdFfaTxRxPageCount|1|UINT64|0x0003000B
 
   ## This dynamic PCD holds the information if the FFA exit boot event is registered.
   # @Prompt FFA Exit Boot Event Registered

--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -594,6 +594,7 @@
   MdeModulePkg/Universal/CapsulePei/CapsuleX64.inf
 
 [Components.ARM, Components.AARCH64]
+  MdeModulePkg/Library/ArmFfaLib/ArmFfaSecLib.inf
   MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.inf
   MdeModulePkg/Library/ArmFfaLib/ArmFfaDxeLib.inf
   MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf

--- a/MdePkg/Include/Library/ArmFfaLib.h
+++ b/MdePkg/Include/Library/ArmFfaLib.h
@@ -23,6 +23,30 @@
 
 #include <Library/ArmSmcLib.h>
 
+/**
+ * Arguments to call FF-A request via SMC/SVC.
+ */
+typedef struct ArmFfaArgs {
+  UINTN    Arg0;
+  UINTN    Arg1;
+  UINTN    Arg2;
+  UINTN    Arg3;
+  UINTN    Arg4;
+  UINTN    Arg5;
+  UINTN    Arg6;
+  UINTN    Arg7;
+  UINTN    Arg8;
+  UINTN    Arg9;
+  UINTN    Arg10;
+  UINTN    Arg11;
+  UINTN    Arg12;
+  UINTN    Arg13;
+  UINTN    Arg14;
+  UINTN    Arg15;
+  UINTN    Arg16;
+  UINTN    Arg17;
+} ARM_FFA_ARGS;
+
 #define FFA_RXTX_MAP_INPUT_PROPERTY_DEFAULT  0x00
 
 /** Implementation define arguments used in
@@ -72,6 +96,18 @@ typedef struct DirectMsgArgs {
   /// Implementation define argument 13, this will be set to/from x17(v2)
   UINTN    Arg13;
 } DIRECT_MSG_ARGS;
+
+/**
+  Trigger FF-A ABI call according to PcdFfaLibConduitSmc.
+
+  @param [in, out]  FfaArgs        Ffa arguments
+
+**/
+VOID
+EFIAPI
+ArmCallFfa (
+  IN OUT ARM_FFA_ARGS  *FfaArgs
+  );
 
 /**
   Convert EFI_STATUS to FFA return code.


### PR DESCRIPTION
## Description

This change cherry-picks the change from EDK2 to support STMM and SEC phase.

Original EDK2 PR:
https://github.com/tianocore/edk2/pull/11166

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

This is tested on both virtual and physical platforms and booted to OS desktop.

## Integration Instructions

For platforms that needs to use TPM in SEC phase needs to use the following library:
`ArmFfaLib|MdeModulePkg/Library/ArmFfaLib/ArmFfaSecLib.inf`