### PR TITLE
MdeModulePkg/Variable: Add PCD to control RT cache allocation

### DIFF
--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -916,6 +916,20 @@
   # @Prompt Enable the UEFI variable runtime cache.
   gEfiMdeModulePkgTokenSpaceGuid.PcdEnableVariableRuntimeCache|TRUE|BOOLEAN|0x00010039
 
+  # MU_CHANGE [BEGIN] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
+  ## Indicates whether to allocate variable runtime cache buffers in PEI or DXE phase.<BR><BR>
+  #  When TRUE, buffers are allocated as EfiBootServicesData in PEI and migrated to
+  #  EfiRuntimeServicesData in DXE to prevent runtime memory fragmentation.<BR>
+  #  When FALSE, buffers are allocated directly as EfiRuntimeServicesData in PEI
+  #  (original behavior).<BR><BR>
+  #  This should only be set to TRUE on platforms that can unblock MM memory in DXE such as those
+  #  with the Project Mu MM Supervisor.<BR><BR>
+  #   TRUE  - Allocate in PEI as boot services data and migrate to runtime in DXE.<BR>
+  #   FALSE - Allocate in PEI directly as runtime services data (default).<BR>
+  # @Prompt Migrate variable runtime cache buffer allocation from PEI to DXE.
+  gEfiMdeModulePkgTokenSpaceGuid.PcdMigrateVariableRuntimeCacheBufferAllocation|FALSE|BOOLEAN|0x0001009d
+  # MU_CHANGE [END] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
+
   ## Indicates if the statistics about variable usage will be collected. This information is
   #  stored as a vendor configuration table into the EFI system table.
   #  Set this PCD to TRUE to use VariableInfo application in MdeModulePkg\Application directory to get

--- a/MdeModulePkg/Universal/Variable/Pei/Variable.c
+++ b/MdeModulePkg/Universal/Variable/Pei/Variable.c
@@ -1447,34 +1447,38 @@ BuildVariableRuntimeCacheInfoHob (
 {
   VARIABLE_RUNTIME_CACHE_INFO  TempHobBuffer;
   VARIABLE_RUNTIME_CACHE_INFO  *VariableRuntimeCacheInfo;
-  // MU_CHANGE [BEGIN] - Comment out unused variable when moving allocation to DXE
-  // EFI_STATUS                   Status;
-  // MU_CHANGE [END]
-  VOID     *Buffer;
-  UINTN    BufferSize;
-  BOOLEAN  NvAuthFlag;
-  UINTN    Pages;
+  EFI_STATUS                   Status;
+  VOID                         *Buffer;
+  UINTN                        BufferSize;
+  BOOLEAN                      NvAuthFlag;
+  UINTN                        Pages;
 
   ZeroMem (&TempHobBuffer, sizeof (VARIABLE_RUNTIME_CACHE_INFO));
 
-  //
   // MU_CHANGE [BEGIN] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
-  // AllocatePages for CACHE_INFO_FLAG buffer (will be relocated to runtime by DXE).
-  //
-  Pages  = EFI_SIZE_TO_PAGES (sizeof (CACHE_INFO_FLAG));
-  Buffer = AllocatePages (Pages);
-  ASSERT (Buffer != NULL);
-  //
-  // MU_CHANGE - Commented out runtime allocation and memory unblock (moved to DXE)
-  // Buffer = AllocateRuntimePages (Pages);
-  // Status = MmUnblockMemoryRequest (
-  //            (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
-  //            Pages
-  //            );
-  // if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-  //   return Status;
-  // }
-  //
+  Pages = EFI_SIZE_TO_PAGES (sizeof (CACHE_INFO_FLAG));
+
+  if (PcdGetBool (PcdMigrateVariableRuntimeCacheBufferAllocation)) {
+    //
+    // AllocatePages for CACHE_INFO_FLAG buffer (will be relocated to runtime by DXE).
+    //
+    Buffer = AllocatePages (Pages);
+    ASSERT (Buffer != NULL);
+  } else {
+    //
+    // AllocateRuntimePages for CACHE_INFO_FLAG and unblock it.
+    //
+    Buffer = AllocateRuntimePages (Pages);
+    ASSERT (Buffer != NULL);
+    Status = MmUnblockMemoryRequest (
+               (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
+               Pages
+               );
+    if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+      return Status;
+    }
+  }
+
   // MU_CHANGE [END]
 
   TempHobBuffer.CacheInfoFlagBuffer = (UINTN)Buffer;
@@ -1485,26 +1489,30 @@ BuildVariableRuntimeCacheInfoHob (
     Pages
     ));
 
-  //
   // MU_CHANGE [BEGIN] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
-  // AllocatePages for VolatileCache buffer (will be relocated to runtime by DXE).
-  //
   BufferSize = PcdGet32 (PcdVariableStoreSize);
   if (BufferSize > 0) {
-    Pages  = EFI_SIZE_TO_PAGES (BufferSize);
-    Buffer = AllocatePages (Pages);
-    ASSERT (Buffer != NULL);
-    //
-    // MU_CHANGE - Commented out runtime allocation and memory unblock (moved to DXE)
-    // Buffer = AllocateRuntimePages (Pages);
-    // Status = MmUnblockMemoryRequest (
-    //            (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
-    //            Pages
-    //            );
-    // if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-    //   return Status;
-    // }
-    //
+    Pages = EFI_SIZE_TO_PAGES (BufferSize);
+    if (PcdGetBool (PcdMigrateVariableRuntimeCacheBufferAllocation)) {
+      //
+      // AllocatePages for VolatileCache buffer (will be relocated to runtime by DXE).
+      //
+      Buffer = AllocatePages (Pages);
+      ASSERT (Buffer != NULL);
+    } else {
+      //
+      // AllocateRuntimePages for VolatileCache and unblock it.
+      //
+      Buffer = AllocateRuntimePages (Pages);
+      ASSERT (Buffer != NULL);
+      Status = MmUnblockMemoryRequest (
+                 (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
+                 Pages
+                 );
+      if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+        return Status;
+      }
+    }
 
     TempHobBuffer.RuntimeVolatileCacheBuffer = (UINTN)Buffer;
     TempHobBuffer.RuntimeVolatileCachePages  = Pages;
@@ -1519,26 +1527,30 @@ BuildVariableRuntimeCacheInfoHob (
     TempHobBuffer.RuntimeVolatileCachePages
     ));
 
-  //
   // MU_CHANGE [BEGIN] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
-  // AllocatePages for NVCache buffer (will be relocated to runtime by DXE).
-  //
   BufferSize = CalculateNvVariableCacheSize (&NvAuthFlag);
   if (BufferSize > 0) {
-    Pages  = EFI_SIZE_TO_PAGES (BufferSize);
-    Buffer = AllocatePages (Pages);
-    ASSERT (Buffer != NULL);
-    //
-    // MU_CHANGE - Commented out runtime allocation and memory unblock (moved to DXE)
-    // Buffer = AllocateRuntimePages (Pages);
-    // Status = MmUnblockMemoryRequest (
-    //            (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
-    //            Pages
-    //            );
-    // if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-    //   return Status;
-    // }
-    //
+    Pages = EFI_SIZE_TO_PAGES (BufferSize);
+    if (PcdGetBool (PcdMigrateVariableRuntimeCacheBufferAllocation)) {
+      //
+      // AllocatePages for NVCache buffer (will be relocated to runtime by DXE).
+      //
+      Buffer = AllocatePages (Pages);
+      ASSERT (Buffer != NULL);
+    } else {
+      //
+      // AllocateRuntimePages for NVCache and unblock it.
+      //
+      Buffer = AllocateRuntimePages (Pages);
+      ASSERT (Buffer != NULL);
+      Status = MmUnblockMemoryRequest (
+                 (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
+                 Pages
+                 );
+      if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+        return Status;
+      }
+    }
 
     TempHobBuffer.RuntimeNvCacheBuffer = (UINTN)Buffer;
     TempHobBuffer.RuntimeNvCachePages  = Pages;
@@ -1553,26 +1565,30 @@ BuildVariableRuntimeCacheInfoHob (
     TempHobBuffer.RuntimeNvCachePages
     ));
 
-  //
   // MU_CHANGE [BEGIN] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
-  // AllocatePages for HobCache buffer (will be relocated to runtime by DXE).
-  //
   BufferSize = CalculateHobVariableCacheSize (NvAuthFlag);
   if (BufferSize > 0) {
-    Pages  = EFI_SIZE_TO_PAGES (BufferSize);
-    Buffer = AllocatePages (Pages);
-    ASSERT (Buffer != NULL);
-    //
-    // MU_CHANGE - Commented out runtime allocation and memory unblock (moved to DXE)
-    // Buffer = AllocateRuntimePages (Pages);
-    // Status = MmUnblockMemoryRequest (
-    //            (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
-    //            Pages
-    //            );
-    // if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-    //   return Status;
-    // }
-    //
+    Pages = EFI_SIZE_TO_PAGES (BufferSize);
+    if (PcdGetBool (PcdMigrateVariableRuntimeCacheBufferAllocation)) {
+      //
+      // AllocatePages for HobCache buffer (will be relocated to runtime by DXE).
+      //
+      Buffer = AllocatePages (Pages);
+      ASSERT (Buffer != NULL);
+    } else {
+      //
+      // AllocateRuntimePages for HobCache and unblock it.
+      //
+      Buffer = AllocateRuntimePages (Pages);
+      ASSERT (Buffer != NULL);
+      Status = MmUnblockMemoryRequest (
+                 (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
+                 Pages
+                 );
+      if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+        return Status;
+      }
+    }
 
     TempHobBuffer.RuntimeHobCacheBuffer = (UINTN)Buffer;
     TempHobBuffer.RuntimeHobCachePages  = Pages;

--- a/MdeModulePkg/Universal/Variable/Pei/Variable.h
+++ b/MdeModulePkg/Universal/Variable/Pei/Variable.h
@@ -22,9 +22,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/PeiServicesLib.h>
 #include <Library/SafeIntLib.h>
 #include <Library/VariableFlashInfoLib.h>
-// MU_CHANGE [BEGIN] - Comment out unused include when moving allocation to DXE
-// #include <Library/MmUnblockMemoryLib.h>
-// MU_CHANGE [END]
+#include <Library/MmUnblockMemoryLib.h>
 #include <Library/MemoryAllocationLib.h>
 
 #include <Guid/VariableFormat.h>

--- a/MdeModulePkg/Universal/Variable/Pei/VariablePei.inf
+++ b/MdeModulePkg/Universal/Variable/Pei/VariablePei.inf
@@ -41,9 +41,7 @@
   PeiServicesLib
   SafeIntLib
   VariableFlashInfoLib
-  # MU_CHANGE [BEGIN] - Comment out unused library when moving allocation to DXE
-  # MmUnblockMemoryLib
-  # MU_CHANGE [END]
+  MmUnblockMemoryLib
   MemoryAllocationLib
 
 [Guids]
@@ -70,6 +68,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvModeEnable         ## SOMETIMES_CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdVariableStoreSize               ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdEnableVariableRuntimeCache      ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdMigrateVariableRuntimeCacheBufferAllocation  ## CONSUMES  # MU_CHANGE
 
 [Depex]
   gEdkiiFaultTolerantWriteGuid

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
@@ -1613,168 +1613,172 @@ InitVariableCache (
       );
 
     CopyMem (&mVariableRtCacheInfo, VariableRuntimeCacheInfo, sizeof (VARIABLE_RUNTIME_CACHE_INFO));
-    //
-    // MU_CHANGE - Commented out old header initialization (moved to individual buffer relocations)
-    // InitVariableStoreHeader ((VOID *)(UINTN)mVariableRtCacheInfo.RuntimeHobCacheBuffer, AllocatedHobCacheSize);
-    // InitVariableStoreHeader ((VOID *)(UINTN)mVariableRtCacheInfo.RuntimeNvCacheBuffer, AllocatedNvCacheSize);
-    // InitVariableStoreHeader ((VOID *)(UINTN)mVariableRtCacheInfo.RuntimeVolatileCacheBuffer, AllocatedVolatileCacheSize);
-    //
 
-    //
-    // MU_CHANGE [BEGIN] - Relocate runtime cache buffers from boot services to runtime services
-    // This prevents runtime memory fragmentation by consolidating allocations in DXE
-    //
-    // Relocate CacheInfoFlag buffer from boot services to runtime services
-    //
-    if (mVariableRtCacheInfo.CacheInfoFlagBuffer != 0) {
-      Pages  = EFI_SIZE_TO_PAGES (sizeof (CACHE_INFO_FLAG));
-      Status = gBS->AllocatePages (
-                      AllocateAnyPages,
-                      EfiRuntimeServicesData,
-                      Pages,
-                      &TempCacheInfoBuffer
-                      );
-      if (EFI_ERROR (Status)) {
-        DEBUG ((DEBUG_WARN, "Failed to allocate runtime CacheInfoFlag buffer: %r\n", Status));
-        AllRtBufferAllocationsSucceeded = FALSE;
-      } else {
-        Status = MmUnblockMemoryRequest (TempCacheInfoBuffer, Pages);
-        if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-          DEBUG ((DEBUG_WARN, "Failed to unblock CacheInfoFlag buffer: %r\n", Status));
-          gBS->FreePages (TempCacheInfoBuffer, Pages);
-          TempCacheInfoBuffer             = 0;
+    // MU_CHANGE [BEGIN] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
+    if (PcdGetBool (PcdMigrateVariableRuntimeCacheBufferAllocation)) {
+      //
+      // Relocate runtime cache buffers from boot services to runtime services
+      // This prevents runtime memory fragmentation by consolidating allocations in DXE
+      //
+      // Relocate CacheInfoFlag buffer from boot services to runtime services
+      //
+      if (mVariableRtCacheInfo.CacheInfoFlagBuffer != 0) {
+        Pages  = EFI_SIZE_TO_PAGES (sizeof (CACHE_INFO_FLAG));
+        Status = gBS->AllocatePages (
+                        AllocateAnyPages,
+                        EfiRuntimeServicesData,
+                        Pages,
+                        &TempCacheInfoBuffer
+                        );
+        if (EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_WARN, "Failed to allocate runtime CacheInfoFlag buffer: %r\n", Status));
           AllRtBufferAllocationsSucceeded = FALSE;
+        } else {
+          Status = MmUnblockMemoryRequest (TempCacheInfoBuffer, Pages);
+          if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+            DEBUG ((DEBUG_WARN, "Failed to unblock CacheInfoFlag buffer: %r\n", Status));
+            gBS->FreePages (TempCacheInfoBuffer, Pages);
+            TempCacheInfoBuffer             = 0;
+            AllRtBufferAllocationsSucceeded = FALSE;
+          }
         }
       }
-    }
 
-    if (AllRtBufferAllocationsSucceeded && (mVariableRtCacheInfo.RuntimeHobCacheBuffer != 0) && (AllocatedHobCacheSize > 0)) {
-      Pages  = EFI_SIZE_TO_PAGES (AllocatedHobCacheSize);
-      Status = gBS->AllocatePages (
-                      AllocateAnyPages,
-                      EfiRuntimeServicesData,
-                      Pages,
-                      &TempHobCacheBuffer
-                      );
-      if (EFI_ERROR (Status)) {
-        DEBUG ((DEBUG_WARN, "Failed to allocate runtime HOB cache buffer: %r\n", Status));
-        AllRtBufferAllocationsSucceeded = FALSE;
-      } else {
-        Status = MmUnblockMemoryRequest (TempHobCacheBuffer, Pages);
-        if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-          DEBUG ((DEBUG_WARN, "Failed to unblock HOB cache buffer: %r\n", Status));
-          gBS->FreePages (TempHobCacheBuffer, Pages);
-          TempHobCacheBuffer              = 0;
+      if (AllRtBufferAllocationsSucceeded && (mVariableRtCacheInfo.RuntimeHobCacheBuffer != 0) && (AllocatedHobCacheSize > 0)) {
+        Pages  = EFI_SIZE_TO_PAGES (AllocatedHobCacheSize);
+        Status = gBS->AllocatePages (
+                        AllocateAnyPages,
+                        EfiRuntimeServicesData,
+                        Pages,
+                        &TempHobCacheBuffer
+                        );
+        if (EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_WARN, "Failed to allocate runtime HOB cache buffer: %r\n", Status));
           AllRtBufferAllocationsSucceeded = FALSE;
+        } else {
+          Status = MmUnblockMemoryRequest (TempHobCacheBuffer, Pages);
+          if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+            DEBUG ((DEBUG_WARN, "Failed to unblock HOB cache buffer: %r\n", Status));
+            gBS->FreePages (TempHobCacheBuffer, Pages);
+            TempHobCacheBuffer              = 0;
+            AllRtBufferAllocationsSucceeded = FALSE;
+          }
         }
       }
-    }
 
-    if (AllRtBufferAllocationsSucceeded && (mVariableRtCacheInfo.RuntimeNvCacheBuffer != 0) && (AllocatedNvCacheSize > 0)) {
-      Pages  = EFI_SIZE_TO_PAGES (AllocatedNvCacheSize);
-      Status = gBS->AllocatePages (
-                      AllocateAnyPages,
-                      EfiRuntimeServicesData,
-                      Pages,
-                      &TempNvCacheBuffer
-                      );
-      if (EFI_ERROR (Status)) {
-        DEBUG ((DEBUG_WARN, "Failed to allocate runtime NV cache buffer: %r\n", Status));
-        AllRtBufferAllocationsSucceeded = FALSE;
-      } else {
-        Status = MmUnblockMemoryRequest (TempNvCacheBuffer, Pages);
-        if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-          DEBUG ((DEBUG_WARN, "Failed to unblock NV cache buffer: %r\n", Status));
-          gBS->FreePages (TempNvCacheBuffer, Pages);
-          TempNvCacheBuffer               = 0;
+      if (AllRtBufferAllocationsSucceeded && (mVariableRtCacheInfo.RuntimeNvCacheBuffer != 0) && (AllocatedNvCacheSize > 0)) {
+        Pages  = EFI_SIZE_TO_PAGES (AllocatedNvCacheSize);
+        Status = gBS->AllocatePages (
+                        AllocateAnyPages,
+                        EfiRuntimeServicesData,
+                        Pages,
+                        &TempNvCacheBuffer
+                        );
+        if (EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_WARN, "Failed to allocate runtime NV cache buffer: %r\n", Status));
           AllRtBufferAllocationsSucceeded = FALSE;
+        } else {
+          Status = MmUnblockMemoryRequest (TempNvCacheBuffer, Pages);
+          if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+            DEBUG ((DEBUG_WARN, "Failed to unblock NV cache buffer: %r\n", Status));
+            gBS->FreePages (TempNvCacheBuffer, Pages);
+            TempNvCacheBuffer               = 0;
+            AllRtBufferAllocationsSucceeded = FALSE;
+          }
         }
       }
-    }
 
-    if (AllRtBufferAllocationsSucceeded && (mVariableRtCacheInfo.RuntimeVolatileCacheBuffer != 0) && (AllocatedVolatileCacheSize > 0)) {
-      Pages  = EFI_SIZE_TO_PAGES (AllocatedVolatileCacheSize);
-      Status = gBS->AllocatePages (
-                      AllocateAnyPages,
-                      EfiRuntimeServicesData,
-                      Pages,
-                      &TempVolatileCacheBuffer
-                      );
-      if (EFI_ERROR (Status)) {
-        DEBUG ((DEBUG_WARN, "Failed to allocate runtime volatile cache buffer: %r\n", Status));
-        AllRtBufferAllocationsSucceeded = FALSE;
-      } else {
-        Status = MmUnblockMemoryRequest (TempVolatileCacheBuffer, Pages);
-        if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-          DEBUG ((DEBUG_WARN, "Failed to unblock volatile cache buffer: %r\n", Status));
-          gBS->FreePages (TempVolatileCacheBuffer, Pages);
-          TempVolatileCacheBuffer         = 0;
+      if (AllRtBufferAllocationsSucceeded && (mVariableRtCacheInfo.RuntimeVolatileCacheBuffer != 0) && (AllocatedVolatileCacheSize > 0)) {
+        Pages  = EFI_SIZE_TO_PAGES (AllocatedVolatileCacheSize);
+        Status = gBS->AllocatePages (
+                        AllocateAnyPages,
+                        EfiRuntimeServicesData,
+                        Pages,
+                        &TempVolatileCacheBuffer
+                        );
+        if (EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_WARN, "Failed to allocate runtime volatile cache buffer: %r\n", Status));
           AllRtBufferAllocationsSucceeded = FALSE;
+        } else {
+          Status = MmUnblockMemoryRequest (TempVolatileCacheBuffer, Pages);
+          if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+            DEBUG ((DEBUG_WARN, "Failed to unblock volatile cache buffer: %r\n", Status));
+            gBS->FreePages (TempVolatileCacheBuffer, Pages);
+            TempVolatileCacheBuffer         = 0;
+            AllRtBufferAllocationsSucceeded = FALSE;
+          }
         }
       }
-    }
 
-    if (AllRtBufferAllocationsSucceeded) {
-      if (TempCacheInfoBuffer != 0) {
-        RuntimeBuffer = (VOID *)(UINTN)TempCacheInfoBuffer;
-        CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.CacheInfoFlagBuffer, sizeof (CACHE_INFO_FLAG));
-        mVariableRtCacheInfo.CacheInfoFlagBuffer = TempCacheInfoBuffer;
+      if (AllRtBufferAllocationsSucceeded) {
+        if (TempCacheInfoBuffer != 0) {
+          RuntimeBuffer = (VOID *)(UINTN)TempCacheInfoBuffer;
+          CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.CacheInfoFlagBuffer, sizeof (CACHE_INFO_FLAG));
+          mVariableRtCacheInfo.CacheInfoFlagBuffer = TempCacheInfoBuffer;
+        }
+
+        if (TempHobCacheBuffer != 0) {
+          RuntimeBuffer = (VOID *)(UINTN)TempHobCacheBuffer;
+          CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeHobCacheBuffer, AllocatedHobCacheSize);
+          mVariableRtCacheInfo.RuntimeHobCacheBuffer = TempHobCacheBuffer;
+          InitVariableStoreHeader (RuntimeBuffer, AllocatedHobCacheSize);
+        }
+
+        if (TempNvCacheBuffer != 0) {
+          RuntimeBuffer = (VOID *)(UINTN)TempNvCacheBuffer;
+          CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeNvCacheBuffer, AllocatedNvCacheSize);
+          mVariableRtCacheInfo.RuntimeNvCacheBuffer = TempNvCacheBuffer;
+          InitVariableStoreHeader (RuntimeBuffer, AllocatedNvCacheSize);
+        }
+
+        if (TempVolatileCacheBuffer != 0) {
+          RuntimeBuffer = (VOID *)(UINTN)TempVolatileCacheBuffer;
+          CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeVolatileCacheBuffer, AllocatedVolatileCacheSize);
+          mVariableRtCacheInfo.RuntimeVolatileCacheBuffer = TempVolatileCacheBuffer;
+          InitVariableStoreHeader (RuntimeBuffer, AllocatedVolatileCacheSize);
+        }
+
+        DEBUG ((DEBUG_INFO, "Runtime variable cache buffers successfully relocated\n"));
+      } else {
+        //
+        // One or more allocations failed - clean up any successful allocations
+        // and disable runtime caching entirely
+        //
+        if (TempCacheInfoBuffer != 0) {
+          gBS->FreePages (TempCacheInfoBuffer, EFI_SIZE_TO_PAGES (sizeof (CACHE_INFO_FLAG)));
+        }
+
+        if (TempHobCacheBuffer != 0) {
+          gBS->FreePages (TempHobCacheBuffer, EFI_SIZE_TO_PAGES (AllocatedHobCacheSize));
+        }
+
+        if (TempNvCacheBuffer != 0) {
+          gBS->FreePages (TempNvCacheBuffer, EFI_SIZE_TO_PAGES (AllocatedNvCacheSize));
+        }
+
+        if (TempVolatileCacheBuffer != 0) {
+          gBS->FreePages (TempVolatileCacheBuffer, EFI_SIZE_TO_PAGES (AllocatedVolatileCacheSize));
+        }
+
+        //
+        // Null all runtime cache pointers to prevent access to boot services memory
+        //
+        InvalidateAllRuntimeCaches ();
+
+        DEBUG ((DEBUG_WARN, "Runtime variable cache disabled due to allocation failure.\n"));
+
+        // Don't return failure - the variable service can function without the runtime cache
       }
-
-      if (TempHobCacheBuffer != 0) {
-        RuntimeBuffer = (VOID *)(UINTN)TempHobCacheBuffer;
-        CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeHobCacheBuffer, AllocatedHobCacheSize);
-        mVariableRtCacheInfo.RuntimeHobCacheBuffer = TempHobCacheBuffer;
-        InitVariableStoreHeader (RuntimeBuffer, AllocatedHobCacheSize);
-      }
-
-      if (TempNvCacheBuffer != 0) {
-        RuntimeBuffer = (VOID *)(UINTN)TempNvCacheBuffer;
-        CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeNvCacheBuffer, AllocatedNvCacheSize);
-        mVariableRtCacheInfo.RuntimeNvCacheBuffer = TempNvCacheBuffer;
-        InitVariableStoreHeader (RuntimeBuffer, AllocatedNvCacheSize);
-      }
-
-      if (TempVolatileCacheBuffer != 0) {
-        RuntimeBuffer = (VOID *)(UINTN)TempVolatileCacheBuffer;
-        CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeVolatileCacheBuffer, AllocatedVolatileCacheSize);
-        mVariableRtCacheInfo.RuntimeVolatileCacheBuffer = TempVolatileCacheBuffer;
-        InitVariableStoreHeader (RuntimeBuffer, AllocatedVolatileCacheSize);
-      }
-
-      DEBUG ((DEBUG_INFO, "Runtime variable cache buffers successfully relocated\n"));
     } else {
       //
-      // One or more allocations failed - clean up any successful allocations
-      // and disable runtime caching entirely
+      // Original behavior: Use buffers allocated in PEI directly (already runtime memory)
       //
-      if (TempCacheInfoBuffer != 0) {
-        gBS->FreePages (TempCacheInfoBuffer, EFI_SIZE_TO_PAGES (sizeof (CACHE_INFO_FLAG)));
-      }
-
-      if (TempHobCacheBuffer != 0) {
-        gBS->FreePages (TempHobCacheBuffer, EFI_SIZE_TO_PAGES (AllocatedHobCacheSize));
-      }
-
-      if (TempNvCacheBuffer != 0) {
-        gBS->FreePages (TempNvCacheBuffer, EFI_SIZE_TO_PAGES (AllocatedNvCacheSize));
-      }
-
-      if (TempVolatileCacheBuffer != 0) {
-        gBS->FreePages (TempVolatileCacheBuffer, EFI_SIZE_TO_PAGES (AllocatedVolatileCacheSize));
-      }
-
-      //
-      // Null all runtime cache pointers to prevent access to boot services memory
-      //
-      InvalidateAllRuntimeCaches ();
-
-      DEBUG ((DEBUG_WARN, "Runtime variable cache disabled due to allocation failure.\n"));
-
-      // Don't return failure - the variable service can function without the runtime cache
+      InitVariableStoreHeader ((VOID *)(UINTN)mVariableRtCacheInfo.RuntimeHobCacheBuffer, AllocatedHobCacheSize);
+      InitVariableStoreHeader ((VOID *)(UINTN)mVariableRtCacheInfo.RuntimeNvCacheBuffer, AllocatedNvCacheSize);
+      InitVariableStoreHeader ((VOID *)(UINTN)mVariableRtCacheInfo.RuntimeVolatileCacheBuffer, AllocatedVolatileCacheSize);
     }
 
-    // MU_CHANGE [END] - Relocate runtime cache buffers using all-or-nothing approach
+    // MU_CHANGE [END] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
   }
 
   return Status;

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf
@@ -87,6 +87,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdAllowVariablePolicyEnforcementDisable     ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdTcgPfpMeasurementRevision                 ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdEnableSpdmDeviceAuthentication             ## PRODUCES AND CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdMigrateVariableRuntimeCacheBufferAllocation  ## CONSUMES  # MU_CHANGE
 
 [Guids]
   ## PRODUCES             ## GUID # Signature of Variable store header


### PR DESCRIPTION
## Description

Add `PcdMigrateVariableRuntimeCacheBufferAllocation` to allow platforms to choose between allocating variable runtime cache buffers directly in PEI as `EfiRuntimeServicesData` (original behavior) or allocating as `EfiBootServicesData` in PEI and migrating to `EfiRuntimeServicesData` in DXE (to prevent runtime memory fragmentation).

The PCD defaults to FALSE to preserve the original behavior.

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Boot to OS on a system without the Mu MM Supervisor (PCD = TRUE)
- Boot to OS on a system with the Mu MM Supervisor (PCD = FALSE)
- Tested on client and server platforms that do not use the Mu MM Supervisor (PCD = FALSE)

## Integration Instructions

- If the platform uses the [Mu MM Supervisor](https://github.com/microsoft/mu_feature_mm_supv), then it is capable of unblocking buffers for MM access in DXE and should set the PCD (`PcdMigrateVariableRuntimeCacheBufferAllocation`) to `TRUE` to avoid memory bucket fragmentation which may affect hibernate stability.
- If not, it likely cannot unblock buffers for MM access after PEI and should retain original behavior (`PcdMigrateVariableRuntimeCacheBufferAllocation` set to `FALSE`), so no platform change is needed.

- Ensure the proper `MmUnblockMemoryLib` is linked for your platform usage.
  - If using the Mu MM Supervisor:
    - `VariableSmmRuntimeDxe` should use [MmSupervisorUnblockMemoryLibDxe](https://github.com/microsoft/mu_feature_mm_supv/blob/main/MmSupervisorPkg/Library/MmSupervisorUnblockMemoryLib) from MmSupervisorPkg
  - If using the edk2 Standalone MM code code:
    - `VariablePei` should use [UefiCpuPkg/Library/MmUnblockMemoryLib](https://github.com/tianocore/edk2/blob/master/UefiCpuPkg/Library/MmUnblockMemoryLib)
    - `VariableSmmRuntimeDxe` should use [MdePkg/Library/MmUnblockMemoryLib](https://github.com/tianocore/edk2/tree/master/MdePkg/Library/MmUnblockMemoryLib)

This is marked as a "breaking change" because it reverts the default behavior in Mu back to the edk2 behavior.