### PR TITLE
NetworkPkg/DxeNetLib: Report SNP workaround status code

### DIFF
--- a/NetworkPkg/Include/Library/NetLib.h
+++ b/NetworkPkg/Include/Library/NetLib.h
@@ -12,6 +12,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #define _NET_LIB_H_
 
 #include <Protocol/Ip6.h>
+#include <Pi/PiStatusCode.h> // MU_CHANGE - Report status code on SNP media detection workaround
 
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
@@ -93,6 +94,15 @@ typedef UINT16  TCP_PORTNO;
 // Number of 100ns units time Interval for network media state detect
 //
 #define MEDIA_STATE_DETECT_TIME_INTERVAL  1000000U
+
+// MU_CHANGE [BEGIN] - Report status code on SNP media detection workaround
+
+//
+// Status code value indicating the SNP media-detection workaround was applied.
+//
+#define NETLIB_STATUS_CODE_SNP_MEDIA_DETECT_WORKAROUND  (EFI_IO_BUS_IP_NETWORK | EFI_IOB_EC_NOT_SUPPORTED)
+
+// MU_CHANGE [END] - Report status code on SNP media detection workaround
 
 // MU_CHANGE [BEGIN] - Consider timeout for NetLibDetectMedia() calls in NetLibDetectMediaWaitTimeout()
 

--- a/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
+++ b/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
@@ -32,6 +32,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/DevicePathLib.h>
 #include <Library/PrintLib.h>
 #include <Library/UefiLib.h>
+#include <Library/ReportStatusCodeLib.h>  // MU_CHANGE - Report status code on SNP media detection workaround
 #include <Protocol/Rng.h>
 
 #define NIC_ITEM_CONFIG_SIZE  (sizeof (NIC_IP4_CONFIG_INFO) + sizeof (EFI_IP4_ROUTE_TABLE) * MAX_IP4_CONFIG_IN_VARIABLE)
@@ -2508,6 +2509,13 @@ NetLibNormalizeMediaReturnStatus (
     DEBUG ((DEBUG_ERROR, "        A workaround to treat unsupported media detection as success is activated.\n"));
     DEBUG ((DEBUG_ERROR, "        Check with your NIC OPROM vendor to determine how proper detection"));
     DEBUG ((DEBUG_ERROR, "        can be supported on your platform.\n"));
+
+    // MU_CHANGE [BEGIN] - Report status code on SNP media detection workaround
+    REPORT_STATUS_CODE (
+      EFI_ERROR_CODE | EFI_ERROR_MINOR,
+      NETLIB_STATUS_CODE_SNP_MEDIA_DETECT_WORKAROUND
+      );
+    // MU_CHANGE [END] - Report status code on SNP media detection workaround
 
     return EFI_SUCCESS;
   }

--- a/NetworkPkg/Library/DxeNetLib/DxeNetLib.inf
+++ b/NetworkPkg/Library/DxeNetLib/DxeNetLib.inf
@@ -44,6 +44,7 @@
   MemoryAllocationLib
   DevicePathLib
   PrintLib
+  ReportStatusCodeLib   # MU_CHANGE - Report status code on SNP media detection workaround
 
 
 [Guids]

--- a/NetworkPkg/NetworkPkg.dsc
+++ b/NetworkPkg/NetworkPkg.dsc
@@ -57,9 +57,16 @@
   FileExplorerLib|MdeModulePkg/Library/FileExplorerLib/FileExplorerLib.inf
   SortLib|MdeModulePkg/Library/UefiSortLib/UefiSortLib.inf
 
+# MU_CHANGE [BEGIN] - Report status code on SNP media detection workaround
+
+[LibraryClasses.common.UEFI_DRIVER, LibraryClasses.common.UEFI_APPLICATION, LibraryClasses.common.DXE_DRIVER]
+  ReportStatusCodeLib|MdeModulePkg/Library/DxeReportStatusCodeLib/DxeReportStatusCodeLib.inf
+
+# MU_CHANGE [END] - Report status code on SNP media detection workaround
+
 [LibraryClasses.common.UEFI_DRIVER]
   HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
-  ReportStatusCodeLib|MdeModulePkg/Library/DxeReportStatusCodeLib/DxeReportStatusCodeLib.inf
+  # ReportStatusCodeLib|MdeModulePkg/Library/DxeReportStatusCodeLib/DxeReportStatusCodeLib.inf # MU_CHANGE - Report status code on SNP media detection workaround
   DebugLib|MdePkg/Library/UefiDebugLibConOut/UefiDebugLibConOut.inf
 
 [LibraryClasses.common.UEFI_APPLICATION]

--- a/NetworkPkg/Test/NetworkPkgHostTest.dsc
+++ b/NetworkPkg/Test/NetworkPkgHostTest.dsc
@@ -75,9 +75,19 @@
   RngLib|MdePkg/Library/BaseRngLib/BaseRngLib.inf
 !endif
 
+# MU_CHANGE [BEGIN] - Report status code on SNP media detection workaround
+
+[LibraryClasses.common.UEFI_DRIVER, LibraryClasses.common.UEFI_APPLICATION, LibraryClasses.common.DXE_DRIVER]
+  ReportStatusCodeLib|MdeModulePkg/Library/DxeReportStatusCodeLib/DxeReportStatusCodeLib.inf
+
+[LibraryClasses.common.HOST_APPLICATION]
+  ReportStatusCodeLib|MdePkg/Library/BaseReportStatusCodeLibNull/BaseReportStatusCodeLibNull.inf
+
+# MU_CHANGE [END] - Report status code on SNP media detection workaround
+
 [LibraryClasses.common.UEFI_DRIVER]
   HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
-  ReportStatusCodeLib|MdeModulePkg/Library/DxeReportStatusCodeLib/DxeReportStatusCodeLib.inf
+  # ReportStatusCodeLib|MdeModulePkg/Library/DxeReportStatusCodeLib/DxeReportStatusCodeLib.inf # MU_CHANGE - Report status code on SNP media detection workaround
   DebugLib|MdePkg/Library/UefiDebugLibConOut/UefiDebugLibConOut.inf
 
 [LibraryClasses.common.UEFI_APPLICATION]


### PR DESCRIPTION
## Description

Closes #1639

When the SNP media-detection workaround is applied in DxeNetLib, report a status code to indicate the workaround is applied.

This allows platform listeners to hook onto the status code to determine when the workaround is used so they can track NIC FW that should be updated to properly support media detection.

The existing error messages are intentionally left. They serve to make application of the workaround obvious in the debug log regardless of whether a status code listener is present.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- NetworkPkg CI

## Integration Instructions

To track when this workaround is used (unable to properly detect a NIC), setup a status code listener on:

- `EFI_IO_BUS_IP_NETWORK | EFI_IOB_EC_NOT_SUPPORTED` at `EFI_ERROR_CODE | EFI_ERROR_MINOR`