### PR TITLE
BaseTools: Add --export-symbol option to GenFw for explicit symbol exports

### DIFF
--- a/BaseTools/Plugin/FlattenPdbs/FlattenPdbs_plug_in.yaml
+++ b/BaseTools/Plugin/FlattenPdbs/FlattenPdbs_plug_in.yaml
@@ -8,6 +8,7 @@
 
 {
   "scope": "global",
+  "id": "flatten-pdbs",
   "name": "Flatten PDBs UEFI Build Plugin",
   "module": "FlattenPdbs"
 }

--- a/BaseTools/Source/C/GenFw/Elf64Convert.c
+++ b/BaseTools/Source/C/GenFw/Elf64Convert.c
@@ -190,7 +190,7 @@ InitializeElf64 (
 
   if (mExportFlag) {
     if ((mEhdr->e_machine != EM_X86_64) && (mEhdr->e_machine != EM_AARCH64)) {
-      Error (NULL, 0, 3000, "Unsupported", "--prm option currently only supports X64 and AArch64 archs.");
+      Error (NULL, 0, 3000, "Unsupported", "--prm/--export-symbol option currently only supports X64 and AArch64 archs.");
       return FALSE;
     }
   }
@@ -1038,12 +1038,25 @@ ScanSections64 (
   //
   if (mExportFlag) {
     UINT32      SymIndex;
+    UINT32      ExpIndex;
     Elf_Sym     *Sym;
     UINT64      SymNum;
     const UINT8 *SymName;
 
     mExportOffset = mCoffOffset;
     mExportSize = sizeof(EFI_IMAGE_EXPORT_DIRECTORY) + strlen(mInImageName) + 1;
+
+    //
+    // If explicit export symbols are specified, pre-populate mExportSymName
+    //
+    if (mExplicitExportSymbolCount > 0) {
+      for (ExpIndex = 0; ExpIndex < mExplicitExportSymbolCount; ExpIndex++) {
+        strncpy(mExportSymName[ExpIndex], mExplicitExportSymbols[ExpIndex], PRM_HANDLER_NAME_MAXIMUM_LENGTH - 1);
+        mExportSymName[ExpIndex][PRM_HANDLER_NAME_MAXIMUM_LENGTH - 1] = '\0';
+        mExportRVA[ExpIndex] = 0;  // Will be filled in below
+      }
+      mExportSymNum = mExplicitExportSymbolCount;
+    }
 
     for (i = 0; i < mEhdr->e_shnum; i++) {
 
@@ -1059,50 +1072,70 @@ ScanSections64 (
       SymNum = (shdr->sh_size) / (shdr->sh_entsize);
 
       //
-      // First Get PrmModuleExportDescriptor
+      // If using PRM mechanism, first get PrmModuleExportDescriptor
       //
-      for (SymIndex = 0; SymIndex < SymNum; SymIndex++) {
-        Sym = (Elf_Sym *)(Symtab + SymIndex * shdr->sh_entsize);
-        SymName = GetSymName(Sym);
-        if (SymName == NULL) {
-            continue;
-        }
+      if (mExplicitExportSymbolCount == 0) {
+        for (SymIndex = 0; SymIndex < SymNum; SymIndex++) {
+          Sym = (Elf_Sym *)(Symtab + SymIndex * shdr->sh_entsize);
+          SymName = GetSymName(Sym);
+          if (SymName == NULL) {
+              continue;
+          }
 
-        if (strcmp((CHAR8*)SymName, PRM_MODULE_EXPORT_DESCRIPTOR_NAME) == 0) {
-          //
-          // Find PrmHandler Number and Name
-          //
-          FindPrmHandler(Sym->st_value);
+          if (strcmp((CHAR8*)SymName, PRM_MODULE_EXPORT_DESCRIPTOR_NAME) == 0) {
+            //
+            // Find PrmHandler Number and Name
+            //
+            FindPrmHandler(Sym->st_value);
 
-          strcpy(mExportSymName[mExportSymNum], (CHAR8*)SymName);
-          mExportRVA[mExportSymNum] = (UINT32)(Sym->st_value);
-          mExportSize += 2 * EFI_IMAGE_EXPORT_ADDR_SIZE + EFI_IMAGE_EXPORT_ORDINAL_SIZE + strlen((CHAR8 *)SymName) + 1;
-          mExportSymNum ++;
-          break;
+            strcpy(mExportSymName[mExportSymNum], (CHAR8*)SymName);
+            mExportRVA[mExportSymNum] = (UINT32)(Sym->st_value);
+            mExportSize += 2 * EFI_IMAGE_EXPORT_ADDR_SIZE + EFI_IMAGE_EXPORT_ORDINAL_SIZE + strlen((CHAR8 *)SymName) + 1;
+            mExportSymNum ++;
+            break;
+          }
         }
       }
 
       //
-      // Second Get PrmHandler
+      // Find RVAs for all export symbols (works for both PRM and explicit modes)
       //
       for (SymIndex = 0; SymIndex < SymNum; SymIndex++) {
-        UINT32   ExpIndex;
         Sym = (Elf_Sym *)(Symtab + SymIndex * shdr->sh_entsize);
         SymName = GetSymName(Sym);
         if (SymName == NULL) {
             continue;
         }
 
-        for (ExpIndex = 0; ExpIndex < (mExportSymNum -1); ExpIndex++) {
+        for (ExpIndex = 0; ExpIndex < mExportSymNum; ExpIndex++) {
           if (strcmp((CHAR8*)SymName, mExportSymName[ExpIndex]) != 0) {
             continue;
           }
-          mExportRVA[ExpIndex] = (UINT32)(Sym->st_value);
-          mExportSize += 2 * EFI_IMAGE_EXPORT_ADDR_SIZE + EFI_IMAGE_EXPORT_ORDINAL_SIZE + strlen((CHAR8 *)SymName) + 1;
+          //
+          // For explicit mode, only update if RVA not yet set
+          // For PRM mode, skip the descriptor (last entry) as it's already set
+          //
+          if ((mExplicitExportSymbolCount > 0 && mExportRVA[ExpIndex] == 0) ||
+              (mExplicitExportSymbolCount == 0 && ExpIndex < mExportSymNum - 1)) {
+            mExportRVA[ExpIndex] = (UINT32)(Sym->st_value);
+            mExportSize += 2 * EFI_IMAGE_EXPORT_ADDR_SIZE + EFI_IMAGE_EXPORT_ORDINAL_SIZE + strlen((CHAR8 *)SymName) + 1;
+          }
         }
       }
 
       break;
+    }
+
+    //
+    // Verify all requested symbols were found (for explicit export mode)
+    //
+    if (mExplicitExportSymbolCount > 0) {
+      for (ExpIndex = 0; ExpIndex < mExportSymNum; ExpIndex++) {
+        if (mExportRVA[ExpIndex] == 0) {
+          Error (NULL, 0, 3000, "Invalid", "Symbol '%s' not found in ELF file.", mExportSymName[ExpIndex]);
+          assert (FALSE);
+        }
+      }
     }
 
     mCoffOffset += mExportSize;

--- a/BaseTools/Source/C/GenFw/ElfConvert.h
+++ b/BaseTools/Source/C/GenFw/ElfConvert.h
@@ -26,6 +26,8 @@ extern UINT32 mOutImageType;
 extern UINT32 mFileBufferSize;
 extern BOOLEAN mExportFlag;
 extern BOOLEAN mBuildIdFlag;
+extern UINT32 mExplicitExportSymbolCount;
+extern CHAR8  *mExplicitExportSymbols[];
 
 //
 // Common EFI specific data.

--- a/BaseTools/Source/C/GenFw/GenFw.c
+++ b/BaseTools/Source/C/GenFw/GenFw.c
@@ -39,6 +39,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include "EfiUtilityMsgs.h"
 
 #include "GenFw.h"
+#include "ElfConvert.h"
 
 //
 // Version of this utility
@@ -90,6 +91,12 @@ BOOLEAN mIsConvertXip = FALSE;
 BOOLEAN mExportFlag = FALSE;
 BOOLEAN mNoNxCompat = FALSE;
 BOOLEAN mBuildIdFlag = FALSE;
+
+//
+// Explicit export symbol support
+//
+UINT32 mExplicitExportSymbolCount = 0;
+CHAR8  *mExplicitExportSymbols[PRM_MODULE_EXPORT_SYMBOL_NUM];
 
 STATIC
 EFI_STATUS
@@ -283,6 +290,10 @@ Returns:
                         input action option will override the previous one.\n");
   fprintf (stdout, "  --prm                 Scan symbol section from ELF image and \n\
                         write export table into PE-COFF.\n\
+                        This option can be used together with -e.\n\
+                        It doesn't work for other options.\n");
+  fprintf (stdout, "  --export-symbol=NAME  Export the specified symbol to PE-COFF export table.\n\
+                        Can be specified multiple times for multiple symbols.\n\
                         This option can be used together with -e.\n\
                         It doesn't work for other options.\n");
   fprintf (stdout, "  --nonxcompat          Do not set the IMAGE_DLLCHARACTERISTICS_NX_COMPAT bit \n\
@@ -1511,6 +1522,23 @@ Returns:
       if (!mExportFlag) {
         mExportFlag = TRUE;
       }
+      argc --;
+      argv ++;
+      continue;
+    }
+
+    if (strnicmp (argv[0], "--export-symbol=", 16) == 0) {
+      if (mExplicitExportSymbolCount >= PRM_MODULE_EXPORT_SYMBOL_NUM) {
+        Error (NULL, 0, 1003, "Invalid option", "Too many --export-symbol options (max %d)", PRM_MODULE_EXPORT_SYMBOL_NUM);
+        goto Finish;
+      }
+      mExplicitExportSymbols[mExplicitExportSymbolCount] = argv[0] + 16;
+      if (strlen(mExplicitExportSymbols[mExplicitExportSymbolCount]) == 0) {
+        Error (NULL, 0, 1003, "Invalid option value", "--export-symbol requires a symbol name");
+        goto Finish;
+      }
+      mExplicitExportSymbolCount++;
+      mExportFlag = TRUE;
       argc --;
       argv ++;
       continue;


### PR DESCRIPTION


## Description

Add --export-symbol option to GenFw for explicit symbol exports

Add support for explicitly specifying symbols to export when converting ELF to PE-COFF format. This enables exporting specific function symbols.

Changes:
- GenFw.c: Add --export-symbol=NAME argument parsing to specify symbols for export. Multiple symbols can be specified with repeated arguments.
- ElfConvert.h: Add extern declarations for export symbol tracking.
- Elf64Convert.c: When explicit export symbols are provided, use those instead of auto-detecting PRM module exports. Searches the ELF symbol table for the specified symbols and adds them to be the PE-COFF export directory.

This feature is needed for GCC/LTO builds where symbols may not be automatically detected for export but need to be explicitly specified in the module's INF BuildOptions.

Usage in INF [BuildOptions]:
  GCC:*_*_*_DLINK_FLAGS = -Wl,--undefined=CryptoEntry
  GCC:*_*_*_OBJCOPY_STRIPFLAG = --strip-unneeded -R .eh_frame --keep-symbol=CryptoEntry
  GCC:*_*_*_GENFW_FLAGS = --export-symbol=CryptoEntry"
For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
