### PR TITLE
[CHERRY-PICK] MdeModulePkg/VariableSmmRuntimeDxe: Fix EFI_UNSUPPORTED leak

### DIFF
--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
@@ -1801,6 +1801,15 @@ InitVariableCache (
       }
 
       if (AllRtBufferAllocationsSucceeded) {
+        //
+        // Reset Status since MmUnblockMemoryRequest() may have returned
+        // EFI_UNSUPPORTED (which is tolerated but leaves Status set to
+        // an error value that would propagate to the caller).
+        //
+        if (Status == EFI_UNSUPPORTED) {
+          Status = EFI_SUCCESS;
+        }
+
         if (TempCacheInfoBuffer != 0) {
           RuntimeBuffer = (VOID *)(UINTN)TempCacheInfoBuffer;
           CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.CacheInfoFlagBuffer, sizeof (CACHE_INFO_FLAG));


### PR DESCRIPTION
## Description

Cherry picks https://github.com/microsoft/mu_basecore/pull/1667 from release/202502 to release/202511.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- See original PR

## Integration Instructions

N/A

(cherry picked from commit 69b01770d3d5e88834a360c190dbda218fb11447)