### PR TITLE
[CHERRY-PICK] Update CryptoPkg to support CLANGPDB and CLANGDWARF

### DIFF
--- a/CryptoPkg/CryptoPkg.dec
+++ b/CryptoPkg/CryptoPkg.dec
@@ -283,6 +283,16 @@
 # ****************************************************************************
 # MU_CHANGE [END]
 
+[PcdsFeatureFlag.IA32, PcdsFeatureFlag.X64]
+  ## Enable the use of NASM assembly source files when building an optimized
+  #  version of OpensslLib from generated assembly source files for IA32 and X64.
+  #  The generated NASM assembly source files only work with MSFT family of tool
+  #  chains or the CLANGPDB tool chain. All other tool chains must use the GAS
+  #  assembly source files. The default setting is to not use the NASM assembly
+  #  source files.
+  # @Prompt Use NASM assembly source files for optimized version of OpensslLib for IA32/X64
+  gEfiCryptoPkgTokenSpaceGuid.PcdOpensslLibAssemblySourceStyleNasm|FALSE|BOOLEAN|0x00000003
+
 [PcdsFixedAtBuild]
   ## Enable/Disable the families and individual services produced by the
   #  EDK II Crypto Protocols/PPIs.  The default is all services disabled.

--- a/CryptoPkg/CryptoPkgFeatureFlagPcds.dsc.inc
+++ b/CryptoPkg/CryptoPkgFeatureFlagPcds.dsc.inc
@@ -8,8 +8,6 @@
 ##
 
 [PcdsFeatureFlag]
-# MU_CHANGE Start
-#!if "$(FAMILY)" == "MSFT" || "$(TOOL_CHAIN_TAG)" == "CLANGPDB"
-#gEfiCryptoPkgTokenSpaceGuid.PcdOpensslLibAssemblySourceStyleNasm|TRUE
-#!endif
-# MU_CHANGE End
+!if "$(FAMILY)" == "MSFT" || "$(TOOL_CHAIN_TAG)" == "CLANGPDB"
+gEfiCryptoPkgTokenSpaceGuid.PcdOpensslLibAssemblySourceStyleNasm|TRUE
+!endif

--- a/CryptoPkg/Test/CryptoPkgHostUnitTest.dsc
+++ b/CryptoPkg/Test/CryptoPkgHostUnitTest.dsc
@@ -19,6 +19,8 @@
 
 !include UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
 
+!include CryptoPkg/CryptoPkgFeatureFlagPcds.dsc.inc
+
 [LibraryClasses]
   BaseCryptLib|CryptoPkg/Library/BaseCryptLibNull/BaseCryptLibNull.inf
   MmServicesTableLib|MdePkg/Library/MmServicesTableLib/MmServicesTableLib.inf

--- a/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/TestBaseCryptLibHost.inf
+++ b/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/TestBaseCryptLibHost.inf
@@ -21,6 +21,7 @@
 
 [Sources]
   UnitTestMain.c
+  UnitTestMainHost.c
   BaseCryptLibUnitTests.c
   TestBaseCryptLib.h
   HashTests.c


### PR DESCRIPTION
## Description

Update the CryptoPkg to support CLANGPDB and CLANGDWARF from both Windows and Linux host environments.

* Add PcdOpensslLibAssemblySourceStyleNasm to select the correct optimized assembly source style for OpensslLib for IA32/X64. NASM style is for MSFT and CLANGPDB. GAS style is for GCC. Use this PCD in OpensslLibAccel.inf and OpensslLibFullAccel.inf to select between .nasm and .S files.
* Add intrinsic functions required by CLANG IA32/X64 builds.
  * __ashlti3
  * __lshrdi3
* Disable warning -Wno-error=unused-function for CLANG build compatibility
* Set -D OPENSSL_NO_INLINE_ASM for CLANG build compatibility
* Update TestBaseCryptLib to split out the implementation of main() into its own C file that is only use for host-based unit tests. This is due to CLANGPDB for host environments injecting a __main() call that can only be resolved in host based builds that link against host libraries.
* Update Configure.py to update IA32/X64 [Sources] sections with feature flag expressions using the new PCD PcdOpensslLibAssemblySourceStyleNasm.


(cherry picked from commit deee46d276c10112dd3a8307c4dedbbfdbf92911)

## Description (continued):

This is necessary for running Host Based Unit Tests

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [X] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Host Based Unit Tests

```bash
stuart_ci_build -c .pytool/CISettings.py  -p OpensslPkg  -t NOOPT  -a X64 --disable-all HostUnitTestCompilerPlugin=run TOOL_CHAIN_TAG=GCC5

# Notice: MbedTlsPkg has a large number of unsupported Host Based Tests due to limitations in implementation
stuart_ci_build -c .pytool/CISettings.py  -p MbedTlsPkg  -t NOOPT  -a X64 --disable-all HostUnitTestCompilerPlugin=run TOOL_CHAIN_TAG=GCC5

```

## Integration Instructions

N/A