### PR TITLE
ArmPkg: Fix incorrect bit width mask for SP_EL0

### DIFF
--- a/ArmPkg/Library/ArmExceptionLib/AArch64/AArch64Exception.c
+++ b/ArmPkg/Library/ArmExceptionLib/AArch64/AArch64Exception.c
@@ -35,7 +35,7 @@ ArchVectorConfig (
 
   // Round down sp by 16 bytes alignment
   RegisterEl0Stack (
-    (VOID *)(((UINTN)mNewStackBase + EL0_STACK_SIZE) & ~0xFUL)
+    (VOID *)(((UINTN)mNewStackBase + EL0_STACK_SIZE) & ~0xFULL)
     );
 
   if (ArmReadCurrentEL () == AARCH64_EL2) {


### PR DESCRIPTION
## Description

The current code uses `0xFUL` for stack alignment. Since this is only specified to be an unsigned long, it will only technically translated to 0xFFFFFFF0, so if the stack resides above 4GB, the high bits of the pointer will be truncated. This will cause a data abort immediately when pushing to the exception stack.

This commit simply changes the mask to `0xFULL` to ensure that the full 64-bit pointer is correctly masked for alignment.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on local SBSA ClangPdb build

## Integration Instructions

N/A
