### PR TITLE
MdeModulePkg: Support for 64bit IoMmu Operations if allowed by attributes in NonDiscoverablePciDeviceDxe

### DIFF
--- a/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceIo.c
+++ b/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceIo.c
@@ -840,6 +840,10 @@ CoherentPciIoMap (
       return EFI_INVALID_PARAMETER;
   }
 
+  if ((Dev->Attributes & EFI_PCI_IO_ATTRIBUTE_DUAL_ADDRESS_CYCLE) != 0) {
+    IoMmuOperation += EdkiiIoMmuOperationBusMasterRead64;
+  }
+
   Status = IoMmuMap (
              IoMmuOperation,
              IoMmuHostAddress,
@@ -1531,6 +1535,10 @@ NonCoherentPciIoMap (
       DEBUG ((DEBUG_ERROR, "%a - Invalid operation %d\n", __func__, Operation));
       ASSERT (FALSE);
       return EFI_INVALID_PARAMETER;
+  }
+
+  if ((Dev->Attributes & EFI_PCI_IO_ATTRIBUTE_DUAL_ADDRESS_CYCLE) != 0) {
+    IoMmuOperation += EdkiiIoMmuOperationBusMasterRead64;
   }
 
   Status = IoMmuMap (


### PR DESCRIPTION
## Description

MdeModulePkg: Support for 64bit IoMmu Operations if allowed by attributes in NonDiscoverablePciDeviceDxe

Improves bounce buffering performance/conditions from https://github.com/microsoft/mu_silicon_arm_tiano/pull/45

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on physical device

## Integration Instructions

N/A