### PR TITLE
[2502][REBASE & FF] Port CLANGPDB AARCH64 Support to 2502

### DIFF
--- a/BaseTools/Conf/build_rule.template
+++ b/BaseTools/Conf/build_rule.template
@@ -397,6 +397,8 @@
         "$(DLINK)" -o ${dst} $(DLINK_FLAGS) $(DLINK_XIPFLAGS) -Wl,--start-group,@$(STATIC_LIBRARY_FILES_LIST),--end-group $(CC_FLAGS) $(CC_XIPFLAGS) $(DLINK2_FLAGS)
         "$(OBJCOPY)" $(OBJCOPY_FLAGS) ${dst}
 
+    <Command.CLANGPDB>
+        "$(DLINK)" /OUT:${dst} $(DLINK_FLAGS) $(DLINK_SPATH) @$(STATIC_LIBRARY_FILES_LIST) $(DLINK2_FLAGS) $(DLINK_XIPFLAGS)
 
 [Static-Library-File.USER_DEFINED]
     <InputFile>

--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -1966,7 +1966,7 @@ DEFINE CLANGPDB_X64_TARGET           = -target x86_64-unknown-windows-gnu
 DEFINE CLANGPDB_AARCH64_TARGET       = -target aarch64-unknown-windows-msvc
 
 DEFINE CLANGPDB_WARNING_OVERRIDES    = -Wno-parentheses-equality -Wno-tautological-compare -Wno-tautological-constant-out-of-range-compare -Wno-empty-body -Wno-unused-const-variable -Wno-varargs -Wno-unknown-warning-option -Wno-unused-but-set-variable -Wno-unused-const-variable -Wno-unaligned-access -Wno-microsoft-enum-forward-reference
-DEFINE CLANGPDB_ALL_CC_FLAGS         = DEF(GCC48_ALL_CC_FLAGS) DEF(CLANGPDB_WARNING_OVERRIDES) -fno-stack-protector -funsigned-char -ftrap-function=undefined_behavior_has_been_optimized_away_by_clang -Wno-address -Wno-shift-negative-value -Wno-unknown-pragmas -Wno-incompatible-library-redeclaration -Wno-null-dereference -mno-implicit-float -mms-bitfields -mno-stack-arg-probe -nostdlib -nostdlibinc -fseh-exceptions
+DEFINE CLANGPDB_ALL_CC_FLAGS         = DEF(GCC_ALL_CC_FLAGS) DEF(CLANGPDB_WARNING_OVERRIDES) -fno-stack-protector -funsigned-char -ftrap-function=undefined_behavior_has_been_optimized_away_by_clang -Wno-address -Wno-shift-negative-value -Wno-unknown-pragmas -Wno-incompatible-library-redeclaration -Wno-null-dereference -mno-implicit-float -mms-bitfields -mno-stack-arg-probe -fno-omit-frame-pointer -D __GNUC__=4 -D __GNUC_MINOR__=2 -D __GNUC_PATCHLEVEL__=1 -D __MINGW32__=1
 
 ###########################
 # CLANGPDB IA32 definitions

--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -27,8 +27,9 @@
 # 3.21 - Can't have comment inline as it breaks concatenation see - # MU_CHANGE - Move GccLto to tools dir for better alignment
 # 3.22 - VS2022 toolchain incorrectly defined for ASL
 # 3.23 - MU_CHANGE - Remove /FILEALIGN from *_CLANGPDB_*_DLINK_FLAGS
+# 3.24 - Cherry-pick CLANGPDB AARCH64 Support
 #
-#!VERSION=3.23
+#!VERSION=3.24
 
 IDENTIFIER = Default TOOL_CHAIN_CONF
 
@@ -1958,9 +1959,11 @@ RELEASE_GCC_LOONGARCH64_CC_FLAGS       = DEF(GCC5_LOONGARCH64_CC_FLAGS) -Wno-unu
 
 DEFINE CLANGPDB_IA32_PREFIX          = ENV(CLANG_BIN)
 DEFINE CLANGPDB_X64_PREFIX           = ENV(CLANG_BIN)
+DEFINE CLANGPDB_AARCH64_PREFIX       = ENV(CLANG_BIN)
 
 DEFINE CLANGPDB_IA32_TARGET          = -target i686-unknown-windows-gnu
 DEFINE CLANGPDB_X64_TARGET           = -target x86_64-unknown-windows-gnu
+DEFINE CLANGPDB_AARCH64_TARGET       = -target aarch64-unknown-windows-msvc
 
 DEFINE CLANGPDB_WARNING_OVERRIDES    = -Wno-parentheses-equality -Wno-tautological-compare -Wno-tautological-constant-out-of-range-compare -Wno-empty-body -Wno-unused-const-variable -Wno-varargs -Wno-unknown-warning-option -Wno-unused-but-set-variable -Wno-unused-const-variable -Wno-unaligned-access -Wno-microsoft-enum-forward-reference
 DEFINE CLANGPDB_ALL_CC_FLAGS         = DEF(GCC48_ALL_CC_FLAGS) DEF(CLANGPDB_WARNING_OVERRIDES) -fno-stack-protector -funsigned-char -ftrap-function=undefined_behavior_has_been_optimized_away_by_clang -Wno-address -Wno-shift-negative-value -Wno-unknown-pragmas -Wno-incompatible-library-redeclaration -Wno-null-dereference -mno-implicit-float -mms-bitfields -mno-stack-arg-probe -nostdlib -nostdlibinc -fseh-exceptions
@@ -2041,6 +2044,47 @@ NOOPT_CLANGPDB_X64_DLINK_FLAGS      = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /OPT:RE
 NOOPT_CLANGPDB_X64_DLINK2_FLAGS     =
 # MU_CHANGE Keep optional header for NX_COMPAT flag
 NOOPT_CLANGPDB_X64_GENFW_FLAGS      = --keepexceptiontable --keepoptionalheader
+
+##########################
+# CLANGPDB AARCH64 definitions
+##########################
+*_CLANGPDB_AARCH64_CC_PATH              = DEF(CLANGPDB_AARCH64_PREFIX)clang
+*_CLANGPDB_AARCH64_SLINK_PATH           = DEF(CLANGPDB_AARCH64_PREFIX)llvm-lib
+*_CLANGPDB_AARCH64_DLINK_PATH           = DEF(CLANGPDB_AARCH64_PREFIX)lld-link
+*_CLANGPDB_AARCH64_ASLDLINK_PATH        = DEF(CLANGPDB_AARCH64_PREFIX)lld-link
+*_CLANGPDB_AARCH64_ASM_PATH             = DEF(CLANGPDB_AARCH64_PREFIX)clang
+*_CLANGPDB_AARCH64_PP_PATH              = DEF(CLANGPDB_AARCH64_PREFIX)clang
+*_CLANGPDB_AARCH64_VFRPP_PATH           = DEF(CLANGPDB_AARCH64_PREFIX)clang
+*_CLANGPDB_AARCH64_ASLCC_PATH           = DEF(CLANGPDB_AARCH64_PREFIX)clang
+*_CLANGPDB_AARCH64_ASLPP_PATH           = DEF(CLANGPDB_AARCH64_PREFIX)clang
+*_CLANGPDB_AARCH64_RC_PATH              = DEF(CLANGPDB_AARCH64_PREFIX)llvm-rc
+
+*_CLANGPDB_AARCH64_ASLCC_FLAGS          = DEF(GCC_ASLCC_FLAGS) -m64 -fno-lto DEF(CLANGPDB_AARCH64_TARGET)
+*_CLANGPDB_AARCH64_ASM_FLAGS            = DEF(GCC_ASM_FLAGS) -m64 DEF(CLANGPDB_AARCH64_TARGET)
+*_CLANGPDB_AARCH64_OBJCOPY_FLAGS        =
+*_CLANGPDB_AARCH64_NASM_FLAGS           = -f win64
+*_CLANGPDB_AARCH64_PP_FLAGS             = DEF(GCC_PP_FLAGS) DEF(CLANGPDB_AARCH64_TARGET)
+*_CLANGPDB_AARCH64_ASLPP_FLAGS          = DEF(GCC_ASLPP_FLAGS) DEF(CLANGPDB_AARCH64_TARGET)
+*_CLANGPDB_AARCH64_VFRPP_FLAGS          = DEF(GCC_VFRPP_FLAGS) DEF(CLANGPDB_AARCH64_TARGET)
+*_CLANGPDB_AARCH64_CC_XIPFLAGS          = -mstrict-align
+
+DEBUG_CLANGPDB_AARCH64_CC_FLAGS         = DEF(CLANGPDB_ALL_CC_FLAGS) -m64 -mcmodel=small -Oz -flto DEF(CLANGPDB_AARCH64_TARGET) -gcodeview  -funwind-tables -Wno-unused-but-set-variable -Wno-deprecated-non-prototype -Wno-constant-conversion -Werror
+DEBUG_CLANGPDB_AARCH64_DLINK_FLAGS      = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /WX /OPT:REF /OPT:ICF=10 /ALIGN:4096 /Machine:ARM64 /DLL /DRIVER /ENTRY:$(IMAGE_ENTRY_POINT) /SUBSYSTEM:EFI_BOOT_SERVICE_DRIVER /SAFESEH:NO /BASE:0 /DEBUG:GHASH /MLLVM:-exception-model=wineh /lldmap
+DEBUG_CLANGPDB_AARCH64_DLINK2_FLAGS     =
+DEBUG_CLANGPDB_AARCH64_GENFW_FLAGS      = --keepexceptiontable
+
+RELEASE_CLANGPDB_AARCH64_CC_FLAGS       = DEF(CLANGPDB_ALL_CC_FLAGS) -m64 -mcmodel=small -Oz -flto DEF(CLANGPDB_AARCH64_TARGET) -fno-unwind-tables -Wno-unused-but-set-variable -Wno-deprecated-non-prototype -Wno-constant-conversion -Werror
+RELEASE_CLANGPDB_AARCH64_DLINK_FLAGS    = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /IGNORE:4254 /WX /OPT:REF /OPT:ICF=10 /ALIGN:4096 /SECTION:.xdata,D /SECTION:.pdata,D /Machine:ARM64 /DLL /DRIVER /ENTRY:$(IMAGE_ENTRY_POINT) /SUBSYSTEM:EFI_BOOT_SERVICE_DRIVER /SAFESEH:NO /BASE:0 /MERGE:.rdata=.data /MLLVM:-exception-model=wineh /lldmap
+RELEASE_CLANGPDB_AARCH64_DLINK2_FLAGS   =
+
+NOOPT_CLANGPDB_AARCH64_CC_FLAGS         = DEF(CLANGPDB_ALL_CC_FLAGS) -m64 -mcmodel=small -O0 DEF(CLANGPDB_AARCH64_TARGET) -gcodeview -funwind-tables -Wno-unused-but-set-variable -Wno-deprecated-non-prototype -Wno-constant-conversion -Werror
+NOOPT_CLANGPDB_AARCH64_DLINK_FLAGS      = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /WX /OPT:REF /OPT:ICF=10 /ALIGN:4096 /Machine:ARM64 /DLL /DRIVER /ENTRY:$(IMAGE_ENTRY_POINT) /SUBSYSTEM:EFI_BOOT_SERVICE_DRIVER /SAFESEH:NO /BASE:0 /DEBUG:GHASH /MLLVM:-exception-model=wineh /lldmap
+NOOPT_CLANGPDB_AARCH64_DLINK2_FLAGS     =
+NOOPT_CLANGPDB_AARCH64_GENFW_FLAGS      = --keepexceptiontable
+
+# BaseTools cannot handle XIP modules with different section and file alignment and CLANGPDB AArch64 is restricted to
+# 4KB section alignment due to an LLVM bug: https://github.com/llvm/llvm-project/issues/172660
+*_CLANGPDB_AARCH64_DLINK_XIPFLAGS    = /FILEALIGN:4096
 
 ####################################################################################
 #

--- a/BaseTools/Conf/tools_def.template
+++ b/BaseTools/Conf/tools_def.template
@@ -1958,11 +1958,9 @@ RELEASE_GCC_LOONGARCH64_CC_FLAGS       = DEF(GCC5_LOONGARCH64_CC_FLAGS) -Wno-unu
 
 DEFINE CLANGPDB_IA32_PREFIX          = ENV(CLANG_BIN)
 DEFINE CLANGPDB_X64_PREFIX           = ENV(CLANG_BIN)
-DEFINE CLANGPDB_AARCH64_PREFIX       = ENV(CLANG_BIN)
 
 DEFINE CLANGPDB_IA32_TARGET          = -target i686-unknown-windows-gnu
 DEFINE CLANGPDB_X64_TARGET           = -target x86_64-unknown-windows-gnu
-DEFINE CLANGPDB_AARCH64_TARGET       = -target aarch64-unknown-windows-gnu
 
 DEFINE CLANGPDB_WARNING_OVERRIDES    = -Wno-parentheses-equality -Wno-tautological-compare -Wno-tautological-constant-out-of-range-compare -Wno-empty-body -Wno-unused-const-variable -Wno-varargs -Wno-unknown-warning-option -Wno-unused-but-set-variable -Wno-unused-const-variable -Wno-unaligned-access -Wno-microsoft-enum-forward-reference
 DEFINE CLANGPDB_ALL_CC_FLAGS         = DEF(GCC48_ALL_CC_FLAGS) DEF(CLANGPDB_WARNING_OVERRIDES) -fno-stack-protector -funsigned-char -ftrap-function=undefined_behavior_has_been_optimized_away_by_clang -Wno-address -Wno-shift-negative-value -Wno-unknown-pragmas -Wno-incompatible-library-redeclaration -Wno-null-dereference -mno-implicit-float -mms-bitfields -mno-stack-arg-probe -nostdlib -nostdlibinc -fseh-exceptions
@@ -2043,46 +2041,6 @@ NOOPT_CLANGPDB_X64_DLINK_FLAGS      = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /OPT:RE
 NOOPT_CLANGPDB_X64_DLINK2_FLAGS     =
 # MU_CHANGE Keep optional header for NX_COMPAT flag
 NOOPT_CLANGPDB_X64_GENFW_FLAGS      = --keepexceptiontable --keepoptionalheader
-##########################
-# CLANGWIN ARM64 definitions
-##########################
-*_CLANGPDB_AARCH64_CC_PATH              = DEF(CLANGPDB_AARCH64_PREFIX)clang
-*_CLANGPDB_AARCH64_SLINK_PATH           = DEF(CLANGPDB_AARCH64_PREFIX)llvm-lib
-*_CLANGPDB_AARCH64_DLINK_PATH           = DEF(CLANGPDB_AARCH64_PREFIX)lld-link
-*_CLANGPDB_AARCH64_ASLDLINK_PATH        = DEF(CLANGPDB_AARCH64_PREFIX)lld-link
-*_CLANGPDB_AARCH64_ASM_PATH             = DEF(CLANGPDB_AARCH64_PREFIX)clang
-*_CLANGPDB_AARCH64_PP_PATH              = DEF(CLANGPDB_AARCH64_PREFIX)clang
-*_CLANGPDB_AARCH64_VFRPP_PATH           = DEF(CLANGPDB_AARCH64_PREFIX)clang
-*_CLANGPDB_AARCH64_ASLCC_PATH           = DEF(CLANGPDB_AARCH64_PREFIX)clang
-*_CLANGPDB_AARCH64_ASLPP_PATH           = DEF(CLANGPDB_AARCH64_PREFIX)clang
-*_CLANGPDB_AARCH64_RC_PATH              = DEF(CLANGPDB_IA32_PREFIX)llvm-rc
-
-*_CLANGPDB_AARCH64_ASLCC_FLAGS          = DEF(GCC_ASLCC_FLAGS) -m64 -fno-lto DEF(CLANGPDB_AARCH64_TARGET)
-*_CLANGPDB_AARCH64_ASM_FLAGS            = DEF(GCC_ASM_FLAGS) -m64 DEF(CLANGPDB_AARCH64_TARGET)
-*_CLANGPDB_AARCH64_OBJCOPY_FLAGS        =
-*_CLANGPDB_AARCH64_NASM_FLAGS           = -f win64
-*_CLANGPDB_AARCH64_PP_FLAGS             = DEF(GCC_PP_FLAGS) DEF(CLANGPDB_AARCH64_TARGET)
-*_CLANGPDB_AARCH64_ASLPP_FLAGS          = DEF(GCC_ASLPP_FLAGS) DEF(CLANGPDB_AARCH64_TARGET)
-*_CLANGPDB_AARCH64_VFRPP_FLAGS          = DEF(GCC_VFRPP_FLAGS) DEF(CLANGPDB_AARCH64_TARGET)
-*_CLANGPDB_AARCH64_CC_XIPFLAGS          = -mstrict-align
-
-DEBUG_CLANGPDB_AARCH64_CC_FLAGS         = DEF(CLANGPDB_ALL_CC_FLAGS) -m64 -mno-red-zone -mcmodel=small -Oz -flto DEF(CLANGPDB_AARCH64_TARGET) -gcodeview  -funwind-tables -Wno-unused-but-set-variable -Wno-deprecated-non-prototype -Wno-constant-conversion
-# MU_CHANGE - Remove /FILEALIGN from *_CLANGPDB_*_DLINK_FLAGS
-DEBUG_CLANGPDB_AARCH64_DLINK_FLAGS      = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /OPT:REF /OPT:ICF=10 /ALIGN:32 /Machine:ARM64 /DLL /ENTRY:$(IMAGE_ENTRY_POINT) /SUBSYSTEM:EFI_BOOT_SERVICE_DRIVER /SAFESEH:NO /BASE:0 /DEBUG:GHASH /MLLVM:-exception-model=wineh /lldmap
-DEBUG_CLANGPDB_AARCH64_DLINK2_FLAGS     =
-DEBUG_CLANGPDB_AARCH64_GENFW_FLAGS      = --keepexceptiontable --keepoptionalheader
-
-RELEASE_CLANGPDB_AARCH64_CC_FLAGS       = DEF(CLANGPDB_ALL_CC_FLAGS) -m64 -mno-red-zone -mcmodel=small -Oz -flto DEF(CLANGPDB_AARCH64_TARGET) -fno-unwind-tables -Wno-unused-but-set-variable -Wno-deprecated-non-prototype -Wno-constant-conversion
-# MU_CHANGE - Remove /FILEALIGN from *_CLANGPDB_*_DLINK_FLAGS
-RELEASE_CLANGPDB_AARCH64_DLINK_FLAGS    = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /IGNORE:4254 /OPT:REF /OPT:ICF=10 /ALIGN:32 /SECTION:.xdata,D /SECTION:.pdata,D /Machine:ARM64 /DLL /ENTRY:$(IMAGE_ENTRY_POINT) /SUBSYSTEM:EFI_BOOT_SERVICE_DRIVER /SAFESEH:NO /BASE:0 /MERGE:.rdata=.data /MLLVM:-exception-model=wineh /lldmap
-RELEASE_CLANGPDB_AARCH64_DLINK2_FLAGS   =
-RELEASE_CLANGPDB_AARCH64_GENFW_FLAGS    = --keepoptionalheader
-
-NOOPT_CLANGPDB_AARCH64_CC_FLAGS         = DEF(CLANGPDB_ALL_CC_FLAGS) -m64 -mno-red-zone -mcmodel=small -O0 DEF(CLANGPDB_AARCH64_TARGET) -gcodeview -funwind-tables -Wno-unused-but-set-variable -Wno-deprecated-non-prototype -Wno-constant-conversion
-# MU_CHANGE - Remove /FILEALIGN from *_CLANGPDB_*_DLINK_FLAGS
-NOOPT_CLANGPDB_AARCH64_DLINK_FLAGS      = /NOLOGO /NODEFAULTLIB /IGNORE:4001 /OPT:REF /OPT:ICF=10 /ALIGN:32 /Machine:ARM64 /DLL /ENTRY:$(IMAGE_ENTRY_POINT) /SUBSYSTEM:EFI_BOOT_SERVICE_DRIVER /SAFESEH:NO /BASE:0 /DEBUG:GHASH /MLLVM:-exception-model=wineh /lldmap
-NOOPT_CLANGPDB_AARCH64_DLINK2_FLAGS     =
-NOOPT_CLANGPDB_AARCH64_GENFW_FLAGS      = --keepexceptiontable --keepoptionalheader
 
 ####################################################################################
 #

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaLibBase.inf
@@ -22,6 +22,7 @@
   ArmFfaCommon.h
   ArmFfaCommon.c
   ArmFfaLibBase.c
+  ArmFfaSecRxTxMap.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/MdePkg/Include/AArch64/AArch64.h
+++ b/MdePkg/Include/AArch64/AArch64.h
@@ -147,8 +147,8 @@
 
 #define VECTOR_END(tbl)           \
   .org 0x800;                     \
-  .previous
-// MU_CHANGE [BEGIN] - ARM64 VS change
+  .section .text
+
 #else
 
 #define VECTOR_BASE(tbl)          \

--- a/MdePkg/Include/AArch64/AArch64.h
+++ b/MdePkg/Include/AArch64/AArch64.h
@@ -135,19 +135,27 @@
 #define RNDR  S3_3_C2_C4_0
 
 #if !defined (_MSC_VER)   // MU_CHANGE - ARM64 VS change
-#define VECTOR_BASE(tbl)          \
+// This macro defines a vector table
+// It is intended to be used as follows:
+//
+// #define MY_VECTOR
+//  VECTOR_ENTRY(MY_VECTOR, <some_offset>)
+//  <custom instructions for this entry>
+//  <more VECTOR_ENTRY(...) as needed>
+//
+// VECTOR_TABLE (MY_VECTOR_TABLE_NAME, MY_VECTOR)
+#define VECTOR_TABLE(tbl, entries) \
   .section .text.##tbl##,"ax";    \
   .align 11;                      \
   .org 0x0;                       \
   GCC_ASM_EXPORT(tbl);            \
   ASM_PFX(tbl):                   \
-
-#define VECTOR_ENTRY(tbl, off)    \
-  .org off
-
-#define VECTOR_END(tbl)           \
+  entries                         \
   .org 0x800;                     \
   .section .text
+
+#define VECTOR_ENTRY(tbl, off)    \
+  .org off;
 
 #else
 
@@ -166,6 +174,7 @@ tbl ENDP                                    __CR__\
 
 #endif
 // MU_CHANGE [END] - ARM64 VS change
+
 VOID
 EFIAPI
 ArmEnableSWPInstruction (

--- a/MdePkg/Include/AArch64/AArch64.h
+++ b/MdePkg/Include/AArch64/AArch64.h
@@ -145,19 +145,9 @@
 #define VECTOR_ENTRY(tbl, off)    \
   .org off
 
-  #ifndef __clang__ // MU_CHANGE
 #define VECTOR_END(tbl)           \
   .org 0x800;                     \
   .previous
-// MU_CHANGE Starts: CLANGPDB support
-  #else
-#define VECTOR_END(tbl)           \
-  .org 0x800;                     \
-  .section .text.##tbl##,"ax";    \
-  .align 3
-  #endif
-// MU_CHANGE Ends
-
 // MU_CHANGE [BEGIN] - ARM64 VS change
 #else
 

--- a/MdePkg/Include/AArch64/AArch64.h
+++ b/MdePkg/Include/AArch64/AArch64.h
@@ -134,7 +134,7 @@
 // so we need to define it here
 #define RNDR  S3_3_C2_C4_0
 
-#if !defined (_MSC_VER)   // MU_CHANGE - ARM64 VS change
+#if !defined (_MSC_VER) || defined (__clang__)  // MU_CHANGE - ARM64 VS change
 // This macro defines a vector table
 // It is intended to be used as follows:
 //

--- a/MdePkg/Include/AArch64/AsmMacroLib.h
+++ b/MdePkg/Include/AArch64/AsmMacroLib.h
@@ -114,43 +114,20 @@ bgt    %b6                  __CR__ \
 // MU_CHANGE - Start - MSVC ARM64 change
 #if !defined (_MSC_VER)
 // MU_CHANGE - End - MSVC ARM64 change
-// MU_CHANGE - Start - Clang Support
-  #ifndef __clang__
-// MU_CHANGE - End - Clang Support
 #define _ASM_FUNC(Name, Section)    \
   .global   Name                  ; \
   .section  #Section, "ax"        ; \
-  .type     Name, %function       ; \
+  _ASM_TYPE(Name)                 ; \
   Name:                           ; \
   AARCH64_BTI(c)
-// MU_CHANGE - Start - Clang Support
-  #else
-#define _ASM_FUNC(Name, Section)    \
-  .global   Name                  ; \
-  .section  #Section, "ax"        ; \
-  Name:                           ; \
-  AARCH64_BTI(c)
-  #endif
 
-  #ifndef __clang__ // MU_CHANGE
-// MU_CHANGE - End - Clang Support
 #define _ASM_FUNC_ALIGN(Name, Section, Align)       \
   .global   Name                                  ; \
   .section  #Section, "ax"                        ; \
-  .type     Name, %function                       ; \
+  _ASM_TYPE(Name)                                 ; \
   .balign   Align                                 ; \
   Name:                                           ; \
   AARCH64_BTI(c)
-// MU_CHANGE - Start - Clang Support
-  #else
-#define _ASM_FUNC_ALIGN(Name, Section, Align)       \
-  .global   Name                                  ; \
-  .section  #Section, "ax"                        ; \
-  .balign   Align                                 ; \
-  Name:                                           ; \
-  AARCH64_BTI(c)
-  #endif
-// MU_CHANGE - End - Clang Support
 
 #define ASM_FUNC(Name)  _ASM_FUNC(ASM_PFX(Name), .text. ## Name)
 
@@ -169,5 +146,24 @@ bgt    %b6                  __CR__ \
 
 // MU_CHANGE - Start - MSVC ARM64 change
 #endif
-// MU_CHANGE - End - MSVC ARM64 change
-#endif // ASM_MACRO_LIB_H_
+
+// CLANGPDB does not support the fixup_aarch64_ldr_pcrel_imm19
+// relocation used for LDR literal loads, so we need to expand
+// LDR literal loads into ADRP + LDR instructions for PE targets.
+#ifdef __ELF__
+#define LDR_LIT(dst, sym)                          \
+    ldr     dst, sym
+
+#define LDR_LIT_TMP(dst, sym, tmp)                 \
+    ldr     dst, sym
+#else
+#define LDR_LIT(dst, sym)                          \
+    adrp    dst, sym                            ;\
+    ldr     dst, [dst, :lo12:sym]
+
+#define LDR_LIT_TMP(dst, sym, tmp)                 \
+    adrp    tmp, sym                            ;\
+    ldr     dst, [tmp, :lo12:sym]
+#endif
+
+#endif // ASM_MACRO_IO_LIBV8_H_

--- a/MdePkg/Include/AArch64/AsmMacroLib.h
+++ b/MdePkg/Include/AArch64/AsmMacroLib.h
@@ -27,7 +27,7 @@
 // This only selects between EL1 and EL2, else we die.
 // Provide the Macro with a safe temp xreg to use.
 // MU_CHANGE - Start - MSVC ARM64 change
-#if !defined (_MSC_VER)
+#if !defined (_MSC_VER) || defined (__clang__)
 // MU_CHANGE - End - MSVC ARM64 change
 #define EL1_OR_EL2(SAFE_XREG)        \
         mrs    SAFE_XREG, CurrentEL ;\
@@ -54,7 +54,7 @@ bgt    %b6                  __CR__ \
 // CurrentEL : 0xC = EL3; 8 = EL2; 4 = EL1
 // This only selects between EL1 and EL2 and EL3, else we die.
 // Provide the Macro with a safe temp xreg to use.
-#if !defined (_MSC_VER)    // MU_CHANGE - ARM64 VS change
+#if !defined (_MSC_VER) || defined (__clang__)   // MU_CHANGE - ARM64 VS change
 #define EL1_OR_EL2_OR_EL3(SAFE_XREG) \
         mrs    SAFE_XREG, CurrentEL ;\
         cmp    SAFE_XREG, #0x8      ;\
@@ -76,7 +76,7 @@ bgt    %b6                  __CR__ \
 
 // MU_CHANGE - Start - MSVC ARM64 change - Add Back Defines
 
-#if defined (_MSC_VER)
+#if defined (_MSC_VER) && !defined (__clang__)
 
 #define LoadConstantToReg(Data, Reg) \
   ldr Reg, =Data
@@ -112,7 +112,7 @@ bgt    %b6                  __CR__ \
 #endif // _MSC_VER
 
 // MU_CHANGE - Start - MSVC ARM64 change
-#if !defined (_MSC_VER)
+#if !defined (_MSC_VER) || defined (__clang__)
 // MU_CHANGE - End - MSVC ARM64 change
 #define _ASM_FUNC(Name, Section)    \
   .global   Name                  ; \

--- a/MdePkg/Include/AArch64/ProcessorBind.h
+++ b/MdePkg/Include/AArch64/ProcessorBind.h
@@ -187,16 +187,9 @@ typedef INT64 INTN;
 ///
 #define ASM_GLOBAL  .globl
 
-  #ifndef __clang__ // MU_CHANGE: Clang does not support the .type
 #define GCC_ASM_EXPORT(func__)  \
          .global  _CONCATENATE (__USER_LABEL_PREFIX__, func__)    ;\
          .type ASM_PFX(func__), %function
-// MU_CHANGE Starts: Clang does not support the .type
-  #else
-#define GCC_ASM_EXPORT(func__)  \
-         .global  _CONCATENATE (__USER_LABEL_PREFIX__, func__)
-  #endif
-// MU_CHANGE Ends
 
 #define GCC_ASM_IMPORT(func__)  \
          .extern  _CONCATENATE (__USER_LABEL_PREFIX__, func__)

--- a/MdePkg/Include/AArch64/ProcessorBind.h
+++ b/MdePkg/Include/AArch64/ProcessorBind.h
@@ -187,9 +187,16 @@ typedef INT64 INTN;
 ///
 #define ASM_GLOBAL  .globl
 
+// PE targets (i.e. building with CLANGPDB) do not support the ELF style .type directive
+  #ifdef __ELF__
+#define _ASM_TYPE(Name)  .type Name, %function
+  #else
+#define _ASM_TYPE(Name)
+  #endif // __ELF__
+
 #define GCC_ASM_EXPORT(func__)  \
-         .global  _CONCATENATE (__USER_LABEL_PREFIX__, func__)    ;\
-         .type ASM_PFX(func__), %function
+         .global  ASM_PFX(func__)    ;\
+         _ASM_TYPE(ASM_PFX(func__))
 
 #define GCC_ASM_IMPORT(func__)  \
          .extern  _CONCATENATE (__USER_LABEL_PREFIX__, func__)

--- a/MdePkg/Include/Arm/AsmMacroLib.h
+++ b/MdePkg/Include/Arm/AsmMacroLib.h
@@ -12,22 +12,12 @@
 #ifndef ASM_MACRO_IO_LIB_H_
 #define ASM_MACRO_IO_LIB_H_
 
-#ifndef __clang__ // MU_CHANGE: Clang does not support the .type
 #define _ASM_FUNC(Name, Section)    \
   .global   Name                  ; \
   .section  #Section, "ax"        ; \
   .type     Name, %function       ; \
   .p2align  2                     ; \
   Name:
-// MU_CHANGE Starts: Clang does not support the .type
-#else
-#define _ASM_FUNC(Name, Section)    \
-  .global   Name                  ; \
-  .section  #Section, "ax"        ; \
-  .p2align  2                     ; \
-  Name:
-#endif
-// MU_CHANGE Ends
 
 #define ASM_FUNC(Name)  _ASM_FUNC(ASM_PFX(Name), .text. ## Name)
 

--- a/MdePkg/Library/CompilerIntrinsicsLib/AArch64/Atomics.S
+++ b/MdePkg/Library/CompilerIntrinsicsLib/AArch64/Atomics.S
@@ -32,12 +32,26 @@
         .macro          fn_start, name:req
         .section        .text.\name
         .globl          \name
+
+        /*
+         * PE targets (e.g. building with CLANGPDB) do not support ELF style
+         * .type directives
+         */
+#ifdef __ELF__
         .type           \name, %function
+#endif
 \name\():
         .endm
 
         .macro          fn_end, name:req
+
+        /*
+         * PE targets (e.g. building with CLANGPDB) do not support ELF style
+         * .size directives
+         */
+#ifdef __ELF__
         .size           \name, . - \name
+#endif
         .endm
 
         /*

--- a/MdePkg/Library/CompilerIntrinsicsLib/AArch64/Atomics.S
+++ b/MdePkg/Library/CompilerIntrinsicsLib/AArch64/Atomics.S
@@ -32,18 +32,12 @@
         .macro          fn_start, name:req
         .section        .text.\name
         .globl          \name
-# MU_CHANGE: Clang does not support the .type
-#ifndef __clang__
         .type           \name, %function
-#endif
 \name\():
         .endm
 
         .macro          fn_end, name:req
-# MU_CHANGE: Clang does not support the .size
-#ifndef __clang__
         .size           \name, . - \name
-#endif
         .endm
 
         /*

--- a/MdePkg/Library/CompilerIntrinsicsLib/memset.c
+++ b/MdePkg/Library/CompilerIntrinsicsLib/memset.c
@@ -33,14 +33,20 @@ __memset (
 // implementation of memset(), which may conflict with this one if this
 // object was pulled into the link due to the definitions below. So make
 // our memset() 'weak' to let the other implementation take precedence.
+// PE targets (i.e. building with CLANGPDB) have different name mangling
+// and as such don't recognize __memset here, so we provide a weak alias
+// that simply calls the internal __memset implementation.
 //
-__attribute__ ((__weak__, __alias__ ("__memset")))
+__attribute__ ((__weak__))
 void *
 memset (
   void    *dest,
   int     c,
   size_t  n
-  );
+  )
+{
+  return __memset (dest, c, n);
+}
 
 #ifdef __arm__
 

--- a/MdePkg/Library/CompilerIntrinsicsLib/memset.c
+++ b/MdePkg/Library/CompilerIntrinsicsLib/memset.c
@@ -34,7 +34,6 @@ __memset (
 // object was pulled into the link due to the definitions below. So make
 // our memset() 'weak' to let the other implementation take precedence.
 //
-#ifndef __clang__ // MU_CHANGE: Add Clang support
 __attribute__ ((__weak__, __alias__ ("__memset")))
 void *
 memset (
@@ -42,22 +41,6 @@ memset (
   int     c,
   size_t  n
   );
-
-// MU_CHANGE Starts: Add Clang support
-#else
-__attribute__ ((__weak__))
-void *
-memset (
-  void    *dest,
-  int     c,
-  size_t  n
-  )
-{
-  return __memset (dest, c, n);
-}
-
-#endif
-// MU_CHANGE Ends
 
 #ifdef __arm__
 

--- a/StandaloneMmPkg/Core/StandaloneMmCore.inf
+++ b/StandaloneMmPkg/Core/StandaloneMmCore.inf
@@ -90,13 +90,13 @@
   gStandaloneMmPkgTokenSpaceGuid.PcdShadowBfv    ##CONSUMES
 
 #
-# This configuration fails for CLANGPDB, which does not support PIE in the GCC
-# sense. Such however is required for ARM family StandaloneMmCore
-# self-relocation, and thus the CLANGPDB toolchain is unsupported for ARM and
-# AARCH64 for this module.
+# Standalone MM Core can be used as an OP-TEE trusted application and needs to do runtime
+# relocation in that scenario. It needs to be built as a position independent executable (PIE)
+# for this use case. However, PE targets do not support PIE, so only ELF targets
+# are built with these flags and support this scenario.
 #
 [BuildOptions]
-  GCC:*_*_ARM_CC_FLAGS = -fpie
-  GCC:*_*_ARM_DLINK_FLAGS = -Wl,-z,text,-Bsymbolic,-pie
-  GCC:*_*_AARCH64_CC_FLAGS = -fpie
-  GCC:*_*_AARCH64_DLINK_FLAGS = -Wl,-z,text,-Bsymbolic,-pie
+  GCC:*_GCC_AARCH64_CC_FLAGS = -fpie
+  GCC:*_GCC_AARCH64_DLINK_FLAGS = -Wl,-z,text,-Bsymbolic,-pie
+  GCC:*_CLANGDWARF_AARCH64_CC_FLAGS = -fpie
+  GCC:*_CLANGDWARF_AARCH64_DLINK_FLAGS = -Wl,-z,text,-Bsymbolic,-pie

--- a/StandaloneMmPkg/StandaloneMmPkg.dsc
+++ b/StandaloneMmPkg/StandaloneMmPkg.dsc
@@ -185,7 +185,7 @@
 #
 ###################################################################################################
 [BuildOptions.AARCH64]
-GCC:*_*_*_DLINK_FLAGS = -z common-page-size=0x1000 -march=armv8-a+nofp -mstrict-align
+GCC:*_GCC_*_DLINK_FLAGS = -z common-page-size=0x1000 -march=armv8-a+nofp -mstrict-align
 GCC:*_*_*_CC_FLAGS = -mstrict-align
 
 [BuildOptions.ARM]


### PR DESCRIPTION
## Description

In order to facilitate platforms moving from MSVC AARCH64 to CLANGPDB AARCH64, port CLANGPDB AARCH64 support to 2502.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A.

## Integration Instructions

N/A.
