### PR TITLE
Change the scope of BmpCheckPlugin to global

### DIFF
--- a/BaseTools/Plugin/BmpCheck/BmpCheck_plug_in.json
+++ b/BaseTools/Plugin/BmpCheck/BmpCheck_plug_in.json
@@ -1,5 +1,5 @@
 {
-  "scope": "surfacefamily",
+  "scope": "global",
   "name": "Bmp Image Encoding Check",
   "module": "BmpCheckPlugin"
 }


### PR DESCRIPTION
## Description

Change the scope of BmpCheckPlugin to global. Requiring platforms to include the 'surfacefamily' scope in order to use this plug-in is unreasonable.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [X] Impacts functionality?
- [X] Impacts security?
- [X] Breaking change?
- [X] Includes tests?
- [X] Includes documentation?
- [X] Backport to release branch?

## How This Was Tested

Verified that BmpCheckPlugin will be loaded by include scope "global".

## Integration Instructions

N/A
