### PR TITLE
MdeModulePkg/Variable: Move RT cache buffer allocation to DXE

### DIFF
--- a/MdeModulePkg/Universal/Variable/Pei/Variable.c
+++ b/MdeModulePkg/Universal/Variable/Pei/Variable.c
@@ -1447,27 +1447,35 @@ BuildVariableRuntimeCacheInfoHob (
 {
   VARIABLE_RUNTIME_CACHE_INFO  TempHobBuffer;
   VARIABLE_RUNTIME_CACHE_INFO  *VariableRuntimeCacheInfo;
-  EFI_STATUS                   Status;
-  VOID                         *Buffer;
-  UINTN                        BufferSize;
-  BOOLEAN                      NvAuthFlag;
-  UINTN                        Pages;
+  // MU_CHANGE [BEGIN] - Comment out unused variable when moving allocation to DXE
+  // EFI_STATUS                   Status;
+  // MU_CHANGE [END]
+  VOID     *Buffer;
+  UINTN    BufferSize;
+  BOOLEAN  NvAuthFlag;
+  UINTN    Pages;
 
   ZeroMem (&TempHobBuffer, sizeof (VARIABLE_RUNTIME_CACHE_INFO));
 
   //
-  // AllocateRuntimePages for CACHE_INFO_FLAG and unblock it.
+  // MU_CHANGE [BEGIN] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
+  // AllocatePages for CACHE_INFO_FLAG buffer (will be relocated to runtime by DXE).
   //
   Pages  = EFI_SIZE_TO_PAGES (sizeof (CACHE_INFO_FLAG));
-  Buffer = AllocateRuntimePages (Pages);
+  Buffer = AllocatePages (Pages);
   ASSERT (Buffer != NULL);
-  Status = MmUnblockMemoryRequest (
-             (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
-             Pages
-             );
-  if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-    return Status;
-  }
+  //
+  // MU_CHANGE - Commented out runtime allocation and memory unblock (moved to DXE)
+  // Buffer = AllocateRuntimePages (Pages);
+  // Status = MmUnblockMemoryRequest (
+  //            (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
+  //            Pages
+  //            );
+  // if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+  //   return Status;
+  // }
+  //
+  // MU_CHANGE [END]
 
   TempHobBuffer.CacheInfoFlagBuffer = (UINTN)Buffer;
   DEBUG ((
@@ -1478,24 +1486,31 @@ BuildVariableRuntimeCacheInfoHob (
     ));
 
   //
-  // AllocateRuntimePages for VolatileCache and unblock it.
+  // MU_CHANGE [BEGIN] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
+  // AllocatePages for VolatileCache buffer (will be relocated to runtime by DXE).
   //
   BufferSize = PcdGet32 (PcdVariableStoreSize);
   if (BufferSize > 0) {
     Pages  = EFI_SIZE_TO_PAGES (BufferSize);
-    Buffer = AllocateRuntimePages (Pages);
+    Buffer = AllocatePages (Pages);
     ASSERT (Buffer != NULL);
-    Status = MmUnblockMemoryRequest (
-               (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
-               Pages
-               );
-    if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-      return Status;
-    }
+    //
+    // MU_CHANGE - Commented out runtime allocation and memory unblock (moved to DXE)
+    // Buffer = AllocateRuntimePages (Pages);
+    // Status = MmUnblockMemoryRequest (
+    //            (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
+    //            Pages
+    //            );
+    // if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+    //   return Status;
+    // }
+    //
 
     TempHobBuffer.RuntimeVolatileCacheBuffer = (UINTN)Buffer;
     TempHobBuffer.RuntimeVolatileCachePages  = Pages;
   }
+
+  // MU_CHANGE [END]
 
   DEBUG ((
     DEBUG_INFO,
@@ -1505,24 +1520,31 @@ BuildVariableRuntimeCacheInfoHob (
     ));
 
   //
-  // AllocateRuntimePages for NVCache and unblock it.
+  // MU_CHANGE [BEGIN] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
+  // AllocatePages for NVCache buffer (will be relocated to runtime by DXE).
   //
   BufferSize = CalculateNvVariableCacheSize (&NvAuthFlag);
   if (BufferSize > 0) {
     Pages  = EFI_SIZE_TO_PAGES (BufferSize);
-    Buffer = AllocateRuntimePages (Pages);
+    Buffer = AllocatePages (Pages);
     ASSERT (Buffer != NULL);
-    Status = MmUnblockMemoryRequest (
-               (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
-               Pages
-               );
-    if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-      return Status;
-    }
+    //
+    // MU_CHANGE - Commented out runtime allocation and memory unblock (moved to DXE)
+    // Buffer = AllocateRuntimePages (Pages);
+    // Status = MmUnblockMemoryRequest (
+    //            (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
+    //            Pages
+    //            );
+    // if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+    //   return Status;
+    // }
+    //
 
     TempHobBuffer.RuntimeNvCacheBuffer = (UINTN)Buffer;
     TempHobBuffer.RuntimeNvCachePages  = Pages;
   }
+
+  // MU_CHANGE [END]
 
   DEBUG ((
     DEBUG_INFO,
@@ -1532,24 +1554,31 @@ BuildVariableRuntimeCacheInfoHob (
     ));
 
   //
-  // AllocateRuntimePages for HobCache and unblock it.
+  // MU_CHANGE [BEGIN] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
+  // AllocatePages for HobCache buffer (will be relocated to runtime by DXE).
   //
   BufferSize = CalculateHobVariableCacheSize (NvAuthFlag);
   if (BufferSize > 0) {
     Pages  = EFI_SIZE_TO_PAGES (BufferSize);
-    Buffer = AllocateRuntimePages (Pages);
+    Buffer = AllocatePages (Pages);
     ASSERT (Buffer != NULL);
-    Status = MmUnblockMemoryRequest (
-               (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
-               Pages
-               );
-    if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-      return Status;
-    }
+    //
+    // MU_CHANGE - Commented out runtime allocation and memory unblock (moved to DXE)
+    // Buffer = AllocateRuntimePages (Pages);
+    // Status = MmUnblockMemoryRequest (
+    //            (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
+    //            Pages
+    //            );
+    // if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+    //   return Status;
+    // }
+    //
 
     TempHobBuffer.RuntimeHobCacheBuffer = (UINTN)Buffer;
     TempHobBuffer.RuntimeHobCachePages  = Pages;
   }
+
+  // MU_CHANGE [END]
 
   DEBUG ((
     DEBUG_INFO,

--- a/MdeModulePkg/Universal/Variable/Pei/Variable.h
+++ b/MdeModulePkg/Universal/Variable/Pei/Variable.h
@@ -22,7 +22,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/PeiServicesLib.h>
 #include <Library/SafeIntLib.h>
 #include <Library/VariableFlashInfoLib.h>
-#include <Library/MmUnblockMemoryLib.h>
+// MU_CHANGE [BEGIN] - Comment out unused include when moving allocation to DXE
+// #include <Library/MmUnblockMemoryLib.h>
+// MU_CHANGE [END]
 #include <Library/MemoryAllocationLib.h>
 
 #include <Guid/VariableFormat.h>

--- a/MdeModulePkg/Universal/Variable/Pei/VariablePei.inf
+++ b/MdeModulePkg/Universal/Variable/Pei/VariablePei.inf
@@ -41,7 +41,9 @@
   PeiServicesLib
   SafeIntLib
   VariableFlashInfoLib
-  MmUnblockMemoryLib
+  # MU_CHANGE [BEGIN] - Comment out unused library when moving allocation to DXE
+  # MmUnblockMemoryLib
+  # MU_CHANGE [END]
   MemoryAllocationLib
 
 [Guids]

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
@@ -1535,6 +1535,27 @@ InitVariableStoreHeader (
   }
 }
 
+//
+// MU_CHANGE [BEGIN] - Add helper function for runtime cache cleanup
+//
+
+/**
+  Invalidates all runtime cache pointers to prevent access to boot services memory.
+
+**/
+VOID
+InvalidateAllRuntimeCaches (
+  VOID
+  )
+{
+  mVariableRtCacheInfo.CacheInfoFlagBuffer        = 0;
+  mVariableRtCacheInfo.RuntimeHobCacheBuffer      = 0;
+  mVariableRtCacheInfo.RuntimeNvCacheBuffer       = 0;
+  mVariableRtCacheInfo.RuntimeVolatileCacheBuffer = 0;
+}
+
+// MU_CHANGE [END] - Add helper function for runtime cache cleanup
+
 /**
   Initialize the runtime variable cache related content.
 
@@ -1558,9 +1579,15 @@ InitVariableCache (
   UINTN                        AllocatedVolatileCacheSize;
   VARIABLE_RUNTIME_CACHE_INFO  *VariableRuntimeCacheInfo;
   // MU_CHANGE [BEGIN] - Add variables for runtime buffer relocation from DXE
-  VOID                  *RuntimeBuffer;
-  EFI_PHYSICAL_ADDRESS  RuntimeBufferPhysicalAddress;
-  UINTN                 Pages;
+  VOID   *RuntimeBuffer;
+  UINTN  Pages;
+
+  // Storage for temporary allocations - only commit to mVariableRtCacheInfo if ALL succeed
+  EFI_PHYSICAL_ADDRESS  TempCacheInfoBuffer             = 0;
+  EFI_PHYSICAL_ADDRESS  TempHobCacheBuffer              = 0;
+  EFI_PHYSICAL_ADDRESS  TempNvCacheBuffer               = 0;
+  EFI_PHYSICAL_ADDRESS  TempVolatileCacheBuffer         = 0;
+  BOOLEAN               AllRtBufferAllocationsSucceeded = TRUE;
 
   // MU_CHANGE [END]
 
@@ -1605,104 +1632,149 @@ InitVariableCache (
                       AllocateAnyPages,
                       EfiRuntimeServicesData,
                       Pages,
-                      &RuntimeBufferPhysicalAddress
+                      &TempCacheInfoBuffer
                       );
-      if (!EFI_ERROR (Status)) {
-        RuntimeBuffer = (VOID *)(UINTN)RuntimeBufferPhysicalAddress;
-        CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.CacheInfoFlagBuffer, sizeof (CACHE_INFO_FLAG));
-        mVariableRtCacheInfo.CacheInfoFlagBuffer = (UINTN)RuntimeBuffer;
-
-        Status = MmUnblockMemoryRequest (RuntimeBufferPhysicalAddress, Pages);
-        if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-          return Status;
-        }
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_WARN, "Failed to allocate runtime CacheInfoFlag buffer: %r\n", Status));
+        AllRtBufferAllocationsSucceeded = FALSE;
       } else {
-        return Status;
+        Status = MmUnblockMemoryRequest (TempCacheInfoBuffer, Pages);
+        if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_WARN, "Failed to unblock CacheInfoFlag buffer: %r\n", Status));
+          gBS->FreePages (TempCacheInfoBuffer, Pages);
+          TempCacheInfoBuffer             = 0;
+          AllRtBufferAllocationsSucceeded = FALSE;
+        }
       }
     }
 
-    //
-    // Relocate RuntimeHobCache buffer from boot services to runtime services
-    //
-    if ((mVariableRtCacheInfo.RuntimeHobCacheBuffer != 0) && (AllocatedHobCacheSize > 0)) {
+    if (AllRtBufferAllocationsSucceeded && (mVariableRtCacheInfo.RuntimeHobCacheBuffer != 0) && (AllocatedHobCacheSize > 0)) {
       Pages  = EFI_SIZE_TO_PAGES (AllocatedHobCacheSize);
       Status = gBS->AllocatePages (
                       AllocateAnyPages,
                       EfiRuntimeServicesData,
                       Pages,
-                      &RuntimeBufferPhysicalAddress
+                      &TempHobCacheBuffer
                       );
-      if (!EFI_ERROR (Status)) {
-        RuntimeBuffer = (VOID *)(UINTN)RuntimeBufferPhysicalAddress;
-        CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeHobCacheBuffer, AllocatedHobCacheSize);
-        mVariableRtCacheInfo.RuntimeHobCacheBuffer = (UINTN)RuntimeBuffer;
-
-        Status = MmUnblockMemoryRequest (RuntimeBufferPhysicalAddress, Pages);
-        if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-          return Status;
-        }
-
-        InitVariableStoreHeader (RuntimeBuffer, AllocatedHobCacheSize);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_WARN, "Failed to allocate runtime HOB cache buffer: %r\n", Status));
+        AllRtBufferAllocationsSucceeded = FALSE;
       } else {
-        return Status;
+        Status = MmUnblockMemoryRequest (TempHobCacheBuffer, Pages);
+        if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_WARN, "Failed to unblock HOB cache buffer: %r\n", Status));
+          gBS->FreePages (TempHobCacheBuffer, Pages);
+          TempHobCacheBuffer              = 0;
+          AllRtBufferAllocationsSucceeded = FALSE;
+        }
       }
     }
 
-    //
-    // Relocate RuntimeNvCache buffer from boot services to runtime services
-    //
-    if ((mVariableRtCacheInfo.RuntimeNvCacheBuffer != 0) && (AllocatedNvCacheSize > 0)) {
+    if (AllRtBufferAllocationsSucceeded && (mVariableRtCacheInfo.RuntimeNvCacheBuffer != 0) && (AllocatedNvCacheSize > 0)) {
       Pages  = EFI_SIZE_TO_PAGES (AllocatedNvCacheSize);
       Status = gBS->AllocatePages (
                       AllocateAnyPages,
                       EfiRuntimeServicesData,
                       Pages,
-                      &RuntimeBufferPhysicalAddress
+                      &TempNvCacheBuffer
                       );
-      if (!EFI_ERROR (Status)) {
-        RuntimeBuffer = (VOID *)(UINTN)RuntimeBufferPhysicalAddress;
-        CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeNvCacheBuffer, AllocatedNvCacheSize);
-        mVariableRtCacheInfo.RuntimeNvCacheBuffer = (UINTN)RuntimeBuffer;
-
-        Status = MmUnblockMemoryRequest (RuntimeBufferPhysicalAddress, Pages);
-        if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-          return Status;
-        }
-
-        InitVariableStoreHeader (RuntimeBuffer, AllocatedNvCacheSize);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_WARN, "Failed to allocate runtime NV cache buffer: %r\n", Status));
+        AllRtBufferAllocationsSucceeded = FALSE;
       } else {
-        return Status;
+        Status = MmUnblockMemoryRequest (TempNvCacheBuffer, Pages);
+        if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_WARN, "Failed to unblock NV cache buffer: %r\n", Status));
+          gBS->FreePages (TempNvCacheBuffer, Pages);
+          TempNvCacheBuffer               = 0;
+          AllRtBufferAllocationsSucceeded = FALSE;
+        }
       }
     }
 
-    //
-    // Relocate RuntimeVolatileCache buffer from boot services to runtime services
-    //
-    if ((mVariableRtCacheInfo.RuntimeVolatileCacheBuffer != 0) && (AllocatedVolatileCacheSize > 0)) {
+    if (AllRtBufferAllocationsSucceeded && (mVariableRtCacheInfo.RuntimeVolatileCacheBuffer != 0) && (AllocatedVolatileCacheSize > 0)) {
       Pages  = EFI_SIZE_TO_PAGES (AllocatedVolatileCacheSize);
       Status = gBS->AllocatePages (
                       AllocateAnyPages,
                       EfiRuntimeServicesData,
                       Pages,
-                      &RuntimeBufferPhysicalAddress
+                      &TempVolatileCacheBuffer
                       );
-      if (!EFI_ERROR (Status)) {
-        RuntimeBuffer = (VOID *)(UINTN)RuntimeBufferPhysicalAddress;
-        CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeVolatileCacheBuffer, AllocatedVolatileCacheSize);
-        mVariableRtCacheInfo.RuntimeVolatileCacheBuffer = (UINTN)RuntimeBuffer;
-
-        Status = MmUnblockMemoryRequest (RuntimeBufferPhysicalAddress, Pages);
-        if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-          return Status;
-        }
-
-        InitVariableStoreHeader (RuntimeBuffer, AllocatedVolatileCacheSize);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_WARN, "Failed to allocate runtime volatile cache buffer: %r\n", Status));
+        AllRtBufferAllocationsSucceeded = FALSE;
       } else {
-        return Status;
+        Status = MmUnblockMemoryRequest (TempVolatileCacheBuffer, Pages);
+        if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_WARN, "Failed to unblock volatile cache buffer: %r\n", Status));
+          gBS->FreePages (TempVolatileCacheBuffer, Pages);
+          TempVolatileCacheBuffer         = 0;
+          AllRtBufferAllocationsSucceeded = FALSE;
+        }
       }
     }
 
-    // MU_CHANGE [END] - Relocate runtime cache buffers from boot services to runtime services
+    if (AllRtBufferAllocationsSucceeded) {
+      if (TempCacheInfoBuffer != 0) {
+        RuntimeBuffer = (VOID *)(UINTN)TempCacheInfoBuffer;
+        CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.CacheInfoFlagBuffer, sizeof (CACHE_INFO_FLAG));
+        mVariableRtCacheInfo.CacheInfoFlagBuffer = TempCacheInfoBuffer;
+      }
+
+      if (TempHobCacheBuffer != 0) {
+        RuntimeBuffer = (VOID *)(UINTN)TempHobCacheBuffer;
+        CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeHobCacheBuffer, AllocatedHobCacheSize);
+        mVariableRtCacheInfo.RuntimeHobCacheBuffer = TempHobCacheBuffer;
+        InitVariableStoreHeader (RuntimeBuffer, AllocatedHobCacheSize);
+      }
+
+      if (TempNvCacheBuffer != 0) {
+        RuntimeBuffer = (VOID *)(UINTN)TempNvCacheBuffer;
+        CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeNvCacheBuffer, AllocatedNvCacheSize);
+        mVariableRtCacheInfo.RuntimeNvCacheBuffer = TempNvCacheBuffer;
+        InitVariableStoreHeader (RuntimeBuffer, AllocatedNvCacheSize);
+      }
+
+      if (TempVolatileCacheBuffer != 0) {
+        RuntimeBuffer = (VOID *)(UINTN)TempVolatileCacheBuffer;
+        CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeVolatileCacheBuffer, AllocatedVolatileCacheSize);
+        mVariableRtCacheInfo.RuntimeVolatileCacheBuffer = TempVolatileCacheBuffer;
+        InitVariableStoreHeader (RuntimeBuffer, AllocatedVolatileCacheSize);
+      }
+
+      DEBUG ((DEBUG_INFO, "Runtime variable cache buffers successfully relocated\n"));
+    } else {
+      //
+      // One or more allocations failed - clean up any successful allocations
+      // and disable runtime caching entirely
+      //
+      if (TempCacheInfoBuffer != 0) {
+        gBS->FreePages (TempCacheInfoBuffer, EFI_SIZE_TO_PAGES (sizeof (CACHE_INFO_FLAG)));
+      }
+
+      if (TempHobCacheBuffer != 0) {
+        gBS->FreePages (TempHobCacheBuffer, EFI_SIZE_TO_PAGES (AllocatedHobCacheSize));
+      }
+
+      if (TempNvCacheBuffer != 0) {
+        gBS->FreePages (TempNvCacheBuffer, EFI_SIZE_TO_PAGES (AllocatedNvCacheSize));
+      }
+
+      if (TempVolatileCacheBuffer != 0) {
+        gBS->FreePages (TempVolatileCacheBuffer, EFI_SIZE_TO_PAGES (AllocatedVolatileCacheSize));
+      }
+
+      //
+      // Null all runtime cache pointers to prevent access to boot services memory
+      //
+      InvalidateAllRuntimeCaches ();
+
+      DEBUG ((DEBUG_WARN, "Runtime variable cache disabled due to allocation failure.\n"));
+
+      // Don't return failure - the variable service can function without the runtime cache
+    }
+
+    // MU_CHANGE [END] - Relocate runtime cache buffers using all-or-nothing approach
   }
 
   return Status;

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
@@ -36,6 +36,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/UefiLib.h>
 #include <Library/BaseLib.h>
 #include <Library/HobLib.h>
+// MU_CHANGE [BEGIN] - Add include for memory unblock when moving allocation to DXE
+#include <Library/MmUnblockMemoryLib.h>
+// MU_CHANGE [END]
 
 #include <Guid/EventGroup.h>
 #include <Guid/SmmVariableCommon.h>
@@ -1554,6 +1557,12 @@ InitVariableCache (
   UINTN                        AllocatedNvCacheSize;
   UINTN                        AllocatedVolatileCacheSize;
   VARIABLE_RUNTIME_CACHE_INFO  *VariableRuntimeCacheInfo;
+  // MU_CHANGE [BEGIN] - Add variables for runtime buffer relocation from DXE
+  VOID                  *RuntimeBuffer;
+  EFI_PHYSICAL_ADDRESS  RuntimeBufferPhysicalAddress;
+  UINTN                 Pages;
+
+  // MU_CHANGE [END]
 
   //
   // Get needed runtime cache buffer size and check if auth variables are to be used from SMM
@@ -1577,9 +1586,123 @@ InitVariableCache (
       );
 
     CopyMem (&mVariableRtCacheInfo, VariableRuntimeCacheInfo, sizeof (VARIABLE_RUNTIME_CACHE_INFO));
-    InitVariableStoreHeader ((VOID *)(UINTN)mVariableRtCacheInfo.RuntimeHobCacheBuffer, AllocatedHobCacheSize);
-    InitVariableStoreHeader ((VOID *)(UINTN)mVariableRtCacheInfo.RuntimeNvCacheBuffer, AllocatedNvCacheSize);
-    InitVariableStoreHeader ((VOID *)(UINTN)mVariableRtCacheInfo.RuntimeVolatileCacheBuffer, AllocatedVolatileCacheSize);
+    //
+    // MU_CHANGE - Commented out old header initialization (moved to individual buffer relocations)
+    // InitVariableStoreHeader ((VOID *)(UINTN)mVariableRtCacheInfo.RuntimeHobCacheBuffer, AllocatedHobCacheSize);
+    // InitVariableStoreHeader ((VOID *)(UINTN)mVariableRtCacheInfo.RuntimeNvCacheBuffer, AllocatedNvCacheSize);
+    // InitVariableStoreHeader ((VOID *)(UINTN)mVariableRtCacheInfo.RuntimeVolatileCacheBuffer, AllocatedVolatileCacheSize);
+    //
+
+    //
+    // MU_CHANGE [BEGIN] - Relocate runtime cache buffers from boot services to runtime services
+    // This prevents runtime memory fragmentation by consolidating allocations in DXE
+    //
+    // Relocate CacheInfoFlag buffer from boot services to runtime services
+    //
+    if (mVariableRtCacheInfo.CacheInfoFlagBuffer != 0) {
+      Pages  = EFI_SIZE_TO_PAGES (sizeof (CACHE_INFO_FLAG));
+      Status = gBS->AllocatePages (
+                      AllocateAnyPages,
+                      EfiRuntimeServicesData,
+                      Pages,
+                      &RuntimeBufferPhysicalAddress
+                      );
+      if (!EFI_ERROR (Status)) {
+        RuntimeBuffer = (VOID *)(UINTN)RuntimeBufferPhysicalAddress;
+        CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.CacheInfoFlagBuffer, sizeof (CACHE_INFO_FLAG));
+        mVariableRtCacheInfo.CacheInfoFlagBuffer = (UINTN)RuntimeBuffer;
+
+        Status = MmUnblockMemoryRequest (RuntimeBufferPhysicalAddress, Pages);
+        if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+          return Status;
+        }
+      } else {
+        return Status;
+      }
+    }
+
+    //
+    // Relocate RuntimeHobCache buffer from boot services to runtime services
+    //
+    if ((mVariableRtCacheInfo.RuntimeHobCacheBuffer != 0) && (AllocatedHobCacheSize > 0)) {
+      Pages  = EFI_SIZE_TO_PAGES (AllocatedHobCacheSize);
+      Status = gBS->AllocatePages (
+                      AllocateAnyPages,
+                      EfiRuntimeServicesData,
+                      Pages,
+                      &RuntimeBufferPhysicalAddress
+                      );
+      if (!EFI_ERROR (Status)) {
+        RuntimeBuffer = (VOID *)(UINTN)RuntimeBufferPhysicalAddress;
+        CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeHobCacheBuffer, AllocatedHobCacheSize);
+        mVariableRtCacheInfo.RuntimeHobCacheBuffer = (UINTN)RuntimeBuffer;
+
+        Status = MmUnblockMemoryRequest (RuntimeBufferPhysicalAddress, Pages);
+        if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+          return Status;
+        }
+
+        InitVariableStoreHeader (RuntimeBuffer, AllocatedHobCacheSize);
+      } else {
+        return Status;
+      }
+    }
+
+    //
+    // Relocate RuntimeNvCache buffer from boot services to runtime services
+    //
+    if ((mVariableRtCacheInfo.RuntimeNvCacheBuffer != 0) && (AllocatedNvCacheSize > 0)) {
+      Pages  = EFI_SIZE_TO_PAGES (AllocatedNvCacheSize);
+      Status = gBS->AllocatePages (
+                      AllocateAnyPages,
+                      EfiRuntimeServicesData,
+                      Pages,
+                      &RuntimeBufferPhysicalAddress
+                      );
+      if (!EFI_ERROR (Status)) {
+        RuntimeBuffer = (VOID *)(UINTN)RuntimeBufferPhysicalAddress;
+        CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeNvCacheBuffer, AllocatedNvCacheSize);
+        mVariableRtCacheInfo.RuntimeNvCacheBuffer = (UINTN)RuntimeBuffer;
+
+        Status = MmUnblockMemoryRequest (RuntimeBufferPhysicalAddress, Pages);
+        if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+          return Status;
+        }
+
+        InitVariableStoreHeader (RuntimeBuffer, AllocatedNvCacheSize);
+      } else {
+        return Status;
+      }
+    }
+
+    //
+    // Relocate RuntimeVolatileCache buffer from boot services to runtime services
+    //
+    if ((mVariableRtCacheInfo.RuntimeVolatileCacheBuffer != 0) && (AllocatedVolatileCacheSize > 0)) {
+      Pages  = EFI_SIZE_TO_PAGES (AllocatedVolatileCacheSize);
+      Status = gBS->AllocatePages (
+                      AllocateAnyPages,
+                      EfiRuntimeServicesData,
+                      Pages,
+                      &RuntimeBufferPhysicalAddress
+                      );
+      if (!EFI_ERROR (Status)) {
+        RuntimeBuffer = (VOID *)(UINTN)RuntimeBufferPhysicalAddress;
+        CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeVolatileCacheBuffer, AllocatedVolatileCacheSize);
+        mVariableRtCacheInfo.RuntimeVolatileCacheBuffer = (UINTN)RuntimeBuffer;
+
+        Status = MmUnblockMemoryRequest (RuntimeBufferPhysicalAddress, Pages);
+        if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+          return Status;
+        }
+
+        InitVariableStoreHeader (RuntimeBuffer, AllocatedVolatileCacheSize);
+      } else {
+        return Status;
+      }
+    }
+
+    // MU_CHANGE [END] - Relocate runtime cache buffers from boot services to runtime services
   }
 
   return Status;

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf
@@ -64,6 +64,9 @@
   PcdLib
   HobLib
   DeviceStateLib # MU_CHANGE - Check device state before locking variable policy
+  # MU_CHANGE [BEGIN] - Add library for memory unblock when moving allocation to DXE
+  MmUnblockMemoryLib
+  # MU_CHANGE [END]
 
 [Protocols]
   gEfiVariableWriteArchProtocolGuid             ## PRODUCES


### PR DESCRIPTION
## Description

Commit `d8f513de3e3ef228af7e6facf0ad3e35c3224032` (an edk2 commit) added runtime memory allocation to VariablePei. That will cause runtime memory bucket fragmentation affecting hibernate stability as these runtime allocations are separate from the main runtime memory type bucket allocation made by the DXE Core.

To preserve the existing functionality but allow the runtime buffer to come from the DXE bucket, the allocations in PEI are changed to boot services data allocations and the contents are moved to the runtime memory buffers (and those pages unblocked to MM) in the DXE variable driver after the bucket has been allocated by the DXE core.

---

> Note: I will upstream this to edk2 but it is urgently needed in Project Mu.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- CI
- Boot to EFI shell on QEMU Q35 and verify allocations come from the DXE allocated bucket buffer

## Integration Instructions

- N/A