### PR TITLE
NetworkPkg/UefiPxeBcDxe: Initialize IPV4 token in IPV4 branch

### DIFF
--- a/NetworkPkg/UefiPxeBcDxe/PxeBcImpl.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcImpl.c
@@ -193,14 +193,16 @@ EfiPxeBcStart (
     //
     // Create event and set status for token to capture ICMP error message.
     //
-    Private->Icmp6Token.Status = EFI_NOT_READY;
-    Status                     = gBS->CreateEvent (
-                                        EVT_NOTIFY_SIGNAL,
-                                        TPL_NOTIFY,
-                                        PxeBcIcmpErrorUpdate,
-                                        Private,
-                                        &Private->IcmpToken.Event
-                                        );
+    // MU_CHANGE [BEGIN] - Use EFI_IP4_COMPLETION_TOKEN in IPV4 conditional branch
+    Private->IcmpToken.Status = EFI_NOT_READY;
+    Status                    = gBS->CreateEvent (
+                                       EVT_NOTIFY_SIGNAL,
+                                       TPL_NOTIFY,
+                                       PxeBcIcmpErrorUpdate,
+                                       Private,
+                                       &Private->IcmpToken.Event
+                                       );
+    // MU_CHANGE [END] - Use EFI_IP4_COMPLETION_TOKEN in IPV4 conditional branch
     if (EFI_ERROR (Status)) {
       goto ON_ERROR;
     }


### PR DESCRIPTION
## Description

`EfiPxeBcStart()` in `PxeBcImpl.c` has condiational code branches for IPV4 and IPV6.

- IPV4 branch should use `EFI_IP4_COMPLETION_TOKEN` which is `Private->IcmpToken`.
- IPV6 branch should use `EFI_IP6_COMPLETION_TOKEN` which is `Private->Icmp6Token`.

Right now, the IPv4 branch incorrectly initializes `Private->Icmp6Token` to `EFI_NOT_READY`. That is changed to `Private->IcmpToken`.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- PXE boot with server setup on a separate device (TFTP + DHCP)

## Integration Instructions

- N/A