### PR TITLE
[CHERRY-PICK] MdeModulePkg: VS22 warning suppressions

### DIFF
--- a/MdeModulePkg/Core/Dxe/Image/Image.c
+++ b/MdeModulePkg/Core/Dxe/Image/Image.c
@@ -790,7 +790,7 @@ CoreLoadPeImage (
   if (!Image->ImageContext.IsTeImage) {
     Image->ImageContext.ImageAddress =
       (Image->ImageContext.ImageAddress + Image->ImageContext.SectionAlignment - 1) &
-      ~((UINTN)Image->ImageContext.SectionAlignment - 1);
+      ~((EFI_PHYSICAL_ADDRESS)Image->ImageContext.SectionAlignment - 1);
   }
 
   //

--- a/MdeModulePkg/Core/Pei/Image/Image.c
+++ b/MdeModulePkg/Core/Pei/Image/Image.c
@@ -402,7 +402,7 @@ LoadAndRelocatePeCoffImage (
       if (ImageContext.SectionAlignment > EFI_PAGE_SIZE) {
         ImageContext.ImageAddress =
           (ImageContext.ImageAddress + ImageContext.SectionAlignment - 1) &
-          ~((UINTN)ImageContext.SectionAlignment - 1);
+          ~((EFI_PHYSICAL_ADDRESS)ImageContext.SectionAlignment - 1);
       }
 
       //

--- a/MdeModulePkg/Core/Pei/Image/Image.c
+++ b/MdeModulePkg/Core/Pei/Image/Image.c
@@ -402,7 +402,7 @@ LoadAndRelocatePeCoffImage (
       if (ImageContext.SectionAlignment > EFI_PAGE_SIZE) {
         ImageContext.ImageAddress =
           (ImageContext.ImageAddress + ImageContext.SectionAlignment - 1) &
-          ~((EFI_PHYSICAL_ADDRESS)ImageContext.SectionAlignment - 1);
+          ~((UINTN)ImageContext.SectionAlignment - 1);
       }
 
       //


### PR DESCRIPTION
## Description

Reverts a Mu-specific change to cherry-pick the equivalent edk2 commit that also includes fixing an additional warning.

---

**Revert "Fix alignment of PE/COFF image address to section alignment (#1580)"**

This reverts commit f6015c4944ce5aa1a3f6d731ed065604ca58d527
to cherry-pick the equivalent upcoming change from edk2.

---

**[CHERRY-PICK] MdeModulePkg: Remove ambiguous negation of narrower type**

Replace UINTN casts with EFI_PHYSICAL_ADDRESS in places where the result
is negated, as otherwise, the top bits may remain 0 unexpectedly.

VS2022 started warning about this, and thus breaking the IA32 CI build.

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- CI

## Integration Instructions

- N/A