### PR TITLE
[REBASE&FF] ReportStatusCode: Always cache protocol before usage

### DIFF
--- a/MdeModulePkg/Library/DxeReportStatusCodeLib/DxeReportStatusCodeLib.inf
+++ b/MdeModulePkg/Library/DxeReportStatusCodeLib/DxeReportStatusCodeLib.inf
@@ -18,7 +18,8 @@
   MODULE_TYPE                    = DXE_DRIVER
   VERSION_STRING                 = 1.0
   LIBRARY_CLASS                  = ReportStatusCodeLib|DXE_CORE DXE_DRIVER DXE_RUNTIME_DRIVER DXE_SMM_DRIVER UEFI_APPLICATION UEFI_DRIVER SMM_CORE
-
+  CONSTRUCTOR                    = ReportStatusCodeLibConstructor # MU_CHANGE - Add constructor to cache protocol or register for protocol notification
+  DESTRUCTOR                     = ReportStatusCodeLibDestructor # MU_CHANGE - Add constructor to cache protocol or register for protocol notification
 #
 # The following information is for reference only and not required by the build tools.
 #

--- a/MdeModulePkg/Library/DxeReportStatusCodeLib/ReportStatusCodeLib.c
+++ b/MdeModulePkg/Library/DxeReportStatusCodeLib/ReportStatusCodeLib.c
@@ -20,6 +20,7 @@
 #include <Guid/StatusCodeDataTypeDebug.h>
 
 EFI_STATUS_CODE_PROTOCOL  *mReportStatusCodeLibStatusCodeProtocol = NULL;
+EFI_EVENT                 mOnStatusCodeProtocolInstallEvent; // MU_CHANGE - Add constructor to cache protocol or register for protocol notification
 
 /**
   Locate the report status code service.
@@ -86,9 +87,8 @@ InternalReportStatusCode (
       (ReportDebugCodeEnabled () && (((Type) & EFI_STATUS_CODE_TYPE_MASK) == EFI_DEBUG_CODE)))
   {
     //
-    // If mReportStatusCodeLibStatusCodeProtocol is NULL, then check if Report Status Code Protocol is available in system.
+    // If mReportStatusCodeLibStatusCodeProtocol is NULL, the protocol has not yet been registered. Return immediately.
     //
-    InternalGetReportStatusCode ();
     if (mReportStatusCodeLibStatusCodeProtocol == NULL) {
       return EFI_UNSUPPORTED;
     }
@@ -611,3 +611,109 @@ ReportDebugCodeEnabled (
 {
   return (BOOLEAN)((PcdGet8 (PcdReportStatusCodePropertyMask) & REPORT_STATUS_CODE_PROPERTY_DEBUG_CODE_ENABLED) != 0);
 }
+
+// MU_CHANGE [BEGIN] - Add constructor to cache protocol or register for protocol notification
+
+/**
+  Notification function called when the Status Code Runtime protocol is installed. Locates and caches the protocol.
+
+    @param    Event           Not Used.
+    @param    Context         Not Used.
+
+   @retval   none
+ **/
+VOID
+EFIAPI
+OnStatusCodeRuntimeProtocolInstalledNotification (
+  IN EFI_EVENT  Event,
+  IN VOID       *Context
+  )
+{
+  InternalGetReportStatusCode ();
+
+  if (mReportStatusCodeLibStatusCodeProtocol != NULL) {
+    gBS->CloseEvent (mOnStatusCodeProtocolInstallEvent);
+  }
+}
+
+/**
+    The constructor attempts to locate and cache StatusCode Protocol. If not found, it will
+    register a notify event triggered
+
+    @param  ImageHandle   The firmware allocated handle for the EFI image.
+    @param  SystemTable   A pointer to the EFI System Table.
+
+    @retval EFI_SUCCESS   The constructor always returns EFI_SUCCESS.
+
+**/
+EFI_STATUS
+EFIAPI
+ReportStatusCodeLibConstructor (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+  VOID        *Registration;
+
+  InternalGetReportStatusCode ();
+
+  //
+  // Register for protocol installation notification if the protocol is not found
+  //
+  if (mReportStatusCodeLibStatusCodeProtocol == NULL) {
+    ASSERT (gBS != NULL);
+
+    //
+    // Create the event
+    //
+    Status = gBS->CreateEvent (
+                    EVT_NOTIFY_SIGNAL,
+                    TPL_CALLBACK,
+                    OnStatusCodeRuntimeProtocolInstalledNotification,
+                    NULL,
+                    &mOnStatusCodeProtocolInstallEvent
+                    );
+    ASSERT_EFI_ERROR (Status);
+
+    //
+    // Register for protocol notifications on this event
+    //
+    Status = gBS->RegisterProtocolNotify (
+                    &gEfiStatusCodeRuntimeProtocolGuid,
+                    mOnStatusCodeProtocolInstallEvent,
+                    &Registration
+                    );
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+    Closes the protocol notification event, if still open, when the library is unloaded.
+
+    @param  ImageHandle   The firmware allocated handle for the EFI image.
+    @param  SystemTable   A pointer to the EFI System Table.
+
+    @retval EFI_SUCCESS   The constructor always returns EFI_SUCCESS.
+
+**/
+EFI_STATUS
+EFIAPI
+ReportStatusCodeLibDestructor (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS  Status;
+
+  if (mReportStatusCodeLibStatusCodeProtocol == NULL) {
+    Status = gBS->CloseEvent (mOnStatusCodeProtocolInstallEvent);
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  return EFI_SUCCESS;
+}
+
+// MU_CHANGE [END] - Add constructor to cache protocol or register for protocol notification

--- a/MdeModulePkg/Library/DxeReportStatusCodeLib/TestDxeReportStatusCodeLibTestApp.c
+++ b/MdeModulePkg/Library/DxeReportStatusCodeLib/TestDxeReportStatusCodeLibTestApp.c
@@ -1,0 +1,84 @@
+/** @file
+  UEFI based application for unit testing the DxeReportStatusCodeLib.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+#include <TestDxeReportStatusCodeLibTestApp.h>
+
+#define UNIT_TEST_NAME     "Dxe Report Status Code Lib Unit Test Application"
+#define UNIT_TEST_VERSION  "0.1"
+
+UNIT_TEST_STATUS
+EFIAPI
+TestReportStatusCodeDoesNotInvertTpl (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  EFI_STATUS        Status;
+  EFI_TPL           OldTpl;
+  EFI_SYSTEM_TABLE  *SystemTable = (EFI_SYSTEM_TABLE *)Context;
+
+  OldTpl = SystemTable->BootServices->RaiseTPL (TPL_HIGH_LEVEL);
+
+  Status = ReportStatusCode (EFI_PROGRESS_CODE, 0x0);
+
+  SystemTable->BootServices->RestoreTPL (OldTpl);
+
+  if (EFI_ERROR (Status)) {
+    UT_LOG_ERROR ("ReportStatusCode returned error: %r", Status);
+    return UNIT_TEST_ERROR_TEST_FAILED;
+  }
+
+  return UNIT_TEST_PASSED;
+}
+
+EFI_STATUS
+EFIAPI
+UefiTestMain (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS                  Status;
+  UNIT_TEST_FRAMEWORK_HANDLE  Framework;
+  UNIT_TEST_SUITE_HANDLE      NoTplInversionTestSuite;
+
+  Status                  = EFI_SUCCESS;
+  Framework               = NULL;
+  NoTplInversionTestSuite = NULL;
+
+  DEBUG ((DEBUG_INFO, "%a v%a\n", UNIT_TEST_NAME, UNIT_TEST_VERSION));
+
+  //
+  // Start setting up the test framework for running the tests.
+  //
+  Status = InitUnitTestFramework (&Framework, UNIT_TEST_NAME, gEfiCallerBaseName, UNIT_TEST_VERSION);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in InitUnitTestFramework. Status = %r\n", Status));
+    Status = EFI_OUT_OF_RESOURCES;
+    goto Exit;
+  }
+
+  //
+  // Test Suite 1
+  //
+  Status = CreateUnitTestSuite (&NoTplInversionTestSuite, Framework, "No TPL Inversion Tests", "Dxe.ReportStatusCode.NoTplInversion", NULL, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in CreateUnitTestSuite for No TPL Inversion Tests\n"));
+    Status = EFI_OUT_OF_RESOURCES;
+    goto Exit;
+  }
+
+  AddTestCase (NoTplInversionTestSuite, "Test ReportStatusCode TPL High", "TestReportStatusCodeTplHigh", TestReportStatusCodeDoesNotInvertTpl, NULL, NULL, SystemTable);
+
+  Status = RunAllTestSuites (Framework);
+
+Exit:
+  if (Framework != NULL) {
+    FreeUnitTestFramework (Framework);
+  }
+
+  return Status;
+}

--- a/MdeModulePkg/Library/DxeReportStatusCodeLib/TestDxeReportStatusCodeLibTestApp.h
+++ b/MdeModulePkg/Library/DxeReportStatusCodeLib/TestDxeReportStatusCodeLibTestApp.h
@@ -1,0 +1,24 @@
+/** @file
+  UEFI based application for unit testing the DxeReportStatusCodeLib.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef TEST_DXE_REPORT_STATUS_CODE_LIB_H_
+#define TEST_DXE_REPORT_STATUS_CODE_LIB_H_
+
+#include <Uefi.h>
+#include <Library/UefiLib.h>
+#include <Library/DebugLib.h>
+#include <Library/UnitTestLib.h>
+#include <Library/ReportStatusCodeLib.h>
+
+UNIT_TEST_STATUS
+EFIAPI
+TestReportStatusCodeDoesNotInvertTpl (
+  IN UNIT_TEST_CONTEXT  Context
+  );
+
+#endif

--- a/MdeModulePkg/Library/DxeReportStatusCodeLib/TestDxeReportStatusCodeLibTestApp.inf
+++ b/MdeModulePkg/Library/DxeReportStatusCodeLib/TestDxeReportStatusCodeLibTestApp.inf
@@ -1,0 +1,34 @@
+## @file
+# UEFI Shell based Application that Unit Tests DxeReportStatusCodeLib
+#
+# Copyright (c) Microsoft Corporation.<BR>
+# Copyright (c) 2019 - 2020, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION     = 0x00010005
+  BASE_NAME       = TestDxeReportStatusCodeLibTestApp
+  FILE_GUID       = D7F3EA2A-1868-4107-82AB-B737BF9FD6B0
+  MODULE_TYPE     = UEFI_APPLICATION
+  VERSION_STRING  = 1.0
+  ENTRY_POINT     = UefiTestMain
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  TestDxeReportStatusCodeLibTestApp.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[LibraryClasses]
+  UefiApplicationEntryPoint
+  BaseLib
+  DebugLib
+  ReportStatusCodeLib
+  UnitTestLib

--- a/MdeModulePkg/Library/RuntimeDxeReportStatusCodeLib/ReportStatusCodeLib.c
+++ b/MdeModulePkg/Library/RuntimeDxeReportStatusCodeLib/ReportStatusCodeLib.c
@@ -22,6 +22,7 @@
 #include <Guid/EventGroup.h>
 
 EFI_STATUS_CODE_PROTOCOL  *mReportStatusCodeLibStatusCodeProtocol = NULL;
+EFI_EVENT                 mOnStatusCodeProtocolInstallEvent; // MU_CHANGE - cache protocol or register for protocol notification
 EFI_EVENT                 mReportStatusCodeLibVirtualAddressChangeEvent;
 EFI_EVENT                 mReportStatusCodeLibExitBootServicesEvent;
 BOOLEAN                   mHaveExitedBootServices = FALSE;
@@ -101,6 +102,32 @@ ReportStatusCodeLibExitBootServices (
   mHaveExitedBootServices = TRUE;
 }
 
+// MU_CHANGE [BEGIN] - cache protocol or register for protocol notification
+
+/**
+  Notification function called when the Status Code Runtime protocol is installed. Locates and caches the protocol.
+
+    @param    Event           Not Used.
+    @param    Context         Not Used.
+
+   @retval   none
+ **/
+VOID
+EFIAPI
+OnStatusCodeRuntimeProtocolInstalledNotification (
+  IN EFI_EVENT  Event,
+  IN VOID       *Context
+  )
+{
+  InternalGetReportStatusCode ();
+
+  if (mReportStatusCodeLibStatusCodeProtocol != NULL) {
+    gBS->CloseEvent (mOnStatusCodeProtocolInstallEvent);
+  }
+}
+
+// MU_CHANGE [END] - cache protocol or register for protocol notification
+
 /**
   The constructor function of Runtime DXE Report Status Code Lib.
 
@@ -121,11 +148,43 @@ ReportStatusCodeLibConstructor (
   )
 {
   EFI_STATUS  Status;
+  VOID        *Registration;  // MU_CHANGE - cache protocol or register for protocol notification
 
   //
   // Cache the report status code service
   //
   InternalGetReportStatusCode ();
+
+  // MU_CHANGE [BEGIN] - cache protocol or register for protocol notification
+
+  //
+  // Register for protocol installation notification if the protocol is not found
+  //
+  if (mReportStatusCodeLibStatusCodeProtocol == NULL) {
+    //
+    // Create the event
+    //
+    Status = gBS->CreateEvent (
+                    EVT_NOTIFY_SIGNAL,
+                    TPL_CALLBACK,
+                    OnStatusCodeRuntimeProtocolInstalledNotification,
+                    NULL,
+                    &mOnStatusCodeProtocolInstallEvent
+                    );
+    ASSERT_EFI_ERROR (Status);
+
+    //
+    // Register for protocol notifications on this event
+    //
+    Status = gBS->RegisterProtocolNotify (
+                    &gEfiStatusCodeRuntimeProtocolGuid,
+                    mOnStatusCodeProtocolInstallEvent,
+                    &Registration
+                    );
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  // MU_CHANGE [END] - cache protocol or register for protocol notification
 
   //
   // Register notify function for EVT_SIGNAL_VIRTUAL_ADDRESS_CHANGE
@@ -178,6 +237,15 @@ ReportStatusCodeLibDestructor (
   EFI_STATUS  Status;
 
   ASSERT (gBS != NULL);
+
+  // MU_CHANGE [BEGIN] - cache protocol or register for protocol notificatio
+  if (mReportStatusCodeLibStatusCodeProtocol == NULL) {
+    Status = gBS->CloseEvent (mOnStatusCodeProtocolInstallEvent);
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  // MU_CHANGE [END] - cache protocol or register for protocol notificatio
+
   Status = gBS->CloseEvent (mReportStatusCodeLibVirtualAddressChangeEvent);
   ASSERT_EFI_ERROR (Status);
 
@@ -224,9 +292,8 @@ InternalReportStatusCode (
       (ReportDebugCodeEnabled () && (((Type) & EFI_STATUS_CODE_TYPE_MASK) == EFI_DEBUG_CODE)))
   {
     //
-    // If mReportStatusCodeLibStatusCodeProtocol is NULL, then check if Report Status Code Protocol is available in system.
+    // If mReportStatusCodeLibStatusCodeProtocol is NULL, the protocol has not yet been registered. Return immediately.
     //
-    InternalGetReportStatusCode ();
     if (mReportStatusCodeLibStatusCodeProtocol == NULL) {
       return EFI_UNSUPPORTED;
     }

--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -351,6 +351,15 @@
   MdeModulePkg/Library/OemHookStatusCodeLibNull/OemHookStatusCodeLibNull.inf
   MdeModulePkg/Library/PeiReportStatusCodeLib/PeiReportStatusCodeLib.inf
   MdeModulePkg/Library/DxeReportStatusCodeLib/DxeReportStatusCodeLib.inf
+  # MU_CHANGE [BEGIN] - Add constructor to cache protocol or register for protocol notification
+  MdeModulePkg/Library/DxeReportStatusCodeLib/TestDxeReportStatusCodeLibTestApp.inf {
+    <LibraryClasses>
+        UnitTestLib|UnitTestFrameworkPkg/Library/UnitTestLib/UnitTestLib.inf
+        UnitTestPersistenceLib|UnitTestFrameworkPkg/Library/UnitTestPersistenceLibNull/UnitTestPersistenceLibNull.inf
+        UnitTestResultReportLib|UnitTestFrameworkPkg/Library/UnitTestResultReportLib/UnitTestResultReportLibDebugLib.inf
+        UnitTestBootLib|UnitTestFrameworkPkg/Library/UnitTestBootLibNull/UnitTestBootLibNull.inf
+  }
+  # MU_CHANGE [END] - Add constructor to cache protocol or register for protocol notification
   MdeModulePkg/Library/RuntimeDxeReportStatusCodeLib/RuntimeDxeReportStatusCodeLib.inf
   MdeModulePkg/Library/RuntimeResetSystemLib/RuntimeResetSystemLib.inf
   MdeModulePkg/Library/BaseSerialPortLib16550/BaseSerialPortLib16550.inf


### PR DESCRIPTION
## Description

This commit stops the library for querying the protocol database for the
status code protocol at the time of use of the library function. This
logic can result in a TPL inversion if the protocol has not yet been
located and the caller is running in a TPL higher then TPL_NOTIFY.

Instead, the protocol is now located during construction of the library
during driver startup. If the protocol is not found, then an on-protocol
install event is registered. A deconstructor is also added to close the
event in the case that the driver is unloaded before the protocol is
installed.

This PR is a rebase and fast forward as it includes a new test.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

1. The written unit test, which failed in the first commit, now passes after the second commit
2. Verified that the event callback is successfully executed in all drivers that run before the protocol is produced, including the DXE Core.
3. Verified the steps to reproduce specified in #1601 no longer reproduces.

## Integration Instructions

N/A
