### PR TITLE
[CHERRY-PICK] MdeModulePkg/ArmFfaLib: add ArmFfaLibPartitionInfoGetRegs()

### DIFF
--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
@@ -593,6 +593,165 @@ ArmFfaLibYield (
 // MU_CHANGE - [END]
 
 /**
+  Get number of Partitions via registers.
+  This function is supported by aarch64 only.
+
+  @param [in]       ServiceGuid       Service guid.
+  @param [out]      PartDescCount     Return number of partition info related to
+                                      ServiceGuid.
+
+  @retval EFI_SUCCESS
+  @retval EFI_UNSUPPORTED
+  @retval EFI_INVALID_PARAMETER
+  @retval Other              Error
+
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaLibPartitionCountGetRegs (
+  IN  EFI_GUID  *ServiceGuid,
+  OUT UINT32    *PartDescCount
+  )
+{
+  EFI_STATUS    Status;
+  ARM_FFA_ARGS  FfaArgs;
+  UINT64        Uuid[2];
+
+  if (PartDescCount == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (ServiceGuid != NULL) {
+    ConvertGuidToUuid (ServiceGuid, (GUID *)Uuid);
+  } else {
+    ZeroMem (Uuid, sizeof (Uuid));
+  }
+
+  ZeroMem (&FfaArgs, sizeof (ARM_FFA_ARGS));
+
+  FfaArgs.Arg0 = ARM_FID_FFA_PARTITION_INFO_GET_REGS;
+  FfaArgs.Arg1 = Uuid[0];
+  FfaArgs.Arg2 = Uuid[1];
+
+  ArmCallFfa (&FfaArgs);
+
+  Status = FfaArgsToEfiStatus (&FfaArgs);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  *PartDescCount = ((FfaArgs.Arg2 >> FFA_PART_INFO_METADATA_LAST_IDX_SHIFT) &
+                    FFA_PART_INFO_IDX_MASK) + 1;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Get Partition info via registers.
+  This function is supported by aarch64 only.
+
+  @param [in]       ServiceGuid       Service guid.
+  @param [in,out]   PartDescCount     Number of PartDesc.
+                                      It'll return the copied number of
+                                      partition info in PartDesc.
+  @param [out]      PartDesc          Partition information Buffer
+
+  @retval EFI_SUCCESS
+  @retval EFI_UNSUPPORTED
+  @retval EFI_INVALID_PARAMETER
+  @retval EFI_BUFFER_TOO_SMALL
+  @retval Other                       Error
+
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaLibPartitionInfoGetRegs (
+  IN EFI_GUID                 *ServiceGuid,
+  IN OUT UINT32               *PartDescCount,
+  OUT EFI_FFA_PART_INFO_DESC  *PartDesc
+  )
+{
+  EFI_STATUS    Status;
+  ARM_FFA_ARGS  FfaArgs;
+  UINT64        Uuid[2];
+  UINT32        DescCount;
+  UINT16        Count;
+  UINT16        PrevIdx;
+  UINT16        StartIdx;
+  UINT16        CurIdx;
+  UINT16        Tag;
+  UINT16        Idx;
+  UINT16        DescSize;
+  UINTN         *Regs;
+
+  if ((PartDescCount == NULL) || (PartDesc == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (*PartDescCount == 0) {
+    return EFI_BUFFER_TOO_SMALL;
+  }
+
+  if (ServiceGuid != NULL) {
+    ConvertGuidToUuid (ServiceGuid, (GUID *)Uuid);
+  } else {
+    ZeroMem (Uuid, sizeof (Uuid));
+  }
+
+  PrevIdx   = 0;
+  Tag       = 0;
+  DescCount = *PartDescCount;
+
+  do {
+    StartIdx = (PrevIdx == 0) ? 0 : PrevIdx + 1;
+
+    ZeroMem (&FfaArgs, sizeof (ARM_FFA_ARGS));
+
+    FfaArgs.Arg0 = ARM_FID_FFA_PARTITION_INFO_GET_REGS;
+    FfaArgs.Arg1 = Uuid[0];
+    FfaArgs.Arg2 = Uuid[1];
+    FfaArgs.Arg3 = (Tag << FFA_PART_INFO_START_TAG_SHIFT) | StartIdx;
+
+    ArmCallFfa (&FfaArgs);
+
+    Status = FfaArgsToEfiStatus (&FfaArgs);
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    Count = ((FfaArgs.Arg2 >> FFA_PART_INFO_METADATA_LAST_IDX_SHIFT) &
+             FFA_PART_INFO_IDX_MASK) + 1;
+
+    CurIdx = ((FfaArgs.Arg2 >> FFA_PART_INFO_METADATA_CURRENT_IDX_SHIFT) &
+              FFA_PART_INFO_IDX_MASK);
+    Tag = ((FfaArgs.Arg2 >> FFA_PART_INFO_METADATA_TAG_SHIFT) &
+           FFA_PART_INFO_TAG_MASK);
+    DescSize = ((FfaArgs.Arg2 >> FFA_PART_INFO_METADATA_DESC_SIZE_SHIFT) &
+                FFA_PART_INFO_DESC_SIZE_MASK);
+
+    if (DescSize != sizeof (EFI_FFA_PART_INFO_DESC)) {
+      return EFI_INVALID_PARAMETER;
+    }
+
+    Regs = &FfaArgs.Arg3;
+    for (Idx = 0; Idx < (CurIdx - StartIdx) + 1; Idx++) {
+      CopyMem (PartDesc, Regs, DescSize);
+      Regs += sizeof (EFI_FFA_PART_INFO_DESC) / sizeof (UINTN);
+      PartDesc++;
+      if (--DescCount == 0) {
+        break;
+      }
+    }
+
+    PrevIdx = CurIdx;
+  } while (CurIdx < (Count - 1) && (DescCount != 0));
+
+  *PartDescCount -= DescCount;
+
+  return EFI_SUCCESS;
+}
+
+/**
   Restore the context which was interrupted with FFA_INTERRUPT (EFI_INTERRUPT_PENDING).
 
   @param [in]   PartId       Partition id

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
@@ -1013,6 +1013,86 @@ ArmFfaLibCommonInit (
 }
 
 /**
+  Helper to retrieve the first partition information associated with
+  a service GUID via registers.
+
+  @param [in]       ServiceGuid       Service guid.
+  @param [in, out]  PartDescCount     Return number of partition info related to
+                                      Service guid when PartDesc == NULL.
+                                      Otherwise return number of partition info
+                                      copied in ParcDesc
+  @param [out]      PartDesc          Partition information Buffer
+
+  @retval EFI_SUCCESS
+  @retval EFI_UNSUPPORTED
+  @retval EFI_INVALID_PARAMETER
+  @retval Other                       Error
+
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaLibGetPartitionInfo (
+  IN EFI_GUID                 *ServiceGuid,
+  OUT EFI_FFA_PART_INFO_DESC  *PartDesc
+  )
+{
+  EFI_STATUS  Status;
+  VOID        *TxBuffer;
+  UINT64      TxBufferSize;
+  VOID        *RxBuffer;
+  UINT64      RxBufferSize;
+  UINT32      Count;
+  UINT32      Size;
+
+  if (PartDesc == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Count = 1;
+
+  Status = ArmFfaLibPartitionInfoGetRegs (ServiceGuid, &Count, PartDesc);
+  if (!EFI_ERROR (Status)) {
+    return EFI_SUCCESS;
+  }
+
+  Status = ArmFfaLibGetRxTxBuffers (
+             &TxBuffer,
+             &TxBufferSize,
+             &RxBuffer,
+             &RxBufferSize
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Failed to get Rx/Tx Buffer. Status: %r\n",
+      __func__,
+      Status
+      ));
+    return Status;
+  }
+
+  Status = ArmFfaLibPartitionInfoGet (
+             ServiceGuid,
+             FFA_PART_INFO_FLAG_TYPE_DESC,
+             &Count,
+             &Size
+             );
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  if ((Size < sizeof (EFI_FFA_PART_INFO_DESC))) {
+    ArmFfaLibRxRelease (gPartId);
+    return EFI_INVALID_PARAMETER;
+  }
+
+  CopyMem (PartDesc, RxBuffer, sizeof (EFI_FFA_PART_INFO_DESC));
+  ArmFfaLibRxRelease (gPartId);
+
+  return EFI_SUCCESS;
+}
+
+/**
   Get first Rx/Tx Buffer allocation hob.
   If UseGuid is TRUE, BufferAddr and BufferSize parameters are ignored.
 

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaDxeLib.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaDxeLib.c
@@ -75,6 +75,8 @@ ArmFfaDxeLibConstructor (
   EFI_STATUS                 Status;
   EFI_HOB_GUID_TYPE          *RxTxBufferHob;
   ARM_FFA_RX_TX_BUFFER_INFO  *BufferInfo;
+  UINTN                      Property1;
+  UINTN                      Property2;
 
   Status = ArmFfaLibCommonInit ();
   if (EFI_ERROR (Status)) {
@@ -126,6 +128,23 @@ ArmFfaDxeLibConstructor (
     }
   } else {
     Status = ArmFfaLibRxTxMap ();
+    if (Status == EFI_UNSUPPORTED) {
+      /*
+       * When ARM_FID_FFA_PARTITION_INFO_GET_REGS is supported,
+       * Rx/Tx buffer might not be required to request service to
+       * secure partition.
+       * So, consider EFI_UNSUPPORTED for Rx/Tx buffer as SUCCESS.
+       */
+      Status = ArmFfaLibGetFeatures (
+                 ARM_FID_FFA_PARTITION_INFO_GET_REGS,
+                 0x00,
+                 &Property1,
+                 &Property2
+                 );
+      if (!EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_INFO, "%a Rx/Tx buffer doesn't support.\n", __func__));
+      }
+    }
 
     /*
      * When first Dxe instance (library or driver) which uses ArmFfaLib loaded,

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.c
@@ -100,6 +100,8 @@ ArmFfaPeiLibConstructor (
   ARM_FFA_RX_TX_BUFFER_INFO  *BufferInfo;
   VOID                       *Dummy;
   EFI_HOB_MEMORY_ALLOCATION  *RxTxBufferAllocationHob;
+  UINTN                      Property1;
+  UINTN                      Property2;
 
   Status = ArmFfaLibCommonInit ();
   if (EFI_ERROR (Status)) {
@@ -124,6 +126,26 @@ ArmFfaPeiLibConstructor (
   if (RxTxBufferHob == NULL) {
     Status = ArmFfaLibRxTxMap ();
     if (EFI_ERROR (Status)) {
+      if (Status != EFI_UNSUPPORTED) {
+        return Status;
+      }
+
+      /*
+       * When ARM_FID_FFA_PARTITION_INFO_GET_REGS is supported,
+       * Rx/Tx buffer might not be required to request service to
+       * secure partition.
+       * So, consider EFI_UNSUPPORTED for Rx/Tx buffer as SUCCESS.
+       */
+      Status = ArmFfaLibGetFeatures (
+                 ARM_FID_FFA_PARTITION_INFO_GET_REGS,
+                 0x00,
+                 &Property1,
+                 &Property2
+                 );
+      if (!EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_INFO, "%a Rx/Tx buffer doesn't support.\n", __func__));
+      }
+
       return Status;
     }
 

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecLib.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecLib.c
@@ -51,6 +51,8 @@ ArmFfaSecLibConstructor (
   EFI_STATUS                 Status;
   ARM_FFA_RX_TX_BUFFER_INFO  *BufferInfo;
   EFI_HOB_MEMORY_ALLOCATION  *RxTxBufferAllocationHob;
+  UINTN                      Property1;
+  UINTN                      Property2;
 
   Status = ArmFfaLibCommonInit ();
   if (EFI_ERROR (Status)) {
@@ -72,6 +74,26 @@ ArmFfaSecLibConstructor (
 
   Status = ArmFfaLibRxTxMap ();
   if (EFI_ERROR (Status)) {
+    if (Status != EFI_UNSUPPORTED) {
+      return Status;
+    }
+
+    /*
+     * When ARM_FID_FFA_PARTITION_INFO_GET_REGS is supported,
+     * Rx/Tx buffer might not be required to request service to
+     * secure partition.
+     * So, consider EFI_UNSUPPORTED for Rx/Tx buffer as SUCCESS.
+     */
+    Status = ArmFfaLibGetFeatures (
+               ARM_FID_FFA_PARTITION_INFO_GET_REGS,
+               0x00,
+               &Property1,
+               &Property2
+               );
+    if (!EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_INFO, "%a Rx/Tx buffer doesn't support.\n", __func__));
+    }
+
     return Status;
   }
 

--- a/MdePkg/Include/IndustryStandard/ArmFfaPartInfo.h
+++ b/MdePkg/Include/IndustryStandard/ArmFfaPartInfo.h
@@ -33,7 +33,8 @@
 #define FFA_PART_INFO_FLAG_TYPE_DESC   0
 
 #define FFA_PART_INFO_IDX_MASK        0xffff
-#define FFA_PART_INFO_START_TAG_MASK  0xffff
+#define FFA_PART_INFO_TAG_MASK        0xffff
+#define FFA_PART_INFO_DESC_SIZE_MASK  0xffff
 
 /** macro used in FFA_PARTITION_INFO_GET_REGS request
  *  See FF-A spec chapter 13.9 FFA_PARTITION_INFO_GET_REGS
@@ -47,6 +48,7 @@
 #define FFA_PART_INFO_METADATA_LAST_IDX_SHIFT     0
 #define FFA_PART_INFO_METADATA_CURRENT_IDX_SHIFT  16
 #define FFA_PART_INFO_METADATA_TAG_SHIFT          32
+#define FFA_PART_INFO_METADATA_DESC_SIZE_SHIFT    48
 
 /** Partition properties values in EFI_FFA_PART_INFO_DESC->PartitionProps
  *  See FF-A spec chapter 6.2 partition discovery.

--- a/MdePkg/Include/Library/ArmFfaLib.h
+++ b/MdePkg/Include/Library/ArmFfaLib.h
@@ -266,6 +266,52 @@ ArmFfaLibPartitionInfoGet (
   );
 
 /**
+  Get number of Partitions via registers.
+  This function is supported by aarch64 only.
+
+  @param [in]       ServiceGuid       Service guid.
+  @param [out]      PartDescCount     Return number of partition info related to
+                                      ServiceGuid.
+
+  @retval EFI_SUCCESS
+  @retval EFI_UNSUPPORTED
+  @retval EFI_INVALID_PARAMETER
+  @retval Other              Error
+
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaLibPartitionCountGetRegs (
+  IN  EFI_GUID  *ServiceGuid,
+  OUT UINT32    *PartDescCount
+  );
+
+/**
+  Get Partition info via registers.
+  This function is supported by aarch64 only.
+
+  @param [in]       ServiceGuid       Service guid.
+  @param [in, out]  PartDescCount     Return number of partition info related to
+                                      Service guid when PartDesc == NULL.
+                                      Otherwise return number of partition info
+                                      copied in ParcDesc
+  @param [out]      PartDesc          Partition information Buffer
+
+  @retval EFI_SUCCESS
+  @retval EFI_UNSUPPORTED
+  @retval EFI_INVALID_PARAMETER
+  @retval Other              Error
+
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaLibPartitionInfoGetRegs (
+  IN EFI_GUID                 *ServiceGuid,
+  IN OUT UINT32               *PartDescCount,
+  OUT EFI_FFA_PART_INFO_DESC  *PartDesc OPTIONAL
+  );
+
+/**
   Get partition or VM id.
   This function is only called in ArmFfaLibConstructor.
 

--- a/MdePkg/Include/Library/ArmFfaLib.h
+++ b/MdePkg/Include/Library/ArmFfaLib.h
@@ -424,4 +424,28 @@ ArmFfaLibMsgSendDirectReq2 (
   IN  OUT DIRECT_MSG_ARGS  *ImpDefArgs
   );
 
+/**
+  Helper to retrieve the first partition information associated with
+  a service GUID via registers.
+
+  @param [in]       ServiceGuid       Service guid.
+  @param [in, out]  PartDescCount     Return number of partition info related to
+                                      Service guid when PartDesc == NULL.
+                                      Otherwise return number of partition info
+                                      copied in ParcDesc
+  @param [out]      PartDesc          Partition information Buffer
+
+  @retval EFI_SUCCESS
+  @retval EFI_UNSUPPORTED
+  @retval EFI_INVALID_PARAMETER
+  @retval Other                       Error
+
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaLibGetPartitionInfo (
+  IN EFI_GUID                 *ServiceGuid,
+  OUT EFI_FFA_PART_INFO_DESC  *PartDesc
+  );
+
 #endif // ARM_FFA_LIB_H_


### PR DESCRIPTION
## Description

This patch adds ArmFfaLibPartitionInfoGetRegs() in ArmFfaLib
As ArmFfaLibPartitionInfoGetRegs() is added, Normal world ArmFfLib Rx/Tx buffer is not a madatory.
That's why return EFI_UNSUPPORTED while Rx/Tx buffer mapping in ArmFfaLib constructor
can be consider as valid return If ARM_FFA_PARTITION_INFO_GET_REGS is supported by SPMC.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on physical ARM64 platform and booted to Windows desktop.

## Integration Instructions

N/A
