### PR TITLE
Fix alignment of PE/COFF image address to section alignment

### DIFF
--- a/MdeModulePkg/Core/Pei/Image/Image.c
+++ b/MdeModulePkg/Core/Pei/Image/Image.c
@@ -402,7 +402,7 @@ LoadAndRelocatePeCoffImage (
       if (ImageContext.SectionAlignment > EFI_PAGE_SIZE) {
         ImageContext.ImageAddress =
           (ImageContext.ImageAddress + ImageContext.SectionAlignment - 1) &
-          ~((UINTN)ImageContext.SectionAlignment - 1);
+          ~((EFI_PHYSICAL_ADDRESS)ImageContext.SectionAlignment - 1);
       }
 
       //


### PR DESCRIPTION
## Description

With MSVC 14.44.35207, and operation for section alignment is causing compilation failure : MdeModulePkg\Core\Pei\Image\Image.c(405): '~': zero extending 'UINT32' to 'PHYSICAL_ADDRESS' of greater size
Use EFI_PHYSICAL_ADDRESS instead of UINTN for ImageAddress assignment to get proper masking address for section alignment.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Build pipeline compilation.

## Integration Instructions

N/A