### PR TITLE
[CHERRY-PICK] NetworkPkg/SnpDxe: Fix Snp used uninitialized

### DIFF
--- a/NetworkPkg/SnpDxe/Snp.c
+++ b/NetworkPkg/SnpDxe/Snp.c
@@ -324,6 +324,8 @@ SimpleNetworkDriverStart (
 
   DEBUG ((DEBUG_NET, "\nSnpNotifyNetworkInterfaceIdentifier()  "));
 
+  Snp = NULL;
+
   Status = gBS->OpenProtocol (
                   Controller,
                   &gEfiDevicePathProtocolGuid,


### PR DESCRIPTION
## Description

Ensures the Snp Structure is initialized as NULL.

cherry-picks back the fix from EDK2

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on physical device

## Integration Instructions

N/A
