### PR TITLE
Bail `PhysicalPresenceCallback` if the mTcgNvs is not ready

### DIFF
--- a/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.c
+++ b/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.c
@@ -146,6 +146,7 @@ PhysicalPresenceCallback (
 
   if (mTcgNvs == NULL) {
     DEBUG ((DEBUG_ERROR, "[%a] - mTcgNvs is not ready!\n", __func__));
+    ASSERT (mTcgNvs != NULL);
     return EFI_SUCCESS;
   }
 

--- a/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.c
+++ b/SecurityPkg/Tcg/Tcg2Smm/Tcg2Smm.c
@@ -144,6 +144,11 @@ PhysicalPresenceCallback (
   UINT32  OperationRequest;
   UINT32  RequestParameter;
 
+  if (mTcgNvs == NULL) {
+    DEBUG ((DEBUG_ERROR, "[%a] - mTcgNvs is not ready!\n", __func__));
+    return EFI_SUCCESS;
+  }
+
   if (mTcgNvs->PhysicalPresence.Parameter == TCG_ACPI_FUNCTION_RETURN_REQUEST_RESPONSE_TO_OS) {
     mTcgNvs->PhysicalPresence.ReturnCode = Tcg2PhysicalPresenceLibReturnOperationResponseToOsFunction (
                                              &MostRecentRequest,


### PR DESCRIPTION
## Description

The current `PhysicalPresenceCallback` will directly access the `mTcgNvs` even if the other handler was not invoked.

This would cause the system to page fault due to the null pointer protection.

This change would bail the handler if the handler is invoked out of order.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This is being tested.

## Integration Instructions

N/A
