### PR TITLE
Xhci DMA buffer Allocation fix

### DIFF
--- a/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
+++ b/MdeModulePkg/Bus/Pci/XhciDxe/XhciSched.c
@@ -1427,6 +1427,7 @@ XhciDelAsyncIntTransfer (
   LIST_ENTRY              *Next;
   URB                     *Urb;
   VOID                    *UrbData;
+  UINTN                   DataLen; // MU_CHANGE
   EFI_USB_DATA_DIRECTION  Direction;
   EFI_STATUS              Status;
 
@@ -1456,9 +1457,19 @@ XhciDelAsyncIntTransfer (
       // and allocates and manages its own data buffer, so free it here.
       //
       UrbData = Urb->Data;
+      DataLen = Urb->DataLen; // MU_CHANGE
       XhcFreeUrb (Xhc, Urb);
       if (UrbData != NULL) {
-        FreePool (UrbData);
+        // MU_CHANGE [BEGIN]
+        Status = Xhc->PciIo->FreeBuffer (Xhc->PciIo, EFI_SIZE_TO_PAGES (DataLen), UrbData);
+        if (EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_ERROR, "%a: failed to free buffer via PciIo\n", __func__));
+          ASSERT_EFI_ERROR (Status);
+          return EFI_SUCCESS;
+        }
+
+        // FreePool (UrbData);
+        // MU_CHANGE [END]
       }
 
       return EFI_SUCCESS;
@@ -1483,6 +1494,7 @@ XhciDelAllAsyncIntTransfers (
   LIST_ENTRY  *Next;
   URB         *Urb;
   VOID        *UrbData;
+  UINTN       DataLen; // MU_CHANGE
   EFI_STATUS  Status;
 
   BASE_LIST_FOR_EACH_SAFE (Entry, Next, &Xhc->AsyncIntTransfers) {
@@ -1503,9 +1515,17 @@ XhciDelAllAsyncIntTransfers (
     // and allocates and manages its own data buffer, so free it here.
     //
     UrbData = Urb->Data;
+    DataLen = Urb->DataLen; // MU_CHANGE
     XhcFreeUrb (Xhc, Urb);
     if (UrbData != NULL) {
-      FreePool (UrbData);
+      // MU_CHANGE [BEGIN]
+      Status = Xhc->PciIo->FreeBuffer (Xhc->PciIo, EFI_SIZE_TO_PAGES (DataLen), UrbData);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "%a: failed to free buffer via PciIo\n", __func__));
+      }
+
+      // FreePool (UrbData);
+      // MU_CHANGE [END]
     }
   }
 }
@@ -1541,11 +1561,32 @@ XhciInsertAsyncIntTransfer (
   VOID  *Data;
   URB   *Urb;
 
-  Data = AllocateZeroPool (DataLen);
-  if (Data == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: failed to allocate buffer\n", __func__));
+  // MU_CHANGE [BEGIN]
+  EFI_STATUS  Status;
+
+  Data = NULL;
+
+  Status = Xhc->PciIo->AllocateBuffer (
+                         Xhc->PciIo,
+                         AllocateAnyPages,
+                         EfiBootServicesData,
+                         EFI_SIZE_TO_PAGES (DataLen),
+                         &Data,
+                         0
+                         );
+  if (EFI_ERROR (Status) || (Data == NULL)) {
+    DEBUG ((DEBUG_ERROR, "%a: failed to allocate buffer via PciIo\n", __func__));
     return NULL;
   }
+
+  ZeroMem (Data, DataLen);
+
+  // Data = AllocateZeroPool (DataLen);
+  // if (Data == NULL) {
+  //   DEBUG ((DEBUG_ERROR, "%a: failed to allocate buffer\n", __func__));
+  //   return NULL;
+  // }
+  // MU_CHANGE [END]
 
   Urb = XhcCreateUrb (
           Xhc,
@@ -1562,7 +1603,14 @@ XhciInsertAsyncIntTransfer (
           );
   if (Urb == NULL) {
     DEBUG ((DEBUG_ERROR, "%a: failed to create URB\n", __func__));
-    FreePool (Data);
+    // MU_CHANGE [BEGIN]
+    Status = Xhc->PciIo->FreeBuffer (Xhc->PciIo, EFI_SIZE_TO_PAGES (DataLen), Data);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: failed to free buffer via PciIo\n", __func__));
+    }
+
+    // FreePool (Data);
+    // MU_CHANGE [END]
     return NULL;
   }
 


### PR DESCRIPTION
## Description

Changes Pool allocations to use the PciIo interface's AllocateBuffer routine

DMA buffers should be page aligned and always allocated with the appropriate PciIo interface.

On some platforms, where IoMmu is enabled it is possible that if two allocations occur within the same page, and one gets unmapped via PciIo->Unmap, it will also unmap the other allocated address.

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on physical arm platform.

## Integration Instructions

N/A