### PR TITLE
[CHERRY-PICK] [REBASE & FF] MdeModulePkg: XhciDxe: Fix USB reset issue

### DIFF
--- a/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/Xhci.c
@@ -837,6 +837,10 @@ XhcTransfer (
   }
 
   Xhc->PciIo->Flush (Xhc->PciIo);
+  //
+  // Do not free URB data, since it is passed in as an external argument
+  // and allocated and managed by the caller.
+  //
   XhcFreeUrb (Xhc, Urb);
   return Status;
 }
@@ -1227,8 +1231,9 @@ ON_EXIT:
                                 sending or receiving.
   @param  DataBuffersNumber     Number of data buffers prepared for the transfer.
   @param  Data                  Array of pointers to the buffers of data to transmit
-                                from or receive into.
-  @param  DataLength            The lenght of the data buffer.
+                                from or receive into. The caller is responsible for freeing
+                                the buffers after the transfers are completed.
+  @param  DataLength            The length of the data buffer.
   @param  DataToggle            On input, the initial data toggle for the transfer;
                                 On output, it is updated to to next data toggle to
                                 use of the subsequent bulk transfer.

--- a/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
@@ -1773,8 +1773,8 @@ XhcMonitorAsyncRequests (
     //
     if (Urb->Callback != NULL) {
       //
-      // Restore the old TPL, USB bus maybe connect device in
-      // his callback. Some drivers may has a lower TPL restriction.
+      // Restore the previous TPL. The USB bus may connect a device in its callback,
+      // and some drivers require a lower TPL to run correctly.
       //
       gBS->RestoreTPL (OldTpl);
       (Urb->Callback)(ProcBuf, cbCompleted, cbContext, cbResult);

--- a/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
@@ -106,6 +106,10 @@ XhcCmdTransfer (
     Status = EFI_SUCCESS;
   }
 
+  //
+  // Do not free URB data, since `XhcCreateCmdTrb` does not allocate any data
+  // and the `Data` field is not used in command transfers.
+  //
   XhcFreeUrb (Xhc, Urb);
 
 ON_EXIT:
@@ -183,6 +187,9 @@ XhcCreateUrb (
 
 /**
   Free an allocated URB.
+  The `Data` field of the URB is not owned by the URB and is not freed here.
+  The caller is which allocates `Data` is responsible for freeing it.
+  Freeing `Data` must be done AFTER calling `XhcFreeUrb`, since this function may unmap the `DataMap` field.
 
   @param  Xhc                   The XHCI device.
   @param  Urb                   The URB to free.
@@ -1419,6 +1426,7 @@ XhciDelAsyncIntTransfer (
   LIST_ENTRY              *Entry;
   LIST_ENTRY              *Next;
   URB                     *Urb;
+  VOID                    *UrbData;
   EFI_USB_DATA_DIRECTION  Direction;
   EFI_STATUS              Status;
 
@@ -1443,8 +1451,16 @@ XhciDelAsyncIntTransfer (
       }
 
       RemoveEntryList (&Urb->UrbList);
-      FreePool (Urb->Data);
+      //
+      // For `XhciDelAsyncIntTransfer`, the URB is created through `XhciInsertAsyncIntTransfer`
+      // and allocates and manages its own data buffer, so free it here.
+      //
+      UrbData = Urb->Data;
       XhcFreeUrb (Xhc, Urb);
+      if (UrbData != NULL) {
+        FreePool (UrbData);
+      }
+
       return EFI_SUCCESS;
     }
   }
@@ -1466,6 +1482,7 @@ XhciDelAllAsyncIntTransfers (
   LIST_ENTRY  *Entry;
   LIST_ENTRY  *Next;
   URB         *Urb;
+  VOID        *UrbData;
   EFI_STATUS  Status;
 
   BASE_LIST_FOR_EACH_SAFE (Entry, Next, &Xhc->AsyncIntTransfers) {
@@ -1481,8 +1498,15 @@ XhciDelAllAsyncIntTransfers (
     }
 
     RemoveEntryList (&Urb->UrbList);
-    FreePool (Urb->Data);
+    //
+    // For `XhciDelAllAsyncIntTransfers`, the URB is created through `XhciInsertAsyncIntTransfer`
+    // and allocates and manages its own data buffer, so free it here.
+    //
+    UrbData = Urb->Data;
     XhcFreeUrb (Xhc, Urb);
+    if (UrbData != NULL) {
+      FreePool (UrbData);
+    }
   }
 }
 

--- a/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
@@ -1686,6 +1686,17 @@ XhcMonitorAsyncRequests (
   Xhc = (USB_XHCI_INSTANCE *)Context;
 
   BASE_LIST_FOR_EACH_SAFE (Entry, Next, &Xhc->AsyncIntTransfers) {
+    //
+    // Save values passed into the callback.
+    // `XhcUpdateAsyncRequest` must be called before the callback
+    // since the callback may free the URB, leading to a fault.
+    // However, the callback depends on values of the URB *before*
+    // `XhcUpdateAsyncRequest` is called, so we must save a copy.
+    //
+    UINTN   cbCompleted;
+    UINT32  cbResult;
+    VOID    *cbContext;
+
     Urb = EFI_LIST_CONTAINER (Entry, URB, UrbList);
 
     //
@@ -1738,6 +1749,19 @@ XhcMonitorAsyncRequests (
     }
 
     //
+    // Store values of URB before `XhcUpdateAsyncRequest`, since the callback depends on these values.
+    //
+    cbCompleted = Urb->Completed;
+    cbResult    = Urb->Result;
+    cbContext   = Urb->Context;
+
+    //
+    // The update call must occur before the callback since the callback
+    // may remove and free the URB, leading to a fault.
+    //
+    XhcUpdateAsyncRequest (Xhc, Urb);
+
+    //
     // Leave error recovery to its related device driver. A
     // common case of the error recovery is to re-submit the
     // interrupt transfer which is linked to the head of the
@@ -1753,15 +1777,13 @@ XhcMonitorAsyncRequests (
       // his callback. Some drivers may has a lower TPL restriction.
       //
       gBS->RestoreTPL (OldTpl);
-      (Urb->Callback)(ProcBuf, Urb->Completed, Urb->Context, Urb->Result);
+      (Urb->Callback)(ProcBuf, cbCompleted, cbContext, cbResult);
       OldTpl = gBS->RaiseTPL (XHC_TPL);
     }
 
     if (ProcBuf != NULL) {
       gBS->FreePool (ProcBuf);
     }
-
-    XhcUpdateAsyncRequest (Xhc, Urb);
   }
   gBS->RestoreTPL (OldTpl);
 }


### PR DESCRIPTION
## Description

Cherry-picks a fix from edk2 to fix USB reset issue seen on Intel platforms.
Original PR: https://github.com/tianocore/edk2/pull/11382

- [X] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested
Booted to frontpage on Intel device and observed the page fault no longer occurs when unplugging USB externals.

## Integration Instructions
N/A