### PR TITLE
MdePkg: FltUsedLib ClangPdb compatability

### DIFF
--- a/MdePkg/Library/FltUsedLib/FltUsedLib.inf
+++ b/MdePkg/Library/FltUsedLib/FltUsedLib.inf
@@ -26,6 +26,13 @@
   MdePkg/MdePkg.dec
 
 [BuildOptions]
-  # Disable GL due to linker error LNK1237
-  # https://docs.microsoft.com/en-us/cpp/error-messages/tool-errors/linker-tools-error-lnk1237?view=vs-2017
+  # We cannot build the MSVC version with /GL (whole program optimization) because we run into linker error
+  # LNK1237, which is a failure to link against a symbol from a library compiled with /GL. The whole program
+  # optimization tries to do away with references to this symbol. The solution is to not compile the stack
+  # check libs with /GL
   MSFT:*_*_*_CC_FLAGS = /GL-
+
+  # We cannot build the GCC version with LTO (link time optimization) because we run into linker errors where
+  # the stack cookie variable has been optimized away, as it looks to GCC like the variable is not used, because
+  # the compiler inserts the usage.
+  GCC:*_*_*_CC_FLAGS = -fno-lto


### PR DESCRIPTION
## Description

FltUsedLib just defines a global variable to satisfy the compiler's insertion of a gloabl variable reference.

MSVC needs GL option disabled to prevent optimization of the variable, since its not referenced by code but by the compiler. Similarly, Clang needs LTO turned off for the library to prevent similar optimizations.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Compiling Q35 with clangpdb. 

## Integration Instructions
No integration necessary.