### PR TITLE
tools_def.template: Remove /FILEALIGN from X64 and AARCH64 CLANGPDB DLINK Flags

### DIFF
--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -26,8 +26,9 @@
 # 3.20 - Move GccLto files to a tools path to be more repository layout agnostic
 # 3.21 - Can't have comment inline as it breaks concatenation see - # MU_CHANGE - Move GccLto to tools dir for better alignment
 # 3.22 - VS2022 toolchain incorrectly defined for ASL
+# 3.23 - MU_CHANGE - Remove /FILEALIGN from *_CLANGPDB_*_DLINK_FLAGS
 #
-#!VERSION=3.02
+#!VERSION=3.23
 
 IDENTIFIER = Default TOOL_CHAIN_CONF
 
@@ -2023,19 +2024,22 @@ NOOPT_CLANGPDB_IA32_DLINK2_FLAGS     =
 *_CLANGPDB_X64_VFRPP_FLAGS          = DEF(GCC_VFRPP_FLAGS) DEF(CLANGPDB_X64_TARGET)
 
 DEBUG_CLANGPDB_X64_CC_FLAGS         = DEF(CLANGPDB_ALL_CC_FLAGS) -m64 "-DEFIAPI=__attribute__((ms_abi))" -mno-red-zone -mcmodel=small -Oz -flto DEF(CLANGPDB_X64_TARGET) -gcodeview -funwind-tables -Wno-unused-but-set-variable -Wno-deprecated-non-prototype
-DEBUG_CLANGPDB_X64_DLINK_FLAGS      = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /OPT:REF /OPT:ICF=10 /ALIGN:32 /FILEALIGN:32 /Machine:X64 /DLL /ENTRY:$(IMAGE_ENTRY_POINT) /SUBSYSTEM:EFI_BOOT_SERVICE_DRIVER /SAFESEH:NO /BASE:0 /DEBUG:GHASH /MLLVM:-exception-model=wineh /lldmap
+# MU_CHANGE - Remove /FILEALIGN from *_CLANGPDB_*_DLINK_FLAGS
+DEBUG_CLANGPDB_X64_DLINK_FLAGS      = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /OPT:REF /OPT:ICF=10 /ALIGN:32 /Machine:X64 /DLL /ENTRY:$(IMAGE_ENTRY_POINT) /SUBSYSTEM:EFI_BOOT_SERVICE_DRIVER /SAFESEH:NO /BASE:0 /DEBUG:GHASH /MLLVM:-exception-model=wineh /lldmap
 DEBUG_CLANGPDB_X64_DLINK2_FLAGS     =
 # MU_CHANGE Keep optional header for NX_COMPAT flag
 DEBUG_CLANGPDB_X64_GENFW_FLAGS      = --keepexceptiontable --keepoptionalheader
 
 RELEASE_CLANGPDB_X64_CC_FLAGS       = DEF(CLANGPDB_ALL_CC_FLAGS) -m64 "-DEFIAPI=__attribute__((ms_abi))" -mno-red-zone -mcmodel=small -Oz -flto DEF(CLANGPDB_X64_TARGET) -fno-unwind-tables -Wno-unused-but-set-variable -Wno-deprecated-non-prototype
-RELEASE_CLANGPDB_X64_DLINK_FLAGS    = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /IGNORE:4254 /OPT:REF /OPT:ICF=10 /ALIGN:32 /FILEALIGN:32 /SECTION:.xdata,D /SECTION:.pdata,D /Machine:X64 /DLL /ENTRY:$(IMAGE_ENTRY_POINT) /SUBSYSTEM:EFI_BOOT_SERVICE_DRIVER /SAFESEH:NO /BASE:0 /MERGE:.rdata=.data /MLLVM:-exception-model=wineh /lldmap
+# MU_CHANGE - Remove /FILEALIGN from *_CLANGPDB_*_DLINK_FLAGS
+RELEASE_CLANGPDB_X64_DLINK_FLAGS    = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /IGNORE:4254 /OPT:REF /OPT:ICF=10 /ALIGN:32 /SECTION:.xdata,D /SECTION:.pdata,D /Machine:X64 /DLL /ENTRY:$(IMAGE_ENTRY_POINT) /SUBSYSTEM:EFI_BOOT_SERVICE_DRIVER /SAFESEH:NO /BASE:0 /MERGE:.rdata=.data /MLLVM:-exception-model=wineh /lldmap
 RELEASE_CLANGPDB_X64_DLINK2_FLAGS   =
 # MU_CHANGE Keep optional header for NX_COMPAT flag
 RELEASE_CLANGPDB_X64_GENFW_FLAGS    = --keepoptionalheader
 
 NOOPT_CLANGPDB_X64_CC_FLAGS         = DEF(CLANGPDB_ALL_CC_FLAGS) -m64 "-DEFIAPI=__attribute__((ms_abi))" -mno-red-zone -mcmodel=small -O0 DEF(CLANGPDB_X64_TARGET) -gcodeview -funwind-tables -Wno-unused-but-set-variable -Wno-deprecated-non-prototype
-NOOPT_CLANGPDB_X64_DLINK_FLAGS      = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /OPT:REF /OPT:ICF=10 /ALIGN:32 /FILEALIGN:32 /Machine:X64 /DLL /ENTRY:$(IMAGE_ENTRY_POINT) /SUBSYSTEM:EFI_BOOT_SERVICE_DRIVER /SAFESEH:NO /BASE:0 /DEBUG:GHASH /MLLVM:-exception-model=wineh /lldmap
+# MU_CHANGE - Remove /FILEALIGN from *_CLANGPDB_*_DLINK_FLAGS
+NOOPT_CLANGPDB_X64_DLINK_FLAGS      = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /OPT:REF /OPT:ICF=10 /ALIGN:32 /Machine:X64 /DLL /ENTRY:$(IMAGE_ENTRY_POINT) /SUBSYSTEM:EFI_BOOT_SERVICE_DRIVER /SAFESEH:NO /BASE:0 /DEBUG:GHASH /MLLVM:-exception-model=wineh /lldmap
 NOOPT_CLANGPDB_X64_DLINK2_FLAGS     =
 # MU_CHANGE Keep optional header for NX_COMPAT flag
 NOOPT_CLANGPDB_X64_GENFW_FLAGS      = --keepexceptiontable --keepoptionalheader
@@ -2063,17 +2067,20 @@ NOOPT_CLANGPDB_X64_GENFW_FLAGS      = --keepexceptiontable --keepoptionalheader
 *_CLANGPDB_AARCH64_CC_XIPFLAGS          = -mstrict-align
 
 DEBUG_CLANGPDB_AARCH64_CC_FLAGS         = DEF(CLANGPDB_ALL_CC_FLAGS) -m64 -mno-red-zone -mcmodel=small -Oz -flto DEF(CLANGPDB_AARCH64_TARGET) -gcodeview  -funwind-tables -Wno-unused-but-set-variable -Wno-deprecated-non-prototype -Wno-constant-conversion
-DEBUG_CLANGPDB_AARCH64_DLINK_FLAGS      = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /OPT:REF /OPT:ICF=10 /ALIGN:32 /FILEALIGN:32 /Machine:ARM64 /DLL /ENTRY:$(IMAGE_ENTRY_POINT) /SUBSYSTEM:EFI_BOOT_SERVICE_DRIVER /SAFESEH:NO /BASE:0 /DEBUG:GHASH /MLLVM:-exception-model=wineh /lldmap
+# MU_CHANGE - Remove /FILEALIGN from *_CLANGPDB_*_DLINK_FLAGS
+DEBUG_CLANGPDB_AARCH64_DLINK_FLAGS      = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /OPT:REF /OPT:ICF=10 /ALIGN:32 /Machine:ARM64 /DLL /ENTRY:$(IMAGE_ENTRY_POINT) /SUBSYSTEM:EFI_BOOT_SERVICE_DRIVER /SAFESEH:NO /BASE:0 /DEBUG:GHASH /MLLVM:-exception-model=wineh /lldmap
 DEBUG_CLANGPDB_AARCH64_DLINK2_FLAGS     =
 DEBUG_CLANGPDB_AARCH64_GENFW_FLAGS      = --keepexceptiontable --keepoptionalheader
 
 RELEASE_CLANGPDB_AARCH64_CC_FLAGS       = DEF(CLANGPDB_ALL_CC_FLAGS) -m64 -mno-red-zone -mcmodel=small -Oz -flto DEF(CLANGPDB_AARCH64_TARGET) -fno-unwind-tables -Wno-unused-but-set-variable -Wno-deprecated-non-prototype -Wno-constant-conversion
-RELEASE_CLANGPDB_AARCH64_DLINK_FLAGS    = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /IGNORE:4254 /OPT:REF /OPT:ICF=10 /ALIGN:32 /FILEALIGN:32 /SECTION:.xdata,D /SECTION:.pdata,D /Machine:ARM64 /DLL /ENTRY:$(IMAGE_ENTRY_POINT) /SUBSYSTEM:EFI_BOOT_SERVICE_DRIVER /SAFESEH:NO /BASE:0 /MERGE:.rdata=.data /MLLVM:-exception-model=wineh /lldmap
+# MU_CHANGE - Remove /FILEALIGN from *_CLANGPDB_*_DLINK_FLAGS
+RELEASE_CLANGPDB_AARCH64_DLINK_FLAGS    = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /IGNORE:4254 /OPT:REF /OPT:ICF=10 /ALIGN:32 /SECTION:.xdata,D /SECTION:.pdata,D /Machine:ARM64 /DLL /ENTRY:$(IMAGE_ENTRY_POINT) /SUBSYSTEM:EFI_BOOT_SERVICE_DRIVER /SAFESEH:NO /BASE:0 /MERGE:.rdata=.data /MLLVM:-exception-model=wineh /lldmap
 RELEASE_CLANGPDB_AARCH64_DLINK2_FLAGS   =
 RELEASE_CLANGPDB_AARCH64_GENFW_FLAGS    = --keepoptionalheader
 
 NOOPT_CLANGPDB_AARCH64_CC_FLAGS         = DEF(CLANGPDB_ALL_CC_FLAGS) -m64 -mno-red-zone -mcmodel=small -O0 DEF(CLANGPDB_AARCH64_TARGET) -gcodeview -funwind-tables -Wno-unused-but-set-variable -Wno-deprecated-non-prototype -Wno-constant-conversion
-NOOPT_CLANGPDB_AARCH64_DLINK_FLAGS      = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /OPT:REF /OPT:ICF=10 /ALIGN:32 /FILEALIGN:32 /Machine:ARM64 /DLL /ENTRY:$(IMAGE_ENTRY_POINT) /SUBSYSTEM:EFI_BOOT_SERVICE_DRIVER /SAFESEH:NO /BASE:0 /DEBUG:GHASH /MLLVM:-exception-model=wineh /lldmap
+# MU_CHANGE - Remove /FILEALIGN from *_CLANGPDB_*_DLINK_FLAGS
+NOOPT_CLANGPDB_AARCH64_DLINK_FLAGS      = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /OPT:REF /OPT:ICF=10 /ALIGN:32 /Machine:ARM64 /DLL /ENTRY:$(IMAGE_ENTRY_POINT) /SUBSYSTEM:EFI_BOOT_SERVICE_DRIVER /SAFESEH:NO /BASE:0 /DEBUG:GHASH /MLLVM:-exception-model=wineh /lldmap
 NOOPT_CLANGPDB_AARCH64_DLINK2_FLAGS     =
 NOOPT_CLANGPDB_AARCH64_GENFW_FLAGS      = --keepexceptiontable --keepoptionalheader
 
@@ -2408,7 +2415,7 @@ RELEASE_XCODE5_X64_CC_FLAGS   = -target x86_64-pc-win32-macho -c    -Os       -W
 #################
 # ASM 16 linker definitions
 #################
-# MU_CHANGE - change to prefix 
+# MU_CHANGE - change to prefix
 *_*_*_ASMLINK_PATH                 = ENV(LINK_16_PREFIX)link16.exe
 *_*_*_ASMLINK_FLAGS                = /nologo /tiny
 


### PR DESCRIPTION
## Description

`FileAlignment` in the PE/COFF Specification states:

```
The alignment factor (in bytes) that is used to align the raw data of
sections in the image file. The value should be a power of 2 between
512 and 64 K, inclusive. The default is 512. If the SectionAlignment
is less than the architecture's page size, then FileAlignment must
match SectionAlignment.
```

Although in UEFI we often use sizes less than 512, that is outside the allowed spec-defined range. Today, /FILEALIGN is not set in X64 VS DLINK flags and is set to a smaller value (often `32`) for IA32 VS DLINK flags.

This change modifies the tools_def.template value to:

1. Be PE/COFF spec-compliant by not explicitly specifying a size less than the spec-supported minimum.
2. Make the `/FILELALIGN` value consistent for X64 modules between the VS and CLANGPDB flags.

Note: A smaller `/FILEALIGN` value is used to save flash space, particularly for uncompressed images that reside directly in flash.

Platforms with 64-bit PEIMs, can explicitly set `/FILEALIGN` for their active toolchain as needed. That is a platform decision to opt out of PE/COFF Specification compatibility to achieve platform size requirements.

This is particularly important because some tools that operate on PE/COFF images, strictly follow the specification behavior. With this change, by default CLANGPDB images will be compliant with those expectations.

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

- Build CLANGPDB X64 images and check the file alignment in the .efi binary

## Integration Instructions

- Review the information in this PR description. If a smaller file alignment value is needed, set that in a platform location such as `[BuildOptions]` in a DSC file.
- This is marked as a breaking change because a larger file alignment value for X64 modules may cause more space flash to be consumed if using CLANGPDB and platform build flags might need to be adjusted for section and file alignment to be compatible with linker requirements.