### PR TITLE
Rust: update build_rule.template to copy symbols to OUTPUT

### DIFF
--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -294,6 +294,7 @@
         $(CP) $(DEBUG_DIR)(+)$(MODULE_NAME).map  $(OUTPUT_DIR)(+)$(MODULE_NAME).map
         $(CP) $(DEBUG_DIR)(+)$(MODULE_NAME).efi $(OUTPUT_DIR)(+)$(MODULE_NAME).efi
         $(CP) $(OUTPUT_DIR)(+)$(MODULE_NAME).efi $(BIN_DIR)(+)$(MODULE_NAME).efi
+        $(CP) $(DEBUG_DIR)(+)$(TARGET_TRIPLE)(+)$(RUST_TARGET)(+)$(MODULE_NAME).pdb $(OUTPUT_DIR)
 
 [Static-Library-File.RUST_MODULE]
     <InputFile>


### PR DESCRIPTION
## Description
Update the [Toml-File.RUST_MODULE] <Command> to support copying the Pdb symbols file to the OUTPUT folder as part of an EDK2 build. This allows the FlattenPdbs plugin to properly pick up the symbols for Rust DXE drivers.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

* Verified locally on my own Rust driver builds via the Stuart build system.

## Integration Instructions

N/A