### PR TITLE
[REBASE & FF]Pulling in CHERRY-PICKS from release/202502

### DIFF
--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
@@ -34,9 +34,6 @@
 
 #include "ArmFfaCommon.h"
 
-BOOLEAN  gFfaSupported;
-UINT16   gPartId;
-
 /**
   Convert EFI_STATUS to FFA return code.
 
@@ -188,22 +185,6 @@ ArmCallFfa (
   } else {
     ArmCallSvc ((ARM_SVC_ARGS *)FfaArgs);
   }
-}
-
-/**
-  Check FF-A support or not.
-
-  @retval TRUE                   Supported
-  @retval FALSE                  Not supported
-
-**/
-BOOLEAN
-EFIAPI
-IsFfaSupported (
-  IN VOID
-  )
-{
-  return gFfaSupported;
 }
 
 /**
@@ -837,15 +818,21 @@ ArmFfaLibMsgSendDirectReq (
 {
   EFI_STATUS    Status;
   ARM_FFA_ARGS  FfaArgs;
+  UINT16        PartId;
 
-  if ((DestPartId == gPartId) || (ImpDefArgs == NULL)) {
+  Status = ArmFfaLibGetPartId (&PartId);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  if ((DestPartId == PartId) || (ImpDefArgs == NULL)) {
     return EFI_INVALID_PARAMETER;
   }
 
   ZeroMem (&FfaArgs, sizeof (ARM_FFA_ARGS));
 
   FfaArgs.Arg0 = ARM_FID_FFA_MSG_SEND_DIRECT_REQ;
-  FfaArgs.Arg1 = PACK_PARTITION_ID_INFO (gPartId, DestPartId);
+  FfaArgs.Arg1 = PACK_PARTITION_ID_INFO (PartId, DestPartId);
   FfaArgs.Arg2 = Flags;
   FfaArgs.Arg3 = ImpDefArgs->Arg0;
   FfaArgs.Arg4 = ImpDefArgs->Arg1;
@@ -892,6 +879,7 @@ ArmFfaLibMsgSendDirectReq2 (
   EFI_STATUS    Status;
   UINT64        Uuid[2];
   ARM_FFA_ARGS  FfaArgs;
+  UINT16        PartId;
 
   /*
    * Direct message request 2 is only supported on AArch64.
@@ -900,7 +888,12 @@ ArmFfaLibMsgSendDirectReq2 (
     return EFI_UNSUPPORTED;
   }
 
-  if ((DestPartId == gPartId) || (ImpDefArgs == NULL)) {
+  Status = ArmFfaLibGetPartId (&PartId);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  if ((DestPartId == PartId) || (ImpDefArgs == NULL)) {
     return EFI_INVALID_PARAMETER;
   }
 
@@ -913,7 +906,7 @@ ArmFfaLibMsgSendDirectReq2 (
   ZeroMem (&FfaArgs, sizeof (ARM_FFA_ARGS));
 
   FfaArgs.Arg0  = ARM_FID_FFA_MSG_SEND_DIRECT_REQ2;
-  FfaArgs.Arg1  = PACK_PARTITION_ID_INFO (gPartId, DestPartId);
+  FfaArgs.Arg1  = PACK_PARTITION_ID_INFO (PartId, DestPartId);
   FfaArgs.Arg2  = Uuid[0];
   FfaArgs.Arg3  = Uuid[1];
   FfaArgs.Arg4  = ImpDefArgs->Arg0;
@@ -959,55 +952,33 @@ ArmFfaLibMsgSendDirectReq2 (
 /**
   Common ArmFfaLib init.
 
+  @param [out] PartId            PartitionId
+  @param [out] IsFfaSupported    FF-A supported flag
+
   @retval EFI_SUCCESS            Success
-  @retval EFI_UNSUPPORTED        FF-A isn't supported
+  @retval EFI_INVALID_PARAMETER  Invalid parameter
   @retval Others                 Error
 
 **/
 EFI_STATUS
 EFIAPI
 ArmFfaLibCommonInit (
-  IN VOID
+  OUT UINT16   *PartId,
+  OUT BOOLEAN  *IsFfaSupported
   )
 {
   EFI_STATUS  Status;
-  UINT16      CurrentMajorVersion;
-  UINT16      CurrentMinorVersion;
 
-  gFfaSupported = FALSE;
-
-  Status = ArmFfaLibGetVersion (
-             ARM_FFA_MAJOR_VERSION,
-             ARM_FFA_MINOR_VERSION,
-             &CurrentMajorVersion,
-             &CurrentMinorVersion
-             );
-  if (EFI_ERROR (Status)) {
-    return EFI_UNSUPPORTED;
+  if ((PartId == NULL) || (IsFfaSupported == NULL)) {
+    return EFI_INVALID_PARAMETER;
   }
 
-  if ((ARM_FFA_MAJOR_VERSION != CurrentMajorVersion) ||
-      (ARM_FFA_MINOR_VERSION > CurrentMinorVersion))
-  {
-    DEBUG ((
-      DEBUG_INFO,
-      "Incompatible FF-A Versions.\n" \
-      "Request Version: Major=0x%x, Minor=0x%x.\n" \
-      "Current Version: Major=0x%x, Minor>=0x%x.\n",
-      ARM_FFA_MAJOR_VERSION,
-      ARM_FFA_MINOR_VERSION,
-      CurrentMajorVersion,
-      CurrentMinorVersion
-      ));
-    return EFI_UNSUPPORTED;
-  }
+  *IsFfaSupported = ArmFfaLibIsFfaSupported ();
 
-  Status = ArmFfaLibPartitionIdGet (&gPartId);
+  Status = ArmFfaLibPartitionIdGet (PartId);
   if (EFI_ERROR (Status)) {
     return Status;
   }
-
-  gFfaSupported = TRUE;
 
   return EFI_SUCCESS;
 }
@@ -1043,6 +1014,7 @@ ArmFfaLibGetPartitionInfo (
   UINT64      RxBufferSize;
   UINT32      Count;
   UINT32      Size;
+  UINT16      PartId;
 
   if (PartDesc == NULL) {
     return EFI_INVALID_PARAMETER;
@@ -1081,13 +1053,18 @@ ArmFfaLibGetPartitionInfo (
     return Status;
   }
 
+  Status = ArmFfaLibGetPartId (&PartId);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
   if ((Size < sizeof (EFI_FFA_PART_INFO_DESC))) {
-    ArmFfaLibRxRelease (gPartId);
+    ArmFfaLibRxRelease (PartId);
     return EFI_INVALID_PARAMETER;
   }
 
   CopyMem (PartDesc, RxBuffer, sizeof (EFI_FFA_PART_INFO_DESC));
-  ArmFfaLibRxRelease (gPartId);
+  ArmFfaLibRxRelease (PartId);
 
   return EFI_SUCCESS;
 }

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
@@ -1234,3 +1234,48 @@ GetRxTxBufferMinSizeAndAlign (
 
   return EFI_SUCCESS;
 }
+
+/**
+  Determine if FF-A is supported
+
+  @retval TRUE if FF-A is supported, FALSE otherwise.
+
+**/
+BOOLEAN
+EFIAPI
+ArmFfaLibIsFfaSupported (
+  IN VOID
+  )
+{
+  EFI_STATUS  Status;
+  UINT16      CurrentMajorVersion;
+  UINT16      CurrentMinorVersion;
+
+  Status = ArmFfaLibGetVersion (
+             ARM_FFA_MAJOR_VERSION,
+             ARM_FFA_MINOR_VERSION,
+             &CurrentMajorVersion,
+             &CurrentMinorVersion
+             );
+  if (EFI_ERROR (Status)) {
+    return FALSE;
+  }
+
+  if ((ARM_FFA_MAJOR_VERSION != CurrentMajorVersion) ||
+      (ARM_FFA_MINOR_VERSION > CurrentMinorVersion))
+  {
+    DEBUG ((
+      DEBUG_INFO,
+      "Incompatible FF-A Versions.\n" \
+      "Request Version: Major=0x%x, Minor=0x%x.\n" \
+      "Current Version: Major=0x%x, Minor>=0x%x.\n",
+      ARM_FFA_MAJOR_VERSION,
+      ARM_FFA_MINOR_VERSION,
+      CurrentMajorVersion,
+      CurrentMinorVersion
+      ));
+    return FALSE;
+  }
+
+  return TRUE;
+}

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.h
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.h
@@ -19,9 +19,6 @@
 
 #include <Library/ArmFfaLib.h>
 
-extern BOOLEAN  gFfaSupported;
-extern UINT16   gPartId;
-
 /**
   Convert FfArgs to EFI_STATUS.
 
@@ -39,14 +36,19 @@ FfaArgsToEfiStatus (
 /**
   Common ArmFfaLib Constructor.
 
-  @retval EFI_SUCCESS
-  @retval Others                  Error
+  @param [out] PartId            PartitionId
+  @param [out] IsFfaSupported    FF-A supported flag
+
+  @retval EFI_SUCCESS            Success
+  @retval EFI_INVALID_PARAMETER  Invalid parameter
+  @retval Others                 Error
 
 **/
 EFI_STATUS
 EFIAPI
 ArmFfaLibCommonInit (
-  IN VOID
+  OUT UINT16   *PartId,
+  OUT BOOLEAN  *IsFfaSupported
   );
 
 /**
@@ -96,6 +98,21 @@ BOOLEAN
 EFIAPI
 ArmFfaLibIsFfaSupported (
   IN VOID
+  );
+
+/**
+  Return partition or VM ID
+
+  @param[out] PartId  The partition or VM ID
+
+  @retval EFI_SUCCESS  Partition ID or VM ID returned
+  @retval Others       Errors
+
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaLibGetPartId (
+  OUT UINT16  *PartId
   );
 
 #endif

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.h
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.h
@@ -34,7 +34,7 @@ FfaArgsToEfiStatus (
   );
 
 /**
-  Common ArmFfaLib Constructor.
+  Common ArmFfaLib init.
 
   @param [out] PartId            PartitionId
   @param [out] IsFfaSupported    FF-A supported flag

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.h
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.h
@@ -86,4 +86,16 @@ GetRxTxBufferMinSizeAndAlign (
   OUT UINTN  *MinSizeAndAlign
   );
 
+/**
+  Determine if FF-A is supported
+
+  @retval TRUE if FF-A is supported, FALSE otherwise.
+
+**/
+BOOLEAN
+EFIAPI
+ArmFfaLibIsFfaSupported (
+  IN VOID
+  );
+
 #endif

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaDxeLib.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaDxeLib.c
@@ -84,12 +84,9 @@ ArmFfaDxeLibConstructor (
   if (EFI_ERROR (Status)) {
     if (!mIsFfaSupported) {
       /*
-       * EFI_UNSUPPORTED return from ArmFfaLibCommonInit() means
-       * FF-A interface doesn't support.
-       * However, It doesn't make failure of loading driver/library instance
-       * (i.e) ArmPkg's MmCommunication Dxe/PEI Driver uses as well as SpmMm.
-       * So If FF-A is not supported the the MmCommunication Dxe/PEI falls
-       * back to SpmMm.
+       * FF-A being unsupported doesn't mean a failure of loading the driver/library
+       * instance (i.e) ArmPkg's MmCommunication Dxe/PEI Driver uses as well as SpmMm.
+       * So If FF-A is not supported the the MmCommunication Dxe/PEI falls back to SpmMm.
        * For this case, return EFI_SUCCESS.
        */
       return EFI_SUCCESS;

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaDxeLib.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaDxeLib.c
@@ -34,6 +34,8 @@
 #include "ArmFfaRxTxMap.h"
 
 STATIC EFI_EVENT  mFfaExitBootServiceEvent;
+STATIC UINT16     mPartId;
+STATIC BOOLEAN    mIsFfaSupported;
 
 /**
   Unmap RX/TX buffer on Exit Boot Service.
@@ -78,9 +80,9 @@ ArmFfaDxeLibConstructor (
   UINTN                      Property1;
   UINTN                      Property2;
 
-  Status = ArmFfaLibCommonInit ();
+  Status = ArmFfaLibCommonInit (&mPartId, &mIsFfaSupported);
   if (EFI_ERROR (Status)) {
-    if (Status == EFI_UNSUPPORTED) {
+    if (!mIsFfaSupported) {
       /*
        * EFI_UNSUPPORTED return from ArmFfaLibCommonInit() means
        * FF-A interface doesn't support.
@@ -193,4 +195,42 @@ ErrorHandler:
   }
 
   return Status;
+}
+
+/**
+  Return partition or VM ID
+
+  @param[out] PartId  The partition or VM ID
+
+  @retval EFI_SUCCESS  Partition ID or VM ID returned
+  @retval Others       Errors
+
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaLibGetPartId (
+  OUT UINT16  *PartId
+  )
+{
+  if (PartId != NULL) {
+    *PartId = mPartId;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Check FF-A support or not.
+
+  @retval TRUE                   Supported
+  @retval FALSE                  Not supported
+
+**/
+BOOLEAN
+EFIAPI
+IsFfaSupported (
+  IN VOID
+  )
+{
+  return mIsFfaSupported;
 }

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaDxeLib.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaDxeLib.c
@@ -231,3 +231,17 @@ IsFfaSupported (
 {
   return mIsFfaSupported;
 }
+
+/**
+  Callback for when Unmap is called to handle any post unmap
+  functionality.
+
+**/
+VOID
+EFIAPI
+UnmapCallback (
+  IN VOID
+  )
+{
+  // Do nothing
+}

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.c
@@ -291,3 +291,33 @@ IsFfaSupported (
 
   return ArmFfaLibIsFfaSupported ();
 }
+
+/**
+  Callback for when Unmap is called to handle any post unmap
+  functionality. In PEI the Rx/Tx buffer HOB needs to be
+  invalidated.
+
+**/
+VOID
+EFIAPI
+UnmapCallback (
+  IN VOID
+  )
+{
+  EFI_HOB_MEMORY_ALLOCATION  *RxTxBufferAllocationHob;
+
+  /*
+   * Rx/Tx buffers are allocated with continuous pages.
+   * See ArmFfaLibRxTxMap(). If HOB is not found, the Rx/Tx
+   * buffers were not successfully mapped.
+   */
+  RxTxBufferAllocationHob = FindRxTxBufferAllocationHob (TRUE);
+  if (RxTxBufferAllocationHob == NULL) {
+    return;
+  }
+
+  /*
+   * Invalidate the HOB.
+   */
+  ZeroMem (RxTxBufferAllocationHob, sizeof (ARM_FFA_RX_TX_BUFFER_INFO));
+}

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.c
@@ -125,14 +125,10 @@ ArmFfaPeiLibConstructor (
     if (EFI_ERROR (Status)) {
       if (!mIsFfaSupported) {
         /*
-         * EFI_UNSUPPORTED return from ArmFfaLibCommonInit() means
-         * FF-A interface doesn't support.
-         * However, It doesn't make failure of loading driver/library instance
-         * (i.e) ArmPkg's MmCommunication Dxe/PEI Driver uses as well as SpmMm.
-         * So If FF-A is not supported the the MmCommunication Dxe/PEI falls
-         * back to SpmMm.
+         * FF-A being unsupported doesn't mean a failure of loading the driver/library
+         * instance (i.e) ArmPkg's MmCommunication Dxe/PEI Driver uses as well as SpmMm.
+         * So If FF-A is not supported the the MmCommunication Dxe/PEI falls back to SpmMm.
          * For this case, return EFI_SUCCESS.
-
          */
         return EFI_SUCCESS;
       }

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.c
@@ -34,6 +34,10 @@
 #include "ArmFfaCommon.h"
 #include "ArmFfaRxTxMap.h"
 
+STATIC UINT16   mPartId;
+STATIC BOOLEAN  mIsFfaSupported;
+STATIC BOOLEAN  mIsPermMemAvailable = FALSE;
+
 /**
   Notification service to be called when gEfiPeiMemoryDiscoveredPpiGuid is installed.
   This function change reamp Rx/Tx buffer with permanent memory from
@@ -102,24 +106,52 @@ ArmFfaPeiLibConstructor (
   EFI_HOB_MEMORY_ALLOCATION  *RxTxBufferAllocationHob;
   UINTN                      Property1;
   UINTN                      Property2;
+  UINT16                     PartId;
+  BOOLEAN                    IsFfaSupported;
 
-  Status = ArmFfaLibCommonInit ();
-  if (EFI_ERROR (Status)) {
-    if (Status == EFI_UNSUPPORTED) {
-      /*
-       * EFI_UNSUPPORTED return from ArmFfaLibCommonInit() means
-       * FF-A interface doesn't support.
-       * However, It doesn't make failure of loading driver/library instance
-       * (i.e) ArmPkg's MmCommunication Dxe/PEI Driver uses as well as SpmMm.
-       * So If FF-A is not supported the the MmCommunication Dxe/PEI falls
-       * back to SpmMm.
-       * For this case, return EFI_SUCCESS.
-
-       */
-      return EFI_SUCCESS;
-    }
-
+  Status = (**PeiServices).RegisterForShadow (FileHandle);
+  if (Status == EFI_NOT_FOUND) {
     return Status;
+  }
+
+  /*
+   * ArmFfaLibCommonInit() sets several pieces of information.
+   * This function should only be called with globals when the PEIM is running in
+   * permanent memory.
+   */
+  if (Status == EFI_ALREADY_STARTED) {
+    mIsPermMemAvailable = TRUE;
+    Status              = ArmFfaLibCommonInit (&mPartId, &mIsFfaSupported);
+    if (EFI_ERROR (Status)) {
+      if (!mIsFfaSupported) {
+        /*
+         * EFI_UNSUPPORTED return from ArmFfaLibCommonInit() means
+         * FF-A interface doesn't support.
+         * However, It doesn't make failure of loading driver/library instance
+         * (i.e) ArmPkg's MmCommunication Dxe/PEI Driver uses as well as SpmMm.
+         * So If FF-A is not supported the the MmCommunication Dxe/PEI falls
+         * back to SpmMm.
+         * For this case, return EFI_SUCCESS.
+
+         */
+        return EFI_SUCCESS;
+      }
+
+      return Status;
+    }
+  } else {
+    /*
+     * When permanent memory is unavailable, we need to use locals rather
+     * than the globals.
+     */
+    Status = ArmFfaLibCommonInit (&PartId, &IsFfaSupported);
+    if (EFI_ERROR (Status)) {
+      if (!IsFfaSupported) {
+        return EFI_SUCCESS;
+      }
+
+      return Status;
+    }
   }
 
   RxTxBufferHob = GetFirstGuidHob (&gArmFfaRxTxBufferInfoGuid);
@@ -219,4 +251,47 @@ ArmFfaPeiLibConstructor (
   }
 
   return EFI_SUCCESS;
+}
+
+/**
+  Return partition or VM ID
+
+  @param[out] PartId  The partition or VM ID
+
+  @retval EFI_SUCCESS  Partition ID or VM ID returned
+  @retval Others       Errors
+
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaLibGetPartId (
+  OUT UINT16  *PartId
+  )
+{
+  if (mIsPermMemAvailable) {
+    *PartId = mPartId;
+    return EFI_SUCCESS;
+  } else {
+    return ArmFfaLibPartitionIdGet (PartId);
+  }
+}
+
+/**
+  Check FF-A support or not.
+
+  @retval TRUE                   Supported
+  @retval FALSE                  Not supported
+
+**/
+BOOLEAN
+EFIAPI
+IsFfaSupported (
+  IN VOID
+  )
+{
+  if (mIsPermMemAvailable) {
+    return mIsFfaSupported;
+  }
+
+  return ArmFfaLibIsFfaSupported ();
 }

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaRxTxMap.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaRxTxMap.c
@@ -189,11 +189,14 @@ ArmFfaLibRxTxUnmap (
   EFI_STATUS    Status;
   ARM_FFA_ARGS  FfaArgs;
   VOID          *Buffers;
+  UINT16        PartId;
+
+  ArmFfaLibGetPartId (&PartId);
 
   ZeroMem (&FfaArgs, sizeof (ARM_FFA_ARGS));
 
   FfaArgs.Arg0 = ARM_FID_FFA_RXTX_UNMAP;
-  FfaArgs.Arg1 = (gPartId << ARM_FFA_SOURCE_EP_SHIFT);
+  FfaArgs.Arg1 = (PartId << ARM_FFA_SOURCE_EP_SHIFT);
 
   ArmCallFfa (&FfaArgs);
 
@@ -283,6 +286,9 @@ RemapFfaRxTxBuffer (
   UINTN                      NewRxBuffer;
   UINTN                      MinSizeAndAlign;
   EFI_HOB_MEMORY_ALLOCATION  *RxTxBufferAllocationHob;
+  UINT16                     PartId;
+
+  ArmFfaLibGetPartId (&PartId);
 
   RxTxBufferAllocationHob = FindRxTxBufferAllocationHob (TRUE);
   if (RxTxBufferAllocationHob == NULL) {
@@ -293,7 +299,7 @@ RemapFfaRxTxBuffer (
 
   ZeroMem (&FfaArgs, sizeof (ARM_FFA_ARGS));
   FfaArgs.Arg0 = ARM_FID_FFA_RXTX_UNMAP;
-  FfaArgs.Arg1 = (gPartId << ARM_FFA_SOURCE_EP_SHIFT);
+  FfaArgs.Arg1 = (PartId << ARM_FFA_SOURCE_EP_SHIFT);
 
   ArmCallFfa (&FfaArgs);
   Status = FfaArgsToEfiStatus (&FfaArgs);

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaRxTxMap.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaRxTxMap.c
@@ -218,6 +218,8 @@ ArmFfaLibRxTxUnmap (
   PcdSet64S (PcdFfaTxBuffer, 0x00);
   PcdSet64S (PcdFfaRxBuffer, 0x00);
 
+  UnmapCallback ();
+
   return EFI_SUCCESS;
 }
 

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaRxTxMap.h
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaRxTxMap.h
@@ -96,4 +96,15 @@ RemapFfaRxTxBuffer (
   IN OUT ARM_FFA_RX_TX_BUFFER_INFO  *BufferInfo
   );
 
+/**
+  Callback for when Unmap is called to handle any post unmap
+  functionality.
+
+**/
+VOID
+EFIAPI
+UnmapCallback (
+  IN VOID
+  );
+
 #endif

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecLib.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecLib.c
@@ -58,12 +58,9 @@ ArmFfaSecLibConstructor (
   if (EFI_ERROR (Status)) {
     if (!IsFfaSupported) {
       /*
-       * EFI_UNSUPPORTED return from ArmFfaLibCommonInit() means
-       * FF-A interface doesn't support.
-       * However, It doesn't make failure of loading driver/library instance
-       * (i.e) ArmPkg's MmCommunication Dxe/PEI Driver uses as well as SpmMm.
-       * So If FF-A is not supported the the MmCommunication Dxe/PEI falls
-       * back to SpmMm.
+       * FF-A being unsupported doesn't mean a failure of loading the driver/library
+       * instance (i.e) ArmPkg's MmCommunication Dxe/PEI Driver uses as well as SpmMm.
+       * So If FF-A is not supported the the MmCommunication Dxe/PEI falls back to SpmMm.
        * For this case, return EFI_SUCCESS.
        */
       return EFI_SUCCESS;
@@ -78,6 +75,8 @@ ArmFfaSecLibConstructor (
       return Status;
     }
 
+    DEBUG ((DEBUG_INFO, "%a Rx/Tx buffer isn't supported.\n", __func__));
+
     /*
      * When ARM_FID_FFA_PARTITION_INFO_GET_REGS is supported,
      * Rx/Tx buffer might not be required to request service to
@@ -91,7 +90,7 @@ ArmFfaSecLibConstructor (
                &Property2
                );
     if (!EFI_ERROR (Status)) {
-      DEBUG ((DEBUG_INFO, "%a Rx/Tx buffer doesn't support.\n", __func__));
+      DEBUG ((DEBUG_INFO, "%a PARTITION_INFO_GET_REGS is available as an alternative to Rx/Tx buffer.\n", __func__));
     }
 
     return Status;

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecLib.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecLib.c
@@ -53,10 +53,12 @@ ArmFfaSecLibConstructor (
   EFI_HOB_MEMORY_ALLOCATION  *RxTxBufferAllocationHob;
   UINTN                      Property1;
   UINTN                      Property2;
+  UINT16                     PartId;
+  BOOLEAN                    IsFfaSupported;
 
-  Status = ArmFfaLibCommonInit ();
+  Status = ArmFfaLibCommonInit (&PartId, &IsFfaSupported);
   if (EFI_ERROR (Status)) {
-    if (Status == EFI_UNSUPPORTED) {
+    if (!IsFfaSupported) {
       /*
        * EFI_UNSUPPORTED return from ArmFfaLibCommonInit() means
        * FF-A interface doesn't support.
@@ -126,4 +128,38 @@ ArmFfaSecLibConstructor (
   BufferInfo->RemapRequired = TRUE;
 
   return EFI_SUCCESS;
+}
+
+/**
+  Return partition or VM ID
+
+  @param[out] PartId  The partition or VM ID
+
+  @retval EFI_SUCCESS  Partition ID or VM ID returned
+  @retval Others       Errors
+
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaLibGetPartId (
+  OUT UINT16  *PartId
+  )
+{
+  return ArmFfaLibPartitionIdGet (PartId);
+}
+
+/**
+  Check FF-A support or not.
+
+  @retval TRUE                   Supported
+  @retval FALSE                  Not supported
+
+**/
+BOOLEAN
+EFIAPI
+IsFfaSupported (
+  IN VOID
+  )
+{
+  return ArmFfaLibIsFfaSupported ();
 }

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecLib.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecLib.c
@@ -48,13 +48,11 @@ ArmFfaSecLibConstructor (
   IN VOID
   )
 {
-  EFI_STATUS                 Status;
-  ARM_FFA_RX_TX_BUFFER_INFO  *BufferInfo;
-  EFI_HOB_MEMORY_ALLOCATION  *RxTxBufferAllocationHob;
-  UINTN                      Property1;
-  UINTN                      Property2;
-  UINT16                     PartId;
-  BOOLEAN                    IsFfaSupported;
+  EFI_STATUS  Status;
+  UINTN       Property1;
+  UINTN       Property2;
+  UINT16      PartId;
+  BOOLEAN     IsFfaSupported;
 
   Status = ArmFfaLibCommonInit (&PartId, &IsFfaSupported);
   if (EFI_ERROR (Status)) {
@@ -98,34 +96,6 @@ ArmFfaSecLibConstructor (
 
     return Status;
   }
-
-  BufferInfo = BuildGuidHob (
-                 &gArmFfaRxTxBufferInfoGuid,
-                 sizeof (ARM_FFA_RX_TX_BUFFER_INFO)
-                 );
-  if (BufferInfo == NULL) {
-    DEBUG ((DEBUG_ERROR, "%a: Failed to create Rx/Tx Buffer Info Hob\n", __func__));
-    ArmFfaLibRxTxUnmap ();
-    return EFI_OUT_OF_RESOURCES;
-  }
-
-  RxTxBufferAllocationHob = FindRxTxBufferAllocationHob (FALSE);
-  ASSERT (RxTxBufferAllocationHob != NULL);
-
-  /*
-   * Set then Name with gArmFfaRxTxBufferInfoGuid, so that ArmFfaPeiLib or
-   * ArmFfaDxeLib can find the Rx/Tx buffer allocation area.
-   */
-  CopyGuid (
-    &RxTxBufferAllocationHob->AllocDescriptor.Name,
-    &gArmFfaRxTxBufferInfoGuid
-    );
-
-  UpdateRxTxBufferInfo (BufferInfo);
-  BufferInfo->RemapOffset =
-    (UINTN)(BufferInfo->TxBufferAddr -
-            RxTxBufferAllocationHob->AllocDescriptor.MemoryBaseAddress);
-  BufferInfo->RemapRequired = TRUE;
 
   return EFI_SUCCESS;
 }

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecLib.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecLib.c
@@ -132,3 +132,33 @@ IsFfaSupported (
 {
   return ArmFfaLibIsFfaSupported ();
 }
+
+/**
+  Callback for when Unmap is called to handle any post unmap
+  functionality. In SEC, the Rx/Tx buffer HOB needs to be
+  invalidated.
+
+**/
+VOID
+EFIAPI
+UnmapCallback (
+  IN VOID
+  )
+{
+  EFI_HOB_MEMORY_ALLOCATION  *RxTxBufferAllocationHob;
+
+  /*
+   * Rx/Tx buffers are allocated with continuous pages.
+   * See ArmFfaLibRxTxMap(). If HOB is not found, the Rx/Tx
+   * buffers were not successfully mapped.
+   */
+  RxTxBufferAllocationHob = FindRxTxBufferAllocationHob (TRUE);
+  if (RxTxBufferAllocationHob == NULL) {
+    return;
+  }
+
+  /*
+   * Invalidate the HOB.
+   */
+  ZeroMem (RxTxBufferAllocationHob, sizeof (ARM_FFA_RX_TX_BUFFER_INFO));
+}

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecRxTxMap.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecRxTxMap.c
@@ -332,6 +332,8 @@ ArmFfaLibRxTxUnmap (
     FreePages (Buffers, (PcdGet64 (PcdFfaTxRxPageCount) * 2));
   }
 
+  UnmapCallback ();
+
   return EFI_SUCCESS;
 }
 

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecRxTxMap.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecRxTxMap.c
@@ -235,11 +235,18 @@ ArmFfaLibRxTxUnmap (
   EFI_STATUS    Status;
   ARM_FFA_ARGS  FfaArgs;
   VOID          *Buffers;
+  UINT16        PartId;
+
+  Status = ArmFfaLibPartitionIdGet (&PartId);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a, Failed to acquire partition ID. Status: %r\n", __func__, Status));
+    return EFI_INVALID_PARAMETER;
+  }
 
   ZeroMem (&FfaArgs, sizeof (ARM_FFA_ARGS));
 
   FfaArgs.Arg0 = ARM_FID_FFA_RXTX_UNMAP;
-  FfaArgs.Arg1 = (gPartId << ARM_FFA_SOURCE_EP_SHIFT);
+  FfaArgs.Arg1 = (PartId << ARM_FFA_SOURCE_EP_SHIFT);
 
   ArmCallFfa (&FfaArgs);
 

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecRxTxMap.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecRxTxMap.c
@@ -64,7 +64,7 @@ ArmFfaLibGetRxTxBuffers (
     return EFI_NOT_READY;
   }
 
-  BufferSize = PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE;
+  BufferSize = EFI_PAGES_TO_SIZE (PcdGet64 (PcdFfaTxRxPageCount));
 
   if (TxBuffer != NULL) {
     *TxBuffer = (VOID *)RxTxBufferAllocationHob->AllocDescriptor.MemoryBaseAddress;
@@ -170,8 +170,8 @@ ArmFfaLibRxTxMap (
 
   MaxSize = ((MaxSize == 0) ? MAX_UINTN : (MaxSize * MinSizeAndAlign));
 
-  if ((MinSizeAndAlign > (PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE)) ||
-      (MaxSize < (PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE)))
+  if ((MinSizeAndAlign > (EFI_PAGES_TO_SIZE (PcdGet64 (PcdFfaTxRxPageCount)))) ||
+      (MaxSize < (EFI_PAGES_TO_SIZE (PcdGet64 (PcdFfaTxRxPageCount)))))
   {
     DEBUG ((
       DEBUG_ERROR,
@@ -190,7 +190,7 @@ ArmFfaLibRxTxMap (
   }
 
   TxBuffer = Buffers;
-  RxBuffer = Buffers + (PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE);
+  RxBuffer = Buffers + (EFI_PAGES_TO_SIZE (PcdGet64 (PcdFfaTxRxPageCount)));
 
   FfaArgs.Arg0 = ARM_FID_FFA_RXTX_MAP;
   FfaArgs.Arg1 = (UINTN)TxBuffer;
@@ -222,7 +222,7 @@ ArmFfaLibRxTxMap (
     goto Unmap;
   }
 
-  RxTxBufferAllocationHob = GetRxTxBufferAllocationHob ((EFI_PHYSICAL_ADDRESS)((UINTN)TxBuffer), PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE * 2, FALSE);
+  RxTxBufferAllocationHob = GetRxTxBufferAllocationHob ((EFI_PHYSICAL_ADDRESS)((UINTN)TxBuffer), EFI_PAGES_TO_SIZE (PcdGet64 (PcdFfaTxRxPageCount)) * 2, FALSE);
   if (RxTxBufferAllocationHob == NULL) {
     DEBUG ((DEBUG_ERROR, "%a: Failed to acquire RxTxBufferAllocationHob\n", __func__));
     goto Unmap;
@@ -235,9 +235,9 @@ ArmFfaLibRxTxMap (
   CopyGuid (&RxTxBufferAllocationHob->AllocDescriptor.Name, &gArmFfaRxTxBufferInfoGuid);
 
   BufferInfo->TxBufferAddr  = (UINTN)RxTxBufferAllocationHob->AllocDescriptor.MemoryBaseAddress;
-  BufferInfo->TxBufferSize  = PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE;
+  BufferInfo->TxBufferSize  = EFI_PAGES_TO_SIZE (PcdGet64 (PcdFfaTxRxPageCount));
   BufferInfo->RxBufferAddr  = (UINTN)RxTxBufferAllocationHob->AllocDescriptor.MemoryBaseAddress + BufferInfo->TxBufferSize;
-  BufferInfo->RxBufferSize  = PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE;
+  BufferInfo->RxBufferSize  = EFI_PAGES_TO_SIZE (PcdGet64 (PcdFfaTxRxPageCount));
   BufferInfo->RemapOffset   = (UINTN)(BufferInfo->TxBufferAddr - RxTxBufferAllocationHob->AllocDescriptor.MemoryBaseAddress);
   BufferInfo->RemapRequired = TRUE;
 
@@ -357,9 +357,9 @@ UpdateRxTxBufferInfo (
 
   if ((RxTxBufferAllocationHob != NULL) && (BufferInfo != NULL)) {
     BufferInfo->TxBufferAddr = (UINTN)RxTxBufferAllocationHob->AllocDescriptor.MemoryBaseAddress;
-    BufferInfo->TxBufferSize = PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE;
+    BufferInfo->TxBufferSize = EFI_PAGES_TO_SIZE (PcdGet64 (PcdFfaTxRxPageCount));
     BufferInfo->RxBufferAddr = (UINTN)RxTxBufferAllocationHob->AllocDescriptor.MemoryBaseAddress + BufferInfo->TxBufferSize;
-    BufferInfo->RxBufferSize = PcdGet64 (PcdFfaTxRxPageCount) * EFI_PAGE_SIZE;
+    BufferInfo->RxBufferSize = EFI_PAGES_TO_SIZE (PcdGet64 (PcdFfaTxRxPageCount));
   }
 }
 

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecRxTxMap.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecRxTxMap.c
@@ -134,7 +134,7 @@ ArmFfaLibRxTxMap (
   if (EFI_ERROR (Status)) {
     DEBUG ((
       DEBUG_ERROR,
-      "%a: Failed to get RX/TX buffer property... Status: %r\n",
+      "%a: Failed to get Rx/Tx buffer property... Status: %r\n",
       __func__,
       Status
       ));
@@ -283,8 +283,8 @@ ErrorHandler:
   Rx/Tx buffer is registered only once per partition.
 
   @retval EFI_SUCCESS
-  @retval EFI_INVALID_PARAMETERS               Already unregistered
-  @retval EFI_UNSUPPORTED                      Not supported
+  @retval EFI_INVALID_PARAMETER  Already unregistered
+  @retval EFI_UNSUPPORTED        Not supported
 
 **/
 EFI_STATUS
@@ -336,9 +336,9 @@ ArmFfaLibRxTxUnmap (
 }
 
 /**
-  Update Rx/TX buffer information.
+  Update Rx/Tx buffer information.
 
-  @param  BufferInfo            Rx/Tx buffer information.
+  @param  BufferInfo  Rx/Tx buffer information.
 
 **/
 VOID
@@ -364,7 +364,7 @@ UpdateRxTxBufferInfo (
 }
 
 /**
-  Find Rx/TX buffer memory allocation hob.
+  Find Rx/Tx buffer memory allocation hob.
 
   @param  UseGuid             Find MemoryAllocationHob using Guid.
 
@@ -389,7 +389,7 @@ FindRxTxBufferAllocationHob (
 }
 
 /**
-  Remap Rx/TX buffer with converted Rx/Tx Buffer address after
+  Remap Rx/Tx buffer with converted Rx/Tx Buffer address after
   using permanent memory.
 
   @param[out] BufferInfo    BufferInfo

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.c
@@ -24,6 +24,9 @@
 #include "ArmFfaCommon.h"
 #include "ArmFfaRxTxMap.h"
 
+STATIC UINT16   mPartId;
+STATIC BOOLEAN  mIsFfaSupported;
+
 /**
   ArmFfaLib Constructor.
 
@@ -43,8 +46,8 @@ ArmFfaStandaloneMmLibConstructor (
 {
   EFI_STATUS  Status;
 
-  Status = ArmFfaLibCommonInit ();
-  if (Status == EFI_UNSUPPORTED) {
+  Status = ArmFfaLibCommonInit (&mPartId, &mIsFfaSupported);
+  if (!mIsFfaSupported) {
     /*
      * EFI_UNSUPPORTED means FF-A interface isn't available.
      * However, for Standalone MM modules, FF-A availability is not required.
@@ -85,4 +88,42 @@ ArmFfaStandaloneMmLibConstructor (
   }
 
   return Status;
+}
+
+/**
+  Return partition or VM ID
+
+  @param[out] PartId  The partition or VM ID
+
+  @retval EFI_SUCCESS  Partition ID or VM ID returned
+  @retval Others       Errors
+
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaLibGetPartId (
+  OUT UINT16  *PartId
+  )
+{
+  if (PartId != NULL) {
+    *PartId = mPartId;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Check FF-A support or not.
+
+  @retval TRUE                   Supported
+  @retval FALSE                  Not supported
+
+**/
+BOOLEAN
+EFIAPI
+IsFfaSupported (
+  IN VOID
+  )
+{
+  return mIsFfaSupported;
 }

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.c
@@ -127,3 +127,17 @@ IsFfaSupported (
 {
   return mIsFfaSupported;
 }
+
+/**
+  Callback for when Unmap is called to handle any post unmap
+  functionality.
+
+**/
+VOID
+EFIAPI
+UnmapCallback (
+  IN VOID
+  )
+{
+  // Do nothing
+}

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.c
@@ -49,7 +49,7 @@ ArmFfaStandaloneMmLibConstructor (
   Status = ArmFfaLibCommonInit (&mPartId, &mIsFfaSupported);
   if (!mIsFfaSupported) {
     /*
-     * EFI_UNSUPPORTED means FF-A interface isn't available.
+     * Unsupported means FF-A interface isn't available.
      * However, for Standalone MM modules, FF-A availability is not required.
      * i.e. Standalone MM could use SpmMm as a legitimate protocol.
      * Thus, returning EFI_SUCCESS here to avoid the entrypoint to assert.

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmRxTxMap.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmRxTxMap.c
@@ -214,6 +214,9 @@ ArmFfaLibRxTxUnmap (
   EFI_STATUS    Status;
   ARM_FFA_ARGS  FfaArgs;
   VOID          *Buffers;
+  UINT16        SourceId;
+
+  ArmFfaLibGetPartId (&SourceId);
 
   if (mArmFfaRxTxBufferStmmInfoHandle == NULL) {
     // This means that the agent tried to unmap the buffers before even know them.
@@ -224,7 +227,7 @@ ArmFfaLibRxTxUnmap (
   ZeroMem (&FfaArgs, sizeof (ARM_FFA_ARGS));
 
   FfaArgs.Arg0 = ARM_FID_FFA_RXTX_UNMAP;
-  FfaArgs.Arg1 = (gPartId << ARM_FFA_SOURCE_EP_SHIFT);
+  FfaArgs.Arg1 = (SourceId << ARM_FFA_SOURCE_EP_SHIFT);
 
   ArmCallFfa (&FfaArgs);
 


### PR DESCRIPTION
## Description

Pulling in the CHERRY-PICKS from release/202502 related to removing globals from ArmFfaCommon which came from EDK2.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A