### PR TITLE
[Rebase & FF] Adding a communication buffer update protocol to save memory fragmentation

### DIFF
--- a/MdeModulePkg/Core/Dxe/Image/Image.c
+++ b/MdeModulePkg/Core/Dxe/Image/Image.c
@@ -208,7 +208,9 @@ CoreInitializeImageServices (
       //
       // Find Dxe Core HOB
       //
-      break;
+      if (CompareGuid (&DxeCoreHob.MemoryAllocationModule->ModuleName, &gEfiCallerIdGuid)) {
+        break;
+      }
     }
 
     DxeCoreHob.Raw = GET_NEXT_HOB (DxeCoreHob);

--- a/MdeModulePkg/Core/Dxe/Mem/MemoryProfileRecord.c
+++ b/MdeModulePkg/Core/Dxe/Mem/MemoryProfileRecord.c
@@ -549,7 +549,9 @@ RegisterDxeCore (
       //
       // Find Dxe Core HOB
       //
-      break;
+      if (CompareGuid (&DxeCoreHob.MemoryAllocationModule->ModuleName, &gEfiCallerIdGuid)) {
+        break;
+      }
     }
 
     DxeCoreHob.Raw = GET_NEXT_HOB (DxeCoreHob);

--- a/MdeModulePkg/Include/Guid/MmCommBuffer.h
+++ b/MdeModulePkg/Include/Guid/MmCommBuffer.h
@@ -47,6 +47,13 @@ typedef struct {
   ///
   BOOLEAN    IsCommBufferValid;
 
+  /// MU_CHANGE Starts
+  ///
+  /// The channel used to communicate with MM.
+  ///
+  BOOLEAN    TalkToSupervisor;
+  /// MU_CHANGE Ends
+
   ///
   /// The return status when returning from MM to non-MM.
   ///

--- a/StandaloneMmPkg/Include/Protocol/MmCommBufferUpdate.h
+++ b/StandaloneMmPkg/Include/Protocol/MmCommBufferUpdate.h
@@ -1,0 +1,40 @@
+/** @file
+  MM communication buffer updated protocol is an indicator of the MM communcation
+  buffer is done and will carry needed updated buffer location.
+
+  Copyright (c), Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef MM_COMMUNICATION_BUFFER_UPDATE_H_
+#define MM_COMMUNICATION_BUFFER_UPDATE_H_
+
+#include <Guid/MmCommBuffer.h>
+
+#define MM_COMMUNICATE_BUFFER_UPDATE_PROTOCOL_GUID \
+  { \
+    0x2a22e38f, 0x9d1c, 0x49d0, { 0xbd, 0xce, 0x7d, 0xda, 0xc1, 0x6d, 0xa4, 0x5d } \
+  }
+
+//
+// Forward reference
+//
+typedef struct _MM_COMM_BUFFER_UPDATE_PROTOCOL MM_COMM_BUFFER_UPDATE_PROTOCOL;
+
+#define MM_COMMUNICATE_BUFFER_UPDATE_PROTOCOL_VERSION  0x00000001
+
+#pragma pack(1)
+
+struct _MM_COMM_BUFFER_UPDATE_PROTOCOL {
+  UINT64            Version;                    // Version of this structure
+  MM_COMM_BUFFER    UpdatedCommBuffer;          // MM communication buffer information
+};
+
+#pragma pack()
+
+STATIC_ASSERT (sizeof (MM_COMM_BUFFER_UPDATE_PROTOCOL) == (sizeof (MM_COMM_BUFFER) + sizeof (UINT64)), "MM_COMM_BUFFER_UPDATE_PROTOCOL size mismatch!");
+
+extern EFI_GUID  gMmCommBufferUpdateProtocolGuid;
+
+#endif // MM_COMMUNICATION_BUFFER_UPDATE_H_

--- a/StandaloneMmPkg/StandaloneMmPkg.dec
+++ b/StandaloneMmPkg/StandaloneMmPkg.dec
@@ -50,6 +50,12 @@
 [Ppis]
   gMmCoreFvLocationPpiGuid                 = { 0x47a00618, 0x237a, 0x4386, { 0x8f, 0xc5, 0x2a, 0x86, 0xd8, 0xac, 0x41, 0x05 }}
 
+# MU_CHANGE Starts
+[Protocols]
+  # Include/Protocol/MmCommBufferUpdate.h
+  gMmCommBufferUpdateProtocolGuid          = { 0x2a22e38f, 0x9d1c, 0x49d0, { 0xbd, 0xce, 0x7d, 0xda, 0xc1, 0x6d, 0xa4, 0x5d }}
+# MU_CHANGE Ends
+
 [PcdsFixedAtBuild, PcdsPatchableInModule]
   ## Maximum permitted encapsulation levels of sections in a firmware volume,
   #  in the MM phase. Minimum value is 1. Sections nested more deeply are rejected.


### PR DESCRIPTION
## Description

The current Standalone MM model does not coalesce the runtime memory when the unblock memory request in PEI allocate runtime memory. This will lead to fragmented memory map and potentially hibernation failure.
 
This change adds a protocol definition that allows an event to be signaled when all the PEI-allocated runtime memory migrate to permanent runtime memory.

This change also adds a byte in the communication buffer status to differentiate the target.

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on both QEMU Q35 and proprietary hardware platforms.

## Integration Instructions

For consumers that need to get signaled, please register an event for `gMmCommBufferUpdateProtocolGuid`.