### PR TITLE
Update FlattenPdbs Plugin to pick up additional symbols.

### DIFF
--- a/BaseTools/Plugin/FlattenPdbs/FlattenPdbs.py
+++ b/BaseTools/Plugin/FlattenPdbs/FlattenPdbs.py
@@ -26,12 +26,10 @@ class FlattenPdbs(IUefiBuildPlugin):
         except Exception:
             logging.critical("Error making PDB directory")
 
-        logging.critical("Copying PDBs to flat directory")
-        for file in Path(build_path).rglob("*.pdb"):
-            # PDB exists in DEBUG and OUTPUT directory. Same file.
+        suffixes = ["pdb", "debug"]
+        logging.critical("Copying Symbols to flat directory")
+        for file in [path for suffix in suffixes for path in Path(build_path).rglob("*."+suffix)]:
             pdb_out = Path(pdb_path / file.name)
-            if file.parent.name != "OUTPUT":
-                continue
 
             # If it exists and has the same file identifier, skip it.
             if pdb_out.exists() and file.stat().st_ino == pdb_out.stat().st_ino:


### PR DESCRIPTION
## Description

Modifies the existing FlattenPdbs plugin to a) pick up additional .PDB files - remove the restriction that they must come from the `OUTPUT` directory, and b) also include *.debug symbol files.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Executed a build, confirmed that additional symbol files now present in the PDB flat directory.

## Integration Instructions

N/A