### PR TITLE
UefiCpuPkg: X64 MpLib: Spinlock RestoreVolatileRegisters

### DIFF
--- a/UefiCpuPkg/Library/MpInitLib/MpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/MpLib.c
@@ -32,17 +32,21 @@ SaveVolatileRegisters (
   OUT CPU_VOLATILE_REGISTERS  *VolatileRegisters
   );
 
+// MU_CHANGE START: Spinlock RestoreVolatileRegisters
+
 /**
   Restore the volatile registers following INIT IPI.
 
   @param[in]  VolatileRegisters   Pointer to volatile resisters
-  @param[in]  IsRestoreDr         TRUE:  Restore DRx if supported
-                                  FALSE: Do not restore DRx
+  @param[in]  MpLock              Pointer to spin lock to synchronize access to GDT
 **/
 VOID
 RestoreVolatileRegisters (
-  IN CPU_VOLATILE_REGISTERS  *VolatileRegisters
+  IN CPU_VOLATILE_REGISTERS  *VolatileRegisters,
+  IN SPIN_LOCK               *MpLock
   );
+
+// MU_CHANGE END: Spinlock RestoreVolatileRegisters
 
 /**
   The function will check if BSP Execute Disable is enabled.
@@ -117,7 +121,7 @@ FutureBSPProc (
   //
   SaveVolatileRegisters (&DataInHob->APInfo.VolatileRegisters);
   AsmExchangeRole (&DataInHob->APInfo, &DataInHob->BSPInfo);
-  RestoreVolatileRegisters (&DataInHob->APInfo.VolatileRegisters);
+  RestoreVolatileRegisters (&DataInHob->APInfo.VolatileRegisters, &DataInHob->MpLock); // MU_CHANGE Spinlock RestoreVolatileRegisters
 }
 
 /**
@@ -239,6 +243,8 @@ SaveVolatileRegisters (
   VolatileRegisters->Tr = AsmReadTr ();
 }
 
+// MU_CHANGE START: Spinlock RestoreVolatileRegisters
+
 /**
   Restore the volatile registers following INIT IPI.
 
@@ -247,11 +253,17 @@ SaveVolatileRegisters (
 **/
 VOID
 RestoreVolatileRegisters (
-  IN CPU_VOLATILE_REGISTERS  *VolatileRegisters
+  IN CPU_VOLATILE_REGISTERS  *VolatileRegisters,
+  IN SPIN_LOCK               *MpLock
   )
 {
   CPUID_VERSION_INFO_EDX  VersionInfoEdx;
   IA32_TSS_DESCRIPTOR     *Tss;
+
+  // The GDT and segment descriptors are shared by all APs and cannot be accessed
+  // concurrently. Acquire the MP lock to prevent other APs from changing them
+  // while we are restoring them.
+  AcquireSpinLock (MpLock);
 
   AsmWriteCr3 (VolatileRegisters->Cr3);
   AsmWriteCr4 (VolatileRegisters->Cr4);
@@ -283,7 +295,11 @@ RestoreVolatileRegisters (
       AsmWriteTr (VolatileRegisters->Tr);
     }
   }
+
+  ReleaseSpinLock (MpLock);
 }
+
+// MU_CHANGE END: Spinlock RestoreVolatileRegisters
 
 /**
   Detect whether Mwait-monitor feature is supported.
@@ -777,7 +793,7 @@ ApWakeupFunction (
       //   to initialize AP in InitConfig path.
       // NOTE: IDTR.BASE stored in CpuMpData->CpuData[ProcessorNumber].VolatileRegisters points to a different IDT shared by all APs.
       //
-      RestoreVolatileRegisters (&CpuMpData->CpuData[ProcessorNumber].VolatileRegisters);
+      RestoreVolatileRegisters (&CpuMpData->CpuData[ProcessorNumber].VolatileRegisters, &CpuMpData->MpLock); // MU_CHANGE Spinlock RestoreVolatileRegisters
       InitializeApData (CpuMpData, ProcessorNumber, BistData, ApTopOfStack);
       ApStartupSignalBuffer = CpuMpData->CpuData[ProcessorNumber].StartupApSignal;
     } else {
@@ -804,7 +820,7 @@ ApWakeupFunction (
         0
         );
 
-      RestoreVolatileRegisters (&CpuMpData->CpuData[ProcessorNumber].VolatileRegisters);
+      RestoreVolatileRegisters (&CpuMpData->CpuData[ProcessorNumber].VolatileRegisters, &CpuMpData->MpLock); // MU_CHANGE Spinlock RestoreVolatileRegisters
 
       if (GetApState (&CpuMpData->CpuData[ProcessorNumber]) == CpuStateReady) {
         Procedure = (EFI_AP_PROCEDURE)CpuMpData->CpuData[ProcessorNumber].ApFunction;
@@ -910,7 +926,7 @@ DxeApEntryPoint (
     AsmWriteMsr64 (MSR_IA32_EFER, EferMsr.Uint64);
   }
 
-  RestoreVolatileRegisters (&CpuMpData->CpuData[ProcessorNumber].VolatileRegisters);
+  RestoreVolatileRegisters (&CpuMpData->CpuData[ProcessorNumber].VolatileRegisters, &CpuMpData->MpLock); // MU_CHANGE Spinlock RestoreVolatileRegisters
   InterlockedIncrement ((UINT32 *)&CpuMpData->FinishedCount);
   PlaceAPInMwaitLoopOrRunLoop (
     CpuMpData->ApLoopMode,
@@ -2703,7 +2719,7 @@ SwitchBSPWorker (
   //
   SaveVolatileRegisters (&CpuMpData->BSPInfo.VolatileRegisters);
   AsmExchangeRole (&CpuMpData->BSPInfo, &CpuMpData->APInfo);
-  RestoreVolatileRegisters (&CpuMpData->BSPInfo.VolatileRegisters);
+  RestoreVolatileRegisters (&CpuMpData->BSPInfo.VolatileRegisters, &CpuMpData->MpLock); // MU_CHANGE Spinlock RestoreVolatileRegisters
   //
   // Set the BSP bit of MSR_IA32_APIC_BASE on new BSP
   //


### PR DESCRIPTION
## Description

All APs share the same GDT and segment descriptors. Each time an AP is started up, the wake up function restores the GDT and other system registers with the RestoreVolatileRegisters function.

A General Protection fault has recently been observed on multiple generations of Intel silicon when the APs have been left in an mwait loop by CpuMpPei and the initial wake up state in DXE is not init-sipi-sipi. The cores all come up at the same time, where they attempt to restore the GDT from the same address. However, the TSS is particular cannot be loaded simultaneously: when the busy bit is set in the TSS (which occurs when loaded by the ltr instruction in RestoreVolatileRegisters) the ltr instruction will fail with a GP fault with an exception context of 0x40, the entry in the GDT corresponding to the TSS.

In other scenarios, the cores will not come up at exactly the same time, either because they've been serialized through an init-sipi-sipi or the timing is right enough that they load the TSS separately. RestoreVolatileRegisters does attempt to clear the busy bit of the TSS before setting it via ltr, but this is not protected by a lock and so the other APs can execute ltr inbetween an AP setting the busy bit to 0 and then doing ltr.

This commit fixes this behavior by using the MpLock, shared among all APs (and the BSP) to serialize execution of RestoreVolatileRegisters. This resolves the bug seen. On systems where the timing was not hitting this, it is essentially a no-op.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Tested on multiple generations of Intel physical platforms that were experiencing the mentioned bug and saw it resolve them.

## Integration Instructions

N/A.
