### PR TITLE
[CHERRY-PICK] .pytool: Add uncrustify disable/enable inline strings

### DIFF
--- a/.pytool/Plugin/UncrustifyCheck/Readme.md
+++ b/.pytool/Plugin/UncrustifyCheck/Readme.md
@@ -142,3 +142,19 @@ indicates a formatting issue was found and the test is marked failed (unless `Au
 The test case log will contain a report of which files failed to format properly, allowing the user to run Uncrustify
 against the file locally to fix the issue. If the `OutputFileDiffs` configuration option is set to `True`, the plugin
 will output diff chunks for all code formatting issues in the test case log.
+
+## Disabling Uncrustify for Code Sections
+
+Due to the number of scenarios presented to Uncrustify, there may be cases when it simply does not format the code as
+expected. While the Uncrustify plugin allows the file to be ignored, in the case where only a small section of code
+needs to be ignored, the following comments can be used to disable Uncrustify processing for a section of code.
+
+```c
+// BEGIN_UNCRUSTIFY_DISABLE
+// Core ignored by Uncrustify...
+// END_UNCRUSTIFY_DISABLE
+```
+
+These marker values are defined in the Uncrustify configuration file used by this plugin.
+
+See: [.pytool/Plugin/UncrustifyCheck/uncrustify.cfg](https://github.com/tianocore/edk2/blob/master/.pytool/Plugin/UncrustifyCheck/uncrustify.cfg).

--- a/.pytool/Plugin/UncrustifyCheck/uncrustify.cfg
+++ b/.pytool/Plugin/UncrustifyCheck/uncrustify.cfg
@@ -460,3 +460,10 @@ set QUALIFIER OUT
 # Explicitly define EDK II types
 set TYPE EFI_STATUS
 set TYPE VOID
+
+# Specify the marker used in comments to disable processing of part of the
+# file.
+disable_processing_cmt          = "BEGIN_UNCRUSTIFY_DISABLE"
+
+# Specify the marker used in comments to (re)enable processing in a file.
+enable_processing_cmt           = "END_UNCRUSTIFY_DISABLE"


### PR DESCRIPTION
## Description

Adds strings that can be specified in files to disable/enable uncrustify processing inline.

For example:

```
  // BEGIN_UNCRUSTIFY_DISABLE
  ...code that should not be processed by uncrustify...
  // END_UNCRUSTIFY_DISABLE
```

(cherry picked from commit 4febebe9c2e8c6b53c2814b2ac113bac1ca335c6)

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Run uncrustify against code using the strings and verify code exempted from formatting.

## Integration Instructions

- N/A