### PR TITLE
[CHERRY-PICK] MdeModulePkg: Add PcdDelayedDispatchMaxEntries

### DIFF
--- a/MdeModulePkg/Core/Pei/Dispatcher/Dispatcher.c
+++ b/MdeModulePkg/Core/Pei/Dispatcher/Dispatcher.c
@@ -134,9 +134,15 @@ PeiDelayedDispatchRegister (
   }
 
   // Check for available entry slots
-  ASSERT (DelayedDispatchTable->Count <= DELAYED_DISPATCH_MAX_ENTRIES);
-  if (DelayedDispatchTable->Count == DELAYED_DISPATCH_MAX_ENTRIES) {
-    DEBUG ((DEBUG_ERROR, "%a Too many entries requested\n", __func__));
+  if (DelayedDispatchTable->Count >= PcdGet32 (PcdDelayedDispatchMaxEntries)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a DelayedDispatchTable->Count = %d. PcdDelayedDispatchMaxEntries (%d) is too small.\n",
+      __func__,
+      DelayedDispatchTable->Count,
+      PcdGet32 (PcdDelayedDispatchMaxEntries)
+      ));
+    ASSERT (DelayedDispatchTable->Count < PcdGet32 (PcdDelayedDispatchMaxEntries));
     Status = EFI_OUT_OF_RESOURCES;
     goto Exit;
   }
@@ -1833,7 +1839,7 @@ PeiDispatcher (
     if (GuidHob != NULL) {
       Private->DelayedDispatchTable = (DELAYED_DISPATCH_TABLE *)(GET_GUID_HOB_DATA (GuidHob));
     } else {
-      TableSize                     = sizeof (DELAYED_DISPATCH_TABLE) + ((DELAYED_DISPATCH_MAX_ENTRIES - 1) * sizeof (DELAYED_DISPATCH_ENTRY));
+      TableSize                     = sizeof (DELAYED_DISPATCH_TABLE) + (PcdGet32 (PcdDelayedDispatchMaxEntries) * sizeof (DELAYED_DISPATCH_ENTRY));
       Private->DelayedDispatchTable = BuildGuidHob (&gEfiDelayedDispatchTableGuid, TableSize);
       if (Private->DelayedDispatchTable != NULL) {
         ZeroMem (Private->DelayedDispatchTable, TableSize);

--- a/MdeModulePkg/Core/Pei/PeiMain.inf
+++ b/MdeModulePkg/Core/Pei/PeiMain.inf
@@ -123,6 +123,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdMigrateTemporaryRamFirmwareVolumes      ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdDelayedDispatchMaxDelayUs               ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdDelayedDispatchCompletionTimeoutUs      ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDelayedDispatchMaxEntries               ## CONSUMES
 
 # [BootMode]
 # S3_RESUME             ## SOMETIMES_CONSUMES

--- a/MdeModulePkg/Include/Guid/DelayedDispatch.h
+++ b/MdeModulePkg/Include/Guid/DelayedDispatch.h
@@ -1,7 +1,7 @@
 /** @file
   Definition for structure & defines exported by Delayed Dispatch PPI
 
-  Copyright (c), Microsoft Corporation.
+  Copyright (c) Microsoft Corporation.
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -14,11 +14,6 @@
 #define EFI_DELAYED_DISPATCH_TABLE_GUID  {\
   0x4b733449, 0x8eff, 0x488c, { 0x92, 0x1a, 0x15, 0x4a, 0xda, 0x25, 0x18, 0x07 } \
   }
-
-//
-// Maximal number of Delayed Dispatch entries supported
-//
-#define DELAYED_DISPATCH_MAX_ENTRIES  32  // MU_CHANGE: Set max delayed dispatch entries to 32
 
 //
 // Internal structure for delayed dispatch entries.
@@ -37,7 +32,7 @@ typedef struct {
 typedef struct {
   UINT32                    Count;
   UINT32                    DispCount;
-  DELAYED_DISPATCH_ENTRY    Entry[DELAYED_DISPATCH_MAX_ENTRIES];
+  DELAYED_DISPATCH_ENTRY    Entry[];   // Number of entries is based on PcdDelayedDispatchMaxEntries
 } DELAYED_DISPATCH_TABLE;
 
 #pragma pack (pop)

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -203,7 +203,7 @@
   ## @libraryclass  This library is used to report memory type information change
   ##                across a reboot.
   MemoryTypeInformationChangeLib|Include/Library/MemoryTypeInformationChangeLib.h
-  
+
   ## MU_CHANGE
   ##  @libraryclass  A public library interface for persisting Capsules across reset.
   #     This provides platform-defined support for persistence on architectures
@@ -484,7 +484,7 @@
 
   ## Include/Guid/EndofS3Resume.h
   gEdkiiEndOfS3ResumeGuid = { 0x96f5296d, 0x05f7, 0x4f3c, {0x84, 0x67, 0xe4, 0x56, 0x89, 0x0e, 0x0c, 0xb5 } }
-  
+
 
   #
   # Guids for NVMe Timeout Events
@@ -718,7 +718,7 @@
   # MU_CHANGE
   # This protocol provides access to Internal Event services that do not need TPL_APPLICATION
   gInternalEventServicesProtocolGuid = {0x7ecd162a, 0xc664, 0x11ec, { 0x9d, 0x64, 0x02, 0x42, 0xac, 0x12, 0x00, 0x02 } }
-  
+
   ## This protocol defines the generic memory test interfaces in Dxe phase.
   # Include/Protocol/GenericMemoryTest.h
   gEfiGenericMemTestProtocolGuid = { 0x309DE7F1, 0x7F5E, 0x4ACE, { 0xB4, 0x9C, 0x53, 0x1B, 0xE5, 0xAA, 0x95, 0xEF }}
@@ -1385,7 +1385,7 @@
   # Default is 2000, it represent delay is 2 ms.
   # @Prompt Delay access XHCI register after it issues HCRST (us)
   gEfiMdeModulePkgTokenSpaceGuid.PcdDelayXhciHCReset|2000|UINT16|0x30001060
-  
+
   # MU_CHANGE [BEGIN] - Support alternative hardware queue sizes in NVME driver
   gEfiMdeModulePkgTokenSpaceGuid.PcdSupportAlternativeQueueSize|FALSE|BOOLEAN|0x40000151
   # MU_CHANGE [END]
@@ -1399,9 +1399,9 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdFfaTxRxPageCount|1|UINT64|0x30001062
 
   # MU_CHANGE [BEGIN] - Support indefinite boot retries
-  # # Some platforms require that all EfiLoadOptions are retried until one of the options 
-  # # succeeds. When True, this Pcd will force Bds to retry all the valid EfiLoadOptions 
-  # # indefinitely until one of the options succeeds. 
+  # # Some platforms require that all EfiLoadOptions are retried until one of the options
+  # # succeeds. When True, this Pcd will force Bds to retry all the valid EfiLoadOptions
+  # # indefinitely until one of the options succeeds.
   # #   TRUE  - Efi boot options will be retried indefinitely.
   # #   FALSE - Efi boot options will not be retried.
   gEfiMdeModulePkgTokenSpaceGuid.PcdSupportInfiniteBootRetries|FALSE|BOOLEAN|0x40000152
@@ -1938,6 +1938,10 @@
   # @Prompt UFS device initial completion timoeout (us), default value is 600ms.
   gEfiMdeModulePkgTokenSpaceGuid.PcdUfsInitialCompletionTimeout|600000|UINT32|0x00000036
 
+  ## Delayed Dispatch Max Entries
+  # @Prompt Maximum number of delayed dispatch entries. Default value is 8.
+  gEfiMdeModulePkgTokenSpaceGuid.PcdDelayedDispatchMaxEntries|8|UINT32|0x00000037
+
   ## MU_CHANGE [BEGIN]
   ## This PCD holds the background color of progress bar.
   # Bit fields:
@@ -1948,7 +1952,6 @@
   # @Prompt Describes background color of progress bar.
   gEfiMdeModulePkgTokenSpaceGuid.PcdProgressBarBackgroundColor|0x00808080|UINT32|0x0000010B
   ## MU_CHANGE [END]
-
 [PcdsPatchableInModule, PcdsDynamic, PcdsDynamicEx]
   ## This PCD defines the Console output row. The default value is 25 according to UEFI spec.
   #  This PCD could be set to 0 then console output would be at max column and max row.
@@ -2516,7 +2519,7 @@
   ## The value of rate limiter event for timeout check. Default value is 100(unit 1ms).
   # @Prompt The value is use for Usb Network rate limiting supported.
   gEfiMdeModulePkgTokenSpaceGuid.PcdUsbNetworkRateLimitingFactor|100|UINT32|0x10000028
-  
+
   ## MU_CHANGE - Configuring timer interval in terminal DXE driver
   ## This PCD determines the timer interval to be set when using serial console.
   # @Prompt Sets the serial console timer interval, in the unit of 100ns.


### PR DESCRIPTION
## Description

The current fixed value of 8 for `DELAYED_DISPATCH_MAX_ENTRIES` is not large enough to accommodate platform usage. This change replaces the macro with a PCD that can be configured by platforms.

In the case the default PCD value is too small, an error message explaining that the PCD should be updated will be printed followed by an assert.

(cherry picked from commit 8a07311710acba244a1b44910324b3b4afd5889a)

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Tested on a a physical Intel platform that uses delayed dispatch

## Integration Instructions

- Adjust `gEfiMdeModulePkgTokenSpaceGuid.PcdDelayedDispatchMaxEntries` as needed to accommodate the number of delayed dispatch entries used by a platform.