### PR TITLE
CLANGPDB: SBSA: UnSafeUint64Mult undefined lld-link failure

### DIFF
--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaDxeLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaDxeLib.inf
@@ -34,6 +34,7 @@
   DebugLib
   HobLib
   MemoryAllocationLib
+  SafeIntLib # MU_CHANGE
   TimerLib  # MU_CHANGE
 
 [Pcd]

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.inf
@@ -34,6 +34,7 @@
   DebugLib
   HobLib
   MemoryAllocationLib
+  SafeIntLib # MU_CHANGE
   TimerLib  # MU_CHANGE
 
 [Pcd]


### PR DESCRIPTION
## Description

Add reference to `SafeIntLib` to fix UnSafeUint64Mult undefined lld-link failure. This dependency on `UnSafeUint64Mult()` and `SafeIntLib` was introduced as part of e775d96

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Booted `patina-qemu|sbsa|clangpdb` to uefi shell.

## Integration Instructions

NA