### PR TITLE
[REBASE & FF] Revert MU Changes In Favor of edk2 Commits

### DIFF
--- a/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
+++ b/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
@@ -260,12 +260,10 @@ DxeMain (
   ASSERT_EFI_ERROR (Status);
 
   //
-  // Setup Stack Guard
+  // Setup Exception Stack
   //
-  if (PcdGetBool (PcdCpuStackGuard)) {
-    Status = InitializeSeparateExceptionStacks (NULL, NULL);
-    ASSERT_EFI_ERROR (Status);
-  }
+  Status = InitializeSeparateExceptionStacks (NULL, NULL);
+  ASSERT_EFI_ERROR (Status);
 
   //
   // Initialize Debug Agent to support source level debug in DXE phase

--- a/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
+++ b/MdeModulePkg/Core/Dxe/DxeMain/DxeMain.c
@@ -246,7 +246,6 @@ DxeMain (
   EFI_VECTOR_HANDOFF_INFO       *VectorInfoList;
   EFI_VECTOR_HANDOFF_INFO       *VectorInfo;
   VOID                          *EntryPoint;
-  EFI_HOB_GUID_TYPE             *GuidHob2; // MU_CHANGE
 
   //
   // Setup the default exception handlers
@@ -263,22 +262,10 @@ DxeMain (
   //
   // Setup Stack Guard
   //
-  // MU_CHANGE START: Check Memory Protection HOB, don't ASSERT if the exception stack init returns unsupported
-  // if (PcdGetBool (PcdCpuStackGuard)) {
-  GuidHob2 = GetFirstGuidHob (&gDxeMemoryProtectionSettingsGuid);
-  if ((GuidHob2 != NULL) &&
-      (((DXE_MEMORY_PROTECTION_SETTINGS *)GET_GUID_HOB_DATA (GuidHob2))->StructVersion == (UINT8)DXE_MEMORY_PROTECTION_SETTINGS_CURRENT_VERSION) &&
-      ((DXE_MEMORY_PROTECTION_SETTINGS *)GET_GUID_HOB_DATA (GuidHob2))->CpuStackGuard)
-  {
+  if (PcdGetBool (PcdCpuStackGuard)) {
     Status = InitializeSeparateExceptionStacks (NULL, NULL);
-    ASSERT (Status == EFI_UNSUPPORTED || !EFI_ERROR (Status));
-    if (EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_ERROR, "%a: Failed to create exception stacks!\n", __func__));
-    }
+    ASSERT_EFI_ERROR (Status);
   }
-
-  // }
-  // MU_CHANGE END
 
   //
   // Initialize Debug Agent to support source level debug in DXE phase
@@ -302,10 +289,7 @@ DxeMain (
   // Start the Image Services.
   //
   Status = CoreInitializeImageServices (HobStart);
-  // MU_CHANGE START Assert Status but omit EFI_NOT_READY as it just implies gCPU is not yet installed
-  if (Status != EFI_NOT_READY) {
-    ASSERT_EFI_ERROR (Status);
-  }
+  ASSERT_EFI_ERROR (Status);
 
   // MU_CHANGE START: Add initialization of the memory protection special region protocol to support
   //                  applying specific settings to memory regions during protection initialization

--- a/MdeModulePkg/Core/Dxe/Image/Image.c
+++ b/MdeModulePkg/Core/Dxe/Image/Image.c
@@ -277,18 +277,7 @@ CoreInitializeImageServices (
 
   InitializeListHead (&mAvailableEmulators);
 
-  // MU_CHANGE START Use Image Failure Status Code
-  Status = ProtectUefiImage (&Image->Info, Image->LoadedImageDevicePath);
-
-  // Omit EFI_NOT_READY as it just implies gCPU is not yet installed
-  if (EFI_ERROR (Status) && (Status != EFI_NOT_READY)) {
-    REPORT_STATUS_CODE (
-      EFI_ERROR_CODE | EFI_ERROR_MAJOR,
-      (EFI_SOFTWARE_DXE_CORE | EFI_SW_DXE_CORE_EC_IMAGE_LOAD_FAILURE)
-      );
-  }
-
-  // MU_CHANGE END
+  ProtectUefiImage (&Image->Info, Image->LoadedImageDevicePath);
 
   return Status;
 }
@@ -1510,17 +1499,7 @@ CoreLoadImageCommon (
     }
   }
 
-  // MU_CHANGE START Use enhanced ProtectUefiImage
-  Status = ProtectUefiImage (&Image->Info, Image->LoadedImageDevicePath);
-
-  // Set to unload if ProtectUefiImage returned an error other than EFI_NOT_READY
-  // which implies the CPU Arch Protocol has not yet been installed
-  Status = (Status == EFI_NOT_READY) ? EFI_SUCCESS : Status;
-  if (EFI_ERROR (Status)) {
-    goto Done;
-  }
-
-  // MU_CHANGE END
+  ProtectUefiImage (&Image->Info, Image->LoadedImageDevicePath);
 
   //
   // Success.  Return the image handle

--- a/MdeModulePkg/Core/Dxe/Image/Image.c
+++ b/MdeModulePkg/Core/Dxe/Image/Image.c
@@ -277,7 +277,20 @@ CoreInitializeImageServices (
 
   InitializeListHead (&mAvailableEmulators);
 
-  ProtectUefiImage (&Image->Info, Image->LoadedImageDevicePath);
+  // MU_CHANGE START Use Image Failure Status Code
+  Status = ProtectUefiImage (&Image->Info, Image->LoadedImageDevicePath);
+
+  // Omit EFI_NOT_READY as it just implies gCPU is not yet installed
+  Status = (Status == EFI_NOT_READY) ? EFI_SUCCESS : Status;
+
+  if (EFI_ERROR (Status)) {
+    REPORT_STATUS_CODE (
+      EFI_ERROR_CODE | EFI_ERROR_MAJOR,
+      (EFI_SOFTWARE_DXE_CORE | EFI_SW_DXE_CORE_EC_IMAGE_LOAD_FAILURE)
+      );
+  }
+
+  // MU_CHANGE END
 
   return Status;
 }
@@ -1499,7 +1512,17 @@ CoreLoadImageCommon (
     }
   }
 
-  ProtectUefiImage (&Image->Info, Image->LoadedImageDevicePath);
+  // MU_CHANGE START Use enhanced ProtectUefiImage
+  Status = ProtectUefiImage (&Image->Info, Image->LoadedImageDevicePath);
+
+  // Set to unload if ProtectUefiImage returned an error other than EFI_NOT_READY
+  // which implies the CPU Arch Protocol has not yet been installed
+  Status = (Status == EFI_NOT_READY) ? EFI_SUCCESS : Status;
+  if (EFI_ERROR (Status)) {
+    goto Done;
+  }
+
+  // MU_CHANGE END
 
   //
   // Success.  Return the image handle

--- a/MdeModulePkg/Library/CpuExceptionHandlerLibNull/CpuExceptionHandlerLibNull.c
+++ b/MdeModulePkg/Library/CpuExceptionHandlerLibNull/CpuExceptionHandlerLibNull.c
@@ -102,5 +102,5 @@ InitializeSeparateExceptionStacks (
   IN OUT UINTN  *BufferSize
   )
 {
-  return EFI_UNSUPPORTED;
+  return EFI_SUCCESS;
 }

--- a/UefiCpuPkg/CpuDxe/CpuDxe.inf
+++ b/UefiCpuPkg/CpuDxe/CpuDxe.inf
@@ -95,7 +95,6 @@
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdPteMemoryEncryptionAddressOrMask    ## CONSUMES
   # MU_CHANGE START Remove memory protection PCD references
-  # gEfiMdeModulePkgTokenSpaceGuid.PcdCpuStackGuard                       ## CONSUMES
   # gEfiMdeModulePkgTokenSpaceGuid.PcdHeapGuardPropertyMask               ## CONSUMES
   # gEfiMdeModulePkgTokenSpaceGuid.PcdNullPointerDetectionPropertyMask    ## CONSUMES
   # MU_CHANGE END

--- a/UefiCpuPkg/CpuDxe/CpuMp.c
+++ b/UefiCpuPkg/CpuDxe/CpuMp.c
@@ -761,11 +761,9 @@ InitializeMpExceptionHandlers (
   }
 
   //
-  // Setup stack switch for Stack Guard feature.
+  // Setup stack switch for Stack Guard feature and separate AP GDTs.
   //
-  if (PcdGetBool (PcdCpuStackGuard)) {
-    InitializeMpExceptionStackSwitchHandlers ();
-  }
+  InitializeMpExceptionStackSwitchHandlers ();
 }
 
 /**

--- a/UefiCpuPkg/CpuDxe/CpuMp.c
+++ b/UefiCpuPkg/CpuDxe/CpuMp.c
@@ -760,13 +760,12 @@ InitializeMpExceptionHandlers (
     RegisterCpuInterruptHandler (EXCEPT_IA32_PAGE_FAULT, PageFaultExceptionHandler);
   }
 
-  // MU_CHANGE: Start Prevent AP Deadlock
   //
   // Setup stack switch for Stack Guard feature.
   //
-  // if (PcdGetBool (PcdCpuStackGuard)) {
-  InitializeMpExceptionStackSwitchHandlers ();
-  // }
+  if (PcdGetBool (PcdCpuStackGuard)) {
+    InitializeMpExceptionStackSwitchHandlers ();
+  }
 }
 
 /**

--- a/UefiCpuPkg/CpuMpPei/CpuMpPei.c
+++ b/UefiCpuPkg/CpuMpPei/CpuMpPei.c
@@ -69,7 +69,8 @@ InitializeExceptionStackSwitchHandlers (
 }
 
 /**
-  Initializes MP exceptions handlers for the sake of stack switch requirement.
+  Initializes MP exceptions handlers for the sake of stack switch requirement and giving the APs
+  their own GDTs.
 
   This function will allocate required resources required to setup stack switch
   and pass them through SwitchStackData to each logic processor.
@@ -86,10 +87,6 @@ InitializeMpExceptionStackSwitchHandlers (
   UINTN                           BufferSize;
   EFI_STATUS                      Status;
   UINT8                           *Buffer;
-
-  if (!PcdGetBool (PcdCpuStackGuard)) {
-    return;
-  }
 
   Status = MpInitLibGetNumberOfProcessors (&NumberOfProcessors, NULL);
   ASSERT_EFI_ERROR (Status);

--- a/UefiCpuPkg/CpuMpPei/CpuMpPei.c
+++ b/UefiCpuPkg/CpuMpPei/CpuMpPei.c
@@ -87,11 +87,9 @@ InitializeMpExceptionStackSwitchHandlers (
   EFI_STATUS                      Status;
   UINT8                           *Buffer;
 
-  // MU_CHANGE START: Prevent AP Deadlock
-  // if (!PcdGetBool (PcdCpuStackGuard)) {
-  //   return;
-  // }
-  // MU_CHANGE END: Prevent AP Deadlock
+  if (!PcdGetBool (PcdCpuStackGuard)) {
+    return;
+  }
 
   Status = MpInitLibGetNumberOfProcessors (&NumberOfProcessors, NULL);
   ASSERT_EFI_ERROR (Status);

--- a/UefiCpuPkg/Library/MpInitLib/MpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/MpLib.c
@@ -278,8 +278,30 @@ RestoreVolatileRegisters (
   {
     Tss = (IA32_TSS_DESCRIPTOR *)(VolatileRegisters->Gdtr.Base +
                                   VolatileRegisters->Tr);
-    if (Tss->Bits.P == 1) {
-      Tss->Bits.Type &= 0xD;  // 1101 - Clear busy bit just in case
+
+    if ((Tss->Bits.P == 1) && ((Tss->Bits.Type & BIT1) == 0)) {
+      // TR is used to enable a separate safe stack when a stack overflow occurs.
+      // When PEI starts up the APs, TR is non-zero and so each processor has its
+      // own GDT. TR is an offset into the GDT and so points to a different TSS entry
+      // in each AP.
+      // There is a small window in early DXE after MpInitLibInitialize() is called
+      // where:
+      // - TR is non-zero because it has been inherited from the PEI phase
+      // - TR is not restored to 0
+      // - The APs are all switched to using the BSP's GDT
+      // - SaveVolatileRegisters() is called from ApWakeupFunction() before the APs
+      //   go to sleep, which saves the non-zero TR value to CpuMpData->CpuData[].VolatileRegisters.Tr,
+      //   cause TR to point to the same TSS entry in the BSP's GDT
+      // - The next time the APs are woken up, RestoreVolatileRegisters() is called
+      //   from ApWakeupFunction() which would attempt to load the non-zero TR value into the actual
+      //   task register, which creates a race condition to a #GP fault because loading the task
+      //   register sets the busy bit in the TSS descriptor and a #GP fault occurs if the busy bit
+      //   is already set when loading the task register.
+      //
+      // To avoid this issue, the task register is only loaded if TR is non-zero and the
+      // TSS descriptor is valid and not busy. HW sets the busy bit and does not clear it. edk2 does
+      // not clear the busy bit, so the BSP's TSS descriptor will be marked busy forever and the APs
+      // will not load the task register until they have their own GDT/TSS set up.
       AsmWriteTr (VolatileRegisters->Tr);
     }
   }

--- a/UefiCpuPkg/Library/MpInitLib/MpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/MpLib.c
@@ -2431,25 +2431,6 @@ MpInitLibInitialize (
     }
   }
 
-  // MU_CHANGE: START Prevent AP Deadlock
-  // After we have executed the APs for the first time, we need to set their TR back to 0 so they do not attempt
-  // to set it on the next wakeup. At this point, the APs are still sharing the GDT/TSS with the BSP. There is a
-  // race condition here where the APs might try to set the TR in quick succession, where the first one sets it
-  // causing the busy bit in the TSS to get set after the next AP has cleared the busy bit. When the second AP
-  // attempts to set the TR, it will GP fault because the busy bit is set. After MpInitLibInitialize() completes,
-  // the next AP wakeup will cause the AP to load its own GDT/TSS, so this contention cannot occur. However, in the
-  // wakeup to switch contexts, we must ensure the APs do not attempt to set the TR as it can fault before they are
-  // able to execute the function to switch GDT/TSS.
-  for (Index = 0; Index < CpuMpData->CpuCount; Index++) {
-    if (Index == CpuMpData->BspNumber) {
-      continue;
-    }
-
-    CpuMpData->CpuData[Index].VolatileRegisters.Tr = 0;
-  }
-
-  // MU_CHANGE: END Prevent AP Deadlock
-
   //
   // Dump the microcode revision for each core.
   //

--- a/UefiCpuPkg/MpDxe/MpDxe.c
+++ b/UefiCpuPkg/MpDxe/MpDxe.c
@@ -815,7 +815,12 @@ InitializeMpExceptionHandlers (
   //
   // Setup stack switch for Stack Guard feature.
   //
-  InitializeMpExceptionStackSwitchHandlers ();
+  // MU_CHANGE START Update to use memory protection settings HOB
+  // if (PcdGetBool (PcdCpuStackGuard)) {
+  if (gDxeMps.CpuStackGuard) {
+    // MU_CHANGE END
+    InitializeMpExceptionStackSwitchHandlers ();
+  }
 }
 
 /**

--- a/UefiCpuPkg/MpDxe/MpDxe.c
+++ b/UefiCpuPkg/MpDxe/MpDxe.c
@@ -815,12 +815,7 @@ InitializeMpExceptionHandlers (
   //
   // Setup stack switch for Stack Guard feature.
   //
-  // MU_CHANGE START Update to use memory protection settings HOB
-  // if (PcdGetBool (PcdCpuStackGuard)) {
-  if (gDxeMps.CpuStackGuard) {
-    // MU_CHANGE END
-    InitializeMpExceptionStackSwitchHandlers ();
-  }
+  InitializeMpExceptionStackSwitchHandlers ();
 }
 
 /**


### PR DESCRIPTION
## Description

This bit tangled PR consists of the following:
- Reverting the MP Lib Task Register Set MU_CHANGE in favor of the edk2 commits fixing it
- Reverting (and dropping) a MU_CHANGE to DxeMain that is no longer required
- Reverting and reapplying with a fixup a different MU_CHANGE to allow us to fully drop the previous MU_CHANGE

The cherry-picks did not apply completely cleanly, I already was doing a lot of reverts and reapplying here, so I chose to just do the small fixups in the cherry-picks and in the next integration we can resolve them; they are trivial.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Cherry-picks from edk2 were tested on physical Intel platforms.

## Integration Instructions

N/A.
