### PR TITLE
[REBASE & FF] Revert Mu Commit in Favor of edk2 Commit

### DIFF
--- a/MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDisk.c
+++ b/MdeModulePkg/Bus/Scsi/ScsiDiskDxe/ScsiDisk.c
@@ -196,67 +196,6 @@ ScsiDiskDriverBindingSupported (
   return Status;
 }
 
-// MU_CHANGE Begin: Add function to check whether the disk is write protected
-
-/**
- Check whether the SCSI disk is write protected.
- @param[in]  ScsiDiskDevice         The SCSI disk device.
- @param[out] WriteProtectionEnabled A pointer to a Boolean that will be set to TRUE if the disk is write protected,
-                                    FALSE otherwise.
- @retval EFI_SUCCESS                The operation completed successfully.
- @retval EFI_INVALID_PARAMETER      One of the input parameters was invalid.
- @retval other                      An error occurred while executing the SCSI command.
- */
-STATIC
-EFI_STATUS
-IsWriteProtected (
-  IN OUT SCSI_DISK_DEV  *ScsiDiskDevice,
-  OUT BOOLEAN           *WriteProtectionEnabled
-  )
-{
-  EFI_STATUS                       Status;
-  EFI_SCSI_IO_SCSI_REQUEST_PACKET  CommandPacket;
-  UINT8                            Cdb[6];
-  UINT8                            DataBuffer[64];
-
-  if ((ScsiDiskDevice == NULL) || (WriteProtectionEnabled == NULL) || (ScsiDiskDevice->ScsiIo == NULL)) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  //
-  // Initialize SCSI REQUEST_PACKET and 6-byte Cdb
-  //
-  ZeroMem (&CommandPacket, sizeof (CommandPacket));
-  ZeroMem (Cdb, sizeof (Cdb));
-
-  // Initialize output parameter to default value
-  *WriteProtectionEnabled = FALSE;
-
-  Cdb[0] = ATA_CMD_MODE_SENSE6;
-  Cdb[1] = BIT3;                         // Setting the bit for Disable Block Descriptor
-  Cdb[2] = ATA_PAGE_CODE_RETURN_ALL_PAGES;
-  Cdb[4] = sizeof (DataBuffer);
-
-  CommandPacket.Timeout          = SCSI_DISK_TIMEOUT;
-  CommandPacket.Cdb              = Cdb;
-  CommandPacket.CdbLength        = (UINT8)sizeof (Cdb);
-  CommandPacket.InDataBuffer     = &DataBuffer;
-  CommandPacket.InTransferLength = sizeof (DataBuffer);
-
-  Status = ScsiDiskDevice->ScsiIo->ExecuteScsiCommand (ScsiDiskDevice->ScsiIo, &CommandPacket, NULL);
-
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
-
-  // Mode Sense 6 Byte Command returns the Write Protection status in the 3rd byte
-  // Bit 7 of the 3rd byte indicates the Write Protection status
-  *WriteProtectionEnabled = (DataBuffer[2] & BIT7) != 0;
-  return EFI_SUCCESS;
-}
-
-// MU_CHANGE End: Add function to check whether the disk is write protected
-
 /**
   Start this driver on ControllerHandle.
 
@@ -295,8 +234,6 @@ ScsiDiskDriverBindingStart (
   CHAR8                 VendorStr[VENDOR_IDENTIFICATION_LENGTH + 1];
   CHAR8                 ProductStr[PRODUCT_IDENTIFICATION_LENGTH + 1];
   CHAR16                DeviceStr[VENDOR_IDENTIFICATION_LENGTH + PRODUCT_IDENTIFICATION_LENGTH + 2];
-  // MU_CHANGE: Add variable to check whether the disk is write protected
-  BOOLEAN  WriteProtectionEnabled = FALSE;
 
   MustReadCapacity = TRUE;
 
@@ -359,20 +296,6 @@ ScsiDiskDriverBindingStart (
       MustReadCapacity = FALSE;
       break;
   }
-
-  // MU_CHANGE Begin: Check whether the disk is write protected and set the ReadOnly flag accordingly
-  if (ScsiDiskDevice->DeviceType == EFI_SCSI_TYPE_DISK) {
-    Status = IsWriteProtected (ScsiDiskDevice, &WriteProtectionEnabled);
-    if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "ScsiDisk: IsWriteProtected() fails. Status = %r\n", Status));
-    }
-
-    if (WriteProtectionEnabled) {
-      ScsiDiskDevice->BlkIo.Media->ReadOnly = TRUE;
-    }
-  }
-
-  // MU_CHANGE End: Check whether the disk is write protected and set the ReadOnly flag accordingly
 
   //
   // The Sense Data Array's initial size is 6

--- a/MdePkg/Include/IndustryStandard/Atapi.h
+++ b/MdePkg/Include/IndustryStandard/Atapi.h
@@ -503,6 +503,7 @@ typedef union {
 #define ATA_CMD_PREVENT_ALLOW_MEDIA_REMOVAL  0x1E              ///< defined in ATAPI Removable Rewritable Media Devices
 #define ATA_CMD_MODE_SELECT                  0x55              ///< defined in ATAPI Removable Rewritable Media Devices
 
+#define ATA_CMD_MODE_SENSE6                         0x1A       ///< defined in ATAPI Removable Rewritable Media Devices
 #define ATA_CMD_MODE_SENSE                          0x5A       ///< defined in ATAPI Removable Rewritable Media Devices
 #define ATA_PAGE_CODE_READ_WRITE_ERROR              0x01       ///< defined in ATAPI Removable Rewritable Media Devices
 #define ATA_PAGE_CODE_CACHING_PAGE                  0x08       ///< defined in ATAPI Removable Rewritable Media Devices

--- a/MdePkg/Include/IndustryStandard/Atapi.h
+++ b/MdePkg/Include/IndustryStandard/Atapi.h
@@ -503,8 +503,6 @@ typedef union {
 #define ATA_CMD_PREVENT_ALLOW_MEDIA_REMOVAL  0x1E              ///< defined in ATAPI Removable Rewritable Media Devices
 #define ATA_CMD_MODE_SELECT                  0x55              ///< defined in ATAPI Removable Rewritable Media Devices
 
-// MU_CHANGE: Add some definitions for MODE SENSE (6-Byte) command
-#define ATA_CMD_MODE_SENSE6                         0x1A       ///< defined in ATAPI Removable Rewritable Media Devices
 #define ATA_CMD_MODE_SENSE                          0x5A       ///< defined in ATAPI Removable Rewritable Media Devices
 #define ATA_PAGE_CODE_READ_WRITE_ERROR              0x01       ///< defined in ATAPI Removable Rewritable Media Devices
 #define ATA_PAGE_CODE_CACHING_PAGE                  0x08       ///< defined in ATAPI Removable Rewritable Media Devices


### PR DESCRIPTION
## Description

This reverts the Mu SCSI Read Only Disk commit in favor of the edk2 commits.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A.

## Integration Instructions

N/A.
