### PR TITLE
MdeModulePkg/PiSmmIpl: Prevent freeing from uninitialized pointers

### DIFF
--- a/MdeModulePkg/Core/PiSmmCore/PiSmmIpl.c
+++ b/MdeModulePkg/Core/PiSmmCore/PiSmmIpl.c
@@ -1619,7 +1619,10 @@ GetFullSmramRanges (
   // MU_CHANGE Start - CodeQL Change
   BOOLEAN  Failed;
 
-  Failed = FALSE;
+  TempSmramRanges     = NULL;
+  SmramRanges         = NULL;
+  SmramReservedRanges = NULL;
+  Failed              = FALSE;
   // MU_CHANGE End - CodeQL Change
 
   //


### PR DESCRIPTION
## Description

There are error cases where the `Done` section of `GetFullSmramRanges()` can call `FreePool()` on uninitialized pointers. These cases trigger clang error `-Wsometimes-uninitialized`.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Build success on CLANGPDB toolchain with LLVM 20.1.8

## Integration Instructions

N/A
