### PR TITLE
Creating a base instance of FFA library

### DIFF
--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.c
@@ -1,0 +1,60 @@
+/** @file
+  Arm Ffa library code for StandaloneMmCore.
+
+  Copyright (c) 2024, Arm Limited. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+   @par Glossary:
+     - FF-A - Firmware Framework for Arm A-profile
+
+   @par Reference(s):
+     - Arm Firmware Framework for Arm A-Profile [https://developer.arm.com/documentation/den0077/latest]
+
+**/
+
+#include <PiMm.h>
+
+#include <Library/ArmLib.h>
+#include <Library/ArmSmcLib.h>
+#include <Library/ArmFfaLib.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+
+#include "ArmFfaCommon.h"
+
+/**
+  ArmFfaLib Constructor.
+
+  @param  [in]  ImageHandle     The firmware allocated handle for the EFI image
+  @param  [in]  MmSystemTable   A pointer to the Management mode System Table
+
+  @retval EFI_SUCCESS            Success
+  @retval Others                 Error
+
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaLibBaseConstructor (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = ArmFfaLibCommonInit ();
+  if (Status == EFI_UNSUPPORTED) {
+    /*
+     * EFI_UNSUPPORTED means FF-A interface isn't available.
+     * However, for Standalone MM modules, FF-A availability is not required.
+     * i.e. Standalone MM could use SpmMm as a legitimate protocol.
+     * Thus, returning EFI_SUCCESS here to avoid the entrypoint to assert.
+     */
+    return EFI_SUCCESS;
+  }
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a failed. Status = %r\n", __func__, Status));
+  }
+
+  return Status;
+}

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.c
@@ -1,6 +1,6 @@
 /** @file
   MU_CHANGE - The whole file.
-  Arm Ffa library code for StandaloneMmCore.
+  Provides FF-A ABI Library used in all environments.
 
   Copyright (c) 2024, Arm Limited. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
@@ -13,13 +13,8 @@
 
 **/
 
-#include <PiMm.h>
+#include <Uefi.h>
 
-#include <Library/ArmLib.h>
-#include <Library/ArmSmcLib.h>
-#include <Library/ArmFfaLib.h>
-#include <Library/BaseLib.h>
-#include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
 
 #include "ArmFfaCommon.h"

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.c
@@ -1,5 +1,7 @@
 /** @file
-  MU_CHANGE - The whole file.
+  MU_CHANGE - This file is originally sourced from ArmFfaStandaloneMmLib, with
+  Rx/Tx-related APIs removed to focus exclusively on FFA primitives.
+
   Provides FF-A ABI Library used in all environments.
 
   Copyright (c) 2024, Arm Limited. All rights reserved.<BR>

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.c
@@ -1,4 +1,5 @@
 /** @file
+  MU_CHANGE - The whole file.
   Arm Ffa library code for StandaloneMmCore.
 
   Copyright (c) 2024, Arm Limited. All rights reserved.<BR>

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.c
@@ -16,6 +16,8 @@
 **/
 
 #include <Uefi.h>
+#include <Pi/PiBootMode.h>
+#include <Pi/PiHob.h>
 
 #include <Library/DebugLib.h>
 

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.c
@@ -27,9 +27,6 @@
 /**
   ArmFfaLib Constructor.
 
-  @param  [in]  ImageHandle     The firmware allocated handle for the EFI image
-  @param  [in]  MmSystemTable   A pointer to the Management mode System Table
-
   @retval EFI_SUCCESS            Success
   @retval Others                 Error
 

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.inf
@@ -33,6 +33,7 @@
   BaseMemoryLib
   DebugLib
   HobLib
+  PcdLib
   TimerLib
 
 [Pcd]

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.inf
@@ -35,6 +35,7 @@
   DebugLib
   HobLib
   PcdLib
+  MemoryAllocationLib
   TimerLib
 
 [Pcd]

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.inf
@@ -1,5 +1,6 @@
 ## @file
-#  MU_CHANGE - The whole file.
+#  MU_CHANGE - This file is originally sourced from ArmFfaStandaloneMmLib, with
+#  Rx/Tx-related APIs removed to focus exclusively on FFA primitives.
 #  Provides FF-A ABI Library used in all environments.
 #
 #  Copyright (c) 2024, Arm Limited. All rights reserved.<BR>

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.inf
@@ -1,0 +1,43 @@
+## @file
+#  Provides FF-A ABI Library used in all environments.
+#
+#  Copyright (c) 2024, Arm Limited. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001B
+  BASE_NAME                      = ArmFfaLibBase
+  FILE_GUID                      = D79FF75E-AD0A-4074-A335-2084533744AF
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  PI_SPECIFICATION_VERSION       = 0x00010032
+  LIBRARY_CLASS                  = ArmFfaLib
+  CONSTRUCTOR                    = ArmFfaLibBaseConstructor
+
+[Sources]
+  ArmFfaCommon.h
+  ArmFfaCommon.c
+  ArmFfaLibBase.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[LibraryClasses]
+  ArmSmcLib
+  ArmSvcLib
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  HobLib
+  MemoryAllocationLib
+  TimerLib  # MU_CHANGE
+
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc
+  gEfiMdeModulePkgTokenSpaceGuid.PcdFfaTxRxPageCount
+
+[Guids]
+  gArmFfaRxTxBufferInfoGuid

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.inf
@@ -1,4 +1,5 @@
 ## @file
+#  MU_CHANGE - The whole file.
 #  Provides FF-A ABI Library used in all environments.
 #
 #  Copyright (c) 2024, Arm Limited. All rights reserved.<BR>
@@ -32,8 +33,7 @@
   BaseMemoryLib
   DebugLib
   HobLib
-  MemoryAllocationLib
-  TimerLib  # MU_CHANGE
+  TimerLib
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc

--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -599,5 +599,6 @@
   MdeModulePkg/Library/ArmFfaLib/ArmFfaDxeLib.inf
   MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf
   MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.inf
+  MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.inf      # MU_CHANGE
 
 [BuildOptions]


### PR DESCRIPTION
## Description

Current usage of Rx/Tx buffer is unnecessarily pulling in UEFI framework related data usage, i.e. PEI, DXE, STMM, etc. This is undesirable for components that only needs to use the basic functionalities.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [x] Backport to release branch?

## How This Was Tested

This was tested on QEMU SBSA and passed the online build + run.

## Integration Instructions

For components that does not need Rx/Tx functionalities, one can use `MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.inf` for `ArmFfaLib`.