### PR TITLE
UefiCpuPkg/PeiMpLib: Only allocate ACPI NVS AP loop code buffer on S3 resume

### DIFF
--- a/UefiCpuPkg/Library/MpInitLib/PeiMpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/PeiMpLib.c
@@ -851,9 +851,22 @@ AllocateApLoopCodeBuffer (
   IN OUT EFI_PHYSICAL_ADDRESS  *Address
   )
 {
-  EFI_STATUS  Status;
+  // MU_CHANGE [BEGIN] - Only allocate RT visible type on S3 resume
+  EFI_STATUS     Status;
+  EFI_BOOT_MODE  BootMode;
 
-  Status = PeiServicesAllocatePages (EfiACPIMemoryNVS, Pages, Address);
+  Status = PeiServicesGetBootMode (&BootMode);
+  ASSERT_EFI_ERROR (Status);
+
+  if (!EFI_ERROR (Status) && (BootMode == BOOT_ON_S3_RESUME)) {
+    // Only allocate RT visible type on S3 resume
+    Status = PeiServicesAllocatePages (EfiACPIMemoryNVS, Pages, Address);
+  } else {
+    Status = PeiServicesAllocatePages (EfiBootServicesData, Pages, Address);
+  }
+
+  // MU_CHANGE [END] - Only allocate RT visible type on S3 resume
+
   if (EFI_ERROR (Status)) {
     *Address = 0;
   }


### PR DESCRIPTION
## Description

This commit allocated an ACPI NVS buffer in PEI:
https://github.com/tianocore/edk2/commit/cdc1a88272237149003d1d1ea301d320f7b3bdf6

This is a RT visible memory type that remains fragmented against the overall `EfiACPIMemoryNVS` memory bucket allocated by the DXE Core.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- CI and boot to EFI shell on QEMU platforms with checks that PEI and DXE buffer allocation code is executed

## Integration Instructions

- N/A - Note `EfiACPIMemoryNVS` will not be allocated in PEI outside of S3 resume (as indicated with boot mode). This is not expected to be breaking or impact other flows.