### PR TITLE
[CHERRY-PICK] Pick up FFA_RUN solution from EDK2

### DIFF
--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
@@ -553,6 +553,7 @@ ErrorHandler:
 
   @param [in]   PartId       Partition id
   @param [in]   CpuNumber    Cpu number in partition
+  @param [out]  DirectMsgArg return arguments for direct msg resp/resp2
 
   @retval EFI_SUCCESS
   @retval Other              Error
@@ -561,10 +562,12 @@ ErrorHandler:
 EFI_STATUS
 EFIAPI
 ArmFfaLibRun (
-  IN  UINT16  PartId,
-  IN  UINT16  CpuNumber
+  IN  UINT16           PartId,
+  IN  UINT16           CpuNumber,
+  OUT DIRECT_MSG_ARGS  *DirectMsgArg OPTIONAL
   )
 {
+  EFI_STATUS    Status;
   ARM_FFA_ARGS  FfaArgs;
 
   ZeroMem (&FfaArgs, sizeof (ARM_FFA_ARGS));
@@ -574,7 +577,39 @@ ArmFfaLibRun (
 
   ArmCallFfa (&FfaArgs);
 
-  return FfaArgsToEfiStatus (&FfaArgs);
+  Status = FfaArgsToEfiStatus (&FfaArgs);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  if (DirectMsgArg != NULL) {
+    ZeroMem (DirectMsgArg, sizeof (DIRECT_MSG_ARGS));
+
+    if (FfaArgs.Arg0 == ARM_FID_FFA_MSG_SEND_DIRECT_RESP) {
+      DirectMsgArg->Arg0 = FfaArgs.Arg3;
+      DirectMsgArg->Arg1 = FfaArgs.Arg4;
+      DirectMsgArg->Arg2 = FfaArgs.Arg5;
+      DirectMsgArg->Arg3 = FfaArgs.Arg6;
+      DirectMsgArg->Arg4 = FfaArgs.Arg7;
+    } else if (FfaArgs.Arg0 == ARM_FID_FFA_MSG_SEND_DIRECT_RESP2) {
+      DirectMsgArg->Arg0  = FfaArgs.Arg4;
+      DirectMsgArg->Arg1  = FfaArgs.Arg5;
+      DirectMsgArg->Arg2  = FfaArgs.Arg6;
+      DirectMsgArg->Arg3  = FfaArgs.Arg7;
+      DirectMsgArg->Arg4  = FfaArgs.Arg8;
+      DirectMsgArg->Arg5  = FfaArgs.Arg9;
+      DirectMsgArg->Arg6  = FfaArgs.Arg10;
+      DirectMsgArg->Arg7  = FfaArgs.Arg11;
+      DirectMsgArg->Arg8  = FfaArgs.Arg12;
+      DirectMsgArg->Arg9  = FfaArgs.Arg13;
+      DirectMsgArg->Arg10 = FfaArgs.Arg14;
+      DirectMsgArg->Arg11 = FfaArgs.Arg15;
+      DirectMsgArg->Arg12 = FfaArgs.Arg16;
+      DirectMsgArg->Arg13 = FfaArgs.Arg17;
+    }
+  }
+
+  return Status;
 }
 
 /**

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
@@ -553,7 +553,6 @@ ErrorHandler:
 
   @param [in]   PartId       Partition id
   @param [in]   CpuNumber    Cpu number in partition
-  @param [out]  CtxFfaArgs   Optional context of FFA_ARGS
 
   @retval EFI_SUCCESS
   @retval Other              Error
@@ -562,13 +561,11 @@ ErrorHandler:
 EFI_STATUS
 EFIAPI
 ArmFfaLibRun (
-  IN  UINT16        PartId,
-  IN  UINT16        CpuNumber,
-  OUT ARM_FFA_ARGS  *CtxFfaArgs OPTIONAL
+  IN  UINT16  PartId,
+  IN  UINT16  CpuNumber
   )
 {
   ARM_FFA_ARGS  FfaArgs;
-  EFI_STATUS    Status;
 
   ZeroMem (&FfaArgs, sizeof (ARM_FFA_ARGS));
 
@@ -577,16 +574,7 @@ ArmFfaLibRun (
 
   ArmCallFfa (&FfaArgs);
 
-  Status = FfaArgsToEfiStatus (&FfaArgs);
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
-
-  if (CtxFfaArgs != NULL) {
-    CopyMem (CtxFfaArgs, &FfaArgs, sizeof (ARM_FFA_ARGS));
-  }
-
-  return Status;
+  return FfaArgsToEfiStatus (&FfaArgs);
 }
 
 /**

--- a/MdePkg/Include/Library/ArmFfaLib.h
+++ b/MdePkg/Include/Library/ArmFfaLib.h
@@ -301,6 +301,7 @@ ArmFfaLibSpmIdGet (
 
   @param [in]   PartId       Partition id
   @param [in]   CpuNumber    Cpu number in partition
+  @param [out]  DirectMsgArg return arguments for direct msg resp/resp2
 
   @retval EFI_SUCCESS
   @retval Other              Error
@@ -309,8 +310,9 @@ ArmFfaLibSpmIdGet (
 EFI_STATUS
 EFIAPI
 ArmFfaLibRun (
-  IN  UINT16  PartId,
-  IN  UINT16  CpuNumber
+  IN  UINT16           PartId,
+  IN  UINT16           CpuNumber,
+  OUT DIRECT_MSG_ARGS  *DirectMsgArg OPTIONAL
   );
 
 /**

--- a/MdePkg/Include/Library/ArmFfaLib.h
+++ b/MdePkg/Include/Library/ArmFfaLib.h
@@ -297,11 +297,10 @@ ArmFfaLibSpmIdGet (
   );
 
 /**
-  Restore the context which was interrupted with FFA_INTERRUPT (EFI_INTERRUPT_PENDING).
+  Restore context which interrupted with FFA_INTERRUPT (EFI_INTERRUPT_PENDING).
 
   @param [in]   PartId       Partition id
   @param [in]   CpuNumber    Cpu number in partition
-  @param [out]  CtxFfaArgs   Optional context of FFA_ARGS
 
   @retval EFI_SUCCESS
   @retval Other              Error
@@ -310,9 +309,8 @@ ArmFfaLibSpmIdGet (
 EFI_STATUS
 EFIAPI
 ArmFfaLibRun (
-  IN  UINT16        PartId,
-  IN  UINT16        CpuNumber,
-  OUT ARM_FFA_ARGS  *CtxFfaArgs OPTIONAL
+  IN  UINT16  PartId,
+  IN  UINT16  CpuNumber
   );
 
 /**


### PR DESCRIPTION
## Description

BASECORE made a change for FFA_RUN change, but EDK2 already has a corresponding change.

This change reverts the original fix and conform to EDK2 version.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on QEMU SBSA and booted to UEFI shell.

## Integration Instructions

N/A
