### PR TITLE
[Cherry-pick] ShellPkg: Smbiosview show type 3, specification 3.9 fields [Rebase & FF]

### DIFF
--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
@@ -469,6 +469,16 @@ SmbiosPrintStructure (
         }
       }
 
+      if (AE_SMBIOS_VERSION (0x3, 0x9)) {
+        if (Struct->Hdr->Length > (0x16 + (Struct->Type3->ContainedElementCount * Struct->Type3->ContainedElementRecordLength))) {
+          ShellPrintEx (-1, -1, L"Rack Type: %x\n", Buffer[0x16 + (Struct->Type3->ContainedElementCount * Struct->Type3->ContainedElementRecordLength)]);
+        }
+
+        if (Struct->Hdr->Length > (0x17 + (Struct->Type3->ContainedElementCount * Struct->Type3->ContainedElementRecordLength))) {
+          ShellPrintEx (-1, -1, L"Rack Height: %x\n", Buffer[0x17 + (Struct->Type3->ContainedElementCount * Struct->Type3->ContainedElementRecordLength)]);
+        }
+      }
+
       break;
 
     //


### PR DESCRIPTION
## Description

Show smbios 3.9 specification fields in smbios view type 3 
(cherry picked from commit a0e8b71ee5356d4539199739f52d0af2fe4bc65b)


- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Local CI build

## Integration Instructions
no integration necessary.