### PR TITLE
NetworkPkg: Handle UDP4 polling failures

### DIFF
--- a/NetworkPkg/Dhcp4Dxe/Dhcp4Impl.c
+++ b/NetworkPkg/Dhcp4Dxe/Dhcp4Impl.c
@@ -824,7 +824,15 @@ EfiDhcp4Start (
 
   if (CompletionEvent == NULL) {
     while (DhcpSb->IoStatus == EFI_ALREADY_STARTED) {
-      DhcpSb->UdpIo->Protocol.Udp4->Poll (DhcpSb->UdpIo->Protocol.Udp4);
+      // MU_CHANGE [BEGIN] - Add Udp4 Polling break support
+      Status = DhcpSb->UdpIo->Protocol.Udp4->Poll (DhcpSb->UdpIo->Protocol.Udp4);
+      if (EFI_ERROR (Status) && (Status != EFI_TIMEOUT)) {
+        // Break out if the NIC goes away or poll fails so we don't spin forever.
+        DhcpSb->IoStatus = Status;
+        break;
+      }
+
+      // MU_CHANGE [END] - Add Udp4 Polling break support
     }
 
     return DhcpSb->IoStatus;


### PR DESCRIPTION
## Description

`EfiDhcp4Start()` would spin forever if `DhcpSb->IoStatus` is not updated from `EFI_ALREADY_STARTED`.

This change captures the poll status (instead of ignoring it) and break out on failures so scenarios like unplug/media-loss return an error instead of hanging.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- PXE boot with USB NIC disconnected during boot

## Integration Instructions

- N/A