### PR TITLE
MdeModulePkg: ArmFfaLib: Add FFA_YIELD handling

### DIFF
--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
@@ -23,6 +23,7 @@
 #include <Library/DebugLib.h>
 #include <Library/HobLib.h>
 #include <Library/PcdLib.h>
+#include <Library/TimerLib.h>  // MU_CHANGE: Handle FFA_YIELD with timeout
 
 #include <IndustryStandard/ArmFfaSvc.h>
 #include <IndustryStandard/ArmFfaPartInfo.h>
@@ -126,6 +127,7 @@ FfaArgsToEfiStatus (
   )
 {
   UINT32  FfaStatus;
+  UINT64  Timeout;  // MU_CHANGE: Handle FFA_YIELD with timeout
 
   if (FfaArgs == NULL) {
     FfaStatus = ARM_FFA_RET_INVALID_PARAMETERS;
@@ -145,6 +147,22 @@ FfaArgsToEfiStatus (
     FfaStatus = ARM_FFA_RET_NOT_SUPPORTED;
   } else if (FfaArgs->Arg0 == ARM_FID_FFA_INTERRUPT) {
     FfaStatus = ARM_FFA_RET_INTERRUPTED;
+  // MU_CHANGE start: Handle FFA_YIELD with timeout
+  } else if (FfaArgs->Arg0 == ARM_FID_FFA_YIELD) {
+    /*
+    * If the FF-A ABI indicates that the call was yielded, we need to pull the
+    * timeout period from Arg2 and Arg3.
+    */
+    Timeout = LShiftU64 (FfaArgs->Arg3, 32) | FfaArgs->Arg2;
+    if (Timeout != 0) {
+      /*
+      * If the timeout is non-zero, we handle the delay here.
+      */
+      NanoSecondDelay (Timeout);
+    }
+
+    FfaStatus = ARM_FFA_RET_INTERRUPTED;
+  // MU_CHANGE end: Handle FFA_YIELD with timeout
   } else {
     FfaStatus = ARM_FFA_RET_SUCCESS;
   }

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
@@ -147,7 +147,7 @@ FfaArgsToEfiStatus (
     FfaStatus = ARM_FFA_RET_NOT_SUPPORTED;
   } else if (FfaArgs->Arg0 == ARM_FID_FFA_INTERRUPT) {
     FfaStatus = ARM_FFA_RET_INTERRUPTED;
-  // MU_CHANGE start: Handle FFA_YIELD with timeout
+    // MU_CHANGE starts: Handle FFA_YIELD with timeout
   } else if (FfaArgs->Arg0 == ARM_FID_FFA_YIELD) {
     /*
     * If the FF-A ABI indicates that the call was yielded, we need to pull the
@@ -162,7 +162,7 @@ FfaArgsToEfiStatus (
     }
 
     FfaStatus = ARM_FFA_RET_INTERRUPTED;
-  // MU_CHANGE end: Handle FFA_YIELD with timeout
+    // MU_CHANGE ends: Handle FFA_YIELD with timeout
   } else {
     FfaStatus = ARM_FFA_RET_SUCCESS;
   }

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaDxeLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaDxeLib.inf
@@ -33,6 +33,7 @@
   BaseMemoryLib
   DebugLib
   HobLib
+  TimerLib  # MU_CHANGE
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.inf
@@ -33,6 +33,7 @@
   BaseMemoryLib
   DebugLib
   HobLib
+  TimerLib  # MU_CHANGE
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecLib.inf
@@ -33,6 +33,7 @@
   BaseMemoryLib
   DebugLib
   HobLib
+  TimerLib  # MU_CHANGE
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf
@@ -34,6 +34,7 @@
   BaseMemoryLib
   DebugLib
   MmServicesTableLib
+  TimerLib  # MU_CHANGE
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.inf
@@ -34,6 +34,7 @@
   BaseMemoryLib
   DebugLib
   MmServicesTableLib
+  TimerLib  # MU_CHANGE
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc


### PR DESCRIPTION
## Description

This change adds the FFA_YIELD handling from ArmFfaLib to support long operations from secure partitions.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

This was tested on proprietary hardware platforms and booted to Windows.

## Integration Instructions

N/A