### PR TITLE
[2511] NetworkPkg/UefiPxeBcDxe: Add UDP Completion Tokens to PXEBC_PRIVATE_DATA

### DIFF
--- a/NetworkPkg/UefiPxeBcDxe/PxeBcImpl.c
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcImpl.c
@@ -323,6 +323,7 @@ EfiPxeBcStop (
     Private->Dhcp6->Stop (Private->Dhcp6);
     Private->Dhcp6->Configure (Private->Dhcp6, NULL);
     Private->Udp6Write->Configure (Private->Udp6Write, NULL);
+    Private->Udp6Read->Cancel (Private->Udp6Read, &Private->Udp6Token); // MU_CHANGE: Track UDP completion tokens
     Private->Udp6Read->Groups (Private->Udp6Read, FALSE, NULL);
     Private->Udp6Read->Configure (Private->Udp6Read, NULL);
     Private->Ip6->Cancel (Private->Ip6, &Private->Icmp6Token);
@@ -332,6 +333,14 @@ EfiPxeBcStop (
       gBS->CloseEvent (Private->Icmp6Token.Event);
       Private->Icmp6Token.Event = NULL;
     }
+
+    // MU_CHANGE [BEGIN] - Track UDP completion tokens
+    if (Private->Udp6Token.Event != NULL) {
+      gBS->CloseEvent (Private->Udp6Token.Event);
+      Private->Udp6Token.Event = NULL;
+    }
+
+    // MU_CHANGE [END] - Track UDP completion tokens
 
     if (Private->Dhcp6Request != NULL) {
       FreePool (Private->Dhcp6Request);
@@ -353,6 +362,7 @@ EfiPxeBcStop (
     Private->Dhcp4->Stop (Private->Dhcp4);
     Private->Dhcp4->Configure (Private->Dhcp4, NULL);
     Private->Udp4Write->Configure (Private->Udp4Write, NULL);
+    Private->Udp4Read->Cancel (Private->Udp4Read, &Private->Udp4Token); // MU_CHANGE: Track UDP completion tokens
     Private->Udp4Read->Groups (Private->Udp4Read, FALSE, NULL);
     Private->Udp4Read->Configure (Private->Udp4Read, NULL);
     Private->Ip4->Cancel (Private->Ip4, &Private->IcmpToken);
@@ -366,6 +376,14 @@ EfiPxeBcStop (
       gBS->CloseEvent (Private->IcmpToken.Event);
       Private->IcmpToken.Event = NULL;
     }
+
+    // MU_CHANGE [BEGIN] - Track UDP completion tokens
+    if (Private->Udp4Token.Event != NULL) {
+      gBS->CloseEvent (Private->Udp4Token.Event);
+      Private->Udp4Token.Event = NULL;
+    }
+
+    // MU_CHANGE [END] - Track UDP completion tokens
 
     Private->BootFileName = NULL;
   }
@@ -1315,22 +1333,24 @@ EfiPxeBcUdpRead (
   IN     VOID                        *BufferPtr
   )
 {
-  PXEBC_PRIVATE_DATA         *Private;
-  EFI_PXE_BASE_CODE_MODE     *Mode;
-  EFI_UDP4_COMPLETION_TOKEN  Udp4Token;
-  EFI_UDP6_COMPLETION_TOKEN  Udp6Token;
-  EFI_UDP4_RECEIVE_DATA      *Udp4Rx;
-  EFI_UDP6_RECEIVE_DATA      *Udp6Rx;
-  EFI_STATUS                 Status;
-  BOOLEAN                    IsDone;
-  BOOLEAN                    IsMatched;
-  UINTN                      CopiedLen;
-  UINTN                      HeaderLen;
-  UINTN                      HeaderCopiedLen;
-  UINTN                      BufferCopiedLen;
-  UINT32                     FragmentLength;
-  UINTN                      FragmentIndex;
-  UINT8                      *FragmentBuffer;
+  PXEBC_PRIVATE_DATA      *Private;
+  EFI_PXE_BASE_CODE_MODE  *Mode;
+  // MU_CHANGE [BEGIN] - Track UDP completion tokens
+  // EFI_UDP4_COMPLETION_TOKEN  Udp4Token;
+  // EFI_UDP6_COMPLETION_TOKEN  Udp6Token;
+  // MU_CHANGE [END] - Track UDP completion tokens
+  EFI_UDP4_RECEIVE_DATA  *Udp4Rx;
+  EFI_UDP6_RECEIVE_DATA  *Udp6Rx;
+  EFI_STATUS             Status;
+  BOOLEAN                IsDone;
+  BOOLEAN                IsMatched;
+  UINTN                  CopiedLen;
+  UINTN                  HeaderLen;
+  UINTN                  HeaderCopiedLen;
+  UINTN                  BufferCopiedLen;
+  UINT32                 FragmentLength;
+  UINTN                  FragmentIndex;
+  UINT8                  *FragmentBuffer;
 
   if (This == NULL) {
     return EFI_INVALID_PARAMETER;
@@ -1362,8 +1382,10 @@ EfiPxeBcUdpRead (
     return EFI_NOT_STARTED;
   }
 
-  ZeroMem (&Udp6Token, sizeof (EFI_UDP6_COMPLETION_TOKEN));
-  ZeroMem (&Udp4Token, sizeof (EFI_UDP4_COMPLETION_TOKEN));
+  // MU_CHANGE [BEGIN] - Track UDP completion tokens
+  ZeroMem (&Private->Udp6Token, sizeof (EFI_UDP6_COMPLETION_TOKEN));
+  ZeroMem (&Private->Udp4Token, sizeof (EFI_UDP4_COMPLETION_TOKEN));
+  // MU_CHANGE [END] - Track UDP completion tokens
 
   if (Mode->UsingIpv6) {
     Status = gBS->CreateEvent (
@@ -1371,7 +1393,7 @@ EfiPxeBcUdpRead (
                     TPL_NOTIFY,
                     PxeBcCommonNotify,
                     &IsDone,
-                    &Udp6Token.Event
+                    &Private->Udp6Token.Event // MU_CHANGE: Track UDP completion tokens
                     );
     if (EFI_ERROR (Status)) {
       return EFI_OUT_OF_RESOURCES;
@@ -1382,7 +1404,7 @@ EfiPxeBcUdpRead (
                     TPL_NOTIFY,
                     PxeBcCommonNotify,
                     &IsDone,
-                    &Udp4Token.Event
+                    &Private->Udp4Token.Event // MU_CHANGE: Track UDP completion tokens
                     );
     if (EFI_ERROR (Status)) {
       return EFI_OUT_OF_RESOURCES;
@@ -1402,7 +1424,7 @@ EfiPxeBcUdpRead (
     if (Mode->UsingIpv6) {
       Status = PxeBcUdp6Read (
                  Private->Udp6Read,
-                 &Udp6Token,
+                 &Private->Udp6Token, // MU_CHANGE: Track UDP completion tokens
                  Mode,
                  Private->UdpTimeOutEvent,
                  OpFlags,
@@ -1416,7 +1438,7 @@ EfiPxeBcUdpRead (
     } else {
       Status = PxeBcUdp4Read (
                  Private->Udp4Read,
-                 &Udp4Token,
+                 &Private->Udp4Token, // MU_CHANGE: Track UDP completion tokens
                  Mode,
                  Private->UdpTimeOutEvent,
                  OpFlags,
@@ -1449,7 +1471,7 @@ EfiPxeBcUdpRead (
     // Copy the received packet to user if matched by filter.
     //
     if (Mode->UsingIpv6) {
-      Udp6Rx = Udp6Token.Packet.RxData;
+      Udp6Rx = Private->Udp6Token.Packet.RxData; // MU_CHANGE: Track UDP completion tokens
       ASSERT (Udp6Rx != NULL);
 
       HeaderLen = 0;
@@ -1505,7 +1527,7 @@ EfiPxeBcUdpRead (
       //
       gBS->SignalEvent (Udp6Rx->RecycleSignal);
     } else {
-      Udp4Rx = Udp4Token.Packet.RxData;
+      Udp4Rx = Private->Udp4Token.Packet.RxData; // MU_CHANGE: Track UDP completion tokens
       ASSERT (Udp4Rx != NULL);
 
       HeaderLen = 0;
@@ -1563,13 +1585,16 @@ EfiPxeBcUdpRead (
     }
   }
 
+  // MU_CHANGE [BEGIN] - Track UDP completion tokens
   if (Mode->UsingIpv6) {
-    Private->Udp6Read->Cancel (Private->Udp6Read, &Udp6Token);
-    gBS->CloseEvent (Udp6Token.Event);
+    Private->Udp6Read->Cancel (Private->Udp6Read, &Private->Udp6Token);
+    gBS->CloseEvent (Private->Udp6Token.Event);
   } else {
-    Private->Udp4Read->Cancel (Private->Udp4Read, &Udp4Token);
-    gBS->CloseEvent (Udp4Token.Event);
+    Private->Udp4Read->Cancel (Private->Udp4Read, &Private->Udp4Token);
+    gBS->CloseEvent (Private->Udp4Token.Event);
   }
+
+  // MU_CHANGE [END] - Track UDP completion tokens
 
   return Status;
 }

--- a/NetworkPkg/UefiPxeBcDxe/PxeBcImpl.h
+++ b/NetworkPkg/UefiPxeBcDxe/PxeBcImpl.h
@@ -221,7 +221,7 @@ struct _PXEBC_PRIVATE_DATA {
   UINT32                     OfferCount[PxeOfferTypeMax];
   UINT32                     OfferIndex[PxeOfferTypeMax][PXEBC_OFFER_MAX_NUM];
 
-  // MU_CHANGE [BEGIN] -  162958
+  // MU_CHANGE [BEGIN] - Track UDP completion tokens
   //
   // The Network stack fails when a USB nic is removed
   // after initialization. This change marks it removed
@@ -229,8 +229,10 @@ struct _PXEBC_PRIVATE_DATA {
   // other code holding onto and using that memory
   // doesn't cause an exception.
   //
-  BOOLEAN    DeviceDisconnected;
-  // MU_CHANGE [END] -  162958
+  BOOLEAN                      DeviceDisconnected;
+  EFI_UDP4_COMPLETION_TOKEN    Udp4Token;
+  EFI_UDP6_COMPLETION_TOKEN    Udp6Token;
+  // MU_CHANGE [END] -  Track UDP completion tokens
 };
 
 extern EFI_PXE_BASE_CODE_PROTOCOL           gPxeBcProtocolTemplate;


### PR DESCRIPTION
## Description

This change tracks UDP completion tokens in the `PXEBC_PRIVATE_DATA` structure, so they are persisted for cleanup in the Stop function in case it is called while a UDP operation is still pending.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- PXE boot with USB NIC disconnect to trigger `EfiPxeBcStop()` during UDP read

## Integration Instructions

- N/A

---

Note: A following PR may apply a similar change to the UDP write functions, but the issue was only observed in the UDP read functions, so this change is applied immediately for the time being.