### PR TITLE
Fix VariableSmmRuntimeDxe MM communicate v3 buffer sizing

### DIFF
--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
@@ -2025,7 +2025,12 @@ SmmVariableReady (
   //
   Status = GetVariablePayloadSize (&mVariableBufferPayloadSize);
   ASSERT_EFI_ERROR (Status);
-  mVariableBufferSize = SMM_COMMUNICATE_HEADER_SIZE + SMM_VARIABLE_COMMUNICATE_HEADER_SIZE + mVariableBufferPayloadSize;
+  if (mMmCommunication3 != NULL) {
+    mVariableBufferSize = SMM_COMMUNICATE_HEADER_SIZE_V3 + SMM_VARIABLE_COMMUNICATE_HEADER_SIZE + mVariableBufferPayloadSize;
+  } else {
+    mVariableBufferSize = SMM_COMMUNICATE_HEADER_SIZE + SMM_VARIABLE_COMMUNICATE_HEADER_SIZE + mVariableBufferPayloadSize;
+  }
+
   mVariableBuffer     = AllocateRuntimePool (mVariableBufferSize);
   ASSERT (mVariableBuffer != NULL);
 

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
@@ -2031,7 +2031,7 @@ SmmVariableReady (
     mVariableBufferSize = SMM_COMMUNICATE_HEADER_SIZE + SMM_VARIABLE_COMMUNICATE_HEADER_SIZE + mVariableBufferPayloadSize;
   }
 
-  mVariableBuffer     = AllocateRuntimePool (mVariableBufferSize);
+  mVariableBuffer = AllocateRuntimePool (mVariableBufferSize);
   ASSERT (mVariableBuffer != NULL);
 
   //


### PR DESCRIPTION
## Description

Fix VariableSmmRuntimeDxe MM communicate v3 buffer sizing

This change fixes `VariableSmmRuntimeDxe` to size its runtime communication buffer correctly when `EFI_MM_COMMUNICATION3_PROTOCOL` is available. 
Since 202511 branch, the variable runtime path can use MM communicate v3, which requires the larger `EFI_MM_COMMUNICATE_HEADER_V3` header (56KB vs 24KB), but the driver was still allocating the buffer using the legacy header size. This update makes the allocation v3-aware so the runtime variable communication buffer matches the header format actually in use and avoids failures on larger variable transactions.

## How This Was Tested

Tested on real hardware, now work as expected.
