### PR TITLE
Revert Handle UDP4 polling failures

### DIFF
--- a/NetworkPkg/Dhcp4Dxe/Dhcp4Impl.c
+++ b/NetworkPkg/Dhcp4Dxe/Dhcp4Impl.c
@@ -824,15 +824,7 @@ EfiDhcp4Start (
 
   if (CompletionEvent == NULL) {
     while (DhcpSb->IoStatus == EFI_ALREADY_STARTED) {
-      // MU_CHANGE [BEGIN] - Add Udp4 Polling break support
-      Status = DhcpSb->UdpIo->Protocol.Udp4->Poll (DhcpSb->UdpIo->Protocol.Udp4);
-      if (EFI_ERROR (Status) && (Status != EFI_TIMEOUT)) {
-        // Break out if the NIC goes away or poll fails so we don't spin forever.
-        DhcpSb->IoStatus = Status;
-        break;
-      }
-
-      // MU_CHANGE [END] - Add Udp4 Polling break support
+      DhcpSb->UdpIo->Protocol.Udp4->Poll (DhcpSb->UdpIo->Protocol.Udp4);
     }
 
     return DhcpSb->IoStatus;


### PR DESCRIPTION
## Description

This reverts commit d9764a7088b9d18fb53c949ec6b0c5f02f62d7e6.

The platform team had mixed up test results when validating this change. In some cases, DhcpSb->UdpIo->Protocol.Udp4->Poll()  might return EFI_NOT_READY and that can cause this to return early. I'd like to revert the change while this is investigated further.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- IPV4 PXE boot

## Integration Instructions

- N/A