### PR TITLE
CryptoPkg: Add OneCrypto binary external dependency

### DIFF
--- a/CryptoPkg/Binaries/OneCrypto_ext_dep.json
+++ b/CryptoPkg/Binaries/OneCrypto_ext_dep.json
@@ -1,0 +1,12 @@
+{
+  "scope": "global",
+  "type": "web",
+  "name": "onecrypto-bin",
+  "source": "https://github.com/microsoft/mu_crypto_release/releases/download/v1.0.0-OneCrypto/OneCrypto-Accelerated.zip",
+  "version": "1.0.0",
+  "sha256": "dbca1dd1e8410df574e5d3cdf258adbc94b660a3844157d1421f668d71164ec2",
+  "compression_type": "zip",
+  "internal_path": "/",
+  "flags": ["set_build_var"],
+  "var_name": "BLD_*_ONE_CRYPTO_PATH"
+}

--- a/CryptoPkg/CryptoPkg.ci.yaml
+++ b/CryptoPkg/CryptoPkg.ci.yaml
@@ -67,7 +67,9 @@
     "GuidCheck": {
         "IgnoreGuidName": [],
         "IgnoreGuidValue": [],
-        "IgnoreFoldersAndFiles": [],
+        "IgnoreFoldersAndFiles": [
+            "CryptoPkg/Binaries/onecrypto-bin_extdep/"
+        ],
         "IgnoreDuplicates": [
             "OneCryptoBinStandaloneMm=OneCryptoBinSupvMm"  # Intentional: Same GUID for loader identification
         ]


### PR DESCRIPTION
## Description

Add ext_dep descriptor to download OneCrypto accelerated crypto driver binaries from mu_crypto_release. This enables the build system to resolve and stage the OneCrypto drivers via stuart_update.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

QemuQ35 and QemuSbsa

## Integration Instructions
Reference Documentation: [BaseCryptLibOnOneCrypto](https://github.com/microsoft/mu_basecore/tree/release/202511/CryptoPkg/Library/BaseCryptLibOnOneCrypto)

Reference Integration: https://github.com/microsoft/mu_tiano_platforms/pull/1278