### PR TITLE
Revert "[dev/202502] Update BaseTools ext dep to dev-v2025020001.0.3 (#1467)"

### DIFF
--- a/BaseTools/Bin/basetoolsbin_ext_dep.yaml
+++ b/BaseTools/Bin/basetoolsbin_ext_dep.yaml
@@ -11,9 +11,9 @@ scope: global
 id: edk-tools-bin
 type: web
 name: Mu-Basetools
-source: https://github.com/microsoft/mu_basecore/releases/download/dev-v2025020001.0.3/basetools-dev-v2025020001.0.3.tar.gz
-version: dev-v2025020001.0.3
-sha256: df6d335589f1ba4cfbb460e0d9b264da3ae7008b285ebf1cfe03e47b4fa2566e
+source: https://github.com/microsoft/mu_basecore/releases/download/dev-v2025020001.0.1/basetools-dev-v2025020001.0.1.tar.gz
+version: dev-v2025020001.0.1
+sha256: 0c9b792c2fac086a8917a2d1274dc73a02ff43b08756c8dd047950493399296b
 internal_path: /basetools/
 compression_type: tar
 flags:


### PR DESCRIPTION

## Description

This reverts commit b535851e3fffe7553f9a6c2e2d871a57cb4be407.

After the commit went in, CI is failing with 

ERROR - ran into an issue when resolving ext_dep Mu-Basetools at https://github.com/microsoft/mu_basecore/releases/download/dev-v2025020001.0.3/basetools-dev-v2025020001.0.3.tar.gz

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested
Reverted back to the last known good version of basetools

## Integration Instructions
No integration necessary.