### PR TITLE
[SQUASH ON REBASE] Clang/Gcc: Move EnableInterruptsAndSleep out of EnableInterrupts.nasm.

### DIFF
--- a/MdePkg/Library/BaseLib/BaseLib.inf
+++ b/MdePkg/Library/BaseLib/BaseLib.inf
@@ -233,6 +233,7 @@
   X64/CpuPause.nasm| MSFT
   X64/DisableInterrupts.nasm| MSFT
   X64/EnableInterrupts.nasm| MSFT
+  X64/EnableInterruptsAndSleep.nasm # MU_CHANGE
   X64/FlushCacheLine.nasm| MSFT
   X64/Invd.nasm| MSFT
   X64/Wbinvd.nasm| MSFT

--- a/MdePkg/Library/BaseLib/X64/EnableInterruptsAndSleep.nasm
+++ b/MdePkg/Library/BaseLib/X64/EnableInterruptsAndSleep.nasm
@@ -1,15 +1,17 @@
+; MU_CHANGE - START
 ;------------------------------------------------------------------------------
 ;
 ; Copyright (c) 2006, Intel Corporation. All rights reserved.<BR>
+; Copyright (c) Microsoft Corporation.
 ; SPDX-License-Identifier: BSD-2-Clause-Patent
 ;
 ; Module Name:
 ;
-;   EnableInterrupts.Asm
+;   EnableInterruptsAndSleep.nasm
 ;
 ; Abstract:
 ;
-;   EnableInterrupts function
+;   EnableInterruptsAndSleep function
 ;
 ; Notes:
 ;
@@ -21,11 +23,13 @@
 ;------------------------------------------------------------------------------
 ; VOID
 ; EFIAPI
-; EnableInterrupts (
+; EnableInterruptsAndSleep (
 ;   VOID
 ;   );
 ;------------------------------------------------------------------------------
-global ASM_PFX(EnableInterrupts)
-ASM_PFX(EnableInterrupts):
+global ASM_PFX(EnableInterruptsAndSleep)
+ASM_PFX(EnableInterruptsAndSleep):
     sti
+    hlt
     ret
+; MU_CHANGE - END


### PR DESCRIPTION
## Description

EnableInterrupts.nasm does not build for clang/gcc, so they cannot link to EnableInterruptsAndSleep.

Squash with 4969b55336aa45859a8f594fca5c175506bc81a8.

- [ ] Impacts functionality? No.
- [ ] Impacts security? No.
- [ ] Breaking change? No.
- [ ] Includes tests? No.
- [ ] Includes documentation? No.

## How This Was Tested

No. But the opposite. I cannot build HyperV-UEFI with Clang or Gcc because of this.

## Integration Instructions

Easy.
