### PR TITLE
[CHERRY-PICK] ArmPkg: Add bounce buffering to IoMmu SmmuDxe implementation

### DIFF
--- a/ArmPkg/Drivers/SmmuDxe/IoMmu.c
+++ b/ArmPkg/Drivers/SmmuDxe/IoMmu.c
@@ -29,9 +29,10 @@
   Used to pass between IoMmuMap, IoMmuUnmap and IoMmuSetAttribute.
 **/
 typedef struct IOMMU_MAP_INFO {
-  UINTN     NumberOfBytes;
-  UINT64    VirtualAddress;
-  UINT64    PhysicalAddress;
+  UINTN                    NumberOfBytes;
+  UINT64                   DeviceAddress;
+  UINT64                   HostAddress;
+  EDKII_IOMMU_OPERATION    Operation;
 } IOMMU_MAP_INFO;
 
 /**
@@ -221,10 +222,14 @@ IoMmuMap (
   OUT    VOID                   **Mapping
   )
 {
-  EFI_STATUS      Status;
-  IOMMU_MAP_INFO  *MapInfo;
+  EFI_STATUS            Status;
+  IOMMU_MAP_INFO        *MapInfo;
+  EFI_PHYSICAL_ADDRESS  PhysicalAddress;
+  BOOLEAN               NeedRemap;
+  EFI_PHYSICAL_ADDRESS  DmaMemoryTop;
 
-  Status = EFI_SUCCESS;
+  Status    = EFI_SUCCESS;
+  NeedRemap = FALSE;
 
   if ((This == NULL) ||
       (HostAddress == NULL) ||
@@ -246,12 +251,62 @@ IoMmuMap (
     goto End;
   }
 
-  *DeviceAddress = (EFI_PHYSICAL_ADDRESS)(UINTN)HostAddress; // Identity mapping
+  DmaMemoryTop    = MAX_UINTN;
+  PhysicalAddress = (EFI_PHYSICAL_ADDRESS)(UINTN)HostAddress;
 
-  MapInfo->NumberOfBytes   = *NumberOfBytes;
-  MapInfo->VirtualAddress  = *DeviceAddress;
-  MapInfo->PhysicalAddress = *DeviceAddress;
-  *Mapping                 = MapInfo;
+  if ((Operation != EdkiiIoMmuOperationBusMasterCommonBuffer) && (Operation != EdkiiIoMmuOperationBusMasterCommonBuffer64)) {
+    if ((*NumberOfBytes != ALIGN_VALUE (*NumberOfBytes, SIZE_4KB)) || (PhysicalAddress != ALIGN_VALUE (PhysicalAddress, SIZE_4KB))) {
+      NeedRemap = TRUE;
+    }
+
+    if ((((Operation != EdkiiIoMmuOperationBusMasterRead64) &&
+          (Operation != EdkiiIoMmuOperationBusMasterWrite64))) &&
+        ((PhysicalAddress + *NumberOfBytes) > SIZE_4GB))
+    {
+      //
+      // If the root bridge or the device cannot handle performing DMA above
+      // 4GB but any part of the DMA transfer being mapped is above 4GB, then
+      // map the DMA transfer to a buffer below 4GB.
+      //
+      NeedRemap    = TRUE;
+      DmaMemoryTop = SIZE_4GB - 1;
+    }
+  }
+
+  MapInfo->NumberOfBytes = *NumberOfBytes;
+  MapInfo->DeviceAddress = DmaMemoryTop;
+  MapInfo->HostAddress   = PhysicalAddress;
+  MapInfo->Operation     = Operation;
+
+  // Bounce buffer case
+  if (NeedRemap) {
+    Status = gBS->AllocatePages (
+                    AllocateMaxAddress,
+                    EfiBootServicesData,
+                    EFI_SIZE_TO_PAGES (MapInfo->NumberOfBytes),
+                    &MapInfo->DeviceAddress
+                    );
+    if (EFI_ERROR (Status)) {
+      FreePool (MapInfo);
+      *NumberOfBytes = 0;
+      DEBUG ((DEBUG_ERROR, "%a: %r\n", __func__, Status));
+      return Status;
+    }
+
+    //
+    // If this is a read operation from the Bus Master's point of view,
+    // then copy the contents of the real buffer into the mapped buffer
+    // so the Bus Master can read the contents of the real buffer.
+    //
+    if ((Operation == EdkiiIoMmuOperationBusMasterRead) || (Operation == EdkiiIoMmuOperationBusMasterRead64)) {
+      CopyMem ((VOID *)(UINTN)MapInfo->DeviceAddress, (VOID *)(UINTN)MapInfo->HostAddress, MapInfo->NumberOfBytes);
+    }
+  } else {
+    MapInfo->DeviceAddress = MapInfo->HostAddress;
+  }
+
+  *DeviceAddress = MapInfo->DeviceAddress;
+  *Mapping       = MapInfo;
 
 End:
   ASSERT_EFI_ERROR (Status);
@@ -276,10 +331,41 @@ IoMmuUnmap (
   IN  VOID                  *Mapping
   )
 {
+  IOMMU_MAP_INFO  *MapInfo;
+
   if ((This == NULL) || (Mapping == NULL)) {
     DEBUG ((DEBUG_ERROR, "%a: Invalid parameter\n", __func__));
     ASSERT (FALSE);
     return EFI_INVALID_PARAMETER;
+  }
+
+  MapInfo = (IOMMU_MAP_INFO *)Mapping;
+
+  // Bounce buffer case
+  if (MapInfo->DeviceAddress != MapInfo->HostAddress) {
+    if ((MapInfo->DeviceAddress == 0) || (MapInfo->HostAddress == 0) || (MapInfo->NumberOfBytes == 0)) {
+      DEBUG ((DEBUG_ERROR, "%a: Invalid fields in MapInfo struct.\n", __func__));
+      ASSERT (FALSE);
+      return EFI_INVALID_PARAMETER;
+    }
+
+    //
+    // If this is a write operation from the Bus Master's point of view,
+    // then copy the contents of the mapped buffer into the real buffer
+    // so the processor can read the contents of the real buffer.
+    //
+    if ((MapInfo->Operation == EdkiiIoMmuOperationBusMasterWrite) || (MapInfo->Operation == EdkiiIoMmuOperationBusMasterWrite64)) {
+      CopyMem (
+        (VOID *)(UINTN)MapInfo->HostAddress,
+        (VOID *)(UINTN)MapInfo->DeviceAddress,
+        MapInfo->NumberOfBytes
+        );
+    }
+
+    //
+    // Free the mapped buffer and the MAP_INFO structure.
+    //
+    gBS->FreePages (MapInfo->DeviceAddress, EFI_SIZE_TO_PAGES (MapInfo->NumberOfBytes));
   }
 
   // Free the mapping structure allocated in IoMmuMap
@@ -425,7 +511,7 @@ IoMmuSetAttribute (
 
   Status = UpdatePageTable (
              mIoMmu->SmmuInfo->PageTableRoot,
-             MapInfo->PhysicalAddress,
+             MapInfo->DeviceAddress,
              MapInfo->NumberOfBytes,
              PAGE_TABLE_READ_WRITE_FROM_IOMMU_ACCESS ((EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE)), // TODO: https://github.com/microsoft/mu_silicon_arm_tiano/issues/375 debug issue on physical platform and revert the permissions
              (IoMmuAccess != 0)

--- a/ArmPkg/Drivers/SmmuDxe/README.md
+++ b/ArmPkg/Drivers/SmmuDxe/README.md
@@ -1,10 +1,17 @@
-# SMMU/IOMMU Driver
+# SmmuDxe Driver
 
 This document describes the System Memory Management Unit (SMMU) driver implementation, and how it integrates with the
 PCI I/O subsystem. The driver configures the SMMUv3 hardware and implements the IOMMU protocol to provide address
 translation and memory protection for DMA operations.
 
 ## Architecture Overview
+
+The SmmuDxe driver will consume the SMMU_CONFIG HOB with the IORT data to configure the SMMU's found on the platform.
+It will set them up for Stage 2 Translation by default. SmmuDxe will install the IoMmu Protocol.
+Translation table mapping can be done by leveraging the IoMmu Protocol. The protocol functions are outlined below.
+Seperatley, an IoMmuLib is provided for platforms to use to do DMA mappings for the SMMU.
+SmmuDxe will install the IORT ACPI Table. Platform should not install the IORT, but instead pass in the IORT data
+with the SMMU_CONFIG HOB.
 
 The system consists of three main components working together:
 
@@ -44,11 +51,11 @@ SMMU Hardware
      };
      ```
 
-   - Configures IOMMU page tables with PageTableInit()
+   - SmmuDxe will handle Translation Table initialization
 
-### DMA Mapping
+## DMA Mapping with IoMmuLib and IoMmu Protocol
 
-- Maintains a 4-level page table to map HostAddress and DeviceAddress
+- Maintains up to a 4-level page table, depending on configuration, to map HostAddress and DeviceAddress
 - Identity Mapped
 
 1. **IoMmu Map**:
@@ -57,7 +64,6 @@ SMMU Hardware
    EFI_STATUS
    EFIAPI
    IoMmuMap (
-     IN     EDKII_IOMMU_PROTOCOL   *This,
      IN     EDKII_IOMMU_OPERATION  Operation,
      IN     VOID                   *HostAddress,
      IN OUT UINTN                  *NumberOfBytes,
@@ -66,16 +72,52 @@ SMMU Hardware
      );
    ```
 
-- Sets access permissions based on operation type:
-  - BusMasterRead: READ access
-  - BusMasterWrite: WRITE access
-  - BusMasterCommonBuffer: READ/WRITE access
-
 - Maps HostAddress to DeviceAddress
 - Validates operation type
 - Called by PciIo protocol for mapping
 
-### DMA Unmapping
+### Bounce Buffering
+
+In certain conditions, `IoMmuMap` will allocate a bounce buffer instead of using the original host address directly.
+A bounce buffer is a temporary intermediate buffer allocated that is used when the original DMA buffer
+cannot be used directly by the device.
+
+**Bounce Buffer Conditions:**
+
+A bounce buffer is allocated when the operation is NOT `EdkiiIoMmuOperationBusMasterCommonBuffer` or
+`EdkiiIoMmuOperationBusMasterCommonBuffer64`, AND any of the following conditions are met:
+
+1. **Alignment Requirements Not Met:**
+   - The `NumberOfBytes` is not 4KB aligned, OR
+   - The `HostAddress` (PhysicalAddress) is not 4KB aligned
+
+2. **32-bit DMA Limitation:**
+   - The operation is a 32-bit DMA operation (`EdkiiIoMmuOperationBusMasterRead` or
+     `EdkiiIoMmuOperationBusMasterWrite`), AND
+   - Any part of the DMA transfer range (`PhysicalAddress + NumberOfBytes`) exceeds 4GB
+
+**Bounce Buffer Behavior:**
+
+- When a bounce buffer is needed due to **alignment issues only** (with 64-bit operations), memory can be allocated
+  anywhere in the address space
+- When a bounce buffer is needed due to the **32-bit DMA limitation**, memory is allocated below 4GB using
+  `AllocateMaxAddress` with `DmaMemoryTop` set to `SIZE_4GB - 1`
+- The `DeviceAddress` returned points to the bounce buffer, not the original host address
+- The `Mapping` handle stores information about both the original host address and the bounce buffer address
+
+**CopyMem on Map (Host → Bounce Buffer):**
+
+A `CopyMem` from the host buffer to the bounce buffer is performed during `IoMmuMap` when:
+
+- A bounce buffer was allocated (NeedRemap is TRUE), AND
+- The operation is a **read operation** from the Bus Master's perspective:
+  - `EdkiiIoMmuOperationBusMasterRead`, OR
+  - `EdkiiIoMmuOperationBusMasterRead64`
+
+This copy ensures the Bus Master can read the correct data from the bounce buffer during the DMA operation.
+For write operations, no copy is needed on Map since the Bus Master will write new data into the bounce buffer.
+
+## DMA Unmapping with IoMmuLib and IoMmu Protocol
 
 1. **PCI Driver Completes DMA**:
    - Calls PciIo->Unmap()
@@ -87,13 +129,57 @@ SMMU Hardware
    EFI_STATUS
    EFIAPI
    IoMmuUnmap (
-     IN  EDKII_IOMMU_PROTOCOL  *This,
      IN  VOID                  *Mapping
      );
    ```
 
    - Invalidates mapping in Page Table
    - Invalidates TLB entries
+
+### Bounce Buffer Handling on Unmap
+
+When unmapping a DMA operation that used a bounce buffer (i.e., `DeviceAddress != HostAddress`):
+
+**CopyMem on Unmap (Bounce Buffer → Host):**
+
+A `CopyMem` from the bounce buffer back to the host buffer is performed during `IoMmuUnmap` when:
+
+- A bounce buffer was used (`DeviceAddress != HostAddress`), AND
+- The operation is a **write operation** from the Bus Master's perspective:
+  - `EdkiiIoMmuOperationBusMasterWrite`, OR
+  - `EdkiiIoMmuOperationBusMasterWrite64`
+
+This copy ensures the processor can access the data that the Bus Master wrote into the bounce buffer.
+For read operations, no copy is needed on Unmap since the Bus Master only read data and did not modify it.
+
+**Cleanup:**
+
+- The bounce buffer pages are freed using `FreePages`
+- The mapping information structure is freed
+
+For direct mappings (no bounce buffer), only the mapping information structure is freed.
+
+### DMA Access Attributes with IoMmuLib and IoMmu Protocol
+
+1. Setting R/W permissions
+   - After mapping an address with IoMmuMap()
+   - Clearning R/W permissions before unmmapping an address with IoMmuUnmap()
+   - Sets access permissions based on IoMmuAccess type:
+      - EDKII_IOMMU_ACCESS_READ: READ only access
+      - EDKII_IOMMU_ACCESS_WRITE: WRITE only access
+      - EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE: READ/WRITE access
+
+2. IoMmu SetAttribute
+
+   ```c
+   EFI_STATUS
+   EFIAPI
+   IoMmuSetAttribute (
+      IN EFI_HANDLE            DeviceHandle,
+      IN VOID                  *Mapping,
+      IN UINT64                IoMmuAccess
+   );
+   ```
 
 ## SMMU Configuration
 
@@ -108,7 +194,7 @@ The SMMU is configured in stage 2 translation mode with:
 
 ### 2. Page Table Structure
 
-The IOMMU uses a 4-level page table structure for DMA address translation:
+The IOMMU uses up to a 4-level page table structure for DMA address translation:
 <https://developer.arm.com/documentation/101811/0104/Translation-granule/The-starting-level-of-address-translation>
 
 ```text
@@ -122,6 +208,10 @@ Level 3 Table (L3)
     ↓
 Physical Page
 ```
+
+Depending on configuration from the SMMU registers, the starting level of translation is chosen.
+Depending on the SMMU configuration found, also supports Concatenated Translation Tables for the
+Translation Table Base.
 
 ### 3. Address Translation Process
 
@@ -195,17 +285,7 @@ The implementation includes optimizations for:
 1. **Integration of SmmuV3 with IOMMU Protocol**
 
 2. **TLB Management**:
-   - TLB invalidation for unmapped entries via the command queue
-
-## Configuration Options
-
-Key SMMU settings controlled through the SMMU config HOB:
-
-```text
-- Smmu base address, num ID's, etc.
-- Stream Table Size: Based on num IDs
-- IORT info
-```
+   - TLB invalidation by VA for unmapped entries via the command queue
 
 ## Limitations
 
@@ -224,16 +304,23 @@ Potential improvements:
 1. Multiple translation granule support
 2. Stage 1 & 2 translation
 3. Different page table mapping schemes
-4. Updated IoMmu Protocol to optimize redundencies
+4. Updated IoMmu Protocol to optimize redundancies
+5. Bounce Buffer Optimization
+   - Remove the `NumberOfBytes` end address alignment check in `IoMmuMap`
+   - Update individual drivers to allocate their DMA buffers by page (page-aligned and page-sized)
+   - This eliminates one case for bounce buffering, improving performance by avoiding unnecessary
+     buffer copies and allocations when only the end address is unaligned
 
-## Relevant Docs
+## Configuration Options
 
-- SMMUv3 specification <https://developer.arm.com/documentation/ihi0070/latest/>
-- Useful ARM SMMU documentation - <https://developer.arm.com/documentation/109242/0100/Programming-the-SMMU>
-- Arm AArch64 memory manegemnt guide - <https://developer.arm.com/documentation/101811/0104>
-- ARM a_a-profile_architecture_reference_manual <https://developer.arm.com/documentation/102105/ka-07>
-- Intel IOMMU for DMA protection in UEFI <https://www.intel.com/content/dam/develop/external/us/en/documents/intel-whitepaper-using-iommu-for-dma-protection-in-uefi.pdf>
-- IORT documentation <https://developer.arm.com/documentation/den0049/latest/>
+Key SMMU settings controlled through the SMMU config HOB:
+
+- IORT data: The complete IORT table data that the SMMU(s) will be configured with.
+
+- SmmuDisabledList: Provides platform the ability to individually disable/bypass an SMMU if needed.
+This list is a set of SMMU base addresses that the platform wants to disable/bypass.
+By default, all SMMU's found are configured for Stage 2 Translation, otherwise set in the SmmuDisabledList,
+in which case translation for that SMMU is disabled and it is set to global bypass mode.
 
 ## Platform Integration Instructions
 
@@ -241,11 +328,16 @@ Generic Platform Integration:
 
 - The Platform will construct a SMMU config HOB and publish for SmmuDxe to consume:
 - Append the IORT structure to this struct and update the fields accordingly.
+- Append the SmmuDisabledList as a UINT64 array. SmmuDxe will parse this Offset and
+interpret as a `(UINT64*)` and iterate on that array of SMMU base addresses based on the SmmuDisabledSize.
+SmmuDxe will derive the number of SMMU's in the SmmuDisabledListOffset with
+`SmmuDisabledListSize / sizeof(UINT64)`
 
   ```c
    // SMMU_CONFIG structure to pass the SMMU configuration data from the platform to the SMMU driver.
+   // Platform will pass in the IORT structure through here.
    // Platform will configure SmmuDisabledList size and offset to the SMMU disabled list appropriatley
-   // for any SMMU that needs be disabled in UEFI and set to bypass.
+   // with the base address for any SMMU that needs be disabled in UEFI and set to bypass.
    typedef struct _SMMU_CONFIG {
       UINT32    VersionMajor;
       UINT32    VersionMinor;
@@ -259,9 +351,18 @@ Generic Platform Integration:
 - Essentialy the same as IORT we want to publish
 - The SMMU expects the entire IORT data to be passed into a HOB gSmmuConfigHobGuid.
 - The platform must create the IORT structure and create gSmmuConfigHobGuid with that data using BuildGuidDataHob.
-- If the platform needs to disable/bypass any Smmu, they can add the SMMU base address to the SmmuDisabledList in the HOB.
+- If the platform needs to disable/bypass any SMMU, they can add the SMMU base address to the SmmuDisabledList in the HOB.
 - This structure is consumed by SmmuDxe to configure the SMMU hardware
 
 Integration with Qemu:
 
 - SMMU is supported on Qemu but on v9.1.50+ <https://gitlab.com/qemu-project/qemu>
+
+## Relevant Docs
+
+- SMMUv3 specification <https://developer.arm.com/documentation/ihi0070/latest/>
+- Useful ARM SMMU documentation - <https://developer.arm.com/documentation/109242/0100/Programming-the-SMMU>
+- Arm AArch64 memory manegemnt guide - <https://developer.arm.com/documentation/101811/0104>
+- ARM a_a-profile_architecture_reference_manual <https://developer.arm.com/documentation/102105/ka-07>
+- Intel IOMMU for DMA protection in UEFI <https://www.intel.com/content/dam/develop/external/us/en/documents/intel-whitepaper-using-iommu-for-dma-protection-in-uefi.pdf>
+- IORT documentation <https://developer.arm.com/documentation/den0049/latest/>


### PR DESCRIPTION
## Description

ArmPkg: Add bounce buffering to IoMmu SmmuDxe implementation

For the cases where we have:
- Non-aligned DMA buffer when we are not using CommonBuffer operations
- An address above 4G for the DMA buffer when the operation only supports below 4G

We need to bounce buffer the original DMA buffer to a newly allocated one under the above conditions. On a Read operation Map() will copy the contents of the DMA buffer into the newly allocated buffer. On a Write operation Unmap() will copy the contents of the newly allocated buffer back to the original DMA buffer.

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [x] Includes documentation?


## How This Was Tested

N/A

## Integration Instructions

N/A
