### PR TITLE
[Cherry-Pick] Ensure section alignment for clangpdb aarch64 builds

### DIFF
--- a/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/SetPermissions.c
+++ b/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/SetPermissions.c
@@ -54,11 +54,13 @@ UpdateMmFoundationPeCoffPermissions (
   EFI_IMAGE_SECTION_HEADER  SectionHeader;
   RETURN_STATUS             Status;
   EFI_PHYSICAL_ADDRESS      Base;
+  UINT64                    SectionAlignment;
   UINTN                     Size;
   UINTN                     ReadSize;
   UINTN                     Index;
 
   ASSERT (ImageContext != NULL);
+  SectionAlignment = ImageContext->SectionAlignment;
 
   //
   // Iterate over the sections
@@ -126,10 +128,10 @@ UpdateMmFoundationPeCoffPermissions (
     if ((SectionHeader.Characteristics & EFI_IMAGE_SCN_MEM_EXECUTE) == 0) {
       Base = ImageBase + SectionHeader.VirtualAddress;
 
-      TextUpdater (Base, SectionHeader.Misc.VirtualSize);
+      TextUpdater (Base, ALIGN_VALUE (SectionHeader.Misc.VirtualSize, SectionAlignment));
 
       if ((SectionHeader.Characteristics & EFI_IMAGE_SCN_MEM_WRITE) != 0) {
-        ReadWriteUpdater (Base, SectionHeader.Misc.VirtualSize);
+        ReadWriteUpdater (Base, ALIGN_VALUE (SectionHeader.Misc.VirtualSize, SectionAlignment));
         DEBUG ((
           DEBUG_INFO,
           "%a: Mapping section %d of image at 0x%lx with RW-XN permissions\n",

--- a/StandaloneMmPkg/Library/StandaloneMmPeCoffExtraActionLib/AArch64/StandaloneMmPeCoffExtraActionLib.c
+++ b/StandaloneMmPkg/Library/StandaloneMmPeCoffExtraActionLib/AArch64/StandaloneMmPeCoffExtraActionLib.c
@@ -45,6 +45,7 @@ UpdatePeCoffPermissions (
   EFI_IMAGE_SECTION_HEADER             SectionHeader;
   PE_COFF_LOADER_IMAGE_CONTEXT         TmpContext;
   EFI_PHYSICAL_ADDRESS                 Base;
+  UINT64                               SectionAlignment;
 
   //
   // We need to copy ImageContext since PeCoffLoaderGetImageInfo ()
@@ -76,6 +77,8 @@ UpdatePeCoffPermissions (
       ));
     return RETURN_SUCCESS;
   }
+
+  SectionAlignment = TmpContext.SectionAlignment;
 
   if (TmpContext.SectionAlignment < EFI_PAGE_SIZE) {
     //
@@ -187,7 +190,7 @@ UpdatePeCoffPermissions (
           Base,
           SectionHeader.Misc.VirtualSize
           ));
-        ReadOnlyUpdater (Base, SectionHeader.Misc.VirtualSize);
+        ReadOnlyUpdater (Base, ALIGN_VALUE (SectionHeader.Misc.VirtualSize, SectionAlignment));
       } else {
         DEBUG ((
           DEBUG_WARN,
@@ -207,8 +210,8 @@ UpdatePeCoffPermissions (
         Base,
         SectionHeader.Misc.VirtualSize
         ));
-      ReadOnlyUpdater (Base, SectionHeader.Misc.VirtualSize);
-      NoExecUpdater (Base, SectionHeader.Misc.VirtualSize);
+      ReadOnlyUpdater (Base, ALIGN_VALUE (SectionHeader.Misc.VirtualSize, SectionAlignment));
+      NoExecUpdater (Base, ALIGN_VALUE (SectionHeader.Misc.VirtualSize, SectionAlignment));
     }
 
     SectionHeaderOffset += sizeof (EFI_IMAGE_SECTION_HEADER);


### PR DESCRIPTION
## Description

ClangPdb/Msvc do not align the virtual address section lengths.
This needs to be handled by the loader to ensure that lengths are
aligned correctly.

Found while compiling Standalone Mm for a virtual platform using
ClangPdb. This has been masked in GCC/ClangDwarf builds by
GenFw conversion enforcing section alignments during conversion.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Compiling the virtual platform with ClangPdb resulted in an assert when attempting 
to set memory protection on an unaligned section length.

## Integration Instructions
No integration necessary.