### PR TITLE
CryptoPkg: Update shared crypto to v1.1.1

### DIFF
--- a/CryptoPkg/Binaries/BaseCryptoDriver_ext_dep.json
+++ b/CryptoPkg/Binaries/BaseCryptoDriver_ext_dep.json
@@ -1,9 +1,12 @@
 {
   "scope": "global",
-  "type": "nuget",
+  "type": "web",
   "name": "edk2-basecrypto-driver-bin",
-  "source": "https://pkgs.dev.azure.com/projectmu/mu/_packaging/Mu-Public/nuget/v3/index.json",
-  "version": "1.1.0",
+  "source": "https://github.com/microsoft/mu_crypto_release/releases/download/v1.1.1/Mu_CryptoBin_v1_1_1.zip",
+  "version": "1.1.1",
+  "sha256": "d27ee53636478b16f81c0409136edd8f3137b99f59c073c47e47226ac3c7a8cf",
+  "compression_type": "zip",
+  "internal_path": "/",
   "flags": ["set_build_var"],
   "var_name": "BLD_*_SHARED_CRYPTO_PATH"
 }


### PR DESCRIPTION
## Description

Updates to the latest version based on EDK II Crypto Version 19 and changes the ext dep to use a zip file attached to the shared crypto GitHub release instead of NuGet.

This release fixes an issue in the previous (v1.1.0 release) where the crypto binary reported EDK II Crypto Version 18 instead of 19.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

- CI and build and boot QEMU Q35 & physical platforms with the change

## Integration Instructions

- N/A