### PR TITLE
[Cherry-Pick] NetworkPkg/UefiPxeBcDxe: Add buffer check before reporting status code

### DIFF
--- a/NetworkPkg/UefiPxeBcDxe/PxeBcBoot.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcBoot.c
@@ -1276,12 +1276,19 @@ ON_EXIT:
     AsciiPrint ("\n  PXE-E99: Unexpected network error.\n");
   }
 
-  REPORT_STATUS_CODE_WITH_EXTENDED_DATA (
-    EFI_ERROR_CODE,
-    (EFI_STATUS_CODE_VALUE)(EFI_IO_BUS_IP_NETWORK | EFI_OEM_SPECIFIC | ((EFI_STATUS_CODE_VALUE)(Status & 0x1F))),
-    (VOID *)&(PxeBcMode->UsingIpv6),
-    sizeof (PxeBcMode->UsingIpv6)
-    );
+  //
+  // Report status code for all errors printed above.
+  // Skip reporting when Buffer is NULL and Status is EFI_BUFFER_TOO_SMALL,
+  // as this is an expected size query, not an error.
+  //
+  if ((Status != EFI_BUFFER_TOO_SMALL) || (Buffer != NULL)) {
+    REPORT_STATUS_CODE_WITH_EXTENDED_DATA (
+      EFI_ERROR_CODE,
+      (EFI_STATUS_CODE_VALUE)(EFI_IO_BUS_IP_NETWORK | EFI_OEM_SPECIFIC | ((EFI_STATUS_CODE_VALUE)(Status & 0x1F))),
+      (VOID *)&(PxeBcMode->UsingIpv6),
+      sizeof (PxeBcMode->UsingIpv6)
+      );
+  }
 
   return Status;
 }


### PR DESCRIPTION
## Description

When PxeBcLoadBootFile() fails, it reports a status code to notify listeners (such as telemetry/SEL logging drivers) about the error. However, the current implementation reports the status code for all error conditions, including benign cases, such as where the caller passes Buffer == NULL with EFI_BUFFER_TOO_SMALL to query the required size.

This causes false positive error reports in telemetry systems, as EFI_BUFFER_TOO_SMALL with Buffer == NULL is an expected and normal operation for size queries, not an actual error condition.

The PXE-E05 error message is already correctly guarded with the condition "(Status == EFI_BUFFER_TOO_SMALL) && (Buffer != NULL)", but the status code reporting was unconditional.

Add a buffer null check before REPORT_STATUS_CODE_WITH_EXTENDED_DATA to ensure status codes are only reported for actual errors:
- Report when Status != EFI_BUFFER_TOO_SMALL (all other errors)
- Report when Status == EFI_BUFFER_TOO_SMALL AND Buffer != NULL (PXE-E05)
- Skip when Status == EFI_BUFFER_TOO_SMALL AND Buffer == NULL (size query)

This prevents spurious error logs while maintaining proper error reporting for genuine failures including PXE-E05, PXE-E07, PXE-E09, PXE-E99, and all other error conditions.


(cherry picked from commit d3a64baf4b6706367c30a4886c01e95589861c9f)
- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
PXE booting physical platform. After change, no longer encounter double status code listener error report.

## Integration Instructions
No integration necessary.