### PR TITLE
MdePkg: StandaloneMmDriverEntryPoint remove unnecessary dependency on MmServicesTableLib

### DIFF
--- a/MdePkg/Library/StandaloneMmDriverEntryPoint/StandaloneMmDriverEntryPoint.c
+++ b/MdePkg/Library/StandaloneMmDriverEntryPoint/StandaloneMmDriverEntryPoint.c
@@ -14,8 +14,15 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Protocol/LoadedImage.h>
 #include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
-#include <Library/MmServicesTableLib.h>
+// #include <Library/MmServicesTableLib.h> // MU_CHANGE
 #include <Library/StandaloneMmDriverEntryPoint.h>
+
+// MU_CHANGE [BEGIN]
+//
+// Cached pointer to the MM System Table that is set during driver initialization.
+//
+EFI_MM_SYSTEM_TABLE  *mCachedMmSystemTable = NULL;
+// MU_CHANGE [END]
 
 /**
   Unloads an image from memory.
@@ -46,9 +53,12 @@ _DriverUnloadHandler (
   // library destructors.  If the unload handler returned an error, then the driver can not be
   // unloaded, and the library destructors should not be called
   //
+  // MU_CHANGE [BEGIN]
   if (!EFI_ERROR (Status)) {
-    ProcessLibraryDestructorList (ImageHandle, gMmst);
+    ProcessLibraryDestructorList (ImageHandle, mCachedMmSystemTable);
   }
+
+  // MU_CHANGE [END]
 
   //
   // Return the status from the driver specific unload handler
@@ -88,12 +98,19 @@ _ModuleEntryPoint (
   EFI_STATUS                 Status;
   EFI_LOADED_IMAGE_PROTOCOL  *LoadedImage;
 
+  // MU_CHANGE [BEGIN]
+
+  //
+  // Cache the System Table
+  //
+  mCachedMmSystemTable = MmSystemTable;
+
   if (_gMmRevision != 0) {
     //
     // Make sure that the MM spec revision of the platform
     // is >= MM spec revision of the driver
     //
-    if (MmSystemTable->Hdr.Revision < _gMmRevision) {
+    if (mCachedMmSystemTable->Hdr.Revision < _gMmRevision) {
       return EFI_INCOMPATIBLE_VERSION;
     }
   }
@@ -101,17 +118,17 @@ _ModuleEntryPoint (
   //
   // Call constructor for all libraries
   //
-  ProcessLibraryConstructorList (ImageHandle, MmSystemTable);
+  ProcessLibraryConstructorList (ImageHandle, mCachedMmSystemTable);
 
   //
   //  Install unload handler...
   //
   if (_gDriverUnloadImageCount != 0) {
-    Status = gMmst->MmHandleProtocol (
-                      ImageHandle,
-                      &gEfiLoadedImageProtocolGuid,
-                      (VOID **)&LoadedImage
-                      );
+    Status = mCachedMmSystemTable->MmHandleProtocol (
+                                     ImageHandle,
+                                     &gEfiLoadedImageProtocolGuid,
+                                     (VOID **)&LoadedImage
+                                     );
     ASSERT_EFI_ERROR (Status);
     LoadedImage->Unload = _DriverUnloadHandler;
   }
@@ -119,14 +136,16 @@ _ModuleEntryPoint (
   //
   // Call the driver entry point
   //
-  Status = ProcessModuleEntryPointList (ImageHandle, MmSystemTable);
+  Status = ProcessModuleEntryPointList (ImageHandle, mCachedMmSystemTable);
 
   //
   // If all of the drivers returned errors, then invoke all of the library destructors
   //
   if (EFI_ERROR (Status)) {
-    ProcessLibraryDestructorList (ImageHandle, MmSystemTable);
+    ProcessLibraryDestructorList (ImageHandle, mCachedMmSystemTable);
   }
+
+  // MU_CHANGE [END]
 
   //
   // Return the cumulative return status code from all of the driver entry points

--- a/MdePkg/Library/StandaloneMmDriverEntryPoint/StandaloneMmDriverEntryPoint.inf
+++ b/MdePkg/Library/StandaloneMmDriverEntryPoint/StandaloneMmDriverEntryPoint.inf
@@ -35,7 +35,7 @@
 [LibraryClasses]
   BaseLib
   DebugLib
-  MmServicesTableLib
+  # MmServicesTableLib # MU_CHANGE
   StackCheckLib
 
 [Protocols]


### PR DESCRIPTION
## Description

This pull request refactors how the MM System Table is accessed within the `StandaloneMmDriverEntryPoint.c` file. Instead of passing the system table pointer around, it introduces a cached global pointer, simplifying function calls and improving code clarity. The unnecessary dependency on `MmServicesTableLib` is also removed.

Refactoring of MM System Table access:

* Introduced a global variable `mCachedMmSystemTable` to cache the MM System Table pointer during driver initialization and replaced all usages of direct `MmSystemTable` or `gMmst` with this cached pointer throughout the file (`StandaloneMmDriverEntryPoint.c`). [[1]](diffhunk://#diff-ad037888cff8416996203a49ee4dd3bca86496ace3031f7552030b0f5217f575L17-R25) [[2]](diffhunk://#diff-ad037888cff8416996203a49ee4dd3bca86496ace3031f7552030b0f5217f575R97-R123) [[3]](diffhunk://#diff-ad037888cff8416996203a49ee4dd3bca86496ace3031f7552030b0f5217f575L122-R143) [[4]](diffhunk://#diff-ad037888cff8416996203a49ee4dd3bca86496ace3031f7552030b0f5217f575L50-R56)

Dependency cleanup:

* Removed the unused `MmServicesTableLib` from both the includes in `StandaloneMmDriverEntryPoint.c` and the `LibraryClasses` section in the INF file (`StandaloneMmDriverEntryPoint.inf`). [[1]](diffhunk://#diff-ad037888cff8416996203a49ee4dd3bca86496ace3031f7552030b0f5217f575L17-R25) [[2]](diffhunk://#diff-8f18183779e42959206c0c46d0d1f455822450b0181da84d1b6eb2d3a53ad7c4L38)

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

QemuQ35

## Integration Instructions

N/A