### PR TITLE
NetworkPkg: DxeNetLib Stability Improvements [Rebase & FF]

### DIFF
--- a/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
+++ b/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
@@ -2696,6 +2696,7 @@ NetLibDetectMediaWaitTimeout (
   EFI_STATUS                        TimerStatus;
   EFI_EVENT                         Timer;
   UINT64                            TimeRemained;
+  EFI_TPL                           OldTpl; // MU_CHANGE: Improve PXE boot stability
 
   if (MediaState == NULL) {
     return EFI_INVALID_PARAMETER;
@@ -2720,7 +2721,9 @@ NetLibDetectMediaWaitTimeout (
                   );
   if (EFI_ERROR (Status)) {
     MediaPresent = TRUE;
+    OldTpl       = gBS->RaiseTPL (TPL_CALLBACK); // MU_CHANGE: Improve PXE boot stability
     Status       = NetLibDetectMedia (ServiceHandle, &MediaPresent);
+    gBS->RestoreTPL (OldTpl); // MU_CHANGE: Improve PXE boot stability
     if (!EFI_ERROR (Status)) {
       if (MediaPresent) {
         *MediaState = EFI_SUCCESS;
@@ -2757,7 +2760,9 @@ NetLibDetectMediaWaitTimeout (
       // If gEfiAdapterInfoMediaStateGuid is not supported, call NetLibDetectMedia to get media state!
       //
       MediaPresent = TRUE;
+      OldTpl       = gBS->RaiseTPL (TPL_CALLBACK); // MU_CHANGE: Improve PXE boot stability
       Status       = NetLibDetectMedia (ServiceHandle, &MediaPresent);
+      gBS->RestoreTPL (OldTpl); // MU_CHANGE: Improve PXE boot stability
       if (!EFI_ERROR (Status)) {
         if (MediaPresent) {
           *MediaState = EFI_SUCCESS;

--- a/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
+++ b/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
@@ -2701,7 +2701,7 @@ NetLibDetectMediaWaitTimeout (
     return EFI_INVALID_PARAMETER;
   }
 
-  *MediaState = EFI_SUCCESS;
+  *MediaState = EFI_NOT_READY;  // MU_CHANGE: Improve PXE boot stability
   MediaInfo   = NULL;
 
   //


### PR DESCRIPTION
- ## Description

**NetworkPkg/DxeNetLib: Initialize MediaState to EFI_NOT_READY**

Initializes the `MediaState` output parameter to `EFI_NOT_READY` at
the start of `DxeNetLibGetMediaState()`. This ensures that the status
only reflects a successful media state after either
`NetLibDetectMedia()` or `GetInfomation()` confirms media is present.

---

**NetworkPkg/DxeNetLib: Make NetLibDetectMedia() calls at TPL_CALLBACK**

Ensures that calls to `NetLibDetectMedia()` in
`NetLibDetectMediaWaitTimeout()` are made at least at `TPL_CALLBACK`.

There are cases where `NetLibDetectMedia()` is being called at
`TPL_APPLICATION` and a teardown of the network interface occurring
at `TPL_CALLBACK` can interrrupt the media detection process, leading
to errors using the Simple Network Protocol.

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- PXE server setup on a separate device (TFTP + DHCP)
- On DUT, set PXE boot as the first boot option
- Boot
- Wait for PXE boot over IPv4 to start
- Unplug a USB hub during network media detection

## Integration Instructions

- N/A