### PR TITLE
[CHERRY-PICK] UefiCpuPkg/PeiMpLib: Only allocate ACPI NVS AP loop code buffer on S3

### DIFF
--- a/UefiCpuPkg/Library/MpInitLib/PeiMpLib.c
+++ b/UefiCpuPkg/Library/MpInitLib/PeiMpLib.c
@@ -478,11 +478,24 @@ InitMpGlobalData (
   IN CPU_MP_DATA  *CpuMpData
   )
 {
-  EFI_STATUS  Status;
+  EFI_STATUS     Status;
+  EFI_BOOT_MODE  BootMode;
 
   BuildMicrocodeCacheHob (CpuMpData);
   SaveCpuMpData (CpuMpData);
-  PrepareApLoopCode (CpuMpData);
+
+  Status = PeiServicesGetBootMode (&BootMode);
+  ASSERT_EFI_ERROR (Status);
+
+  if (!EFI_ERROR (Status) && (BootMode == BOOT_ON_S3_RESUME)) {
+    //
+    // Only allocate the AP loop code buffer on S3 resume.
+    // This allocates ACPI NVS memory which is a RT visible memory type that
+    // remains fragmented against the overall EfiACPIMemoryNVS memory bucket
+    // allocated by the DXE Core.
+    //
+    PrepareApLoopCode (CpuMpData);
+  }
 
   ///
   /// Install Notify


### PR DESCRIPTION
## Description

This commit allocated an ACPI NVS buffer in PEI:
https://github.com/tianocore/edk2/commit/cdc1a88272237149003d1d1ea301d320f7b3bdf6

This is a RT visible memory type that remains fragmented against the overall `EfiACPIMemoryNVS` memory bucket allocated by the DXE Core. The code now only calls `PrepareApLoopCode()` on S3 boot to prevent the buffer from being allocated outside of S3.

(cherry picked from commit db4d32390911e393033d69b0d0dfbfa3e8c0f1f7)

- [X] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Check memory buckets reported on the system before and after the change on a non-S3 boot

## Integration Instructions

- N/A