### PR TITLE
BaseTools: Fix extdep for base tool binaries

### DIFF
--- a/BaseTools/Bin/basetoolsbin_ext_dep.yaml
+++ b/BaseTools/Bin/basetoolsbin_ext_dep.yaml
@@ -11,9 +11,9 @@ scope: global
 id: edk-tools-bin
 type: web
 name: Mu-Basetools
-source: https://github.com/microsoft/mu_basecore/releases/download/dev-v2025020001.0.1/basetools-dev-v2025020001.0.1.tar.gz
-version: dev-v2025020001.0.1
-sha256: 0c9b792c2fac086a8917a2d1274dc73a02ff43b08756c8dd047950493399296b
+source: https://github.com/microsoft/mu_basecore/releases/download/dev-v2025020001.0.3/basetools-dev-v2025020001.0.3.tar.gz
+version: dev-v2025020001.0.3
+sha256: fa0ea1920b56ed3fa584def73a67804e6f803ee70de22946f4e220e722ee1477
 internal_path: /basetools/
 compression_type: tar
 flags:


### PR DESCRIPTION

## Description

Due to some errors in generating releases, base tool binaries were regenerated.

Update the ext dep hashes to use latest versions.


- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested
Local stuart setup after the changes.

## Integration Instructions
No integration necessary.