### PR TITLE
BaseTools/Plugin/FlattenPdbs: Add plugin id to allow for easier overrides

### DIFF
--- a/BaseTools/Plugin/FlattenPdbs/FlattenPdbs_plug_in.yaml
+++ b/BaseTools/Plugin/FlattenPdbs/FlattenPdbs_plug_in.yaml
@@ -8,6 +8,7 @@
 
 {
   "scope": "global",
+  "id": "flatten-pdbs",
   "name": "Flatten PDBs UEFI Build Plugin",
   "module": "FlattenPdbs"
 }


### PR DESCRIPTION
## Description

* Add a Plugin ID for FlattenPdbs. This allows for the plug-in override functionality to work on the plugin. Currently we generate a copy of this plug-in that allows for copying additional symbols. Having the id will make that process easier.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

* Tested locally via plug-in override features.

## Integration Instructions

* N/A