### PR TITLE
[Rebase & FF] MdePkg: TpmPtp: Add CRB Interface Version 2 Definition

### DIFF
--- a/MdePkg/Include/IndustryStandard/TpmPtp.h
+++ b/MdePkg/Include/IndustryStandard/TpmPtp.h
@@ -5,6 +5,11 @@
 Copyright (c) 2016 - 2018, Intel Corporation. All rights reserved.<BR>
 SPDX-License-Identifier: BSD-2-Clause-Patent
 
+  // MU_CHANGE: Add CRB v2 from Spec v1.06
+  @par Reference(s)
+    - TCG PC Client Platform TPM Profile (PTP) Specification
+      (https://trustedcomputinggroup.org/resource/pc-client-platform-tpm-profile-ptp-specification/)
+
 **/
 
 #ifndef _TPM_PTP_H_
@@ -356,6 +361,8 @@ typedef union {
 ///
 #define PTP_INTERFACE_IDENTIFIER_INTERFACE_VERSION_FIFO  0x0
 #define PTP_INTERFACE_IDENTIFIER_INTERFACE_VERSION_CRB   0x1
+// MU_CHANGE: Add CRB v2 from Spec v1.06
+#define PTP_INTERFACE_IDENTIFIER_INTERFACE_VERSION_CRB_V2  0x2
 
 ///
 /// InterfaceSelector


### PR DESCRIPTION
## Description

Introduces support for CRB Interface Version 2 as defined in the TCG PC Client Platform TPM Profile (PTP) Specification v1.06:
https://trustedcomputinggroup.org/wp-content/uploads/PC-Client-Specific-Platform-TPM-Profile-for-TPM-2p0-Version-1p06_pub.pdf

This enables firmware to identify TPMs that support the CRB buffer interface.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

This change was tested on proprietary hardware platform.

## Integration Instructions

N/A