### PR TITLE
[CHERRY-PICK] ShellPkg: SMBIOS type 20 Extended Starting/Ending Address print type error

### DIFF
--- a/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
+++ b/ShellPkg/Library/UefiShellDebug1CommandsLib/SmbiosView/PrintInfo.c
@@ -969,8 +969,8 @@ SmbiosPrintStructure (
       PRINT_STRUCT_VALUE_H (Struct, Type20, InterleavePosition);
       PRINT_STRUCT_VALUE_H (Struct, Type20, InterleavedDataDepth);
       if (AE_SMBIOS_VERSION (0x2, 0x7) && (Struct->Hdr->Length > 0x13)) {
-        PRINT_STRUCT_VALUE_LH (Struct, Type19, ExtendedStartingAddress);
-        PRINT_STRUCT_VALUE_LH (Struct, Type19, ExtendedEndingAddress);
+        PRINT_STRUCT_VALUE_LH (Struct, Type20, ExtendedStartingAddress);
+        PRINT_STRUCT_VALUE_LH (Struct, Type20, ExtendedEndingAddress);
       }
 
       break;


### PR DESCRIPTION
## Description

Wrong structure is used to print the SMBIOS type 20 Extended Starting/Ending Address in SmbiosView

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on real machine

## Integration Instructions

N/A

(cherry picked from commit 96572d4d72be4fc8192f35a1772b2ccf8cbdc5f4)