### PR TITLE
[SQUASH ON REBASE]fltused: Simplify and comment.

### DIFF
--- a/MdePkg/Library/FltUsedLib/FltUsedLib.c
+++ b/MdePkg/Library/FltUsedLib/FltUsedLib.c
@@ -8,4 +8,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 
 // create a global to satisfy the compilers insertion of the _fltused
 // in reponse to detecting floating point type operations.
-int  _fltused = 0x9875;
+//
+// In some systems (not EDK2) this is used to tune static C runtime linking.
+// i.e. There are (larger) working and (small stub) non-working floating point functions,
+// and _fltused is in the object files with the working functions.
+char  _fltused;


### PR DESCRIPTION
## Description

The value and size of _fltused do not matter.
You just need a symbol.

Squash with 6c8a30ed32a26c6573a3bc0bef89ddc371228d82 on rebase.

- [ ] Impacts functionality? No.
- [ ] Impacts security? No.
- [ ] Breaking change? No.
- [ ] Includes tests? No, not needed.
- [ ] Includes documentation? No, not needed.

## How This Was Tested

Build.

## Integration Instructions

Nothing special.