### PR TITLE
CryptoPkg: Cleanup Host Tests

### DIFF
--- a/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/RsaPkcs7Tests.c
+++ b/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/RsaPkcs7Tests.c
@@ -606,17 +606,20 @@ TestVerifyPkcs7SignVerifyNonSelfIssued (
   BOOLEAN  Status;
   UINT8    *P7SignedData;
   UINTN    P7SignedDataSize;
-  UINT8    *SignCert;
+
+  // UINT8    *SignCert;  // MU_CHANGE [TCBZ3925] - Pkcs7Sign is broken
 
   P7SignedData = NULL;
-  SignCert     = NULL;
+  // SignCert     = NULL; // MU_CHANGE [TCBZ3925] - Pkcs7Sign is broken
 
+  // MU_CHANGE [TCBZ3925] [BEGIN] - Pkcs7Sign is broken
   //
   // Construct Signer Certificate from RAW data.
   //
-  Status = X509ConstructCertificate (TestCert2, sizeof (TestCert2), (UINT8 **)&SignCert);
-  UT_ASSERT_TRUE (Status);
-  UT_ASSERT_NOT_NULL (SignCert);
+  // Status = X509ConstructCertificate (TestCert2, sizeof (TestCert2), (UINT8 **)&SignCert);
+  // UT_ASSERT_TRUE (Status);
+  // UT_ASSERT_NOT_NULL (SignCert);
+  // MU_CHANGE [TCBZ3925] [END] - Pkcs7Sign is broken
 
   //
   // Create PKCS#7 signedData on Payload.
@@ -628,10 +631,8 @@ TestVerifyPkcs7SignVerifyNonSelfIssued (
              (CONST UINT8 *)TestKeyCert2PemPass,
              (UINT8 *)Payload,
              AsciiStrLen (Payload),
-             SignCert,
-             // MU_CHANGE # [TCBZ3925] - Pkcs7Sign is broken
-             sizeof (TestCert2),
-             // MU_CHANGE # [TCBZ3925] - Pkcs7Sign is broken
+             TestCert2,            // MU_CHANGE [TCBZ3925] - Pkcs7Sign is broken
+             sizeof (TestCert2),   // MU_CHANGE [TCBZ3925] - Pkcs7Sign is broken
              NULL,
              &P7SignedData,
              &P7SignedDataSize
@@ -653,9 +654,11 @@ TestVerifyPkcs7SignVerifyNonSelfIssued (
     FreePool (P7SignedData);
   }
 
-  if (SignCert != NULL) {
-    X509Free (SignCert);
-  }
+  // MU_CHANGE [TCBZ3925] [BEGIN] - Pkcs7Sign is broken
+  // if (SignCert != NULL) {
+  //   X509Free (SignCert);
+  // }
+  // MU_CHANGE [TCBZ3925] [END] - Pkcs7Sign is broken
 
   return UNIT_TEST_PASSED;
 }

--- a/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/TestBaseCryptLibHost.inf
+++ b/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/TestBaseCryptLibHost.inf
@@ -37,7 +37,7 @@
   Pkcs7EkuTests.c
   OaepEncryptTests.c
   RsaPssTests.c
-  ParallelhashTests.c
+  # ParallelhashTests.c # MU_CHANGE
   HkdfTests.c
   AeadAesGcmTests.c
   BnTests.c
@@ -55,39 +55,3 @@
   UnitTestLib
   MmServicesTableLib
   SynchronizationLib
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServicePkcs5HashPassword           ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServicePkcs1v2Encrypt              ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServicePkcs7Sign                   ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceVerifyEKUsInPkcs7Signature  ##CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceAuthenticodeVerify          ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceImageTimestampVerify        ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceDhNew                       ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceDhFree                      ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceDhGenerateParameter         ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceDhSetParameter              ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceDhGenerateKey               ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceDhComputeKey                ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceRandomSeed                  ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceRandomBytes                 ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceRsaSetKey                   ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceRsaGetKey                   ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceRsaGenerateKey              ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceRsaPkcs1Sign                ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceRsaPkcs1Verify              ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceRsaPssSign                  ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceRsaPssVerify                ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceRsaGetPrivateKeyFromPem     ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceRsaGetPublicKeyFromX509     ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceSha1Init                    ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceSha256Init                  ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceSha384Init                  ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceSha512Init                  ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceSha1HashAll                 ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceSha256HashAll               ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceSha384HashAll               ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceSha512HashAll               ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceParallelHash256HashAll      ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceAesGetContextSize           ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceAesInit                     ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceAesCbcEncrypt               ## CONSUMES
-  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceAesCbcDecrypt               ## CONSUMES


### PR DESCRIPTION
## Description

### Test suite adjustments

* Commented out `ParallelhashTests.c`, This is to reflect the changes to BaseCryptLib.h where we are intentionally deprecating ParallelHashSha256.
### PKCS#7 signing test workaround

* Commented out certificate construction and freeing logic in `TestVerifyPkcs7SignVerifyNonSelfIssued` due to a broken `Pkcs7Sign` implementation, and switched to using raw test certificate data directly. This is inline with Openssl implementation and prevents a segfault - however the test still fails due to limitations in MbedTlsPkg not supporting certificate chains.

### Cleanup

* Removed a large block of PCD consumption declarations from the test INF file that were mistakenly added.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [X] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

```bash
stuart_ci_build -c .pytool/CISettings.py  -p OpensslPkg  -t NOOPT  -a X64 --disable-all HostUnitTestCompilerPlugin=run TOOL_CHAIN_TAG=GCC5

# Notice: MbedTlsPkg has a large number of unsupported Host Based Tests due to limitations in implementation
stuart_ci_build -c .pytool/CISettings.py  -p MbedTlsPkg  -t NOOPT  -a X64 --disable-all HostUnitTestCompilerPlugin=run TOOL_CHAIN_TAG=GCC5

```
## Integration Instructions

N/A