### PR TITLE
Add Repo Remote Check Plugin

### DIFF
--- a/.pytool/Plugin/RepoRemoteCheck/ReadMe.md
+++ b/.pytool/Plugin/RepoRemoteCheck/ReadMe.md
@@ -1,0 +1,185 @@
+# Repository Remote Check - Pre-Build Git Repository Validation Plugin
+
+This plugin validates git repositories against remote commit criteria before the build starts. It allows you to define
+rules that check whether the current HEAD commit in specified repositories is present or absent in specified remote
+URLs.
+
+This is useful for enforcing that your local repositories are using commits from the correct upstream sources, and
+not from incompatible forks or remotes. For example, some workspaces might use a "public" and an "internal" upstream
+and need to verify that both work as expected when used for a given platform build.
+
+**Important**:
+
+- This check verifies commit hashes. Therefore, the hashes will need to be consistent between the two repositories
+  being compared.
+- This plugin is enabled by adding the `remote_repo_check` scope to the scopes reported by the platform in
+  `GetActiveScopes()`. It is NOT enabled by default (i.e. it does not use the `global` scope).
+
+## Integration Instructions
+
+This plugin serves a special purpose so it is not enabled by default. As mentioned above, it is enabled by activating
+the `remote_repo_check` scope. You can enable only running this plugin in a server-side CI build, by adding the
+following logic to the `GetActiveScopes()` implementation:
+
+```python
+        # Add remote_repo_check scope if running in server CI.
+        #   - TF_BUILD is set by Azure DevOps pipelines
+        #   - GITHUB_ACTIONS is set in GitHub workflow execution
+        if os.environ.get('TF_BUILD') or os.environ.get('GITHUB_ACTIONS'):
+            ps.extend(['remote_repo_check'])
+```
+
+This is recommended to allow developers to customize the repo (e.g. submodule) as needed locally while developing and
+testing.
+
+## Configuration
+
+The plugin can be configured via a YAML or JSON configuration file. The configuration file path can be provided in two
+ways:
+
+1. **Command line**: `REPO_REMOTE_CHECK_CONFIG_PATH=<PATH>`
+2. **PlatformBuild.py**: In the `SetPlatformEnv()` method:
+
+   ```python
+   self.env.SetValue("REPO_REMOTE_CHECK_CONFIG_PATH", <PATH>, "Platform Hardcoded")
+   ```
+
+If no configuration path is provided, the plugin looks for `RepoRemoteCheckConfig.yml` in the workspace root. If this
+file is not found, the plugin exits successfully and does not perform any validation.
+
+## Configuration File Format
+
+The configuration file defines a list of repositories and their validation conditions for the current `HEAD` commit
+in that repository path.
+
+### YAML Example
+
+```yaml
+repositories:
+  - path: "Common/MU_BASECORE"
+    conditions:
+      - type: "present_in_remote"
+        remote: "https://github.com/microsoft/mu_basecore.git"
+      - type: "not_present_in_remote"
+        remote: "https://github.com/tianocore/edk2.git"
+
+  - path: "Silicon/INTEL/IntelSiliconPkg"
+    conditions:
+      - type: "present_in_remote"
+        remote: "https://github.com/tianocore/edk2-platforms.git"
+```
+
+### JSON Example
+
+```json
+{
+  "repositories": [
+    {
+      "path": "Common/MU_BASECORE",
+      "conditions": [
+        {
+          "type": "present_in_remote",
+          "remote": "https://github.com/microsoft/mu_basecore.git"
+        },
+        {
+          "type": "not_present_in_remote",
+          "remote": "https://github.com/tianocore/edk2.git"
+        }
+      ]
+    },
+    {
+      "path": "Silicon/INTEL/IntelSiliconPkg",
+      "conditions": [
+        {
+          "type": "present_in_remote",
+          "remote": "https://github.com/tianocore/edk2-platforms.git"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Configuration Keys
+
+### Top Level
+
+- **repositories** (required): A list of repository configurations
+
+### Repository Level
+
+- **path** (required): Relative path from workspace root to the repository directory
+- **conditions** (optional): A list of conditions to check against this repository
+
+### Condition Level
+
+- **type** (required): The type of check to perform. Valid values are:
+  - `present_in_remote`: Verifies that the current `HEAD` commit exists in the specified remote
+  - `not_present_in_remote`: Verifies that the current `HEAD` commit does NOT exist in the specified remote
+- **remote** (required): The remote git URL to check against
+
+## How It Works
+
+1. The plugin reads the configuration file
+2. For each repository in the configuration:
+   - Validates that the repository path exists
+   - Validates that the path is a git repository
+   - Gets the current `HEAD` commit SHA in the local repository
+   - Evaluates each condition for the repository path
+     - Validates that the result matches the condition type
+3. Returns success (`0`) if all conditions pass, failure (`1`) if any condition
+   fails
+
+**Note:** The plugin checks if a commit is *reachable* from any branch in the
+remote repository. This means the commit must exist in the remote's history and
+be part of at least one branch. Commits that exist in the remote but are not
+part of any branch (orphaned commits, dangling commits) will not be detected.
+
+## Common Errors
+
+### Repository path does not exist: \<path\>
+
+The specified repository path does not exist in the workspace. Check that:
+
+- The path is correct and relative to the workspace root
+- The repository has been cloned/initialized
+- Stuart dependencies have been fetched
+
+### Path is not a valid git repository: \<path\>
+
+The specified path exists but is not a git repository. Ensure:
+
+- The path points to a directory containing a `.git` folder
+- The repository was properly initialized
+
+### CONDITION FAILED: Repository '\<path\>' commit \<sha\> is NOT present in remote '\<url\>' (expected: present)
+
+The current `HEAD` commit in the repository does not exist in the specified remote,
+or is not reachable from any branch in that remote. This could mean:
+
+- You're using a local commit that hasn't been pushed
+- You're using a commit from a different fork
+- The repository is on the wrong branch/commit
+- The commit exists but is not part of any branch (orphaned/dangling commit)
+
+**Solution**: Check the commit history and ensure you're using the correct commit
+from the expected remote.
+
+### CONDITION FAILED: Repository '\<path\>' commit \<sha\> IS present in remote '\<url\>' (expected: not present)
+
+The current `HEAD` commit exists in a remote where it shouldn't, and is reachable
+from at least one branch in that remote. This could mean:
+
+- You're accidentally using commits from an incompatible upstream
+- The repository is tracking the wrong remote
+
+**Solution**: Verify the repository's current state and rebase/reset to the
+correct commit.
+
+### Invalid git remote URL: \<url\>
+
+The specified remote URL is not a valid git repository URL. Check:
+
+- The URL is correct and accessible
+- You have network connectivity
+- Authentication is properly configured if the remote requires it

--- a/.pytool/Plugin/RepoRemoteCheck/RepoRemoteCheck.py
+++ b/.pytool/Plugin/RepoRemoteCheck/RepoRemoteCheck.py
@@ -1,0 +1,312 @@
+# @file RepoRemoteCheck.py
+#
+# Plugin that validates git repositories against remote criteria.
+#
+##
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+import logging
+import os
+import uuid
+import yaml
+from datetime import datetime
+from edk2toolext.environment.plugintypes.uefi_build_plugin import (
+    IUefiBuildPlugin
+)
+from typing import Dict, Any
+from git import Repo, GitCommandError
+
+DEFAULT_CONFIG_FILE = "RepoRemoteCheckConfig.yml"
+
+
+class RepoRemoteCheck(IUefiBuildPlugin):
+    """Plugin to validate git repositories against remote commit criteria.
+
+    This plugin checks whether commits in specified git repositories are
+    present or absent in specified remote URLs based on configuration rules.
+    """
+
+    def __init__(self):
+        """Initialize the RepoRemoteCheck plugin."""
+        pass
+
+    def do_pre_build(self, thebuilder):
+        """Execute the repository remote check before the build.
+
+        Args:
+            thebuilder: The build environment object
+
+        Returns:
+            int: 0 on success, 1 on failure
+        """
+        starttime = datetime.now()
+        logging.info("-" * 57)
+        logging.info("----------- Repo Remote Check Starting -----------")
+        logging.info("-" * 57)
+
+        # Load the configuration file
+        config_path = thebuilder.env.GetValue(
+            "REPO_REMOTE_CHECK_CONFIG_PATH", None)
+        if config_path is None:
+            # Use default configuration file in workspace root
+            config_path = os.path.join(thebuilder.ws, DEFAULT_CONFIG_FILE)
+            if not os.path.isfile(config_path):
+                logging.info(
+                    "REPO_REMOTE_CHECK_CONFIG_PATH not set and default "
+                    f"config '{DEFAULT_CONFIG_FILE}' not found. Skipping "
+                    "repository remote check.")
+                return 0
+            logging.info(f"Using default configuration: {config_path}")
+        elif not os.path.isfile(config_path):
+            logging.error(
+                "Invalid REPO_REMOTE_CHECK_CONFIG_PATH. "
+                f"File not found: {config_path}")
+            return 1
+
+        # Parse the configuration file
+        try:
+            with open(config_path, 'r') as f:
+                if config_path.endswith('.json'):
+                    import json
+                    config_data = json.load(f)
+                else:
+                    config_data = yaml.safe_load(f)
+        except Exception as e:
+            logging.error(
+                f"Error parsing configuration file "
+                f"{config_path}: {e}")
+            return 1
+
+        # Validate the overal configuration structure
+        if not config_data or 'repositories' not in config_data:
+            logging.error(
+                "Configuration file must contain a 'repositories' key")
+            return 1
+
+        repositories = config_data.get('repositories', [])
+        if not isinstance(repositories, list):
+            logging.error("'repositories' must be a list")
+            return 1
+
+        # Process each repository
+        failed = False
+        for repo_config in repositories:
+            if not self._check_repository(thebuilder.ws, repo_config):
+                failed = True
+
+        endtime = datetime.now()
+        elapsed = endtime - starttime
+
+        if failed:
+            logging.error("-" * 57)
+            logging.error("----------- Repo Remote Check Failed -----------")
+            logging.error(
+                f"----------- {elapsed.total_seconds():.2f}s "
+                "elapsed -----------")
+            logging.error("-" * 57)
+            return 1
+
+        logging.info("-" * 57)
+        logging.info("----------- Repo Remote Check Passed -----------")
+        logging.info(
+            f"----------- {elapsed.total_seconds():.2f}s "
+            "elapsed -----------")
+        logging.info("-" * 57)
+        return 0
+
+    def _check_repository(self, workspace_root: str,
+                          repo_config: Dict[str, Any]) -> bool:
+        """Check a single repository against its configured conditions.
+
+        Args:
+            workspace_root: The root workspace path
+            repo_config: Dictionary containing repository configuration
+
+        Returns:
+            bool: True if all conditions pass, False otherwise
+        """
+        # Validate repository configuration
+        if 'path' not in repo_config:
+            logging.error("Repository configuration missing 'path' key")
+            return False
+
+        repo_path = repo_config['path']
+        abs_repo_path = os.path.join(workspace_root, repo_path)
+
+        # Check if the repo path exists
+        if not os.path.exists(abs_repo_path):
+            logging.error(f"Repository path does not exist: {repo_path}")
+            return False
+
+        # Check if the repo path is a git repository
+        try:
+            repo = Repo(abs_repo_path)
+        except Exception as e:
+            logging.error(
+                f"Path is not a valid git repository: "
+                f"{repo_path} - {e}")
+            return False
+
+        # Get the current HEAD commit
+        try:
+            current_commit = repo.head.commit.hexsha
+            logging.debug(
+                f"Repository {repo_path}: "
+                f"Current HEAD is {current_commit[:8]}")
+        except Exception as e:
+            logging.error(
+                f"Failed to get HEAD commit for {repo_path}: {e}")
+            return False
+
+        # Get all conditions for this repo
+        conditions = repo_config.get('conditions', [])
+        if not isinstance(conditions, list):
+            logging.error(
+                f"'conditions' must be a list for repository {repo_path}")
+            return False
+
+        if not conditions:
+            logging.warning(
+                f"No conditions specified for repository "
+                f"{repo_path}, skipping")
+            return True
+
+        # Check each condition
+        all_passed = True
+        for condition in conditions:
+            if not self._check_condition(
+                    repo, repo_path, current_commit, condition):
+                all_passed = False
+
+        return all_passed
+
+    def _check_condition(self, repo: Repo, repo_path: str, commit_sha: str,
+                         condition: Dict[str, Any]) -> bool:
+        """Check a single condition against a repository.
+
+        Args:
+            repo: GitPython Repo object
+            repo_path: Display path for the repository
+            commit_sha: The commit SHA to check
+            condition: Dictionary containing condition configuration
+
+        Returns:
+            bool: True if condition passes, False otherwise
+        """
+        if 'type' not in condition:
+            logging.error(
+                f"Condition missing 'type' key for repository {repo_path}")
+            return False
+
+        condition_type = condition['type']
+        remote_url = condition.get('remote')
+
+        if not remote_url:
+            logging.error(
+                f"Condition missing 'remote' key for repository {repo_path}")
+            return False
+
+        # Check if the commit exists in the remote
+        try:
+            commit_in_remote = self._is_commit_in_remote(
+                repo, commit_sha, remote_url)
+        except Exception as e:
+            logging.error(
+                f"Error checking remote {remote_url} for repository "
+                f"{repo_path}: {e}")
+            return False
+
+        # Evaluate the condition
+        if condition_type == "present_in_remote":
+            if not commit_in_remote:
+                logging.error(
+                    f"CONDITION FAILED: Repository '{repo_path}' "
+                    f"commit {commit_sha[:8]} is NOT present in remote "
+                    f"'{remote_url}' (expected: present)")
+                return False
+            logging.info(
+                f"Repository '{repo_path}' commit {commit_sha[:8]} "
+                f"is present in remote '{remote_url}'")
+            return True
+
+        elif condition_type == "not_present_in_remote":
+            if commit_in_remote:
+                logging.error(
+                    f"CONDITION FAILED: Repository '{repo_path}' "
+                    f"commit {commit_sha[:8]} IS present in remote "
+                    f"'{remote_url}' (expected: not present)")
+                return False
+            logging.info(
+                f"Repository '{repo_path}' commit {commit_sha[:8]} "
+                f"is NOT present in remote '{remote_url}'")
+            return True
+
+        else:
+            logging.error(
+                f"Unknown condition type '{condition_type}' for repository "
+                f"{repo_path}. Valid types: 'present_in_remote', "
+                "'not_present_in_remote'")
+            return False
+
+    def _is_commit_in_remote(self, repo: Repo, commit_sha: str,
+                             remote_url: str) -> bool:
+        """Check if a commit exists in a remote repository.
+
+        Args:
+            repo: GitPython Repo object
+            commit_sha: The commit SHA to check
+            remote_url: The remote URL to check against
+
+        Returns:
+            bool: True if commit exists in remote, False otherwise
+
+        Raises:
+            Exception: If there's an error accessing the remote
+        """
+        try:
+            # Use git branch -r --contains to check if commit exists
+            # Fetch from the remote (with depth limited to avoid fetching
+            # everything). A temporary remote name is used to avoid
+            # potential naming conflicts.
+            temp_remote_name = f"temp_remote_{uuid.uuid4().hex[:8]}"
+
+            try:
+                repo.git.remote('add', temp_remote_name, remote_url)
+                repo.git.fetch(temp_remote_name, '--quiet')
+
+                # Check if the commit exists in any remote branch
+                # git branch -r --contains returns a list of branches
+                # containing the commit. If the list is empty, then
+                # the commit doesn't exist on the remote.
+                try:
+                    result = repo.git.branch(
+                        '-r',
+                        '--contains',
+                        commit_sha,
+                        f'{temp_remote_name}/*'
+                    )
+                    return bool(result.strip())
+                except GitCommandError:
+                    # Command failed, likely because the commit doesn't exist
+                    return False
+
+            finally:
+                try:
+                    repo.git.remote('remove', temp_remote_name)
+                except Exception:
+                    pass
+
+        except GitCommandError as e:
+            if "does not appear to be a git repository" in str(e).lower():
+                raise Exception(f"Invalid git remote URL: {remote_url}")
+            elif ("could not read" in str(e).lower() or
+                  "failed to connect" in str(e).lower() or
+                  "authentication failed" in str(e).lower()):
+                raise Exception(
+                    f"Failed to connect to remote: {remote_url}")
+            else:
+                raise Exception(f"Git error checking remote: {e}")
+        except Exception as e:
+            raise Exception(f"Unexpected error checking remote: {e}")

--- a/.pytool/Plugin/RepoRemoteCheck/RepoRemoteCheck_plug_in.yaml
+++ b/.pytool/Plugin/RepoRemoteCheck/RepoRemoteCheck_plug_in.yaml
@@ -1,0 +1,11 @@
+## @file
+# Checks that a git repository meets certain remote URL criteria.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+{
+    "scope": "remote_repo_check",
+    "name": "Repository Remote Check Plugin",
+    "module": "RepoRemoteCheck"
+}


### PR DESCRIPTION
## Description

Adds a plugin that is not active by default but can be opted into that validates git repositories against remote commit criteria before the build starts. It allows you to define rules that check whether the current HEAD commit in specified repositories is present or absent in specified remote URLs.

This is useful for enforcing that your local repositories are using commits from the correct upstream sources, and not from incompatible forks or remotes. For example, some workspaces might use a "public" and an "internal" upstream and need to verify that both work as expected and are set to the appropriate upstream when used for a given platform build.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?

## How This Was Tested

- Verify that the plugin does not run unless the scope is set
- Verify JSON and YAML files can be parsed
- Verify repo check logic returns expected results

## Integration Instructions

- See the plugin readme file