### PR TITLE
[CHERRY-PICK] ArmFfaLib INF Changes [Rebase & FF]

### DIFF
--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaDxeLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaDxeLib.inf
@@ -33,6 +33,7 @@
   BaseMemoryLib
   DebugLib
   HobLib
+  MemoryAllocationLib
   TimerLib  # MU_CHANGE
 
 [Pcd]

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.inf
@@ -33,6 +33,7 @@
   BaseMemoryLib
   DebugLib
   HobLib
+  MemoryAllocationLib
   TimerLib  # MU_CHANGE
 
 [Pcd]

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecLib.inf
@@ -33,6 +33,7 @@
   BaseMemoryLib
   DebugLib
   HobLib
+  MemoryAllocationLib
   TimerLib  # MU_CHANGE
 
 [Pcd]

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf
@@ -34,6 +34,7 @@
   BaseMemoryLib
   DebugLib
   HobLib
+  MemoryAllocationLib
   MmServicesTableLib
   TimerLib  # MU_CHANGE
 

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf
@@ -33,6 +33,7 @@
   BaseLib
   BaseMemoryLib
   DebugLib
+  HobLib
   MmServicesTableLib
   TimerLib  # MU_CHANGE
 

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.inf
@@ -34,6 +34,7 @@
   BaseMemoryLib
   DebugLib
   HobLib
+  MemoryAllocationLib
   MmServicesTableLib
   TimerLib  # MU_CHANGE
 

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.inf
@@ -33,6 +33,7 @@
   BaseLib
   BaseMemoryLib
   DebugLib
+  HobLib
   MmServicesTableLib
   TimerLib  # MU_CHANGE
 


### PR DESCRIPTION
## Description

Cherry-picks two changes from edk2.

---

**[CHERRY-PICK] MdeModulePkg/ArmFfaLib: Add HobLib to StMm instances**

ArmFfaCommon.c is built by both ArmFfaStandaloneMmCoreLib and
ArmFfaStandaloneMmLib. It links against HobLiib APIs such as
`GetFirstHob()`. Right now, the symbols fail to link:

```
lld-link: error: undefined symbol: GetFirstHob
          ArmFfaStandaloneMmCoreLib.lib(ArmFfaCommon.obj)
```

---

**[CHERRY-PICK] MdeModulePkg/ArmFfaLib: Add MemoryAllocationLib**

ArmFfaRxTxMap.c is built by both ArmFfaPeiLib and ArmFfaDxeLib.

ArmFfaSecRxTxMap.c is built by ArmFfaSecLib.

ArmFfaStandaloneMmRxTxMap.c is built by ArmFfaStandaloneMm*Lib.

The files depend on `MemoryAllocationLib` APIs such as
`AllocateAlignedPages()`. This change adds `MemoryAllocationLib` to
those library INF files.

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

- CI and platform integration build

## Integration Instructions

- N/A