### PR TITLE
Adding check for underflow/overflow when iterating through resource descriptor hobs

### DIFF
--- a/MdeModulePkg/Core/Dxe/DxeMain.h
+++ b/MdeModulePkg/Core/Dxe/DxeMain.h
@@ -89,6 +89,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/CpuExceptionHandlerLib.h>
 #include <Library/OrderedCollectionLib.h>
 #include <Library/DxeMemoryProtectionHobLib.h>   // MU_CHANGE
+#include <Library/SafeIntLib.h> // MU_CHANGE
 
 //
 // attributes for reserved memory before it is promoted to system memory

--- a/MdeModulePkg/Core/Dxe/DxeMain.h
+++ b/MdeModulePkg/Core/Dxe/DxeMain.h
@@ -88,7 +88,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/DebugAgentLib.h>
 #include <Library/CpuExceptionHandlerLib.h>
 #include <Library/OrderedCollectionLib.h>
-#include <Library/DxeMemoryProtectionHobLib.h> // MU_CHANGE
+#include <Library/DxeMemoryProtectionHobLib.h>   // MU_CHANGE
 
 //
 // attributes for reserved memory before it is promoted to system memory

--- a/MdeModulePkg/Core/Dxe/DxeMain.h
+++ b/MdeModulePkg/Core/Dxe/DxeMain.h
@@ -88,8 +88,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/DebugAgentLib.h>
 #include <Library/CpuExceptionHandlerLib.h>
 #include <Library/OrderedCollectionLib.h>
-#include <Library/DxeMemoryProtectionHobLib.h>   // MU_CHANGE
-#include <Library/SafeIntLib.h> // MU_CHANGE
+#include <Library/DxeMemoryProtectionHobLib.h> // MU_CHANGE
+#include <Library/SafeIntLib.h>                // MU_CHANGE
 
 //
 // attributes for reserved memory before it is promoted to system memory

--- a/MdeModulePkg/Core/Dxe/DxeMain.h
+++ b/MdeModulePkg/Core/Dxe/DxeMain.h
@@ -89,7 +89,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/CpuExceptionHandlerLib.h>
 #include <Library/OrderedCollectionLib.h>
 #include <Library/DxeMemoryProtectionHobLib.h> // MU_CHANGE
-#include <Library/SafeIntLib.h>                // MU_CHANGE
 
 //
 // attributes for reserved memory before it is promoted to system memory

--- a/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
+++ b/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
@@ -2448,10 +2448,10 @@ CoreInitializeMemoryServices (
     Attributes  = PhitResourceHob->ResourceAttribute;
     BaseAddress = PageAlignAddress (PhitHob->EfiMemoryTop);
     // MU_CHANGE START - Check for potential underflow before subtraction
-    if (PhitHob->EfiMemoryTop > (ResourceHob->PhysicalStart + ResourceHob->ResourceLength)) {
+    if (BaseAddress > (ResourceHob->PhysicalStart + ResourceHob->ResourceLength)) {
       Length = 0;
     } else {
-      Length      = PageAlignLength (ResourceHob->PhysicalStart + ResourceHob->ResourceLength - BaseAddress);
+      Length = PageAlignLength (ResourceHob->PhysicalStart + ResourceHob->ResourceLength - BaseAddress);
       FindLargestFreeRegion (&BaseAddress, &Length, (EFI_HOB_MEMORY_ALLOCATION *)GetFirstHob (EFI_HOB_TYPE_MEMORY_ALLOCATION));
     }
     // MU_CHANGE END - Check for potential underflow before subtraction

--- a/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
+++ b/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
@@ -2462,6 +2462,7 @@ CoreInitializeMemoryServices (
       Length = PageAlignLength (HighAddress - BaseAddress);
       FindLargestFreeRegion (&BaseAddress, &Length, (EFI_HOB_MEMORY_ALLOCATION *)GetFirstHob (EFI_HOB_TYPE_MEMORY_ALLOCATION));
     }
+
     // MU_CHANGE END - Check for potential underflow before subtraction
 
     if (Length < MinimalMemorySizeNeeded) {

--- a/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
+++ b/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
@@ -2431,9 +2431,11 @@ CoreInitializeMemoryServices (
     } else {
       ResourceHobMemoryTop = ResourceHob->PhysicalStart + ResourceHob->ResourceLength;
     }
+
     // MU_CHANGE END - Check for potential overflow before addition
 
-    if (PhitHob->EfiFreeMemoryTop > ResourceHobMemoryTop) { // MU_CHANGE
+    if (PhitHob->EfiFreeMemoryTop > ResourceHobMemoryTop) {
+      // MU_CHANGE
       continue;
     }
 
@@ -2457,10 +2459,11 @@ CoreInitializeMemoryServices (
     //
     Attributes  = PhitResourceHob->ResourceAttribute;
     BaseAddress = PageAlignAddress (PhitHob->EfiMemoryTop);
-    if (BaseAddress > ResourceHobMemoryTop) { // MU_CHANGE
+    if (BaseAddress > ResourceHobMemoryTop) {
+      // MU_CHANGE
       Length = 0;
     } else {
-      Length = PageAlignLength (HighAddress - BaseAddress);
+      Length = PageAlignLength (ResourceHobMemoryTop - BaseAddress);
       FindLargestFreeRegion (&BaseAddress, &Length, (EFI_HOB_MEMORY_ALLOCATION *)GetFirstHob (EFI_HOB_TYPE_MEMORY_ALLOCATION));
     }
 
@@ -2541,7 +2544,8 @@ CoreInitializeMemoryServices (
         continue;
       }
 
-      if (ResourceHobMemoryTop > (EFI_PHYSICAL_ADDRESS)MAX_ALLOC_ADDRESS) { // MU_CHANGE
+      if (ResourceHobMemoryTop > (EFI_PHYSICAL_ADDRESS)MAX_ALLOC_ADDRESS) {
+        // MU_CHANGE
         continue;
       }
 

--- a/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
+++ b/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
@@ -2458,7 +2458,7 @@ CoreInitializeMemoryServices (
     Attributes  = PhitResourceHob->ResourceAttribute;
     BaseAddress = PageAlignAddress (PhitHob->EfiMemoryTop);
 
-    // MU_CHANGE END - Check for potential underflow before subtraction
+    // MU_CHANGE START - Check for potential underflow before subtraction
     if (BaseAddress > ResourceHobMemoryTop) {
       Length = 0;
     } else {
@@ -2543,8 +2543,16 @@ CoreInitializeMemoryServices (
         continue;
       }
 
-      // MU_CHANGE
+      // MU_CHANGE START - Check for potential overflow before addition
+      if (ResourceHob->PhysicalStart > MAX_UINT64 - ResourceHob->ResourceLength) {
+        ASSERT (FALSE);
+        ResourceHobMemoryTop = MAX_UINT64;
+      } else {
+        ResourceHobMemoryTop = ResourceHob->PhysicalStart + ResourceHob->ResourceLength;
+      }
+
       if (ResourceHobMemoryTop > (EFI_PHYSICAL_ADDRESS)MAX_ALLOC_ADDRESS) {
+        // MU_CHANGE END - Check for potential overflow before addition
         continue;
       }
 

--- a/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
+++ b/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
@@ -2302,6 +2302,7 @@ CoreInitializeMemoryServices (
   EFI_HOB_GUID_TYPE            *GuidHob;
   UINT32                       ReservedCodePageNumber;
   UINT64                       MinimalMemorySizeNeeded;
+  EFI_STATUS                   Status;
 
   //
   // Point at the first HOB.  This must be the PHIT HOB.
@@ -2448,10 +2449,17 @@ CoreInitializeMemoryServices (
     Attributes  = PhitResourceHob->ResourceAttribute;
     BaseAddress = PageAlignAddress (PhitHob->EfiMemoryTop);
     // MU_CHANGE START - Check for potential underflow before subtraction
-    if (BaseAddress > (ResourceHob->PhysicalStart + ResourceHob->ResourceLength)) {
+    Status = SafeUint64Add (ResourceHob->PhysicalStart, ResourceHob->ResourceLength, &HighAddress);
+    if (EFI_ERROR (Status)) {
+      // This hob can't be right...
+      ASSERT_EFI_ERROR (Status);
+      HighAddress = MAX_UINT64;
+    }
+
+    if (BaseAddress > HighAddress) {
       Length = 0;
     } else {
-      Length = PageAlignLength (ResourceHob->PhysicalStart + ResourceHob->ResourceLength - BaseAddress);
+      Length = PageAlignLength (HighAddress - BaseAddress);
       FindLargestFreeRegion (&BaseAddress, &Length, (EFI_HOB_MEMORY_ALLOCATION *)GetFirstHob (EFI_HOB_TYPE_MEMORY_ALLOCATION));
     }
     // MU_CHANGE END - Check for potential underflow before subtraction

--- a/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
+++ b/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
@@ -2302,7 +2302,7 @@ CoreInitializeMemoryServices (
   EFI_HOB_GUID_TYPE            *GuidHob;
   UINT32                       ReservedCodePageNumber;
   UINT64                       MinimalMemorySizeNeeded;
-  EFI_STATUS                   Status;
+  EFI_STATUS                   Status;  // MU_CHANGE
 
   //
   // Point at the first HOB.  This must be the PHIT HOB.

--- a/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
+++ b/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
@@ -2432,10 +2432,8 @@ CoreInitializeMemoryServices (
       ResourceHobMemoryTop = ResourceHob->PhysicalStart + ResourceHob->ResourceLength;
     }
 
-    // MU_CHANGE END - Check for potential overflow before addition
-
     if (PhitHob->EfiFreeMemoryTop > ResourceHobMemoryTop) {
-      // MU_CHANGE
+      // MU_CHANGE END - Check for potential overflow before addition
       continue;
     }
 
@@ -2459,8 +2457,9 @@ CoreInitializeMemoryServices (
     //
     Attributes  = PhitResourceHob->ResourceAttribute;
     BaseAddress = PageAlignAddress (PhitHob->EfiMemoryTop);
+
+    // MU_CHANGE END - Check for potential underflow before subtraction
     if (BaseAddress > ResourceHobMemoryTop) {
-      // MU_CHANGE
       Length = 0;
     } else {
       Length = PageAlignLength (ResourceHobMemoryTop - BaseAddress);
@@ -2544,8 +2543,8 @@ CoreInitializeMemoryServices (
         continue;
       }
 
+      // MU_CHANGE
       if (ResourceHobMemoryTop > (EFI_PHYSICAL_ADDRESS)MAX_ALLOC_ADDRESS) {
-        // MU_CHANGE
         continue;
       }
 

--- a/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
+++ b/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
@@ -2302,7 +2302,7 @@ CoreInitializeMemoryServices (
   EFI_HOB_GUID_TYPE            *GuidHob;
   UINT32                       ReservedCodePageNumber;
   UINT64                       MinimalMemorySizeNeeded;
-  EFI_STATUS                   Status;  // MU_CHANGE
+  EFI_PHYSICAL_ADDRESS         ResourceHobMemoryTop;  // MU_CHANGE
 
   //
   // Point at the first HOB.  This must be the PHIT HOB.
@@ -2424,7 +2424,16 @@ CoreInitializeMemoryServices (
       continue;
     }
 
-    if (PhitHob->EfiFreeMemoryTop > (ResourceHob->PhysicalStart + ResourceHob->ResourceLength)) {
+    // MU_CHANGE START - Check for potential overflow before addition
+    if (ResourceHob->PhysicalStart > MAX_UINT64 - ResourceHob->ResourceLength) {
+      ASSERT (FALSE);
+      ResourceHobMemoryTop = MAX_UINT64;
+    } else {
+      ResourceHobMemoryTop = ResourceHob->PhysicalStart + ResourceHob->ResourceLength;
+    }
+    // MU_CHANGE END - Check for potential overflow before addition
+
+    if (PhitHob->EfiFreeMemoryTop > ResourceHobMemoryTop) { // MU_CHANGE
       continue;
     }
 
@@ -2448,15 +2457,7 @@ CoreInitializeMemoryServices (
     //
     Attributes  = PhitResourceHob->ResourceAttribute;
     BaseAddress = PageAlignAddress (PhitHob->EfiMemoryTop);
-    // MU_CHANGE START - Check for potential underflow before subtraction
-    Status = SafeUint64Add (ResourceHob->PhysicalStart, ResourceHob->ResourceLength, &HighAddress);
-    if (EFI_ERROR (Status)) {
-      // This hob can't be right...
-      ASSERT_EFI_ERROR (Status);
-      HighAddress = MAX_UINT64;
-    }
-
-    if (BaseAddress > HighAddress) {
+    if (BaseAddress > ResourceHobMemoryTop) { // MU_CHANGE
       Length = 0;
     } else {
       Length = PageAlignLength (HighAddress - BaseAddress);
@@ -2540,7 +2541,7 @@ CoreInitializeMemoryServices (
         continue;
       }
 
-      if ((ResourceHob->PhysicalStart + ResourceHob->ResourceLength) > (EFI_PHYSICAL_ADDRESS)MAX_ALLOC_ADDRESS) {
+      if (ResourceHobMemoryTop > (EFI_PHYSICAL_ADDRESS)MAX_ALLOC_ADDRESS) { // MU_CHANGE
         continue;
       }
 
@@ -2555,7 +2556,7 @@ CoreInitializeMemoryServices (
       // Skip Resource Descriptor HOBs that are not large enough to initilize the DXE Core
       //
       TestedMemoryBaseAddress = PageAlignAddress (ResourceHob->PhysicalStart);
-      TestedMemoryLength      = PageAlignLength (ResourceHob->PhysicalStart + ResourceHob->ResourceLength - TestedMemoryBaseAddress);
+      TestedMemoryLength      = PageAlignLength (ResourceHobMemoryTop - TestedMemoryBaseAddress); // MU_CHANGE
       FindLargestFreeRegion (&TestedMemoryBaseAddress, &TestedMemoryLength, (EFI_HOB_MEMORY_ALLOCATION *)GetFirstHob (EFI_HOB_TYPE_MEMORY_ALLOCATION));
       if (TestedMemoryLength < MinimalMemorySizeNeeded) {
         continue;

--- a/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
+++ b/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
@@ -2447,8 +2447,15 @@ CoreInitializeMemoryServices (
     //
     Attributes  = PhitResourceHob->ResourceAttribute;
     BaseAddress = PageAlignAddress (PhitHob->EfiMemoryTop);
-    Length      = PageAlignLength (ResourceHob->PhysicalStart + ResourceHob->ResourceLength - BaseAddress);
-    FindLargestFreeRegion (&BaseAddress, &Length, (EFI_HOB_MEMORY_ALLOCATION *)GetFirstHob (EFI_HOB_TYPE_MEMORY_ALLOCATION));
+    // MU_CHANGE START - Check for potential underflow before subtraction
+    if (PhitHob->EfiMemoryTop > (ResourceHob->PhysicalStart + ResourceHob->ResourceLength)) {
+      Length = 0;
+    } else {
+      Length      = PageAlignLength (ResourceHob->PhysicalStart + ResourceHob->ResourceLength - BaseAddress);
+      FindLargestFreeRegion (&BaseAddress, &Length, (EFI_HOB_MEMORY_ALLOCATION *)GetFirstHob (EFI_HOB_TYPE_MEMORY_ALLOCATION));
+    }
+    // MU_CHANGE END - Check for potential underflow before subtraction
+
     if (Length < MinimalMemorySizeNeeded) {
       //
       // If that range is not large enough to intialize the DXE Core, then


### PR DESCRIPTION
## Description

During DXE core memory service initialization, the system would check available resource descriptor hobs against the memory top from PHIT hob.

However, it is possible that a given resource descriptor hob will not be larger than the cover the memory top, causing the Length calculation to underflow. Or the hob is not properly prepared and cause the calculation to overflow.

This change adds a check for potential underflow/overflow before performing the subtraction.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This change was tested on QEMU SBSA and booted to both UEFI shell and Windows VOS.

## Integration Instructions

N/A