### PR TITLE
[CHERRYPICK] BaseTools: Prevent Subsection PCDs from polluting global expressions

### DIFF
--- a/BaseTools/Source/Python/Workspace/MetaFileParser.py
+++ b/BaseTools/Source/Python/Workspace/MetaFileParser.py
@@ -1715,8 +1715,9 @@ class DscParser(MetaFileParser):
             ValList[Index] = '0'
 
         if (not self._DirectiveEvalStack) or (False not in self._DirectiveEvalStack):
-            GlobalData.gPlatformPcds[TAB_SPLIT.join(self._ValueList[0:2])] = PcdValue
-            self._Symbols[TAB_SPLIT.join(self._ValueList[0:2])] = PcdValue
+            if not self._InSubsection:
+                GlobalData.gPlatformPcds[TAB_SPLIT.join(self._ValueList[0:2])] = PcdValue
+                self._Symbols[TAB_SPLIT.join(self._ValueList[0:2])] = PcdValue
         try:
             self._ValueList[2] = '|'.join(ValList)
         except Exception:


### PR DESCRIPTION
## Description

The PCD value defined in module subsections can be added to global PCD database. Therefore the unsolved expressions, even belongs to the global scope, can incorrectly refer to the value from module subsection.

This only happens when the referred PCD has no value assignment in the platform dsc file. Which also should raise an error.

This PR cherry-picks https://github.com/tianocore/edk2/pull/12009

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Use test code from https://github.com/PaddyDengAmi/edk2/commit/8673d4046673634fc747dc794c51b033e14e24ad
Run `test_build.bat` after setting up edk2 build environment.

Check the produced `build_report.log`, the value of `PcdIpmiKcsIoBaseAddress` in both HelloWorld.inf instances are polluted by `gEfiMdePkgTokenSpaceGuid.PcdIpmiSsifSmbusSlaveAddr|2` in the subsection.

Compares to `build_report_gPcd.log`, which produced by `TestPkg_gPcd.dsc` that has a proper global value of `PcdIpmiSsifSmbusSlaveAddr`, the subsection override of `PcdIpmiSsifSmbusSlaveAddr|2` only affects this PCD itself.
All value evaluated by `gEfiMdePkgTokenSpaceGuid.PcdIpmiKcsIoBaseAddress|gEfiMdePkgTokenSpaceGuid.PcdIpmiSsifSmbusSlaveAddr` are not affected and correctly refer to `PcdIpmiSsifSmbusSlaveAddr|1` in global scope.

After applying the change of this PR, the build for `TestPkg.dsc` will fail due to `gEfiMdePkgTokenSpaceGuid.PcdIpmiKcsIoBaseAddress|gEfiMdePkgTokenSpaceGuid.PcdIpmiSsifSmbusSlaveAddr` is referring `PcdIpmiSsifSmbusSlaveAddr` which is not given a default value in this dsc and raising an error:

```
D:\work\edk2\TestPkg.dsc(36): error 3000: The PCD should be FeatureFlag type or FixedAtBuild type: [gEfiMdePkgTokenSpaceGuid.PcdIpmiSsifSmbusSlaveAddr].
        PCD [gEfiMdePkgTokenSpaceGuid.PcdIpmiKcsIoBaseAddress] Value "gEfiMdePkgTokenSpaceGuid.PcdIpmiSsifSmbusSlaveAddr"
```

## Integration Instructions

N/A