### PR TITLE
ArmPkg/PeilessSec: Consume Tpm2StartupLib

### DIFF
--- a/ArmPlatformPkg/ArmPlatformPkg.dsc
+++ b/ArmPlatformPkg/ArmPlatformPkg.dsc
@@ -99,6 +99,7 @@
   Tpm2DeviceLib|SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2DeviceSecLibFfa.inf
   HashLib|SecurityPkg/Library/HashLibTpm2/HashLibTpm2PeilessSecLib.inf
   PeilessSecMeasureLib|SecurityPkg/Library/PeilessSecMeasureLib/PeilessSecMeasureLib.inf
+  Tpm2StartupLib|SecurityPkg/Library/Tpm2StartupLibNull/Tpm2StartupLibNull.inf  # MU_CHANGE
 
 [LibraryClasses.AARCH64.MM_STANDALONE]
   HobLib|StandaloneMmPkg/Library/StandaloneMmHobLib/StandaloneMmHobLib.inf

--- a/ArmPlatformPkg/PeilessSec/PeilessSec.c
+++ b/ArmPlatformPkg/PeilessSec/PeilessSec.c
@@ -7,6 +7,7 @@
 **/
 
 #include "PeilessSec.h"
+#include <Library/Tpm2StartupLib.h> // MU_CHANGE
 
 #define IS_XIP()  (((UINT64)FixedPcdGet64 (PcdFdBaseAddress) > mSystemMemoryEnd) ||\
                   ((FixedPcdGet64 (PcdFdBaseAddress) + FixedPcdGet32 (PcdFdSize)) <= FixedPcdGet64 (PcdSystemMemoryBase)))
@@ -204,6 +205,12 @@ SecMain (
 
   // SEC phase needs to run library constructors by hand.
   ProcessLibraryConstructorList ();
+
+  // MU_CHANGE [BEGIN] - Add Tpm2StartupInit call
+  // Initialize the TPM before loading the DXE core
+  Status = Tpm2StartupInit ();
+  ASSERT_EFI_ERROR (Status);
+  // MU_CHANGE [END]
 
   // MU_CHANGE [BEGIN] - Remove DXE Core FV placement assumption
 

--- a/ArmPlatformPkg/PeilessSec/PeilessSec.c
+++ b/ArmPlatformPkg/PeilessSec/PeilessSec.c
@@ -209,7 +209,17 @@ SecMain (
   // MU_CHANGE [BEGIN] - Add Tpm2StartupInit call
   // Initialize the TPM before loading the DXE core
   Status = Tpm2StartupInit ();
-  ASSERT_EFI_ERROR (Status);
+
+  /* NOTE: EFI_UNSUPPORTED is treated as a success due to the possibility of there
+   *       not being a TPM on the system and if so, the NULL instance of the startup
+   *       lib should be linked in which returns UNSUPPORTED. Also, even if TPM is
+   *       enabled, Tpm2StartupInit could return UNSUPPORTED depending on the TPM
+   *       instance. */
+  if ((Status != EFI_SUCCESS) && (Status != EFI_UNSUPPORTED)) {
+    DEBUG ((DEBUG_ERROR, "Failed to initialize the TPM\n"));
+    ASSERT_EFI_ERROR (Status);
+  }
+
   // MU_CHANGE [END]
 
   // MU_CHANGE [BEGIN] - Remove DXE Core FV placement assumption

--- a/ArmPlatformPkg/PeilessSec/PeilessSec.inf
+++ b/ArmPlatformPkg/PeilessSec/PeilessSec.inf
@@ -51,6 +51,7 @@
   TimerLib
   StackCheckLib
   ArmTransferListLib
+  Tpm2StartupLib # MU_CHANGE
 
 [Ppis]
   gArmMpCoreInfoPpiGuid


### PR DESCRIPTION
## Description

Pulling in the commits made to Silicon/Arm/MU_TIANO release/202502 regarding PeilessSec. Adding TpmStartupLib to PeilessSec.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A