### PR TITLE
[CHERRY-PICK] Fix MM communicate V3 in PEI

### DIFF
--- a/MdeModulePkg/Universal/Variable/MmVariablePei/MmVariablePei.h
+++ b/MdeModulePkg/Universal/Variable/MmVariablePei/MmVariablePei.h
@@ -18,6 +18,7 @@
 #include <Library/PeiServicesLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/HobLib.h>
+#include <Library/SafeIntLib.h>
 
 #include <Guid/SmmVariableCommon.h>
 

--- a/MdeModulePkg/Universal/Variable/MmVariablePei/MmVariablePei.inf
+++ b/MdeModulePkg/Universal/Variable/MmVariablePei/MmVariablePei.inf
@@ -28,6 +28,7 @@
   PeimEntryPoint
   MemoryAllocationLib
   HobLib
+  SafeIntLib
 
 [Protocols]
   gEfiSmmVariableProtocolGuid             ## CONSUMES

--- a/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplPei.c
+++ b/StandaloneMmPkg/Drivers/StandaloneMmIplPei/StandaloneMmIplPei.c
@@ -188,7 +188,7 @@ Communicate3 (
     //
     // Check if the HeaderGuid is valid
     //
-    if (CompareGuid (&CommunicateHeader->HeaderGuid, &gEfiMmCommunicateHeaderV3Guid)) {
+    if (CompareGuid (&CommunicateHeader->HeaderGuid, &gEfiMmCommunicateHeaderV3Guid) == FALSE) {
       DEBUG ((DEBUG_ERROR, "HeaderGuid is not valid!\n"));
       return EFI_INVALID_PARAMETER;
     }


### PR DESCRIPTION
## Description

There was an issue with variable service in PEI phase when MM communicate v3 PPI is produced.

This change cherry-picks the commits from edk2 to fix that.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on proprietary ARM64 hardware with variable service used in PEI and fixed the variable storage breakage.

## Integration Instructions

N/A