### PR TITLE
Change the scope of BmpCheckPlugin to global

### DIFF
--- a/BaseTools/Plugin/BmpCheck/BmpCheck_plug_in.json
+++ b/BaseTools/Plugin/BmpCheck/BmpCheck_plug_in.json
@@ -1,5 +1,5 @@
 {
-  "scope": "surfacefamily",
+  "scope": "global",
   "name": "Bmp Image Encoding Check",
   "module": "BmpCheckPlugin"
 }


### PR DESCRIPTION
## Description

Change the scope of BmpCheckPlugin to global. 
Requiring platforms to include the 'surfacefamily' scope in order to use this plug-in is unreasonable.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

Verified that BmpCheckPlugin will be loaded by include scope "global".

## Integration Instructions
This will enable a new post build plugin, where it was previously only scoped to surfacefamily.

If this plugin breaks in a project, it means that the BMP file the project is using is either malformed or that it contains excessive data that is not part of the BMP. Close examination of the BMP is recommend, or regeneration of the BMP.