### PR TITLE
[CHERRY-PICK] Making StandaloneMmIplPei compatible with supervisor

### DIFF
--- a/StandaloneMmPkg/Drivers/StandaloneMmIplPei/MmFoundationHob.c
+++ b/StandaloneMmPkg/Drivers/StandaloneMmIplPei/MmFoundationHob.c
@@ -1026,9 +1026,12 @@ CreateMmFoundationHobList (
   //
   // Build ACPI variable HOB
   //
-  HobLength = GetRemainingHobSize (*FoundationHobSize, UsedSize);
-  MmIplCopyGuidHob (FoundationHobList + UsedSize, &HobLength, &gEfiAcpiVariableGuid, FALSE);
-  UsedSize += HobLength;
+  if (PcdGetBool (PcdAcpiS3Enable)) {
+    // Only check on this variable when S3 needs it.
+    HobLength = GetRemainingHobSize (*FoundationHobSize, UsedSize);
+    MmIplCopyGuidHob (FoundationHobList + UsedSize, &HobLength, &gEfiAcpiVariableGuid, FALSE);
+    UsedSize += HobLength;
+  }
 
   if (FeaturePcdGet (PcdCpuSmmProfileEnable)) {
     //


### PR DESCRIPTION
## Description

Current implementation of the `StandaloneMmIplPei` has a few design differences compared to MM supervisor.

This will introduce more maintenance burden as we move to the next phase of MM supervisor.

This change is made to try to converge the 2 designs, at least from the perspective of IPL, in order to use the IPL as is and still conform to the MM supervisor modelity.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This is tested on QEMU Q35 and booted to UEFI shell.

## Integration Instructions

N/A