### PR TITLE
NetworkPkg: Add IP address error handling in PxeBcDhcp6Sarr()

### DIFF
--- a/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp6.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcDhcp6.c
@@ -2472,7 +2472,14 @@ PxeBcDhcp6Sarr (
     return Status;
   }
 
-  ASSERT ((Mode.Ia != NULL) && (Mode.Ia->State == Dhcp6Bound));
+  // MU_CHANGE [BEGIN] - Explicitly check IA state
+  if ((Mode.Ia == NULL) || (Mode.Ia->State != Dhcp6Bound)) {
+    Dhcp6->Stop (Dhcp6);
+    return EFI_DEVICE_ERROR;
+  }
+
+  // MU_CHANGE [END] - Explicitly check IA state
+
   //
   // DHCP6 doesn't have an option to specify the router address on the subnet, the only way to get the
   // router address in IP6 is the router discovery mechanism (the RS and RA, which only be handled when


### PR DESCRIPTION
## Description

Return `EFI_DEVICE_ERROR` if the IA state is invalid instead of asserting to have consistent error handling regardless of assertion enable status and to allow better error recovery in PXE boot scenarios.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- CI
- PXE boot on a physical Intel system

## Integration Instructions

- N/A