### PR TITLE
[2511] NetworkPkg/UefiPxeBcDxe: Add missing Token.Context initialization

### DIFF
--- a/NetworkPkg/UefiPxeBcDxe/PxeBcMtftp.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcMtftp.c
@@ -419,6 +419,7 @@ PxeBcMtftp6WriteFile (
   Token.CheckPacket     = PxeBcMtftp6CheckPacket;
   Token.TimeoutCallback = NULL;
   Token.PacketNeeded    = NULL;
+  Token.Context         = Private;  // MU_CHANGE: Initialize private context in MTFTP write functions
 
   Status = Mtftp6->WriteFile (Mtftp6, &Token);
   //
@@ -936,6 +937,7 @@ PxeBcMtftp4WriteFile (
   Token.CheckPacket     = PxeBcMtftp4CheckPacket;
   Token.TimeoutCallback = NULL;
   Token.PacketNeeded    = NULL;
+  Token.Context         = Private;  // MU_CHANGE: Initialize private context in MTFTP write functions
 
   Status = Mtftp4->WriteFile (Mtftp4, &Token);
   //


### PR DESCRIPTION
## Description

Adds missing `Token.Context = Private` initialization in two MTFTP write-file functions. Without this, the `Context` field passed to the MTFTP `WriteFile` callback was uninitialized, which could lead to a page fault when the callback attempted to access the `Private` driver context. The corresponding read-file functions already set this field correctly.

This has been an issue since the initial implementation of NetworkPkg (2010).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Test file write to TFTP server with memory protections enabled.

## Integration Instructions

- N/A