### PR TITLE
DelayedDispatch.h: Increase delayed dispatch entry max to 32

### DIFF
--- a/MdeModulePkg/Include/Guid/DelayedDispatch.h
+++ b/MdeModulePkg/Include/Guid/DelayedDispatch.h
@@ -18,7 +18,7 @@
 //
 // Maximal number of Delayed Dispatch entries supported
 //
-#define DELAYED_DISPATCH_MAX_ENTRIES  8
+#define DELAYED_DISPATCH_MAX_ENTRIES  32  // MU_CHANGE: Set max delayed dispatch entries to 32
 
 //
 // Internal structure for delayed dispatch entries.


### PR DESCRIPTION
## Description

The current value of 8 is not large enough to accommodate platform usage.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

- MdeModule package build
- Integrate into a platform >8 delayed dispatch entries

## Integration Instructions

- N/A