### PR TITLE
NetworkPkg: Reset DHCP Service Binding IO Status on Stop

### DIFF
--- a/NetworkPkg/Dhcp4Dxe/Dhcp4Impl.c
+++ b/NetworkPkg/Dhcp4Dxe/Dhcp4Impl.c
@@ -1094,6 +1094,7 @@ EfiDhcp4Stop (
 
   DhcpSb->DhcpState    = Dhcp4Stopped;
   DhcpSb->ServiceState = DHCP_UNCONFIGED;
+  DhcpSb->IoStatus     = EFI_NOT_STARTED;   // MU_CHANGE: Improve PXE boot stability
 
   gBS->RestoreTPL (OldTpl);
   return EFI_SUCCESS;


### PR DESCRIPTION
## Description

Resets `DhcpSb->IoStatus` on stop to prevent a stale state from
persisting which might impact future operations dependent on
the IO status.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- PXE Boot (TFTP + DHCP)

## Integration Instructions

- N/A