### PR TITLE
[SQUASH ON REBASE]DisableNullDetection: Make calling convention consistent.

### DIFF
--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtectionSupport.c
@@ -126,7 +126,6 @@ SetUefiImageMemoryAttributes (
   Disable NULL pointer detection.
 **/
 VOID
-EFIAPI
 DisableNullDetection (
   VOID
   );


### PR DESCRIPTION
## Description

The calling convention on DisableNullDetection is inconsistent and this breaks builds.
EFIAPI is for separately compiled code, and, pragmatically, assembly.
You don't have to use it everywhere, but functions declarations and definitions need to be consistent.
Some compilers ignore EFIAPI, some do not.

These should all be moved to .h files?

Squash with b8374261aae751adae10f005b67bea2858d59358 on rebase.

- [ ] Impacts functionality? No.
- [ ] Impacts security? No.
- [ ] Breaking change? No.
- [ ] Includes tests? No, not needed.
- [ ] Includes documentation? No, not needed.

## How This Was Tested

Build.

## Integration Instructions

Nothing special.
