### PR TITLE
NetworkPkg/Dhcp6Dxe: Prevent potential infinite hang in EfiDhcp6Stop()

### DIFF
--- a/NetworkPkg/Dhcp6Dxe/Dhcp6Impl.c
+++ b/NetworkPkg/Dhcp6Dxe/Dhcp6Impl.c
@@ -174,20 +174,26 @@ EfiDhcp6Stop (
   IN EFI_DHCP6_PROTOCOL  *This
   )
 {
-  EFI_TPL            OldTpl;
-  EFI_STATUS         Status;
-  EFI_UDP6_PROTOCOL  *Udp6;
-  DHCP6_INSTANCE     *Instance;
-  DHCP6_SERVICE      *Service;
+  // MU_CHANGE [BEGIN] - Prevent potential infinite loop in Dhcp6Stop()
+  EFI_TPL         OldTpl;
+  EFI_STATUS      Status;
+  DHCP6_INSTANCE  *Instance;
+
+  // EFI_UDP6_PROTOCOL  *Udp6;
+  // DHCP6_SERVICE   *Service;
+
+  // MU_CHANGE [END] - Prevent potential infinite loop in Dhcp6Stop()
 
   if (This == NULL) {
     return EFI_INVALID_PARAMETER;
   }
 
   Instance = DHCP6_INSTANCE_FROM_THIS (This);
-  Service  = Instance->Service;
-  Udp6     = Service->UdpIo->Protocol.Udp6;
-  Status   = EFI_SUCCESS;
+  // MU_CHANGE [BEGIN] - Prevent potential infinite loop in Dhcp6Stop()
+  // Service  = Instance->Service;
+  // Udp6     = Service->UdpIo->Protocol.Udp6;
+  // MU_CHANGE [END] - Prevent potential infinite loop in Dhcp6Stop()
+  Status = EFI_SUCCESS;
 
   //
   // The instance hasn't been configured.
@@ -209,29 +215,48 @@ EfiDhcp6Stop (
     goto ON_EXIT;
   }
 
+  // MU_CHANGE [BEGIN] - Prevent potential infinite loop in Dhcp6Stop()
+
   //
-  // Release the current ready Ia.
+  // Send a Release message as a best-effort notification to the server.
+  //
+  // There is no polling for a reply.
+  //
+  // 1. The server will act on the release message regardless of acknowledgment.
+  // 2. A server reply would allow TxCb to be removed from TxList, however,
+  //    Dhcp6CleanupSession() will free every stateful TxCb in TxList anyway
+  //    (in Dhcp6CleanupRetry()).
+  //
+  // The simplifies cases such as USB NIC removal where this function will be
+  // invoked at TPL_CALLBACK during disconnect and Dhcp6OnTimerTick() is not
+  // able to run (due to TPL).
+  //
+  // For more details, see: RFC 8415 Dynamic Host Configuration Protocol for IPv6 (DHCPv6):
+  //   Section 18.2.7 Creation and Transmission of Release Messages
   //
   OldTpl = gBS->RaiseTPL (TPL_CALLBACK);
 
-  Instance->UdpSts = EFI_ALREADY_STARTED;
-  Status           = Dhcp6SendReleaseMsg (Instance, Instance->IaCb.Ia);
+  // Instance->UdpSts = EFI_ALREADY_STARTED;
+  Status = Dhcp6SendReleaseMsg (Instance, Instance->IaCb.Ia);
   gBS->RestoreTPL (OldTpl);
   if (EFI_ERROR (Status)) {
-    goto ON_EXIT;
+    DEBUG ((DEBUG_ERROR, "%a: Dhcp6SendReleaseMsg() failed: %r\n", __func__, Status));
+    // goto ON_EXIT;
   }
 
-  //
-  // Poll udp out of the net tpl if synchronous call.
-  //
-  if (Instance->Config->IaInfoEvent == NULL) {
-    ASSERT (Udp6 != NULL);
-    while (Instance->UdpSts == EFI_ALREADY_STARTED) {
-      Udp6->Poll (Udp6);
-    }
+  // //
+  // // Poll udp out of the net tpl if synchronous call.
+  // //
+  // if (Instance->Config->IaInfoEvent == NULL) {
+  //   ASSERT (Udp6 != NULL);
+  //   while (Instance->UdpSts == EFI_ALREADY_STARTED) {
+  //     Udp6->Poll (Udp6);
+  //   }
 
-    Status = Instance->UdpSts;
-  }
+  //   Status = Instance->UdpSts;
+  // }
+
+  // MU_CHANGE [END] - Prevent potential infinite loop in Dhcp6Stop()
 
 ON_EXIT:
   //


### PR DESCRIPTION
## Description

When a USB network adapter is removed while a DHCPv6 lease is active, the USB stack calls DisconnectController() at TPL_CALLBACK. The network stack teardown eventually invokes EfiDhcp6Stop(), which sends a Release message and enters a while loop polling Udp6->Poll() for the server's Reply:

  while (Instance->UdpSts == EFI_ALREADY_STARTED) {
    Udp6->Poll (Udp6);
  }

This loop never terminates because:

1. The NIC hardware is physically gone
2. The timeout mechanism relies on Dhcp6OnTimerTick(), a timer event registered at TPL_CALLBACK. Since EfiDhcp6Stop() is already running at TPL_CALLBACK (called from DisconnectController()), the timer event does not fire. So, UdpSts is never updated, and the loop never exits.

Note: Dhcp6OnTimerTick() is not in the packet receive path.

Udp6->Poll() drives packet reception synchronously through the network stack (MNP -> IP6 -> UDP6 -> Dhcp6ReceivePacket()), and Dhcp6HandleReplyMsg() sets Instance->UdpSts = EFI_SUCCESS when a Release Reply arrives.

The timer event's role for Release messages is retransmission and to reach timeout. Which are blocked because of the TPL in this case.

This change removes the synchronous polling loop from EfiDhcp6Stop().

This matches how Dhcp4Dxe handles EfiDhcp4Stop() and EfiDhcp4Release(), which send the Release and immediately clean up without polling.

This is considered acceptable because:

- Dhcp6SendReleaseMsg() calls Dhcp6TransmitPacket(), which synchronously hands the packet to hardware by calling SNP->Transmit() before returning.

- The server acts on the Release immediately upon receipt per RFC 8415 Section 18.3.7. It does not wait for client acknowledgment.

- RFC 8415 Section 18.2.7 states:

  "implementations SHOULD retransmit one or more times, but MAY choose to terminate the retransmission procedure early"

- The Release Reply carries no information we (the client) need.

- Dhcp6CleanupSession(), called immediately after sending Release, invokes Dhcp6CleanupRetry(DHCP6_PACKET_STATEFUL) which iterates TxList and frees the Release TxCb and its packet. The same memory cleanup occurs whether or not a Reply was received.

---

For reference: [RFC 8415 Section 18.2.7](https://datatracker.ietf.org/doc/html/rfc8415#section-18.2.7)

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- PR is in draft while platform testing occurs

## Integration Instructions

- N/A