### PR TITLE
[CHERRY-PICK] NetworkPkg/SnpDxe: Update SnpDxe SNP_DRIVER struct out of DMA-able memory

### DIFF
--- a/NetworkPkg/SnpDxe/Mcast_ip_to_mac.c
+++ b/NetworkPkg/SnpDxe/Mcast_ip_to_mac.c
@@ -35,20 +35,25 @@ PxeIp2Mac (
   PXE_CPB_MCAST_IP_TO_MAC  *Cpb;
   PXE_DB_MCAST_IP_TO_MAC   *Db;
 
-  Cpb              = Snp->Cpb;
-  Db               = Snp->Db;
-  Snp->Cdb.OpCode  = PXE_OPCODE_MCAST_IP_TO_MAC;
-  Snp->Cdb.OpFlags = (UINT16)(IPv6 ? PXE_OPFLAGS_MCAST_IPV6_TO_MAC : PXE_OPFLAGS_MCAST_IPV4_TO_MAC);
-  Snp->Cdb.CPBsize = (UINT16)sizeof (PXE_CPB_MCAST_IP_TO_MAC);
-  Snp->Cdb.DBsize  = (UINT16)sizeof (PXE_DB_MCAST_IP_TO_MAC);
+  if (Snp->Cdb == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Snp->Cdb is NULL\n", __func__));
+    return EFI_DEVICE_ERROR;
+  }
 
-  Snp->Cdb.CPBaddr = (UINT64)(UINTN)Cpb;
-  Snp->Cdb.DBaddr  = (UINT64)(UINTN)Db;
+  Cpb               = Snp->Cpb;
+  Db                = Snp->Db;
+  Snp->Cdb->OpCode  = PXE_OPCODE_MCAST_IP_TO_MAC;
+  Snp->Cdb->OpFlags = (UINT16)(IPv6 ? PXE_OPFLAGS_MCAST_IPV6_TO_MAC : PXE_OPFLAGS_MCAST_IPV4_TO_MAC);
+  Snp->Cdb->CPBsize = (UINT16)sizeof (PXE_CPB_MCAST_IP_TO_MAC);
+  Snp->Cdb->DBsize  = (UINT16)sizeof (PXE_DB_MCAST_IP_TO_MAC);
 
-  Snp->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  Snp->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  Snp->Cdb.IFnum     = Snp->IfNum;
-  Snp->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  Snp->Cdb->CPBaddr = (UINT64)(UINTN)Cpb;
+  Snp->Cdb->DBaddr  = (UINT64)(UINTN)Db;
+
+  Snp->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  Snp->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  Snp->Cdb->IFnum     = Snp->IfNum;
+  Snp->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   CopyMem (&Cpb->IP, IP, sizeof (PXE_IP_ADDR));
 
@@ -57,9 +62,9 @@ PxeIp2Mac (
   //
   DEBUG ((DEBUG_NET, "\nSnp->undi.mcast_ip_to_mac()  "));
 
-  (*Snp->IssueUndi32Command)((UINT64)(UINTN)&Snp->Cdb);
+  (*Snp->IssueUndi32Command)((UINT64)(UINTN)Snp->Cdb);
 
-  switch (Snp->Cdb.StatCode) {
+  switch (Snp->Cdb->StatCode) {
     case PXE_STATCODE_SUCCESS:
       break;
 
@@ -70,8 +75,8 @@ PxeIp2Mac (
       DEBUG (
         (DEBUG_NET,
          "\nSnp->undi.mcast_ip_to_mac()  %xh:%xh\n",
-         Snp->Cdb.StatFlags,
-         Snp->Cdb.StatCode)
+         Snp->Cdb->StatFlags,
+         Snp->Cdb->StatCode)
         );
       return EFI_UNSUPPORTED;
 
@@ -83,8 +88,8 @@ PxeIp2Mac (
       DEBUG (
         (DEBUG_NET,
          "\nSnp->undi.mcast_ip_to_mac()  %xh:%xh\n",
-         Snp->Cdb.StatFlags,
-         Snp->Cdb.StatCode)
+         Snp->Cdb->StatFlags,
+         Snp->Cdb->StatCode)
         );
 
       return EFI_DEVICE_ERROR;

--- a/NetworkPkg/SnpDxe/Nvdata.c
+++ b/NetworkPkg/SnpDxe/Nvdata.c
@@ -33,30 +33,35 @@ PxeNvDataRead (
 {
   PXE_DB_NVDATA  *Db;
 
-  Db              = Snp->Db;
-  Snp->Cdb.OpCode = PXE_OPCODE_NVDATA;
+  if (Snp->Cdb == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Snp->Cdb is NULL\n", __func__));
+    return EFI_DEVICE_ERROR;
+  }
 
-  Snp->Cdb.OpFlags = PXE_OPFLAGS_NVDATA_READ;
+  Db               = Snp->Db;
+  Snp->Cdb->OpCode = PXE_OPCODE_NVDATA;
 
-  Snp->Cdb.CPBsize = PXE_CPBSIZE_NOT_USED;
-  Snp->Cdb.CPBaddr = PXE_CPBADDR_NOT_USED;
+  Snp->Cdb->OpFlags = PXE_OPFLAGS_NVDATA_READ;
 
-  Snp->Cdb.DBsize = (UINT16)sizeof (PXE_DB_NVDATA);
-  Snp->Cdb.DBaddr = (UINT64)(UINTN)Db;
+  Snp->Cdb->CPBsize = PXE_CPBSIZE_NOT_USED;
+  Snp->Cdb->CPBaddr = PXE_CPBADDR_NOT_USED;
 
-  Snp->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  Snp->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  Snp->Cdb.IFnum     = Snp->IfNum;
-  Snp->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  Snp->Cdb->DBsize = (UINT16)sizeof (PXE_DB_NVDATA);
+  Snp->Cdb->DBaddr = (UINT64)(UINTN)Db;
+
+  Snp->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  Snp->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  Snp->Cdb->IFnum     = Snp->IfNum;
+  Snp->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   //
   // Issue UNDI command and check result.
   //
   DEBUG ((DEBUG_NET, "\nsnp->undi.nvdata ()  "));
 
-  (*Snp->IssueUndi32Command)((UINT64)(UINTN)&Snp->Cdb);
+  (*Snp->IssueUndi32Command)((UINT64)(UINTN)Snp->Cdb);
 
-  switch (Snp->Cdb.StatCode) {
+  switch (Snp->Cdb->StatCode) {
     case PXE_STATCODE_SUCCESS:
       break;
 
@@ -64,8 +69,8 @@ PxeNvDataRead (
       DEBUG (
         (DEBUG_NET,
          "\nsnp->undi.nvdata()  %xh:%xh\n",
-         Snp->Cdb.StatFlags,
-         Snp->Cdb.StatCode)
+         Snp->Cdb->StatFlags,
+         Snp->Cdb->StatCode)
         );
 
       return EFI_UNSUPPORTED;
@@ -74,8 +79,8 @@ PxeNvDataRead (
       DEBUG (
         (DEBUG_NET,
          "\nsnp->undi.nvdata()  %xh:%xh\n",
-         Snp->Cdb.StatFlags,
-         Snp->Cdb.StatCode)
+         Snp->Cdb->StatFlags,
+         Snp->Cdb->StatCode)
         );
 
       return EFI_DEVICE_ERROR;

--- a/NetworkPkg/SnpDxe/Receive.c
+++ b/NetworkPkg/SnpDxe/Receive.c
@@ -49,6 +49,11 @@ PxeReceive (
   PXE_DB_RECEIVE   *Db;
   UINTN            BuffSize;
 
+  if (Snp->Cdb == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Snp->Cdb is NULL\n", __func__));
+    return EFI_DEVICE_ERROR;
+  }
+
   Cpb      = Snp->Cpb;
   Db       = Snp->Db;
   BuffSize = *BufferSize;
@@ -58,28 +63,28 @@ PxeReceive (
 
   Cpb->reserved = 0;
 
-  Snp->Cdb.OpCode  = PXE_OPCODE_RECEIVE;
-  Snp->Cdb.OpFlags = PXE_OPFLAGS_NOT_USED;
+  Snp->Cdb->OpCode  = PXE_OPCODE_RECEIVE;
+  Snp->Cdb->OpFlags = PXE_OPFLAGS_NOT_USED;
 
-  Snp->Cdb.CPBsize = (UINT16)sizeof (PXE_CPB_RECEIVE);
-  Snp->Cdb.CPBaddr = (UINT64)(UINTN)Cpb;
+  Snp->Cdb->CPBsize = (UINT16)sizeof (PXE_CPB_RECEIVE);
+  Snp->Cdb->CPBaddr = (UINT64)(UINTN)Cpb;
 
-  Snp->Cdb.DBsize = (UINT16)sizeof (PXE_DB_RECEIVE);
-  Snp->Cdb.DBaddr = (UINT64)(UINTN)Db;
+  Snp->Cdb->DBsize = (UINT16)sizeof (PXE_DB_RECEIVE);
+  Snp->Cdb->DBaddr = (UINT64)(UINTN)Db;
 
-  Snp->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  Snp->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  Snp->Cdb.IFnum     = Snp->IfNum;
-  Snp->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  Snp->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  Snp->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  Snp->Cdb->IFnum     = Snp->IfNum;
+  Snp->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   //
   // Issue UNDI command and check result.
   //
   DEBUG ((DEBUG_NET, "\nsnp->undi.receive ()  "));
 
-  (*Snp->IssueUndi32Command)((UINT64)(UINTN)&Snp->Cdb);
+  (*Snp->IssueUndi32Command)((UINT64)(UINTN)Snp->Cdb);
 
-  switch (Snp->Cdb.StatCode) {
+  switch (Snp->Cdb->StatCode) {
     case PXE_STATCODE_SUCCESS:
       break;
 
@@ -87,8 +92,8 @@ PxeReceive (
       DEBUG (
         (DEBUG_NET,
          "\nsnp->undi.receive ()  %xh:%xh\n",
-         Snp->Cdb.StatFlags,
-         Snp->Cdb.StatCode)
+         Snp->Cdb->StatFlags,
+         Snp->Cdb->StatCode)
         );
 
       return EFI_NOT_READY;
@@ -97,8 +102,8 @@ PxeReceive (
       DEBUG (
         (DEBUG_ERROR,
          "\nsnp->undi.receive()  %xh:%xh\n",
-         Snp->Cdb.StatFlags,
-         Snp->Cdb.StatCode)
+         Snp->Cdb->StatFlags,
+         Snp->Cdb->StatCode)
         );
 
       return EFI_DEVICE_ERROR;

--- a/NetworkPkg/SnpDxe/Reset.c
+++ b/NetworkPkg/SnpDxe/Reset.c
@@ -23,30 +23,35 @@ PxeReset (
   SNP_DRIVER  *Snp
   )
 {
-  Snp->Cdb.OpCode    = PXE_OPCODE_RESET;
-  Snp->Cdb.OpFlags   = PXE_OPFLAGS_NOT_USED;
-  Snp->Cdb.CPBsize   = PXE_CPBSIZE_NOT_USED;
-  Snp->Cdb.DBsize    = PXE_DBSIZE_NOT_USED;
-  Snp->Cdb.CPBaddr   = PXE_CPBADDR_NOT_USED;
-  Snp->Cdb.DBaddr    = PXE_DBADDR_NOT_USED;
-  Snp->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  Snp->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  Snp->Cdb.IFnum     = Snp->IfNum;
-  Snp->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  if (Snp->Cdb == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Snp->Cdb is NULL\n", __func__));
+    return EFI_DEVICE_ERROR;
+  }
+
+  Snp->Cdb->OpCode    = PXE_OPCODE_RESET;
+  Snp->Cdb->OpFlags   = PXE_OPFLAGS_NOT_USED;
+  Snp->Cdb->CPBsize   = PXE_CPBSIZE_NOT_USED;
+  Snp->Cdb->DBsize    = PXE_DBSIZE_NOT_USED;
+  Snp->Cdb->CPBaddr   = PXE_CPBADDR_NOT_USED;
+  Snp->Cdb->DBaddr    = PXE_DBADDR_NOT_USED;
+  Snp->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  Snp->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  Snp->Cdb->IFnum     = Snp->IfNum;
+  Snp->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   //
   // Issue UNDI command and check result.
   //
   DEBUG ((DEBUG_NET, "\nsnp->undi.reset()  "));
 
-  (*Snp->IssueUndi32Command)((UINT64)(UINTN)&Snp->Cdb);
+  (*Snp->IssueUndi32Command)((UINT64)(UINTN)Snp->Cdb);
 
-  if (Snp->Cdb.StatCode != PXE_STATCODE_SUCCESS) {
+  if (Snp->Cdb->StatCode != PXE_STATCODE_SUCCESS) {
     DEBUG (
       (DEBUG_WARN,
        "\nsnp->undi32.reset()  %xh:%xh\n",
-       Snp->Cdb.StatFlags,
-       Snp->Cdb.StatCode)
+       Snp->Cdb->StatFlags,
+       Snp->Cdb->StatCode)
       );
 
     //

--- a/NetworkPkg/SnpDxe/Shutdown.c
+++ b/NetworkPkg/SnpDxe/Shutdown.c
@@ -22,29 +22,34 @@ PxeShutdown (
   IN SNP_DRIVER  *Snp
   )
 {
-  Snp->Cdb.OpCode    = PXE_OPCODE_SHUTDOWN;
-  Snp->Cdb.OpFlags   = PXE_OPFLAGS_NOT_USED;
-  Snp->Cdb.CPBsize   = PXE_CPBSIZE_NOT_USED;
-  Snp->Cdb.DBsize    = PXE_DBSIZE_NOT_USED;
-  Snp->Cdb.CPBaddr   = PXE_CPBADDR_NOT_USED;
-  Snp->Cdb.DBaddr    = PXE_DBADDR_NOT_USED;
-  Snp->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  Snp->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  Snp->Cdb.IFnum     = Snp->IfNum;
-  Snp->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  if (Snp->Cdb == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Snp->Cdb is NULL\n", __func__));
+    return EFI_DEVICE_ERROR;
+  }
+
+  Snp->Cdb->OpCode    = PXE_OPCODE_SHUTDOWN;
+  Snp->Cdb->OpFlags   = PXE_OPFLAGS_NOT_USED;
+  Snp->Cdb->CPBsize   = PXE_CPBSIZE_NOT_USED;
+  Snp->Cdb->DBsize    = PXE_DBSIZE_NOT_USED;
+  Snp->Cdb->CPBaddr   = PXE_CPBADDR_NOT_USED;
+  Snp->Cdb->DBaddr    = PXE_DBADDR_NOT_USED;
+  Snp->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  Snp->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  Snp->Cdb->IFnum     = Snp->IfNum;
+  Snp->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   //
   // Issue UNDI command and check result.
   //
   DEBUG ((DEBUG_NET, "\nsnp->undi.shutdown()  "));
 
-  (*Snp->IssueUndi32Command)((UINT64)(UINTN)&Snp->Cdb);
+  (*Snp->IssueUndi32Command)((UINT64)(UINTN)Snp->Cdb);
 
-  if (Snp->Cdb.StatCode != PXE_STATCODE_SUCCESS) {
+  if (Snp->Cdb->StatCode != PXE_STATCODE_SUCCESS) {
     //
     // UNDI could not be shutdown. Return UNDI error.
     //
-    DEBUG ((DEBUG_WARN, "\nsnp->undi.shutdown()  %xh:%xh\n", Snp->Cdb.StatFlags, Snp->Cdb.StatCode));
+    DEBUG ((DEBUG_WARN, "\nsnp->undi.shutdown()  %xh:%xh\n", Snp->Cdb->StatFlags, Snp->Cdb->StatCode));
 
     return EFI_DEVICE_ERROR;
   }

--- a/NetworkPkg/SnpDxe/Snp.h
+++ b/NetworkPkg/SnpDxe/Snp.h
@@ -100,7 +100,7 @@ typedef struct {
   // Buffers for command descriptor block, command parameter block
   // and data block.
   //
-  PXE_CDB                        Cdb;
+  PXE_CDB                        *Cdb;
   VOID                           *Cpb;
   VOID                           *CpbUnmap;
   VOID                           *Db;

--- a/NetworkPkg/SnpDxe/Start.c
+++ b/NetworkPkg/SnpDxe/Start.c
@@ -24,28 +24,33 @@ PxeStart (
 {
   PXE_CPB_START_31  *Cpb31;
 
+  if (Snp->Cdb == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Snp->Cdb is NULL\n", __func__));
+    return EFI_DEVICE_ERROR;
+  }
+
   Cpb31 = Snp->Cpb;
   //
   // Initialize UNDI Start CDB for H/W UNDI
   //
-  Snp->Cdb.OpCode    = PXE_OPCODE_START;
-  Snp->Cdb.OpFlags   = PXE_OPFLAGS_NOT_USED;
-  Snp->Cdb.CPBsize   = PXE_CPBSIZE_NOT_USED;
-  Snp->Cdb.DBsize    = PXE_DBSIZE_NOT_USED;
-  Snp->Cdb.CPBaddr   = PXE_CPBADDR_NOT_USED;
-  Snp->Cdb.DBaddr    = PXE_DBADDR_NOT_USED;
-  Snp->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  Snp->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  Snp->Cdb.IFnum     = Snp->IfNum;
-  Snp->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  Snp->Cdb->OpCode    = PXE_OPCODE_START;
+  Snp->Cdb->OpFlags   = PXE_OPFLAGS_NOT_USED;
+  Snp->Cdb->CPBsize   = PXE_CPBSIZE_NOT_USED;
+  Snp->Cdb->DBsize    = PXE_DBSIZE_NOT_USED;
+  Snp->Cdb->CPBaddr   = PXE_CPBADDR_NOT_USED;
+  Snp->Cdb->DBaddr    = PXE_DBADDR_NOT_USED;
+  Snp->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  Snp->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  Snp->Cdb->IFnum     = Snp->IfNum;
+  Snp->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   //
   // Make changes to H/W UNDI Start CDB if this is
   // a S/W UNDI.
   //
   if (Snp->IsSwUndi) {
-    Snp->Cdb.CPBsize = (UINT16)sizeof (PXE_CPB_START_31);
-    Snp->Cdb.CPBaddr = (UINT64)(UINTN)Cpb31;
+    Snp->Cdb->CPBsize = (UINT16)sizeof (PXE_CPB_START_31);
+    Snp->Cdb->CPBaddr = (UINT64)(UINTN)Cpb31;
 
     Cpb31->Delay = (UINT64)(UINTN)&SnpUndi32CallbackDelay;
     Cpb31->Block = (UINT64)(UINTN)&SnpUndi32CallbackBlock;
@@ -68,17 +73,17 @@ PxeStart (
   //
   DEBUG ((DEBUG_NET, "\nsnp->undi.start()  "));
 
-  (*Snp->IssueUndi32Command)((UINT64)(UINTN)&Snp->Cdb);
+  (*Snp->IssueUndi32Command)((UINT64)(UINTN)Snp->Cdb);
 
-  if (Snp->Cdb.StatCode != PXE_STATCODE_SUCCESS) {
+  if (Snp->Cdb->StatCode != PXE_STATCODE_SUCCESS) {
     //
     // UNDI could not be started. Return UNDI error.
     //
     DEBUG (
       (DEBUG_ERROR,
        "\nsnp->undi.start()  %xh:%xh\n",
-       Snp->Cdb.StatCode,
-       Snp->Cdb.StatFlags)
+       Snp->Cdb->StatCode,
+       Snp->Cdb->StatFlags)
       );
 
     return EFI_DEVICE_ERROR;

--- a/NetworkPkg/SnpDxe/Station_address.c
+++ b/NetworkPkg/SnpDxe/Station_address.c
@@ -25,34 +25,39 @@ PxeGetStnAddr (
 {
   PXE_DB_STATION_ADDRESS  *Db;
 
-  Db               = Snp->Db;
-  Snp->Cdb.OpCode  = PXE_OPCODE_STATION_ADDRESS;
-  Snp->Cdb.OpFlags = PXE_OPFLAGS_STATION_ADDRESS_READ;
+  if (Snp->Cdb == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Snp->Cdb is NULL\n", __func__));
+    return EFI_DEVICE_ERROR;
+  }
 
-  Snp->Cdb.CPBaddr = PXE_CPBADDR_NOT_USED;
-  Snp->Cdb.CPBsize = PXE_CPBSIZE_NOT_USED;
+  Db                = Snp->Db;
+  Snp->Cdb->OpCode  = PXE_OPCODE_STATION_ADDRESS;
+  Snp->Cdb->OpFlags = PXE_OPFLAGS_STATION_ADDRESS_READ;
 
-  Snp->Cdb.DBsize = (UINT16)sizeof (PXE_DB_STATION_ADDRESS);
-  Snp->Cdb.DBaddr = (UINT64)(UINTN)Db;
+  Snp->Cdb->CPBaddr = PXE_CPBADDR_NOT_USED;
+  Snp->Cdb->CPBsize = PXE_CPBSIZE_NOT_USED;
 
-  Snp->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  Snp->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  Snp->Cdb.IFnum     = Snp->IfNum;
-  Snp->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  Snp->Cdb->DBsize = (UINT16)sizeof (PXE_DB_STATION_ADDRESS);
+  Snp->Cdb->DBaddr = (UINT64)(UINTN)Db;
+
+  Snp->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  Snp->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  Snp->Cdb->IFnum     = Snp->IfNum;
+  Snp->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   //
   // Issue UNDI command and check result.
   //
   DEBUG ((DEBUG_NET, "\nsnp->undi.station_addr()  "));
 
-  (*Snp->IssueUndi32Command)((UINT64)(UINTN)&Snp->Cdb);
+  (*Snp->IssueUndi32Command)((UINT64)(UINTN)Snp->Cdb);
 
-  if (Snp->Cdb.StatCode != PXE_STATCODE_SUCCESS) {
+  if (Snp->Cdb->StatCode != PXE_STATCODE_SUCCESS) {
     DEBUG (
       (DEBUG_ERROR,
        "\nsnp->undi.station_addr()  %xh:%xh\n",
-       Snp->Cdb.StatFlags,
-       Snp->Cdb.StatCode)
+       Snp->Cdb->StatFlags,
+       Snp->Cdb->StatCode)
       );
 
     return EFI_DEVICE_ERROR;
@@ -101,46 +106,51 @@ PxeSetStnAddr (
   PXE_CPB_STATION_ADDRESS  *Cpb;
   PXE_DB_STATION_ADDRESS   *Db;
 
-  Cpb             = Snp->Cpb;
-  Db              = Snp->Db;
-  Snp->Cdb.OpCode = PXE_OPCODE_STATION_ADDRESS;
+  if (Snp->Cdb == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Snp->Cdb is NULL\n", __func__));
+    return EFI_DEVICE_ERROR;
+  }
+
+  Cpb              = Snp->Cpb;
+  Db               = Snp->Db;
+  Snp->Cdb->OpCode = PXE_OPCODE_STATION_ADDRESS;
 
   if (NewMacAddr == NULL) {
-    Snp->Cdb.OpFlags = PXE_OPFLAGS_STATION_ADDRESS_RESET;
-    Snp->Cdb.CPBsize = PXE_CPBSIZE_NOT_USED;
-    Snp->Cdb.CPBaddr = PXE_CPBADDR_NOT_USED;
+    Snp->Cdb->OpFlags = PXE_OPFLAGS_STATION_ADDRESS_RESET;
+    Snp->Cdb->CPBsize = PXE_CPBSIZE_NOT_USED;
+    Snp->Cdb->CPBaddr = PXE_CPBADDR_NOT_USED;
   } else {
-    Snp->Cdb.OpFlags = PXE_OPFLAGS_STATION_ADDRESS_WRITE;
+    Snp->Cdb->OpFlags = PXE_OPFLAGS_STATION_ADDRESS_WRITE;
     //
     // Supplying a new address in the CPB will make undi change the mac address to the new one.
     //
     CopyMem (&Cpb->StationAddr, NewMacAddr, Snp->Mode.HwAddressSize);
 
-    Snp->Cdb.CPBsize = (UINT16)sizeof (PXE_CPB_STATION_ADDRESS);
-    Snp->Cdb.CPBaddr = (UINT64)(UINTN)Cpb;
+    Snp->Cdb->CPBsize = (UINT16)sizeof (PXE_CPB_STATION_ADDRESS);
+    Snp->Cdb->CPBaddr = (UINT64)(UINTN)Cpb;
   }
 
-  Snp->Cdb.DBsize = (UINT16)sizeof (PXE_DB_STATION_ADDRESS);
-  Snp->Cdb.DBaddr = (UINT64)(UINTN)Db;
+  Snp->Cdb->DBsize = (UINT16)sizeof (PXE_DB_STATION_ADDRESS);
+  Snp->Cdb->DBaddr = (UINT64)(UINTN)Db;
 
-  Snp->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  Snp->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  Snp->Cdb.IFnum     = Snp->IfNum;
-  Snp->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  Snp->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  Snp->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  Snp->Cdb->IFnum     = Snp->IfNum;
+  Snp->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   //
   // Issue UNDI command and check result.
   //
   DEBUG ((DEBUG_NET, "\nsnp->undi.station_addr()  "));
 
-  (*Snp->IssueUndi32Command)((UINT64)(UINTN)&Snp->Cdb);
+  (*Snp->IssueUndi32Command)((UINT64)(UINTN)Snp->Cdb);
 
-  if (Snp->Cdb.StatCode != PXE_STATCODE_SUCCESS) {
+  if (Snp->Cdb->StatCode != PXE_STATCODE_SUCCESS) {
     DEBUG (
       (DEBUG_ERROR,
        "\nsnp->undi.station_addr()  %xh:%xh\n",
-       Snp->Cdb.StatFlags,
-       Snp->Cdb.StatCode)
+       Snp->Cdb->StatFlags,
+       Snp->Cdb->StatCode)
       );
 
     //

--- a/NetworkPkg/SnpDxe/Statistics.c
+++ b/NetworkPkg/SnpDxe/Statistics.c
@@ -82,6 +82,11 @@ SnpUndi32Statistics (
 
   Snp = EFI_SIMPLE_NETWORK_DEV_FROM_THIS (This);
 
+  if (Snp->Cdb == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Snp->Cdb is NULL\n", __func__));
+    return EFI_DEVICE_ERROR;
+  }
+
   OldTpl = gBS->RaiseTPL (TPL_CALLBACK);
 
   //
@@ -112,23 +117,23 @@ SnpUndi32Statistics (
   //
   // Initialize UNDI Statistics CDB
   //
-  Snp->Cdb.OpCode    = PXE_OPCODE_STATISTICS;
-  Snp->Cdb.CPBsize   = PXE_CPBSIZE_NOT_USED;
-  Snp->Cdb.CPBaddr   = PXE_CPBADDR_NOT_USED;
-  Snp->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  Snp->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  Snp->Cdb.IFnum     = Snp->IfNum;
-  Snp->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  Snp->Cdb->OpCode    = PXE_OPCODE_STATISTICS;
+  Snp->Cdb->CPBsize   = PXE_CPBSIZE_NOT_USED;
+  Snp->Cdb->CPBaddr   = PXE_CPBADDR_NOT_USED;
+  Snp->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  Snp->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  Snp->Cdb->IFnum     = Snp->IfNum;
+  Snp->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   if (Reset) {
-    Snp->Cdb.OpFlags = PXE_OPFLAGS_STATISTICS_RESET;
-    Snp->Cdb.DBsize  = PXE_DBSIZE_NOT_USED;
-    Snp->Cdb.DBaddr  = PXE_DBADDR_NOT_USED;
-    Db               = Snp->Db;
+    Snp->Cdb->OpFlags = PXE_OPFLAGS_STATISTICS_RESET;
+    Snp->Cdb->DBsize  = PXE_DBSIZE_NOT_USED;
+    Snp->Cdb->DBaddr  = PXE_DBADDR_NOT_USED;
+    Db                = Snp->Db;
   } else {
-    Snp->Cdb.OpFlags = PXE_OPFLAGS_STATISTICS_READ;
-    Snp->Cdb.DBsize  = (UINT16)sizeof (PXE_DB_STATISTICS);
-    Snp->Cdb.DBaddr  = (UINT64)(UINTN)(Db = Snp->Db);
+    Snp->Cdb->OpFlags = PXE_OPFLAGS_STATISTICS_READ;
+    Snp->Cdb->DBsize  = (UINT16)sizeof (PXE_DB_STATISTICS);
+    Snp->Cdb->DBaddr  = (UINT64)(UINTN)(Db = Snp->Db);
   }
 
   //
@@ -136,9 +141,9 @@ SnpUndi32Statistics (
   //
   DEBUG ((DEBUG_NET, "\nsnp->undi.statistics()  "));
 
-  (*Snp->IssueUndi32Command)((UINT64)(UINTN)&Snp->Cdb);
+  (*Snp->IssueUndi32Command)((UINT64)(UINTN)Snp->Cdb);
 
-  switch (Snp->Cdb.StatCode) {
+  switch (Snp->Cdb->StatCode) {
     case PXE_STATCODE_SUCCESS:
       break;
 
@@ -146,8 +151,8 @@ SnpUndi32Statistics (
       DEBUG (
         (DEBUG_ERROR,
          "\nsnp->undi.statistics()  %xh:%xh\n",
-         Snp->Cdb.StatFlags,
-         Snp->Cdb.StatCode)
+         Snp->Cdb->StatFlags,
+         Snp->Cdb->StatCode)
         );
 
       Status = EFI_UNSUPPORTED;
@@ -157,8 +162,8 @@ SnpUndi32Statistics (
       DEBUG (
         (DEBUG_ERROR,
          "\nsnp->undi.statistics()  %xh:%xh\n",
-         Snp->Cdb.StatFlags,
-         Snp->Cdb.StatCode)
+         Snp->Cdb->StatFlags,
+         Snp->Cdb->StatCode)
         );
 
       Status = EFI_DEVICE_ERROR;

--- a/NetworkPkg/SnpDxe/Stop.c
+++ b/NetworkPkg/SnpDxe/Stop.c
@@ -22,30 +22,35 @@ PxeStop (
   SNP_DRIVER  *Snp
   )
 {
-  Snp->Cdb.OpCode    = PXE_OPCODE_STOP;
-  Snp->Cdb.OpFlags   = PXE_OPFLAGS_NOT_USED;
-  Snp->Cdb.CPBsize   = PXE_CPBSIZE_NOT_USED;
-  Snp->Cdb.DBsize    = PXE_DBSIZE_NOT_USED;
-  Snp->Cdb.CPBaddr   = PXE_CPBADDR_NOT_USED;
-  Snp->Cdb.DBaddr    = PXE_DBADDR_NOT_USED;
-  Snp->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  Snp->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  Snp->Cdb.IFnum     = Snp->IfNum;
-  Snp->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  if (Snp->Cdb == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Snp->Cdb is NULL\n", __func__));
+    return EFI_DEVICE_ERROR;
+  }
+
+  Snp->Cdb->OpCode    = PXE_OPCODE_STOP;
+  Snp->Cdb->OpFlags   = PXE_OPFLAGS_NOT_USED;
+  Snp->Cdb->CPBsize   = PXE_CPBSIZE_NOT_USED;
+  Snp->Cdb->DBsize    = PXE_DBSIZE_NOT_USED;
+  Snp->Cdb->CPBaddr   = PXE_CPBADDR_NOT_USED;
+  Snp->Cdb->DBaddr    = PXE_DBADDR_NOT_USED;
+  Snp->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  Snp->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  Snp->Cdb->IFnum     = Snp->IfNum;
+  Snp->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   //
   // Issue UNDI command
   //
   DEBUG ((DEBUG_NET, "\nsnp->undi.stop()  "));
 
-  (*Snp->IssueUndi32Command)((UINT64)(UINTN)&Snp->Cdb);
+  (*Snp->IssueUndi32Command)((UINT64)(UINTN)Snp->Cdb);
 
-  if (Snp->Cdb.StatCode != PXE_STATCODE_SUCCESS) {
+  if (Snp->Cdb->StatCode != PXE_STATCODE_SUCCESS) {
     DEBUG (
       (DEBUG_WARN,
        "\nsnp->undi.stop()  %xh:%xh\n",
-       Snp->Cdb.StatFlags,
-       Snp->Cdb.StatCode)
+       Snp->Cdb->StatFlags,
+       Snp->Cdb->StatCode)
       );
 
     return EFI_DEVICE_ERROR;

--- a/NetworkPkg/SnpDxe/Transmit.c
+++ b/NetworkPkg/SnpDxe/Transmit.c
@@ -38,6 +38,11 @@ PxeFillHeader (
 {
   PXE_CPB_FILL_HEADER_FRAGMENTED  *Cpb;
 
+  if (Snp->Cdb == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Snp->Cdb is NULL\n", __func__));
+    return EFI_DEVICE_ERROR;
+  }
+
   Cpb = Snp->Cpb;
   if (SrcAddr != NULL) {
     CopyMem (
@@ -77,28 +82,28 @@ PxeFillHeader (
 
   Cpb->FragDesc[0].reserved = Cpb->FragDesc[1].reserved = 0;
 
-  Snp->Cdb.OpCode  = PXE_OPCODE_FILL_HEADER;
-  Snp->Cdb.OpFlags = PXE_OPFLAGS_FILL_HEADER_FRAGMENTED;
+  Snp->Cdb->OpCode  = PXE_OPCODE_FILL_HEADER;
+  Snp->Cdb->OpFlags = PXE_OPFLAGS_FILL_HEADER_FRAGMENTED;
 
-  Snp->Cdb.DBsize = PXE_DBSIZE_NOT_USED;
-  Snp->Cdb.DBaddr = PXE_DBADDR_NOT_USED;
+  Snp->Cdb->DBsize = PXE_DBSIZE_NOT_USED;
+  Snp->Cdb->DBaddr = PXE_DBADDR_NOT_USED;
 
-  Snp->Cdb.CPBsize = (UINT16)sizeof (PXE_CPB_FILL_HEADER_FRAGMENTED);
-  Snp->Cdb.CPBaddr = (UINT64)(UINTN)Cpb;
+  Snp->Cdb->CPBsize = (UINT16)sizeof (PXE_CPB_FILL_HEADER_FRAGMENTED);
+  Snp->Cdb->CPBaddr = (UINT64)(UINTN)Cpb;
 
-  Snp->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  Snp->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  Snp->Cdb.IFnum     = Snp->IfNum;
-  Snp->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  Snp->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  Snp->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  Snp->Cdb->IFnum     = Snp->IfNum;
+  Snp->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   //
   // Issue UNDI command and check result.
   //
   DEBUG ((DEBUG_NET, "\nSnp->undi.fill_header()  "));
 
-  (*Snp->IssueUndi32Command)((UINT64)(UINTN)&Snp->Cdb);
+  (*Snp->IssueUndi32Command)((UINT64)(UINTN)Snp->Cdb);
 
-  switch (Snp->Cdb.StatCode) {
+  switch (Snp->Cdb->StatCode) {
     case PXE_STATCODE_SUCCESS:
       return EFI_SUCCESS;
 
@@ -106,8 +111,8 @@ PxeFillHeader (
       DEBUG (
         (DEBUG_ERROR,
          "\nSnp->undi.fill_header()  %xh:%xh\n",
-         Snp->Cdb.StatFlags,
-         Snp->Cdb.StatCode)
+         Snp->Cdb->StatFlags,
+         Snp->Cdb->StatCode)
         );
 
       return EFI_INVALID_PARAMETER;
@@ -116,8 +121,8 @@ PxeFillHeader (
       DEBUG (
         (DEBUG_ERROR,
          "\nSnp->undi.fill_header()  %xh:%xh\n",
-         Snp->Cdb.StatFlags,
-         Snp->Cdb.StatCode)
+         Snp->Cdb->StatFlags,
+         Snp->Cdb->StatCode)
         );
 
       return EFI_DEVICE_ERROR;
@@ -145,6 +150,11 @@ PxeTransmit (
   PXE_CPB_TRANSMIT  *Cpb;
   EFI_STATUS        Status;
 
+  if (Snp->Cdb == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Snp->Cdb is NULL\n", __func__));
+    return EFI_DEVICE_ERROR;
+  }
+
   Cpb            = Snp->Cpb;
   Cpb->FrameAddr = (UINT64)(UINTN)Buffer;
   Cpb->DataLen   = (UINT32)BufferSize;
@@ -152,37 +162,37 @@ PxeTransmit (
   Cpb->MediaheaderLen = 0;
   Cpb->reserved       = 0;
 
-  Snp->Cdb.OpFlags = PXE_OPFLAGS_TRANSMIT_WHOLE;
+  Snp->Cdb->OpFlags = PXE_OPFLAGS_TRANSMIT_WHOLE;
 
-  Snp->Cdb.CPBsize = (UINT16)sizeof (PXE_CPB_TRANSMIT);
-  Snp->Cdb.CPBaddr = (UINT64)(UINTN)Cpb;
+  Snp->Cdb->CPBsize = (UINT16)sizeof (PXE_CPB_TRANSMIT);
+  Snp->Cdb->CPBaddr = (UINT64)(UINTN)Cpb;
 
-  Snp->Cdb.OpCode = PXE_OPCODE_TRANSMIT;
-  Snp->Cdb.DBsize = PXE_DBSIZE_NOT_USED;
-  Snp->Cdb.DBaddr = PXE_DBADDR_NOT_USED;
+  Snp->Cdb->OpCode = PXE_OPCODE_TRANSMIT;
+  Snp->Cdb->DBsize = PXE_DBSIZE_NOT_USED;
+  Snp->Cdb->DBaddr = PXE_DBADDR_NOT_USED;
 
-  Snp->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  Snp->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  Snp->Cdb.IFnum     = Snp->IfNum;
-  Snp->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  Snp->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  Snp->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  Snp->Cdb->IFnum     = Snp->IfNum;
+  Snp->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   //
   // Issue UNDI command and check result.
   //
   DEBUG ((DEBUG_NET, "\nSnp->undi.transmit()  "));
-  DEBUG ((DEBUG_NET, "\nSnp->Cdb.OpCode  == %x", Snp->Cdb.OpCode));
-  DEBUG ((DEBUG_NET, "\nSnp->Cdb.CPBaddr == %LX", Snp->Cdb.CPBaddr));
-  DEBUG ((DEBUG_NET, "\nSnp->Cdb.DBaddr  == %LX", Snp->Cdb.DBaddr));
+  DEBUG ((DEBUG_NET, "\nSnp->Cdb->OpCode  == %x", Snp->Cdb->OpCode));
+  DEBUG ((DEBUG_NET, "\nSnp->Cdb->CPBaddr == %LX", Snp->Cdb->CPBaddr));
+  DEBUG ((DEBUG_NET, "\nSnp->Cdb->DBaddr  == %LX", Snp->Cdb->DBaddr));
   DEBUG ((DEBUG_NET, "\nCpb->FrameAddr   == %LX\n", Cpb->FrameAddr));
 
-  (*Snp->IssueUndi32Command)((UINT64)(UINTN)&Snp->Cdb);
+  (*Snp->IssueUndi32Command)((UINT64)(UINTN)Snp->Cdb);
 
   DEBUG ((DEBUG_NET, "\nexit Snp->undi.transmit()  "));
 
   //
   // we will unmap the buffers in get_status call, not here
   //
-  switch (Snp->Cdb.StatCode) {
+  switch (Snp->Cdb->StatCode) {
     case PXE_STATCODE_SUCCESS:
       return EFI_SUCCESS;
 
@@ -193,8 +203,8 @@ PxeTransmit (
       DEBUG (
         (DEBUG_NET,
          "\nSnp->undi.transmit()  %xh:%xh\n",
-         Snp->Cdb.StatFlags,
-         Snp->Cdb.StatCode)
+         Snp->Cdb->StatFlags,
+         Snp->Cdb->StatCode)
         );
       break;
 
@@ -202,8 +212,8 @@ PxeTransmit (
       DEBUG (
         (DEBUG_ERROR,
          "\nSnp->undi.transmit()  %xh:%xh\n",
-         Snp->Cdb.StatFlags,
-         Snp->Cdb.StatCode)
+         Snp->Cdb->StatFlags,
+         Snp->Cdb->StatCode)
         );
       Status = EFI_DEVICE_ERROR;
   }

--- a/NetworkPkg/SnpDxe/WaitForPacket.c
+++ b/NetworkPkg/SnpDxe/WaitForPacket.c
@@ -31,6 +31,11 @@ SnpWaitForPacketNotify (
     return;
   }
 
+  if (((SNP_DRIVER *)SnpPtr)->Cdb == NULL) {
+    DEBUG ((DEBUG_ERROR, "%a: Snp->Cdb is NULL\n", __func__));
+    return;
+  }
+
   //
   // Do nothing if the SNP interface is not initialized.
   //
@@ -47,16 +52,16 @@ SnpWaitForPacketNotify (
   //
   // Fill in CDB for UNDI GetStatus().
   //
-  ((SNP_DRIVER *)SnpPtr)->Cdb.OpCode    = PXE_OPCODE_GET_STATUS;
-  ((SNP_DRIVER *)SnpPtr)->Cdb.OpFlags   = 0;
-  ((SNP_DRIVER *)SnpPtr)->Cdb.CPBsize   = PXE_CPBSIZE_NOT_USED;
-  ((SNP_DRIVER *)SnpPtr)->Cdb.CPBaddr   = PXE_CPBADDR_NOT_USED;
-  ((SNP_DRIVER *)SnpPtr)->Cdb.DBsize    = (UINT16)(sizeof (UINT32) * 2);
-  ((SNP_DRIVER *)SnpPtr)->Cdb.DBaddr    = (UINT64)(UINTN)(((SNP_DRIVER *)SnpPtr)->Db);
-  ((SNP_DRIVER *)SnpPtr)->Cdb.StatCode  = PXE_STATCODE_INITIALIZE;
-  ((SNP_DRIVER *)SnpPtr)->Cdb.StatFlags = PXE_STATFLAGS_INITIALIZE;
-  ((SNP_DRIVER *)SnpPtr)->Cdb.IFnum     = ((SNP_DRIVER *)SnpPtr)->IfNum;
-  ((SNP_DRIVER *)SnpPtr)->Cdb.Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
+  ((SNP_DRIVER *)SnpPtr)->Cdb->OpCode    = PXE_OPCODE_GET_STATUS;
+  ((SNP_DRIVER *)SnpPtr)->Cdb->OpFlags   = 0;
+  ((SNP_DRIVER *)SnpPtr)->Cdb->CPBsize   = PXE_CPBSIZE_NOT_USED;
+  ((SNP_DRIVER *)SnpPtr)->Cdb->CPBaddr   = PXE_CPBADDR_NOT_USED;
+  ((SNP_DRIVER *)SnpPtr)->Cdb->DBsize    = (UINT16)(sizeof (UINT32) * 2);
+  ((SNP_DRIVER *)SnpPtr)->Cdb->DBaddr    = (UINT64)(UINTN)(((SNP_DRIVER *)SnpPtr)->Db);
+  ((SNP_DRIVER *)SnpPtr)->Cdb->StatCode  = PXE_STATCODE_INITIALIZE;
+  ((SNP_DRIVER *)SnpPtr)->Cdb->StatFlags = PXE_STATFLAGS_INITIALIZE;
+  ((SNP_DRIVER *)SnpPtr)->Cdb->IFnum     = ((SNP_DRIVER *)SnpPtr)->IfNum;
+  ((SNP_DRIVER *)SnpPtr)->Cdb->Control   = PXE_CONTROL_LAST_CDB_IN_LIST;
 
   //
   // Clear contents of DB buffer.
@@ -66,9 +71,9 @@ SnpWaitForPacketNotify (
   //
   // Issue UNDI command and check result.
   //
-  (*((SNP_DRIVER *)SnpPtr)->IssueUndi32Command)((UINT64)(UINTN)&((SNP_DRIVER *)SnpPtr)->Cdb);
+  (*((SNP_DRIVER *)SnpPtr)->IssueUndi32Command)((UINT64)(UINTN)((SNP_DRIVER *)SnpPtr)->Cdb);
 
-  if (((SNP_DRIVER *)SnpPtr)->Cdb.StatCode != EFI_SUCCESS) {
+  if (((SNP_DRIVER *)SnpPtr)->Cdb->StatCode != EFI_SUCCESS) {
     return;
   }
 


### PR DESCRIPTION
## Description

CPB, DB, and CDB structs to use DMA-able memory.

Updates the overall SNP_DRIVER allocation to use AllocatePool() instead of PciIo->AllocateBuffer(). This moves this struct out of DMA-able memory. Allocates the PXE_CDB struct as a pointer instead, using PciIo->AllocateBuffer() for DMA-able memory.

End result:
CPB, DB, and CDB are allocated with individual PciIo->AllocateBuffer() calls with a size of 4096 for CPB and DB. and sizeof(PXE_CDB) for CDB. Each of these members point to locations within the Allocated Buffer, and all of these pointers are at-least 8-Byte aligned.
SNP_DRIVER is allocated with AllocatePool()
In the SNP_DRIVER structure, the PXE_CDB member is changed to a pointer so we can allocate it with PciIo->AllocateBuffer()

This PR is cherry-picking https://github.com/tianocore/edk2/commit/302cc88ab36ffb96622987a55f4abc22a4751fed

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on physical device

## Integration Instructions

N/A
