### PR TITLE
MdeModulePkg/VariableSmmRuntimeDxe: Fix missing protocol dependency

### DIFF
--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf
@@ -119,7 +119,8 @@
   gEdkiiVariableRuntimeCacheInfoHobGuid
 
 [Depex]
-  gEfiMmCommunication2ProtocolGuid
+  gEfiMmCommunication2ProtocolGuid AND
+  gEfiSmmVariableProtocolGuid
 
 [UserExtensions.TianoCore."ExtraFiles"]
   VariableSmmRuntimeDxeExtra.uni


### PR DESCRIPTION
This pull request updates the dependency expressions in the `VariableSmmRuntimeDxe.inf` file to ensure that the driver only loads when both the `gEfiMmCommunication2ProtocolGuid` and `gEfiSmmVariableProtocolGuid` protocols are available.

Dependency management:

* Updated the `[Depex]` section in `VariableSmmRuntimeDxe.inf` to require both `gEfiMmCommunication2ProtocolGuid` and `gEfiSmmVariableProtocolGuid` protocols for driver initialization.

When testing crypto changes, the new depex's caused this bug to appear. We depend on gEfiSmmVariableProtocolGuid but we don't have a depex for it

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

QemuQ35 

## Integration Instructions

N/A