### PR TITLE
[Cherry-Pick] Revert "MdeModulePkg/PciBusDxe: Degrade MEM64 to PMEM64…

### DIFF
--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciBusDxe.inf
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciBusDxe.inf
@@ -104,6 +104,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdPcieResizableBarSupport     ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdDisableBMEonEBS             ## MU_CHANGE
   gEfiMdeModulePkgTokenSpaceGuid.PcdPcieInitializeMps           ## MU_CHANGE: Add support for initializing PCIe MPS
+  gEfiMdeModulePkgTokenSpaceGuid.PcdPciDegradeMem64toPMem64     ## CONSUMES # MU_CHANGE - MEM64 to PMEM64 conversion
 
 [UserExtensions.TianoCore."ExtraFiles"]
   PciBusDxeExtra.uni

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciResourceSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciResourceSupport.c
@@ -1000,19 +1000,6 @@ ResourcePaddingPolicy (
   PMEM64 -> PMEM32 -> MEM32
   IO32   -> IO16.
 
-  Additionally, if the upstream bridge supports PMEM64 but not MEM64,
-  MEM64 resources are degraded to PMEM64 to enable 64-bit allocation
-  through the bridge's prefetchable window. So the below degradation
-  path is also now supported:
-
-  MEM64  -> PMEM64
-
-  This is safe per PCI-SIG's ECN title "Removing Prefetchable Terminology"
-  (2024-04-05).
-
-  The terms prefetchable and non-prefetchable have also been removed from
-  the PCIe base specification starting with version 6.3.
-
   @param Bridge     Pci device instance.
   @param Mem32Node  Resource info node for 32-bit memory.
   @param PMem32Node Resource info node for 32-bit Prefetchable Memory.
@@ -1103,34 +1090,14 @@ DegradeResource (
       );
   } else {
     //
-    // If the upstream bridge does not support MEM64, check if we can
-    // degrade to PMEM64 first, instead of degrading to MEM32 directly.
-    //
-    // This is allowed per PCIe Base Spec 6.3+ which removes the terms
-    // prefetchable/non-prefetchable from the specification.
-    // The distinction originally only described P2P bridge read-ahead
-    // behavior, not resource allocation policy.
-    //
-    // We will still fall back and degrade to MEM32 if the upstream
-    // bridge lacks PMEM64 support.
-    //
-    // Refer to PCI-SIG ECN "Removing Prefetchable Terminology"
-    // (2024-04-05) for more details.
+    // if the bridge does not support MEM64, degrade MEM64 to MEM32
     //
     if (!BridgeSupportResourceDecode (Bridge, EFI_BRIDGE_MEM64_DECODE_SUPPORTED)) {
-      if (BridgeSupportResourceDecode (Bridge, EFI_BRIDGE_PMEM64_DECODE_SUPPORTED)) {
-        MergeResourceTree (
-          PMem64Node,
-          Mem64Node,
-          TRUE
-          );
-      } else {
-        MergeResourceTree (
-          Mem32Node,
-          Mem64Node,
-          TRUE
-          );
-      }
+      MergeResourceTree (
+        Mem32Node,
+        Mem64Node,
+        TRUE
+        );
     }
 
     //

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciResourceSupport.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciResourceSupport.c
@@ -1089,15 +1089,40 @@ DegradeResource (
       TRUE
       );
   } else {
+    // MU_CHANGE Start - MEM64 to PMEM64 conversion
     //
-    // if the bridge does not support MEM64, degrade MEM64 to MEM32
+    // If the upstream bridge does not support MEM64, check if we can
+    // degrade to PMEM64 first, instead of degrading to MEM32 directly.
+    //
+    // This is allowed per PCIe Base Spec 6.3+ which removes the terms
+    // prefetchable/non-prefetchable from the specification.
+    // The distinction originally only described P2P bridge read-ahead
+    // behavior, not resource allocation policy.
+    //
+    // We will still fall back and degrade to MEM32 if the upstream
+    // bridge lacks PMEM64 support.
+    //
+    // Refer to PCI-SIG ECN "Removing Prefetchable Terminology"
+    // (2024-04-05) for more details.
     //
     if (!BridgeSupportResourceDecode (Bridge, EFI_BRIDGE_MEM64_DECODE_SUPPORTED)) {
-      MergeResourceTree (
-        Mem32Node,
-        Mem64Node,
-        TRUE
-        );
+      if (PcdGetBool (PcdPciDegradeMem64toPMem64) &&
+          BridgeSupportResourceDecode (Bridge, EFI_BRIDGE_PMEM64_DECODE_SUPPORTED))
+      {
+        MergeResourceTree (
+          PMem64Node,
+          Mem64Node,
+          TRUE
+          );
+      } else {
+        MergeResourceTree (
+          Mem32Node,
+          Mem64Node,
+          TRUE
+          );
+      }
+
+      // MU_CHANGE End - MEM64 to PMEM64 conversion
     }
 
     //

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -2548,6 +2548,19 @@
   # @Prompt Disable BME on Exit Boot Services
   gEfiMdeModulePkgTokenSpaceGuid.PcdDisableBMEonEBS|TRUE|BOOLEAN|0x30002051
   
+  # MU_CHANGE Start - MEM64 to PMEM64 conversion
+  ## Indicates if Mem64 resource requests can be allocated using the PMem64
+  #  pool during PCI enumeration in case Mem64 resources are not available.
+  #  This is supported as per PCI Base spec 6.3+. which recommends that software
+  #  should not use the prefetchable/non-prefetchable bits for determining BAR
+  #  allocations. The default is to support PI Base spec 6.3+ recommendation and
+  #  allow Mem64 to use PMem64 when needed.
+  #    TRUE  - Degrade Mem64 resources to use PMem64 when needed
+  #    FALSE - Mem64 will be degraded to Mem32 and never to PMem64
+  # @Prompt Support degrading Mem64 to PMem64 during PCI enumeration
+  gEfiMdeModulePkgTokenSpaceGuid.PcdPciDegradeMem64toPMem64|FALSE|BOOLEAN|0x1000002C
+  # MU_CHANGE End - MEM64 to PMEM64 conversion
+
 [PcdsPatchableInModule]
   ## Specify memory size with page number for PEI code when
   #  Loading Module at Fixed Address feature is enabled.


### PR DESCRIPTION


## Description

This reverts commit f6489621b8ae1164c5e4930902988ba7c86847ba.

MdeModulePkg/PciBusDxe: Degrade MEM64 to PMEM64 when bridge lacks MEM64

A number of compatibility issues have been reported with this change to the PciBusDxe behavior. Revert this change at this time to give time for all the issues to be reviewed and options for supporting this new behavior to be evaluated and fully validated.


(cherry picked from commit defbd14d637313bdded40c717892497deec89be0)

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Booting windows on physical platform failed prior to revert.

## Integration Instructions
No Integration necessary.