### PR TITLE
[CHERRY-PICK] StandaloneMmPkg: Split MmEvent to a separate Driver

### DIFF
--- a/StandaloneMmPkg/Drivers/MmCommunicationDxe/MmCommunicationDxe.c
+++ b/StandaloneMmPkg/Drivers/MmCommunicationDxe/MmCommunicationDxe.c
@@ -33,188 +33,7 @@ EFI_MM_COMMUNICATION_PROTOCOL  mMmCommunication = {
 MM_COMM_BUFFER             mMmCommonBuffer;
 EFI_SMM_CONTROL2_PROTOCOL  *mSmmControl2;
 EFI_SMM_ACCESS2_PROTOCOL   *mSmmAccess;
-BOOLEAN                    mSmmLocked = FALSE;
-BOOLEAN                    mEndOfDxe  = FALSE;
-
-//
-// Table of Protocol notification and GUIDed Event notifications that the Standalone Mm requires
-//
-MM_EVENT_NOTIFICATION  mMmEvents[] = {
-  //
-  // Declare protocol notification on DxeMmReadyToLock protocols.  When this notification is established,
-  // the associated event is immediately signalled, so the notification function will be executed and the
-  // DXE Mm Ready To Lock Protocol will be found if it is already in the handle database.
-  //
-  { ProtocolNotify, TRUE,  &gEfiDxeMmReadyToLockProtocolGuid,  MmReadyToLockEventNotify,    &gEfiDxeMmReadyToLockProtocolGuid, NULL },
-  //
-  // Declare event notification on Ready To Boot Event Group.  This is an extra event notification that is
-  // used to make sure SMRAM is locked before any boot options are processed.
-  //
-  { EventNotify,    TRUE,  &gEfiEventReadyToBootGuid,          MmReadyToLockEventNotify,    &gEfiEventReadyToBootGuid,         NULL },
-  //
-  // Declare event notification on Ready To Boot Event Group.  This is used to inform the MM Core
-  // to notify MM driver that system enter ready to boot.
-  //
-  { EventNotify,    FALSE, &gEfiEventReadyToBootGuid,          MmGuidedEventNotify,         &gEfiEventReadyToBootGuid,         NULL },
-  //
-  // Declare event notification on EndOfDxe event.  When this notification is established,
-  // the associated event is immediately signalled, so the notification function will be executed and the
-  // End Of Dxe Protocol will be found if it is already in the handle database.
-  //
-  { EventNotify,    TRUE,  &gEfiEndOfDxeEventGroupGuid,        MmGuidedEventNotify,         &gEfiEndOfDxeEventGroupGuid,       NULL },
-  //
-  // Declare event notification on EndOfDxe event.  This is used to set EndOfDxe event signaled flag.
-  //
-  { EventNotify,    TRUE,  &gEfiEndOfDxeEventGroupGuid,        MmEndOfDxeEventNotify,       &gEfiEndOfDxeEventGroupGuid,       NULL },
-  //
-  // Declare event notification on Exit Boot Services Event Group.  This is used to inform the MM Core
-  // to notify MM driver that system enter exit boot services.
-  //
-  { EventNotify,    FALSE, &gEfiEventExitBootServicesGuid,     MmGuidedEventNotify,         &gEfiEventExitBootServicesGuid,    NULL },
-  //
-  // Declare event notification on SetVirtualAddressMap() Event Group.  This is used to convert fixed MM communication buffer
-  // and MM_COMM_BUFFER_STATUS in mMmCommonBuffer, mSmmControl2 from physical addresses to virtual addresses.
-  //
-  { EventNotify,    FALSE, &gEfiEventVirtualAddressChangeGuid, MmVirtualAddressChangeEvent, NULL,                              NULL },
-  //
-  // Terminate the table of event notifications
-  //
-  { EndNotify,      FALSE, NULL,                               NULL,                        NULL,                              NULL }
-};
-
-/**
-  Event notification that is fired when GUIDed Event Group is signaled.
-
-  @param  Event                 The Event that is being processed, not used.
-  @param  Context               Event Context, not used.
-
-**/
-VOID
-EFIAPI
-MmGuidedEventNotify (
-  IN EFI_EVENT  Event,
-  IN VOID       *Context
-  )
-{
-  UINTN                      Size;
-  EFI_MM_COMMUNICATE_HEADER  *CommunicateHeader;
-
-  CommunicateHeader = (EFI_MM_COMMUNICATE_HEADER *)(UINTN)mMmCommonBuffer.PhysicalStart;
-
-  //
-  // Use Guid to initialize EFI_MM_COMMUNICATE_HEADER structure
-  //
-  CopyGuid (&CommunicateHeader->HeaderGuid, (EFI_GUID *)Context);
-  CommunicateHeader->MessageLength = 1;
-  CommunicateHeader->Data[0]       = 0;
-
-  //
-  // Generate the Software SMI and return the result
-  //
-  Size = sizeof (EFI_MM_COMMUNICATE_HEADER);
-  MmCommunicate2 (&mMmCommunication2, CommunicateHeader, CommunicateHeader, &Size);
-}
-
-/**
-  Event notification that is fired every time a DxeSmmReadyToLock protocol is added
-  or if gEfiEventReadyToBootGuid is signaled.
-
-  @param  Event                 The Event that is being processed, not used.
-  @param  Context               Event Context, not used.
-
-**/
-VOID
-EFIAPI
-MmReadyToLockEventNotify (
-  IN EFI_EVENT  Event,
-  IN VOID       *Context
-  )
-{
-  EFI_STATUS  Status;
-  VOID        *Interface;
-  UINTN       Index;
-
-  //
-  // See if we are already locked
-  //
-  if (mSmmLocked) {
-    return;
-  }
-
-  //
-  // Make sure this notification is for this handler
-  //
-  if (CompareGuid ((EFI_GUID *)Context, &gEfiDxeMmReadyToLockProtocolGuid)) {
-    Status = gBS->LocateProtocol (&gEfiDxeMmReadyToLockProtocolGuid, NULL, &Interface);
-    if (EFI_ERROR (Status)) {
-      return;
-    }
-  } else {
-    //
-    // If MM is not locked yet and we got here from gEfiEventReadyToBootGuid being
-    // signaled, then gEfiDxeMmReadyToLockProtocolGuid was not installed as expected.
-    // Print a warning on debug builds.
-    //
-    DEBUG ((DEBUG_WARN, "DXE Mm Ready To Lock Protocol not installed before Ready To Boot signal\n"));
-  }
-
-  if (!mEndOfDxe) {
-    DEBUG ((DEBUG_ERROR, "EndOfDxe Event must be signaled before DxeSmmReadyToLock Protocol installation!\n"));
-    REPORT_STATUS_CODE (
-      EFI_ERROR_CODE | EFI_ERROR_UNRECOVERED,
-      (EFI_SOFTWARE_SMM_DRIVER | EFI_SW_EC_ILLEGAL_SOFTWARE_STATE)
-      );
-    ASSERT (FALSE);
-  }
-
-  //
-  // Lock the SMRAM (Note: Locking SMRAM may not be supported on all platforms)
-  //
-  mSmmAccess->Lock (mSmmAccess);
-
-  //
-  // Close protocol and event notification events that do not apply after the
-  // DXE MM Ready To Lock Protocol has been installed or the Ready To Boot
-  // event has been signalled.
-  //
-  for (Index = 0; mMmEvents[Index].NotifyFunction != NULL; Index++) {
-    if (mMmEvents[Index].CloseOnLock) {
-      gBS->CloseEvent (mMmEvents[Index].Event);
-    }
-  }
-
-  //
-  // Inform MM Core that the DxeSmmReadyToLock protocol was installed
-  //
-  MmGuidedEventNotify (Event, (VOID *)&gEfiDxeMmReadyToLockProtocolGuid);
-
-  //
-  // Print debug message that the SMRAM window is now locked.
-  //
-  DEBUG ((DEBUG_INFO, "MmCommunicationDxe locked SMRAM window\n"));
-
-  //
-  // Set flag so this operation will not be performed again
-  //
-  mSmmLocked = TRUE;
-}
-
-/**
-  Event notification that is fired when EndOfDxe Event Group is signaled.
-
-  @param  Event                 The Event that is being processed, not used.
-  @param  Context               Event Context, not used.
-
-**/
-VOID
-EFIAPI
-MmEndOfDxeEventNotify (
-  IN EFI_EVENT  Event,
-  IN VOID       *Context
-  )
-{
-  mEndOfDxe = TRUE;
-}
+EFI_EVENT                  mVirtualAddressChangeEvent = NULL;
 
 /**
   Notification function of EVT_SIGNAL_VIRTUAL_ADDRESS_CHANGE.
@@ -458,8 +277,6 @@ MmCommunicationEntryPoint (
   EFI_HANDLE         Handle;
   EFI_HOB_GUID_TYPE  *GuidHob;
   MM_COMM_BUFFER     *MmCommonBuffer;
-  UINTN              Index;
-  VOID               *Registration;
 
   //
   // Locate gMmCommBufferHobGuid and cache the content
@@ -507,29 +324,16 @@ MmCommunicationEntryPoint (
   ASSERT_EFI_ERROR (Status);
 
   //
-  // Create the set of protocol and event notifications that the Standalone Mm requires
+  // Register the event to convert the pointer for runtime.
   //
-  for (Index = 0; mMmEvents[Index].NotificationType != EndNotify; Index++) {
-    if (mMmEvents[Index].NotificationType == ProtocolNotify) {
-      mMmEvents[Index].Event = EfiCreateProtocolNotifyEvent (
-                                 mMmEvents[Index].Guid,
-                                 TPL_CALLBACK,
-                                 mMmEvents[Index].NotifyFunction,
-                                 mMmEvents[Index].NotifyContext,
-                                 &Registration
-                                 );
-    } else {
-      Status = gBS->CreateEventEx (
-                      EVT_NOTIFY_SIGNAL,
-                      TPL_CALLBACK,
-                      mMmEvents[Index].NotifyFunction,
-                      mMmEvents[Index].NotifyContext,
-                      mMmEvents[Index].Guid,
-                      &mMmEvents[Index].Event
-                      );
-      ASSERT_EFI_ERROR (Status);
-    }
-  }
+  gBS->CreateEventEx (
+         EVT_NOTIFY_SIGNAL,
+         TPL_NOTIFY,
+         MmVirtualAddressChangeEvent,
+         NULL,
+         &gEfiEventVirtualAddressChangeGuid,
+         &mVirtualAddressChangeEvent
+         );
 
   return EFI_SUCCESS;
 }

--- a/StandaloneMmPkg/Drivers/MmCommunicationDxe/MmCommunicationDxe.inf
+++ b/StandaloneMmPkg/Drivers/MmCommunicationDxe/MmCommunicationDxe.inf
@@ -42,8 +42,6 @@
 [Guids]
   gMmCommBufferHobGuid
   gEfiEventVirtualAddressChangeGuid
-  gEfiEndOfDxeEventGroupGuid
-  gEfiEventExitBootServicesGuid
   gEfiMmCommunicateHeaderV3Guid
 
 [Protocols]
@@ -51,7 +49,6 @@
   gEfiMmCommunication2ProtocolGuid
   gEfiSmmControl2ProtocolGuid
   gEfiMmCommunicationProtocolGuid
-  gEfiDxeMmReadyToLockProtocolGuid
   gEfiSmmAccess2ProtocolGuid
 
 [Depex]

--- a/StandaloneMmPkg/Drivers/MmCommunicationNotifyDxe/MmCommunicationNotifyDxe.c
+++ b/StandaloneMmPkg/Drivers/MmCommunicationNotifyDxe/MmCommunicationNotifyDxe.c
@@ -1,0 +1,265 @@
+/** @file
+  MmCommunicationNotifyDxe driver creates the notifications of
+  some protocols and event.
+
+  Copyright (c) 2025, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "MmCommunicationNotifyDxe.h"
+
+//
+// PI 1.7 MM Communication Protocol 2 instance
+//
+EFI_MM_COMMUNICATION2_PROTOCOL  *mMmCommunication2;
+MM_COMM_BUFFER                  mMmCommonBuffer;
+EFI_SMM_ACCESS2_PROTOCOL        *mSmmAccess;
+BOOLEAN                         mSmmLocked = FALSE;
+BOOLEAN                         mEndOfDxe  = FALSE;
+
+//
+// Table of Protocol notification and GUIDed Event notifications that the Standalone Mm requires
+//
+MM_EVENT_NOTIFICATION  mMmEvents[] = {
+  //
+  // Declare protocol notification on DxeMmReadyToLock protocols.  When this notification is established,
+  // the associated event is immediately signalled, so the notification function will be executed and the
+  // DXE Mm Ready To Lock Protocol will be found if it is already in the handle database.
+  //
+  { ProtocolNotify, TRUE,  &gEfiDxeMmReadyToLockProtocolGuid, MmReadyToLockEventNotify, &gEfiDxeMmReadyToLockProtocolGuid, NULL },
+  //
+  // Declare event notification on Ready To Boot Event Group.  This is an extra event notification that is
+  // used to make sure SMRAM is locked before any boot options are processed.
+  //
+  { EventNotify,    TRUE,  &gEfiEventReadyToBootGuid,         MmReadyToLockEventNotify, &gEfiEventReadyToBootGuid,         NULL },
+  //
+  // Declare event notification on Ready To Boot Event Group.  This is used to inform the MM Core
+  // to notify MM driver that system enter ready to boot.
+  //
+  { EventNotify,    FALSE, &gEfiEventReadyToBootGuid,         MmGuidedEventNotify,      &gEfiEventReadyToBootGuid,         NULL },
+  //
+  // Declare event notification on EndOfDxe event.  When this notification is established,
+  // the associated event is immediately signalled, so the notification function will be executed and the
+  // End Of Dxe Protocol will be found if it is already in the handle database.
+  //
+  { EventNotify,    TRUE,  &gEfiEndOfDxeEventGroupGuid,       MmGuidedEventNotify,      &gEfiEndOfDxeEventGroupGuid,       NULL },
+  //
+  // Declare event notification on EndOfDxe event.  This is used to set EndOfDxe event signaled flag.
+  //
+  { EventNotify,    TRUE,  &gEfiEndOfDxeEventGroupGuid,       MmEndOfDxeEventNotify,    &gEfiEndOfDxeEventGroupGuid,       NULL },
+  //
+  // Declare event notification on Exit Boot Services Event Group.  This is used to inform the MM Core
+  // to notify MM driver that system enter exit boot services.
+  //
+  { EventNotify,    FALSE, &gEfiEventExitBootServicesGuid,    MmGuidedEventNotify,      &gEfiEventExitBootServicesGuid,    NULL },
+  //
+  // Terminate the table of event notifications
+  //
+  { EndNotify,      FALSE, NULL,                              NULL,                     NULL,                              NULL }
+};
+
+/**
+  Event notification that is fired when GUIDed Event Group is signaled.
+
+  @param  Event                 The Event that is being processed, not used.
+  @param  Context               Event Context, not used.
+
+**/
+VOID
+EFIAPI
+MmGuidedEventNotify (
+  IN EFI_EVENT  Event,
+  IN VOID       *Context
+  )
+{
+  UINTN                      Size;
+  EFI_MM_COMMUNICATE_HEADER  *CommunicateHeader;
+
+  CommunicateHeader = (EFI_MM_COMMUNICATE_HEADER *)(UINTN)mMmCommonBuffer.PhysicalStart;
+
+  //
+  // Use Guid to initialize EFI_MM_COMMUNICATE_HEADER structure
+  //
+  CopyGuid (&CommunicateHeader->HeaderGuid, (EFI_GUID *)Context);
+  CommunicateHeader->MessageLength = 1;
+  CommunicateHeader->Data[0]       = 0;
+
+  //
+  // Generate the Software SMI and return the result
+  //
+  Size = sizeof (EFI_MM_COMMUNICATE_HEADER);
+  mMmCommunication2->Communicate (mMmCommunication2, CommunicateHeader, CommunicateHeader, &Size);
+}
+
+/**
+  Event notification that is fired every time a DxeSmmReadyToLock protocol is added
+  or if gEfiEventReadyToBootGuid is signaled.
+
+  @param  Event                 The Event that is being processed, not used.
+  @param  Context               Event Context, not used.
+
+**/
+VOID
+EFIAPI
+MmReadyToLockEventNotify (
+  IN EFI_EVENT  Event,
+  IN VOID       *Context
+  )
+{
+  EFI_STATUS  Status;
+  VOID        *Interface;
+  UINTN       Index;
+
+  //
+  // See if we are already locked
+  //
+  if (mSmmLocked) {
+    return;
+  }
+
+  //
+  // Make sure this notification is for this handler
+  //
+  if (CompareGuid ((EFI_GUID *)Context, &gEfiDxeMmReadyToLockProtocolGuid)) {
+    Status = gBS->LocateProtocol (&gEfiDxeMmReadyToLockProtocolGuid, NULL, &Interface);
+    if (EFI_ERROR (Status)) {
+      return;
+    }
+  } else {
+    //
+    // If MM is not locked yet and we got here from gEfiEventReadyToBootGuid being
+    // signaled, then gEfiDxeMmReadyToLockProtocolGuid was not installed as expected.
+    // Print a warning on debug builds.
+    //
+    DEBUG ((DEBUG_WARN, "DXE Mm Ready To Lock Protocol not installed before Ready To Boot signal\n"));
+  }
+
+  if (!mEndOfDxe) {
+    DEBUG ((DEBUG_ERROR, "EndOfDxe Event must be signaled before DxeSmmReadyToLock Protocol installation!\n"));
+    REPORT_STATUS_CODE (
+      EFI_ERROR_CODE | EFI_ERROR_UNRECOVERED,
+      (EFI_SOFTWARE_SMM_DRIVER | EFI_SW_EC_ILLEGAL_SOFTWARE_STATE)
+      );
+    ASSERT (FALSE);
+  }
+
+  //
+  // Lock the SMRAM (Note: Locking SMRAM may not be supported on all platforms)
+  //
+  mSmmAccess->Lock (mSmmAccess);
+
+  //
+  // Close protocol and event notification events that do not apply after the
+  // DXE MM Ready To Lock Protocol has been installed or the Ready To Boot
+  // event has been signalled.
+  //
+  for (Index = 0; mMmEvents[Index].NotifyFunction != NULL; Index++) {
+    if (mMmEvents[Index].CloseOnLock) {
+      gBS->CloseEvent (mMmEvents[Index].Event);
+    }
+  }
+
+  //
+  // Inform MM Core that the DxeSmmReadyToLock protocol was installed
+  //
+  MmGuidedEventNotify (Event, (VOID *)&gEfiDxeMmReadyToLockProtocolGuid);
+
+  //
+  // Print debug message that the SMRAM window is now locked.
+  //
+  DEBUG ((DEBUG_INFO, "MmCommunicationNotifyDxe locked SMRAM window\n"));
+
+  //
+  // Set flag so this operation will not be performed again
+  //
+  mSmmLocked = TRUE;
+}
+
+/**
+  Event notification that is fired when EndOfDxe Event Group is signaled.
+
+  @param  Event                 The Event that is being processed, not used.
+  @param  Context               Event Context, not used.
+
+**/
+VOID
+EFIAPI
+MmEndOfDxeEventNotify (
+  IN EFI_EVENT  Event,
+  IN VOID       *Context
+  )
+{
+  mEndOfDxe = TRUE;
+}
+
+/**
+  The Entry Point for MmCommunicateNotifyDxe driver.
+
+  @param  ImageHandle    The firmware allocated handle for the EFI image.
+  @param  SystemTable    A pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS    The entry point is executed successfully.
+  @retval Other          Some error occurred when executing this entry point.
+
+**/
+EFI_STATUS
+EFIAPI
+MmCommunicationNotifyEntryPoint (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS         Status;
+  EFI_HOB_GUID_TYPE  *GuidHob;
+  MM_COMM_BUFFER     *MmCommonBuffer;
+  UINTN              Index;
+  VOID               *Registration;
+
+  //
+  // Locate gMmCommBufferHobGuid and cache the content
+  //
+  GuidHob = GetFirstGuidHob (&gMmCommBufferHobGuid);
+  ASSERT (GuidHob != NULL);
+  MmCommonBuffer = GET_GUID_HOB_DATA (GuidHob);
+  CopyMem (&mMmCommonBuffer, MmCommonBuffer, sizeof (MM_COMM_BUFFER));
+
+  //
+  // Get SMM Access Protocol
+  //
+  Status = gBS->LocateProtocol (&gEfiSmmAccess2ProtocolGuid, NULL, (VOID **)&mSmmAccess);
+  ASSERT_EFI_ERROR (Status);
+
+  //
+  // Get MM Communication Protocol 2 instance
+  //
+  Status = gBS->LocateProtocol (&gEfiMmCommunication2ProtocolGuid, NULL, (VOID **)&mMmCommunication2);
+  ASSERT_EFI_ERROR (Status);
+
+  //
+  // Create the set of protocol and event notifications that the Standalone Mm requires
+  //
+  for (Index = 0; mMmEvents[Index].NotificationType != EndNotify; Index++) {
+    if (mMmEvents[Index].NotificationType == ProtocolNotify) {
+      mMmEvents[Index].Event = EfiCreateProtocolNotifyEvent (
+                                 mMmEvents[Index].Guid,
+                                 TPL_CALLBACK,
+                                 mMmEvents[Index].NotifyFunction,
+                                 mMmEvents[Index].NotifyContext,
+                                 &Registration
+                                 );
+    } else {
+      Status = gBS->CreateEventEx (
+                      EVT_NOTIFY_SIGNAL,
+                      TPL_CALLBACK,
+                      mMmEvents[Index].NotifyFunction,
+                      mMmEvents[Index].NotifyContext,
+                      mMmEvents[Index].Guid,
+                      &mMmEvents[Index].Event
+                      );
+      ASSERT_EFI_ERROR (Status);
+    }
+  }
+
+  return EFI_SUCCESS;
+}

--- a/StandaloneMmPkg/Drivers/MmCommunicationNotifyDxe/MmCommunicationNotifyDxe.h
+++ b/StandaloneMmPkg/Drivers/MmCommunicationNotifyDxe/MmCommunicationNotifyDxe.h
@@ -1,62 +1,50 @@
 /** @file
 
-  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  Copyright (c) 2025, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
 
-#ifndef MM_COMMUNICATION_DXE_H_
-#define MM_COMMUNICATION_DXE_H_
+#ifndef MM_COMMUNICATION_NOTIFY_DXE_H_
+#define MM_COMMUNICATION_NOTIFY_DXE_H_
 
 #include <PiDxe.h>
 
 #include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
 #include <Library/HobLib.h>
-#include <Library/PcdLib.h>
 #include <Library/UefiLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/BaseMemoryLib.h>
-#include <Library/MemoryAllocationLib.h>
-#include <Library/UefiRuntimeLib.h>
 #include <Library/ReportStatusCodeLib.h>
 
 #include <Protocol/SmmControl2.h>
-#include <Protocol/MmCommunication3.h>
 #include <Protocol/MmCommunication2.h>
 #include <Protocol/MmCommunication.h>
+#include <Protocol/DxeMmReadyToLock.h>
 #include <Protocol/SmmAccess2.h>
 
 #include <Guid/MmCommBuffer.h>
+#include <Guid/EventGroup.h>
 
-/**
-  Communicates with a registered handler.
+typedef enum {
+  EventNotify,
+  ProtocolNotify,
+  EndNotify,
+} NOTIFICATION_TYPE;
 
-  This function provides a service to send and receive messages from a registered UEFI service.
-
-  @param[in] This                     The EFI_MM_COMMUNICATION3_PROTOCOL instance.
-  @param[in, out] CommBufferPhysical  Physical address of the MM communication buffer, of which content must
-                                      start with EFI_MM_COMMUNICATE_HEADER_V3.
-  @param[in, out] CommBufferVirtual   Virtual address of the MM communication buffer, of which content must
-                                      start with EFI_MM_COMMUNICATE_HEADER_V3.
-
-  @retval EFI_SUCCESS                 The message was successfully posted.
-  @retval EFI_INVALID_PARAMETER       CommBufferPhysical was NULL or CommBufferVirtual was NULL.
-  @retval EFI_BAD_BUFFER_SIZE         The buffer is too large for the MM implementation.
-                                      If this error is returned, the MessageSize field
-                                      in the CommBuffer header, are updated to reflect
-                                      the maximum payload size the implementation can accommodate.
-  @retval EFI_ACCESS_DENIED           The CommunicateBuffer parameter are in address range
-                                      that cannot be accessed by the MM environment.
-
-**/
-EFI_STATUS
-EFIAPI
-MmCommunicate3 (
-  IN CONST EFI_MM_COMMUNICATION3_PROTOCOL  *This,
-  IN OUT VOID                              *CommBufferPhysical,
-  IN OUT VOID                              *CommBufferVirtual
-  );
+//
+// Data structure used to declare a table of protocol notifications and event
+// notifications required by the Standalone Mm environment
+//
+typedef struct {
+  NOTIFICATION_TYPE    NotificationType;
+  BOOLEAN              CloseOnLock;
+  EFI_GUID             *Guid;
+  EFI_EVENT_NOTIFY     NotifyFunction;
+  VOID                 *NotifyContext;
+  EFI_EVENT            Event;
+} MM_EVENT_NOTIFICATION;
 
 /**
   Communicates with a registered handler.
@@ -123,18 +111,44 @@ MmCommunicate (
   );
 
 /**
-  Notification function of EVT_SIGNAL_VIRTUAL_ADDRESS_CHANGE.
+  Event notification that is fired every time a DxeSmmReadyToLock protocol is added
+  or if gEfiEventReadyToBootGuid is signaled.
 
-  This is a notification function registered on EVT_SIGNAL_VIRTUAL_ADDRESS_CHANGE event.
-  It convers pointer to new virtual address.
-
-  @param[in]  Event        Event whose notification function is being invoked.
-  @param[in]  Context      Pointer to the notification function's context.
+  @param  Event                 The Event that is being processed, not used.
+  @param  Context               Event Context, not used.
 
 **/
 VOID
 EFIAPI
-MmVirtualAddressChangeEvent (
+MmReadyToLockEventNotify (
+  IN EFI_EVENT  Event,
+  IN VOID       *Context
+  );
+
+/**
+  Event notification that is fired when GUIDed Event Group is signaled.
+
+  @param  Event                 The Event that is being processed, not used.
+  @param  Context               Event Context, not used.
+
+**/
+VOID
+EFIAPI
+MmGuidedEventNotify (
+  IN EFI_EVENT  Event,
+  IN VOID       *Context
+  );
+
+/**
+  Event notification that is fired when EndOfDxe Event Group is signaled.
+
+  @param  Event                 The Event that is being processed, not used.
+  @param  Context               Event Context, not used.
+
+**/
+VOID
+EFIAPI
+MmEndOfDxeEventNotify (
   IN EFI_EVENT  Event,
   IN VOID       *Context
   );

--- a/StandaloneMmPkg/Drivers/MmCommunicationNotifyDxe/MmCommunicationNotifyDxe.inf
+++ b/StandaloneMmPkg/Drivers/MmCommunicationNotifyDxe/MmCommunicationNotifyDxe.inf
@@ -1,0 +1,51 @@
+## @file
+# MmCommunicationNotifyDxe driver create the notifications of
+# some protocols and event.
+#
+# Copyright (c) 2025, Intel Corporation. All rights reserved.<BR>
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001A
+  BASE_NAME                      = MmCommunicationNotifyDxe
+  FILE_GUID                      = DE05B887-A2EF-4D81-BFFE-FF9CDE458753
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  PI_SPECIFICATION_VERSION       = 0x00010032
+  ENTRY_POINT                    = MmCommunicationNotifyEntryPoint
+
+[Sources]
+  MmCommunicationNotifyDxe.c
+  MmCommunicationNotifyDxe.h
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  UefiCpuPkg/UefiCpuPkg.dec
+  StandaloneMmPkg/StandaloneMmPkg.dec
+
+[LibraryClasses]
+  UefiDriverEntryPoint
+  BaseLib
+  DebugLib
+  HobLib
+  BaseMemoryLib
+  UefiBootServicesTableLib
+  UefiLib
+  ReportStatusCodeLib
+
+[Guids]
+  gMmCommBufferHobGuid
+  gEfiEndOfDxeEventGroupGuid
+  gEfiEventExitBootServicesGuid
+
+[Protocols]
+  gEfiDxeMmReadyToLockProtocolGuid
+  gEfiSmmAccess2ProtocolGuid
+  gEfiMmCommunication2ProtocolGuid
+
+[Depex]
+  gEfiMmCommunication2ProtocolGuid

--- a/StandaloneMmPkg/StandaloneMmPkg.dsc
+++ b/StandaloneMmPkg/StandaloneMmPkg.dsc
@@ -105,6 +105,8 @@
 
 [LibraryClasses.common.DXE_RUNTIME_DRIVER]
   UefiRuntimeLib|MdePkg/Library/UefiRuntimeLib/UefiRuntimeLib.inf
+
+[LibraryClasses.common.DXE_RUNTIME_DRIVER, LibraryClasses.common.DXE_DRIVER]
   UefiDriverEntryPoint|MdePkg/Library/UefiDriverEntryPoint/UefiDriverEntryPoint.inf
   MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
   UefiBootServicesTableLib|MdePkg/Library/UefiBootServicesTableLib/UefiBootServicesTableLib.inf
@@ -156,6 +158,7 @@
   StandaloneMmPkg/Library/SmmLockBoxMmDependency/SmmLockBoxMmDependency.inf
   StandaloneMmPkg/Library/MmPlatformHobProducerLibNull/MmPlatformHobProducerLibNull.inf
   StandaloneMmPkg/Drivers/MmCommunicationDxe/MmCommunicationDxe.inf
+  StandaloneMmPkg/Drivers/MmCommunicationNotifyDxe/MmCommunicationNotifyDxe.inf
   StandaloneMmPkg/Library/StandaloneMmExtractGuidedSectionLib/StandaloneMmExtractGuidedSectionLib.inf
 
   # MU_CHANGE TCBZ3205 [BEGIN]


### PR DESCRIPTION
## Description

Needed to integrate Intel ref code without the change due to a build issue.

---

Due to PEIM will do following MM notify event under API mode:

1. MM end of dxe notify Event
2. MM ready to lock notify Event
3. MM ready to boot notify Event
4. MM exit boot services notify Event

It will conflict with the notify event in MmCommunicationDxe.inf on edk2 bootloader under API mode, so split following MmEvent to MmCommunicationNotifyDxe.inf, and avoid run this driver under API mode.

Cc: Ray Ni <ray.ni@intel.com>
Cc: Star Zeng <star.zeng@intel.com>
Cc: Jiaxin Wu <jiaxin.wu@intel.com>
Cc: Dun Tan <dun.tan@intel.com>
Cc: Khor Swee Aun <swee.aun.khor@intel.com>
Cc: Sami Mujawar <sami.mujawar@arm.com>
Cc: Ard Biesheuvel <ardb+tianocore@kernel.org>
(cherry picked from commit e44cb970da6da149dc796a4782be570e101a7fed)

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Code that uses this change on a server platform

## Integration Instructions

Todo