### PR TITLE
StandaloneMmPkg/MmCommunicationDxe: Enforce CommSize validation

### DIFF
--- a/StandaloneMmPkg/Drivers/MmCommunicationDxe/MmCommunicationDxe.c
+++ b/StandaloneMmPkg/Drivers/MmCommunicationDxe/MmCommunicationDxe.c
@@ -250,7 +250,7 @@ MmVirtualAddressChangeEvent (
                                       This parameter is optional and may be NULL.
 
   @retval EFI_SUCCESS                 The message was successfully posted.
-  @retval EFI_INVALID_PARAMETER       The CommBuffer was NULL.
+  @retval EFI_INVALID_PARAMETER       The CommBuffer was NULL or CommSize was invalid. // MU_CHANGE: CommSize validation
   @retval EFI_BAD_BUFFER_SIZE         The buffer is too large for the MM implementation.
                                       If this error is returned, the MessageLength field
                                       in the CommBuffer header or the integer pointed by
@@ -292,8 +292,20 @@ ProcessCommunicationBuffer (
     BufferSize = OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, Data) + CommunicateHeader->MessageLength;
   }
 
+  // MU_CHANGE [BEGIN]: CommSize validation
+  if (BufferSize > EFI_PAGES_TO_SIZE (mMmCommonBuffer.NumberOfPages)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  // MU_CHANGE [END]: CommSize validation
+
   if (CommSize != NULL) {
-    ASSERT (*CommSize == BufferSize);
+    // MU_CHANGE [BEGIN]: CommSize validation
+    if (*CommSize != BufferSize) {
+      return EFI_INVALID_PARAMETER;
+    }
+
+    // MU_CHANGE [END]: CommSize validation
   }
 
   CommonBufferStatus = (MM_COMM_BUFFER_STATUS *)(UINTN)mMmCommonBuffer.Status;


### PR DESCRIPTION
## Description

CommSize is an optional parameter to ProcessCommunicationBuffer().

If it is provided, the size it points to must match the total incoming comm buffer size (header + data) where that size is calculated as needed for the comm header version.

If the sizes do not match, the copy from the user provided comm buffer (pointed to by the CommBuffer parameter) to the shared comm buffer (mMmCommonBuffer.PhysicalStart) could be incorrect, for example, only copying part of the buffer.

This change returns EFI_INVALID_PARAMETER if the provided CommSize does not match the expected size instead of asserting to ensure this behavior is enforced in scenarios when asserts are disabled and to allow the caller to operate on the return status.

In addition, for the copy from the user provided buffer to the common buffer to be valid, the total size must be less than or equal to the size of the common buffer.  This change adds that validation as well.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- QEMU boot with MmCommunicationDxe driver present and communicate calls issued

## Integration Instructions

- N/A