### PR TITLE
MdeModulePkg/VariableSmmRuntimeDxe: Fix EFI_UNSUPPORTED leak from InitVariableCache

### DIFF
--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
@@ -1711,6 +1711,15 @@ InitVariableCache (
       }
 
       if (AllRtBufferAllocationsSucceeded) {
+        //
+        // Reset Status since MmUnblockMemoryRequest() may have returned
+        // EFI_UNSUPPORTED (which is tolerated but leaves Status set to
+        // an error value that would propagate to the caller).
+        //
+        if (Status == EFI_UNSUPPORTED) {
+          Status = EFI_SUCCESS;
+        }
+
         if (TempCacheInfoBuffer != 0) {
           RuntimeBuffer = (VOID *)(UINTN)TempCacheInfoBuffer;
           CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.CacheInfoFlagBuffer, sizeof (CACHE_INFO_FLAG));


### PR DESCRIPTION
## Description

When `PcdMigrateVariableRuntimeCacheBufferAllocation` is TRUE (or before the PCD
was added, unconditionally), `InitVariableCache()` calls `MmUnblockMemoryRequest()`
for each relocated runtime cache buffer. On platforms using
`MmUnblockMemoryLibNull`, these calls return `EFI_UNSUPPORTED`.

The code correctly tolerates `EFI_UNSUPPORTED` for the
`AllRtBufferAllocationsSucceeded` flag (lines 1638-1648, 1660-1670, etc.), but
fails to reset the `Status` variable before returning. This causes the caller
(`SmmVariableReady`) to see `EFI_UNSUPPORTED` as the return value from
`InitVariableCache()`, which:
1. Skips the call to `SendRuntimeVariableCacheContextToSmm()`
2. Triggers `ASSERT_EFI_ERROR(Status)` at line ~1912

This affects all platforms that link `MmUnblockMemoryLibNull` (the majority of
platforms, including all that don't use Standalone MM memory unblocking).

The fix resets `Status = EFI_SUCCESS` at the beginning of the
`AllRtBufferAllocationsSucceeded` success path, since at that point all
allocations and unblock requests have been processed successfully (with
`EFI_UNSUPPORTED` from `MmUnblockMemoryRequest` being an expected/tolerated
return value).

Introduced by: #1519 (eee3687b62)
Not fixed by: #1588 (c7ea0e10af) — the PCD workaround avoids the code path
but doesn't fix the Status leak when the feature is enabled.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on Intel Birch Stream (Granite Rapids) platform under Simics simulation:
- Before fix: `ASSERT_EFI_ERROR (Status = Unsupported)` at VariableSmmRuntimeDxe.c:1912
  immediately after "Runtime variable cache buffers successfully relocated"
- After fix: Boot proceeds normally through DXE/BDS to OS

Platform uses `MmUnblockMemoryLibNull` (confirmed via DSC library class resolution).

## Integration Instructions

N/A — drop-in bug fix, no integration changes needed.