### PR TITLE
pip-requirements: Update Edk2-pytool-extensions from 0.30.2 to 0.30.3

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -13,7 +13,7 @@
 ##
 
 edk2-pytool-library~=0.23.8 # MU_CHANGE
-edk2-pytool-extensions~=0.30.2 # MU_CHANGE
+edk2-pytool-extensions~=0.30.3 # MU_CHANGE
 antlr4-python3-runtime==4.13.2
 lcov-cobertura==2.1.1
 pygount==3.1.0 # MU_CHANGE


### PR DESCRIPTION
## Description
When processing ext_deps, if the zip file did not contain valid permissions on the files contained in the zips, a Permission Denied error would be output under a linux platform. This was observed with zip files that were generated under windows when attempting to use them on a linux platform.

Update to the version of edk2-pytool-extensions which fixed this oddity.
- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
CI (which was breaking)

## Integration Instructions
No integration necesssary.