### PR TITLE
[Cherry-Pick] MdePkg/BaseFdtLib: Implement new libfdt wrappers

### DIFF
--- a/MdePkg/Include/Library/FdtLib.h
+++ b/MdePkg/Include/Library/FdtLib.h
@@ -203,6 +203,11 @@ typedef struct {
 #define FdtSetPropEmpty(Fdt, NodeOffset, Name) \
   FdtSetProp ((Fdt), (NodeOffset), (Name), NULL, 0)
 
+#define FdtForEachPropertyOffset(Property, Fdt, Node)   \
+  for (Property = FdtFirstPropertyOffset(Fdt, Node);    \
+       Property >= 0;                                   \
+       Property = FdtNextPropertyOffset(Fdt, Property))
+
 /**
   Convert UINT16 data of the FDT blob to little-endian
 
@@ -970,6 +975,22 @@ EFIAPI
 FdtGetPhandle (
   IN CONST VOID  *Fdt,
   IN INT32       NodeOffset
+  );
+
+/**
+  Find and return the highest phandle in a tree. The value returned in Phandle
+  is only valid if the function returns success.
+
+  @param[in]  Fdt            The pointer to FDT blob.
+  @param[out] Phandle        The return location for the highest Phandle value found in the tree
+
+  @return 0 on success or a negative error code on failure
+**/
+INT32
+EFIAPI
+FdtFindMaxPhandle (
+  IN CONST VOID  *Fdt,
+  OUT UINT32     *Phandle
   );
 
 /**

--- a/MdePkg/Include/Library/FdtLib.h
+++ b/MdePkg/Include/Library/FdtLib.h
@@ -996,22 +996,20 @@ FdtFindMaxPhandle (
 /**
   Applies a DT overlay on a base DT.
 
-  @param[in] Fdt            The pointer to FDT blob.
-  @param[in] Fdto           The pointer to FDT overlay blob.
+  @param[in,out] Fdt        The pointer to FDT blob.
+  @param[in]     Fdto       The pointer to FDT overlay blob.
 
-  @return 0 on success, or negative error code.
+  @return 0 on success, or negative error code on failure.
 **/
 INT32
 EFIAPI
 FdtOverlayApply (
-  IN VOID  *Fdt,
-  IN VOID  *Fdto
+  IN OUT VOID  *Fdt,
+  IN     VOID  *Fdto
   );
 
 /* Debug functions. */
-CONST
-CHAR8
-*
+CONST CHAR8 *
 FdtStrerror (
   IN INT32  ErrVal
   );

--- a/MdePkg/Include/Library/FdtLib.h
+++ b/MdePkg/Include/Library/FdtLib.h
@@ -875,9 +875,9 @@ FdtPathOffset (
 CONST CHAR8 *
 EFIAPI
 FdtGetName (
-  IN VOID   *Fdt,
-  IN INT32  NodeOffset,
-  IN INT32  *Length
+  IN CONST VOID  *Fdt,
+  IN INT32       NodeOffset,
+  IN INT32       *Length
   );
 
 /**
@@ -893,10 +893,10 @@ FdtGetName (
 INT32
 EFIAPI
 FdtGetPath (
-  IN VOID    *Fdt,
-  IN INT32   NodeOffset,
-  IN VOID    *Buffer,
-  IN UINT32  BufferSize
+  IN CONST VOID  *Fdt,
+  IN INT32       NodeOffset,
+  IN VOID        *Buffer,
+  IN UINT32      BufferSize
   );
 
 /**

--- a/MdePkg/Library/BaseFdtLib/FdtLib.c
+++ b/MdePkg/Library/BaseFdtLib/FdtLib.c
@@ -919,6 +919,25 @@ FdtGetPhandle (
 }
 
 /**
+  Find and return the highest phandle in a tree. The value returned in Phandle
+  is only valid if the function returns success.
+
+  @param[in]  Fdt            The pointer to FDT blob.
+  @param[out] Phandle        The return location for the highest Phandle value found in the tree
+
+  @return 0 on success or a negative error code on failure
+**/
+INT32
+EFIAPI
+FdtFindMaxPhandle (
+  IN CONST VOID  *Fdt,
+  OUT UINT32     *Phandle
+  )
+{
+  return fdt_find_max_phandle (Fdt, Phandle);
+}
+
+/**
   Applies a DT overlay on a base DT.
 
   @param[in] Fdt            The pointer to FDT blob.

--- a/MdePkg/Library/BaseFdtLib/FdtLib.c
+++ b/MdePkg/Library/BaseFdtLib/FdtLib.c
@@ -940,25 +940,23 @@ FdtFindMaxPhandle (
 /**
   Applies a DT overlay on a base DT.
 
-  @param[in] Fdt            The pointer to FDT blob.
-  @param[in] Fdto           The pointer to FDT overlay blob.
+  @param[in,out] Fdt        The pointer to FDT blob.
+  @param[in]     Fdto       The pointer to FDT overlay blob.
 
-  @return 0 on success, or negative error code.
+  @return 0 on success, or negative error code on failure.
 **/
 INT32
 EFIAPI
 FdtOverlayApply (
-  IN VOID  *Fdt,
-  IN VOID  *Fdto
+  IN OUT VOID  *Fdt,
+  IN     VOID  *Fdto
   )
 {
   return fdt_overlay_apply (Fdt, Fdto);
 }
 
 /* Debug functions. */
-CONST
-CHAR8
-*
+CONST CHAR8 *
 FdtStrerror (
   IN INT32  ErrVal
   )

--- a/MdePkg/Library/BaseFdtLib/FdtLib.c
+++ b/MdePkg/Library/BaseFdtLib/FdtLib.c
@@ -795,9 +795,9 @@ FdtPathOffset (
 CONST CHAR8 *
 EFIAPI
 FdtGetName (
-  IN VOID   *Fdt,
-  IN INT32  NodeOffset,
-  IN INT32  *Length
+  IN CONST VOID  *Fdt,
+  IN INT32       NodeOffset,
+  IN INT32       *Length
   )
 {
   return fdt_get_name (Fdt, NodeOffset, Length);
@@ -816,10 +816,10 @@ FdtGetName (
 INT32
 EFIAPI
 FdtGetPath (
-  IN VOID    *Fdt,
-  IN INT32   NodeOffset,
-  IN VOID    *Buffer,
-  IN UINT32  BufferSize
+  IN CONST VOID  *Fdt,
+  IN INT32       NodeOffset,
+  IN VOID        *Buffer,
+  IN UINT32      BufferSize
   )
 {
   return fdt_get_path (Fdt, NodeOffset, Buffer, BufferSize);

--- a/MdePkg/MdePkg.ci.yaml
+++ b/MdePkg/MdePkg.ci.yaml
@@ -73,6 +73,7 @@
             "Include/IndustryStandard/Tpm20.h",
             "Include/IndustryStandard/IoRemappingTable.h",
             "Include/IndustryStandard/UefiTcgPlatform.h",
+            "Include/Library/FdtLib.h",
             "Include/Library/PcdLib.h",
             "Include/Library/SafeIntLib.h",
             "Include/Protocol/DebugSupport.h",

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockFdtLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockFdtLib.h
@@ -149,9 +149,9 @@ struct MockFdtLib {
   MOCK_FUNCTION_DECLARATION (
     CONST CHAR8 *,
     FdtGetName,
-    (IN VOID    *Fdt,
-     IN INT32   NodeOffset,
-     IN INT32   *Length)
+    (IN CONST VOID  *Fdt,
+     IN INT32       NodeOffset,
+     IN INT32       *Length)
     );
   MOCK_FUNCTION_DECLARATION (
     INT32,
@@ -168,10 +168,10 @@ struct MockFdtLib {
   MOCK_FUNCTION_DECLARATION (
     INT32,
     FdtGetPath,
-    (IN VOID    *Fdt,
-     IN INT32   NodeOffset,
-     IN VOID    *Buffer,
-     IN UINT32  BufferSize)
+    (IN CONST VOID  *Fdt,
+     IN INT32       NodeOffset,
+     IN VOID        *Buffer,
+     IN UINT32      BufferSize)
     );
 };
 


### PR DESCRIPTION
## Description

Add support for the #define FdtForEachPropertyOffset and FdtFindMaxPhandle() wrapper.
Updates FdtOverlayApply() to mark the Fdt pointer as an IN OUT variable. The internal fdt_overlay_apply() function returns the merged blob in the Fdt variable.

Update FdtGetName() and FdtGetPath() to correctly mark the VOID *Fdt as a CONST variable. This aligns with the internal libfdt implementation.
libfdt implementation of fdt_get_name(): https://github.com/devicetree-org/pylibfdt/blob/0dd30a1815414a54327094ff3b8223026ebb673c/libfdt/fdt_ro.c#L303
libfdt implementation of fdt_get_path(): https://github.com/devicetree-org/pylibfdt/blob/0dd30a1815414a54327094ff3b8223026ebb673c/libfdt/fdt_ro.c#L571

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
CI build validation passes.
Usage of FdtGetName, FdtForEachPropertyOffset, and FdtFindMaxPhandle verified as part of a migration from the EmbeddedPkg implementation of FdtLib.

## Integration Instructions
N/A