### PR TITLE
Remove MemoryAllocationLib for ArmFfaSecLib

### DIFF
--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecLib.inf
@@ -33,7 +33,6 @@
   BaseMemoryLib
   DebugLib
   HobLib
-  MemoryAllocationLib
   TimerLib  # MU_CHANGE
 
 [Pcd]


### PR DESCRIPTION
## Description

UefiPayloadEntry module provides memory allocation related APIs through its own file, instead of going through the library interface. Adding a library linkage will enforce a failure on the build if UefiPayloadEntry is used for SEC phase on ARM64 platforms.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?
- [ ] Backport to release branch?

## How This Was Tested

This is tested on ARM64 platform and fixed the build break.

## Integration Instructions

N/A