### PR TITLE
MdeModulePkg: CodeQL: Fix potential overflow issue in HiiLib.c and ConfigRouter.c

### DIFF
--- a/MdeModulePkg/Library/UefiHiiLib/HiiLib.c
+++ b/MdeModulePkg/Library/UefiHiiLib/HiiLib.c
@@ -2120,8 +2120,8 @@ GetBlockDataInfo (
   while ((Link != &BlockArray->Entry) && (Link->ForwardLink != &BlockArray->Entry)) {
     BlockData    = BASE_CR (Link, IFR_BLOCK_DATA, Entry);
     NewBlockData = BASE_CR (Link->ForwardLink, IFR_BLOCK_DATA, Entry);
-    if ((NewBlockData->Offset >= BlockData->Offset) && (NewBlockData->Offset <= (BlockData->Offset + BlockData->Width))) {
-      if ((NewBlockData->Offset + NewBlockData->Width) > (BlockData->Offset + BlockData->Width)) {
+    if ((NewBlockData->Offset >= BlockData->Offset) && (NewBlockData->Offset <= ((UINT32)BlockData->Offset + BlockData->Width))) { // MU_CHANGE: CodeQL
+      if (((UINT32)NewBlockData->Offset + NewBlockData->Width) > ((UINT32)BlockData->Offset + BlockData->Width)) { // MU_CHANGE: CodeQL
         BlockData->Width = (UINT16)(NewBlockData->Offset + NewBlockData->Width - BlockData->Offset);
       }
 

--- a/MdeModulePkg/Universal/HiiDatabaseDxe/ConfigRouting.c
+++ b/MdeModulePkg/Universal/HiiDatabaseDxe/ConfigRouting.c
@@ -3580,8 +3580,8 @@ GetBlockElement (
   while ((Link != &RequestBlockArray->Entry) && (Link->ForwardLink != &RequestBlockArray->Entry)) {
     BlockData     = BASE_CR (Link, IFR_BLOCK_DATA, Entry);
     NextBlockData = BASE_CR (Link->ForwardLink, IFR_BLOCK_DATA, Entry);
-    if ((NextBlockData->Offset >= BlockData->Offset) && (NextBlockData->Offset <= (BlockData->Offset + BlockData->Width))) {
-      if ((NextBlockData->Offset + NextBlockData->Width) > (BlockData->Offset + BlockData->Width)) {
+    if ((NextBlockData->Offset >= BlockData->Offset) && (NextBlockData->Offset <= ((UINT32)BlockData->Offset + BlockData->Width))) { // MU_CHANGE: CodeQL
+      if (((UINT32)NextBlockData->Offset + NextBlockData->Width) > ((UINT32)BlockData->Offset + BlockData->Width)) { // MU_CHANGE: CodeQL
         BlockData->Width = (UINT16)(NextBlockData->Offset + NextBlockData->Width - BlockData->Offset);
       }
 
@@ -4145,7 +4145,8 @@ UpdateBlockDataArray (
 
     for (TempLink = Link->ForwardLink; TempLink != BlockLink; TempLink = TempLink->ForwardLink) {
       NextBlockData = BASE_CR (TempLink, IFR_BLOCK_DATA, Entry);
-      if (!NextBlockData->IsBitVar || (NextBlockData->Offset >= BlockData->Offset + BlockData->Width) || (BlockData->Offset >= NextBlockData->Offset + NextBlockData->Width)) {
+      // MU_CHANGE: CodeQL
+      if (!NextBlockData->IsBitVar || (NextBlockData->Offset >= (UINT32)BlockData->Offset + BlockData->Width) || (BlockData->Offset >= (UINT32)NextBlockData->Offset + NextBlockData->Width)) {
         continue;
       }
 


### PR DESCRIPTION
## Description

Fixes a potential overflow in the comparison for the block data offsets using UINT16 by casting to UINT32 before addition to prevent overflow. This was reported by CodeQL. 

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
