### PR TITLE
CryptoPkg: Add BaseCryptLib performance test application

### DIFF
--- a/CryptoPkg/CryptoPkg.dsc
+++ b/CryptoPkg/CryptoPkg.dsc
@@ -140,6 +140,18 @@
     ## MU_CHANGE [END]
   }
   ## MU_CHANGE [END]
+  ## MU_CHANGE [START] add performance test application
+  CryptoPkg/Test/UnitTest/Library/BaseCryptLib/Performance/CryptoPerfTestApp.inf {
+    <LibraryClasses>
+      DebugLib|MdePkg/Library/UefiDebugLibDebugPortProtocol/UefiDebugLibDebugPortProtocol.inf
+      DebugPrintErrorLevelLib|MdePkg/Library/BaseDebugPrintErrorLevelLib/BaseDebugPrintErrorLevelLib.inf
+      UefiRuntimeServicesTableLib|MdePkg/Library/UefiRuntimeServicesTableLib/UefiRuntimeServicesTableLib.inf
+      ReportStatusCodeLib|MdeModulePkg/Library/DxeReportStatusCodeLib/DxeReportStatusCodeLib.inf
+      MemoryAllocationLib|MdePkg/Library/UefiMemoryAllocationLib/UefiMemoryAllocationLib.inf
+    <PcdsFixedAtBuild>
+      gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel|0xFFFFFFFF
+  }
+  ## MU_CHANGE [END]
 ## MU_CHANGE [END]
   #
 [Components.IA32, Components.X64]

--- a/CryptoPkg/Test/CryptoPkgHostUnitTest.dsc
+++ b/CryptoPkg/Test/CryptoPkgHostUnitTest.dsc
@@ -35,6 +35,12 @@
   # Build HOST_APPLICATION that tests the SampleUnitTest
   #
   CryptoPkg/Test/UnitTest/Library/BaseCryptLib/TestBaseCryptLibHost.inf
+  # MU_CHANGE [START]
+  #
+  # Build HOST_APPLICATION for performance tests
+  #
+  CryptoPkg/Test/UnitTest/Library/BaseCryptLib/Performance/CryptoPerfTestHost.inf
+  # MU_CHANGE [END]
 [Components.IA32, Components.X64]
   #
   # Build HOST_APPLICATION that tests the SampleUnitTest

--- a/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/BaseCryptLibUnitTestApp.inf
+++ b/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/BaseCryptLibUnitTestApp.inf
@@ -53,7 +53,8 @@
   UnitTestLib
   PrintLib
   BaseCryptLib
-  
+  TimerLib
+
 [FixedPcd]
   gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceHmacSha256New               ## CONSUMES
   gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceHmacSha256Free              ## CONSUMES

--- a/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/Performance/AesPerfTests.c
+++ b/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/Performance/AesPerfTests.c
@@ -1,0 +1,204 @@
+/** @file
+  AES performance benchmarks for BaseCryptLib.
+
+  Benchmarks AES-256-CBC and AES-256-GCM encryption throughput
+  on 1 MB data buffers.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "CryptoPerfLib.h"
+
+//
+// AES-256 test key (32 bytes)
+//
+STATIC CONST UINT8  mAesPerfKey[32] = {
+  0x60, 0x3d, 0xeb, 0x10, 0x15, 0xca, 0x71, 0xbe,
+  0x2b, 0x73, 0xae, 0xf0, 0x85, 0x7d, 0x77, 0x81,
+  0x1f, 0x35, 0x2c, 0x07, 0x3b, 0x61, 0x08, 0xd7,
+  0x2d, 0x98, 0x10, 0xa3, 0x09, 0x14, 0xdf, 0xf4
+};
+
+//
+// AES-CBC initialization vector (16 bytes)
+//
+STATIC CONST UINT8  mAesPerfIv[16] = {
+  0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+  0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
+};
+
+//
+// AES-GCM initialization vector (12 bytes)
+//
+STATIC CONST UINT8  mGcmPerfIv[12] = {
+  0x99, 0xaa, 0x3e, 0x68, 0xed, 0x81, 0x73, 0xa0,
+  0xee, 0xd0, 0x66, 0x84
+};
+
+UNIT_TEST_STATUS
+EFIAPI
+TestPerfAesCbcEncrypt (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  VOID     *AesContext;
+  UINT8    *DataBuffer;
+  UINT8    *OutBuffer;
+  UINT8    Iv[16];
+  BOOLEAN  Status;
+  UINTN    Index;
+  UINTN    CtxSize;
+  UINT64   StartTick;
+  UINT64   EndTick;
+
+  CtxSize = AesGetContextSize ();
+  if (CtxSize == 0) {
+    UT_LOG_WARNING ("AES not supported, skipping benchmark.");
+    return UNIT_TEST_PASSED;
+  }
+
+  AesContext = AllocatePool (CtxSize);
+  UT_ASSERT_NOT_NULL (AesContext);
+
+  DataBuffer = AllocatePool (PERF_DATA_SIZE);
+  UT_ASSERT_NOT_NULL (DataBuffer);
+
+  OutBuffer = AllocatePool (PERF_DATA_SIZE);
+  UT_ASSERT_NOT_NULL (OutBuffer);
+
+  SetMem (DataBuffer, PERF_DATA_SIZE, 0xA5);
+
+  Status = AesInit (AesContext, mAesPerfKey, 256);
+  UT_ASSERT_TRUE (Status);
+
+  //
+  // Verify it works
+  //
+  CopyMem (Iv, mAesPerfIv, sizeof (Iv));
+  Status = AesCbcEncrypt (AesContext, DataBuffer, PERF_DATA_SIZE, Iv, OutBuffer);
+  if (!Status) {
+    UT_LOG_WARNING ("AES-CBC Encrypt not supported, skipping benchmark.");
+    FreePool (AesContext);
+    FreePool (DataBuffer);
+    FreePool (OutBuffer);
+    return UNIT_TEST_PASSED;
+  }
+
+  //
+  // Benchmark
+  //
+  StartTick = GetPerformanceCounter ();
+  for (Index = 0; Index < SYMMETRIC_ITERATIONS; Index++) {
+    CopyMem (Iv, mAesPerfIv, sizeof (Iv));
+    AesCbcEncrypt (AesContext, DataBuffer, PERF_DATA_SIZE, Iv, OutBuffer);
+  }
+
+  EndTick = GetPerformanceCounter ();
+
+  PerfLogResult (
+    "AES-256-CBC Encrypt",
+    PerfElapsedNanoSeconds (StartTick, EndTick),
+    SYMMETRIC_ITERATIONS,
+    PERF_DATA_SIZE
+    );
+
+  FreePool (AesContext);
+  FreePool (DataBuffer);
+  FreePool (OutBuffer);
+  return UNIT_TEST_PASSED;
+}
+
+UNIT_TEST_STATUS
+EFIAPI
+TestPerfAeadAesGcmEncrypt (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UINT8    *DataBuffer;
+  UINT8    *OutBuffer;
+  UINT8    Tag[16];
+  UINTN    OutSize;
+  BOOLEAN  Status;
+  UINTN    Index;
+  UINT64   StartTick;
+  UINT64   EndTick;
+
+  DataBuffer = AllocatePool (PERF_DATA_SIZE);
+  UT_ASSERT_NOT_NULL (DataBuffer);
+
+  OutBuffer = AllocatePool (PERF_DATA_SIZE);
+  UT_ASSERT_NOT_NULL (OutBuffer);
+
+  SetMem (DataBuffer, PERF_DATA_SIZE, 0xA5);
+
+  //
+  // Verify it works
+  //
+  OutSize = PERF_DATA_SIZE;
+  Status  = AeadAesGcmEncrypt (
+              mAesPerfKey,
+              sizeof (mAesPerfKey),
+              mGcmPerfIv,
+              sizeof (mGcmPerfIv),
+              NULL,
+              0,
+              DataBuffer,
+              PERF_DATA_SIZE,
+              Tag,
+              sizeof (Tag),
+              OutBuffer,
+              &OutSize
+              );
+  if (!Status) {
+    UT_LOG_WARNING ("AES-GCM Encrypt not supported, skipping benchmark.");
+    FreePool (DataBuffer);
+    FreePool (OutBuffer);
+    return UNIT_TEST_PASSED;
+  }
+
+  //
+  // Benchmark
+  //
+  StartTick = GetPerformanceCounter ();
+  for (Index = 0; Index < SYMMETRIC_ITERATIONS; Index++) {
+    OutSize = PERF_DATA_SIZE;
+    AeadAesGcmEncrypt (
+      mAesPerfKey,
+      sizeof (mAesPerfKey),
+      mGcmPerfIv,
+      sizeof (mGcmPerfIv),
+      NULL,
+      0,
+      DataBuffer,
+      PERF_DATA_SIZE,
+      Tag,
+      sizeof (Tag),
+      OutBuffer,
+      &OutSize
+      );
+  }
+
+  EndTick = GetPerformanceCounter ();
+
+  PerfLogResult (
+    "AES-256-GCM Encrypt",
+    PerfElapsedNanoSeconds (StartTick, EndTick),
+    SYMMETRIC_ITERATIONS,
+    PERF_DATA_SIZE
+    );
+
+  FreePool (DataBuffer);
+  FreePool (OutBuffer);
+  return UNIT_TEST_PASSED;
+}
+
+PERF_TEST_DESC  mAesPerfTest[] = {
+  //
+  // -----Description------------------Class-------------------------------------Function---------------------Pre--Post--Context
+  //
+  { "PerfAesCbcEncrypt()",     "CryptoPkg.BaseCryptLib.Perf.Aes", TestPerfAesCbcEncrypt,     NULL, NULL, NULL },
+  { "PerfAeadAesGcmEncrypt()", "CryptoPkg.BaseCryptLib.Perf.Aes", TestPerfAeadAesGcmEncrypt, NULL, NULL, NULL },
+};
+
+UINTN  mAesPerfTestNum = ARRAY_SIZE (mAesPerfTest);

--- a/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/Performance/CryptoPerfLib.h
+++ b/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/Performance/CryptoPerfLib.h
@@ -1,0 +1,134 @@
+/** @file
+  Header for BaseCryptLib Performance Tests.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef CRYPTO_PERF_LIB_H_
+#define CRYPTO_PERF_LIB_H_
+
+#include <PiPei.h>
+#include <Uefi.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/PrintLib.h>
+#include <Library/TimerLib.h>
+#include <Library/UnitTestLib.h>
+#include <Library/BaseCryptLib.h>
+
+#define PERF_TEST_NAME     "BaseCryptLib Performance Test"
+#define PERF_TEST_VERSION  "1.0"
+
+//
+// Standard benchmark data size (1 MB).
+//
+#define PERF_DATA_SIZE  SIZE_1MB
+
+//
+// Iteration counts for each operation category.
+//
+#define HASH_ITERATIONS          100
+#define SYMMETRIC_ITERATIONS     100
+#define HMAC_ITERATIONS          100
+#define RSA_KEYGEN_ITERATIONS     10
+#define RSA_SIGN_ITERATIONS       50
+#define RSA_VERIFY_ITERATIONS    100
+#define EC_ITERATIONS            100
+
+/**
+  Compute elapsed nanoseconds between two performance counter readings.
+  Handles counters that count up or down.
+
+  @param[in]  StartTick  Performance counter value at start.
+  @param[in]  EndTick    Performance counter value at end.
+
+  @return  Elapsed time in nanoseconds.
+**/
+UINT64
+PerfElapsedNanoSeconds (
+  IN UINT64  StartTick,
+  IN UINT64  EndTick
+  );
+
+/**
+  Log a performance measurement result via DEBUG output.
+
+  For bulk data operations (DataSize > 0), reports throughput in MB/s.
+  For discrete operations (DataSize == 0), reports ops/sec.
+
+  @param[in]  Label       Description of the operation benchmarked.
+  @param[in]  ElapsedNs   Elapsed time in nanoseconds.
+  @param[in]  Iterations  Number of iterations performed.
+  @param[in]  DataSize    Bytes processed per iteration (0 for asymmetric ops).
+**/
+VOID
+PerfLogResult (
+  IN CONST CHAR8  *Label,
+  IN UINT64       ElapsedNs,
+  IN UINTN        Iterations,
+  IN UINTN        DataSize
+  );
+
+//
+// Test descriptor types (mirrors existing TEST_DESC / SUITE_DESC pattern).
+//
+typedef struct {
+  CHAR8                     *Description;
+  CHAR8                     *ClassName;
+  UNIT_TEST_FUNCTION        Func;
+  UNIT_TEST_PREREQUISITE    PreReq;
+  UNIT_TEST_CLEANUP         CleanUp;
+  UNIT_TEST_CONTEXT         Context;
+} PERF_TEST_DESC;
+
+typedef struct {
+  CHAR8                       *Title;
+  CHAR8                       *Package;
+  UNIT_TEST_SUITE_SETUP       Sup;
+  UNIT_TEST_SUITE_TEARDOWN    Tdn;
+  UINTN                       *TestNum;
+  PERF_TEST_DESC              *TestDesc;
+} PERF_SUITE_DESC;
+
+//
+// Test suite externs from individual test files.
+//
+extern UINTN           mHashPerfTestNum;
+extern PERF_TEST_DESC  mHashPerfTest[];
+
+extern UINTN           mAesPerfTestNum;
+extern PERF_TEST_DESC  mAesPerfTest[];
+
+extern UINTN           mHmacPerfTestNum;
+extern PERF_TEST_DESC  mHmacPerfTest[];
+
+extern UINTN           mRsaPerfTestNum;
+extern PERF_TEST_DESC  mRsaPerfTest[];
+
+extern UINTN           mEcPerfTestNum;
+extern PERF_TEST_DESC  mEcPerfTest[];
+
+/**
+  Create the performance test framework and register all test suites.
+**/
+EFI_STATUS
+EFIAPI
+CreatePerfTest (
+  IN     CHAR8                       *UnitTestName,
+  IN     CHAR8                       *UnitTestVersion,
+  IN OUT UNIT_TEST_FRAMEWORK_HANDLE  *Framework
+  );
+
+/**
+  Main entry point for the performance tests.
+**/
+EFI_STATUS
+EFIAPI
+UefiTestMain (
+  VOID
+  );
+
+#endif // CRYPTO_PERF_LIB_H_

--- a/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/Performance/CryptoPerfMain.c
+++ b/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/Performance/CryptoPerfMain.c
@@ -1,0 +1,143 @@
+/** @file
+  Performance test entry point and timing helpers for BaseCryptLib.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "CryptoPerfLib.h"
+
+UINT64
+PerfElapsedNanoSeconds (
+  IN UINT64  StartTick,
+  IN UINT64  EndTick
+  )
+{
+  if (EndTick >= StartTick) {
+    return GetTimeInNanoSecond (EndTick - StartTick);
+  } else {
+    return GetTimeInNanoSecond (StartTick - EndTick);
+  }
+}
+
+VOID
+PerfLogResult (
+  IN CONST CHAR8  *Label,
+  IN UINT64       ElapsedNs,
+  IN UINTN        Iterations,
+  IN UINTN        DataSize
+  )
+{
+  UINT64  ElapsedMs;
+
+  ElapsedMs = ElapsedNs / 1000000;
+
+  if (DataSize > 0) {
+    //
+    // Bulk data operation - compute throughput in MB/s.
+    // TotalKB = Iterations * (DataSize / 1024)
+    // MB/s = TotalKB * 1000000 / ElapsedUs / 1024
+    //
+    UINT64  TotalKB;
+    UINT64  ElapsedUs;
+    UINT64  MBps;
+
+    TotalKB   = (UINT64)Iterations * ((UINT64)DataSize / 1024);
+    ElapsedUs = ElapsedNs / 1000;
+    MBps      = 0;
+    if (ElapsedUs > 0) {
+      MBps = (TotalKB * 1000000ULL) / ElapsedUs / 1024;
+    }
+
+    DEBUG ((
+      DEBUG_INFO,
+      "  %-35a : %6lu ms  (%lu MB/s)  [%u iters x %u KB]\n",
+      Label,
+      ElapsedMs,
+      MBps,
+      (UINT32)Iterations,
+      (UINT32)(DataSize / 1024)
+      ));
+  } else {
+    //
+    // Discrete operation - compute ops/sec.
+    //
+    UINT64  OpsPerSec;
+
+    OpsPerSec = 0;
+    if (ElapsedNs > 0) {
+      OpsPerSec = (UINT64)Iterations * 1000000000ULL / ElapsedNs;
+    }
+
+    DEBUG ((
+      DEBUG_INFO,
+      "  %-35a : %6lu ms  (%lu ops/s)  [%u iters]\n",
+      Label,
+      ElapsedMs,
+      OpsPerSec,
+      (UINT32)Iterations
+      ));
+  }
+}
+
+EFI_STATUS
+EFIAPI
+UefiTestMain (
+  VOID
+  )
+{
+  EFI_STATUS                  Status;
+  UNIT_TEST_FRAMEWORK_HANDLE  Framework;
+  UINT64                      StartTick;
+  UINT64                      EndTick;
+  UINT64                      ElapsedNs;
+
+  DEBUG ((DEBUG_INFO, "%a v%a\n", PERF_TEST_NAME, PERF_TEST_VERSION));
+
+  Status = CreatePerfTest (PERF_TEST_NAME, PERF_TEST_VERSION, &Framework);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed to create perf test framework! Status = %r\n", Status));
+    goto Done;
+  }
+
+  StartTick = GetPerformanceCounter ();
+  Status    = RunAllTestSuites (Framework);
+  EndTick   = GetPerformanceCounter ();
+
+  ElapsedNs = PerfElapsedNanoSeconds (StartTick, EndTick);
+  DEBUG ((DEBUG_INFO, "\nAll performance tests completed in %lu ms\n", ElapsedNs / 1000000));
+
+Done:
+  if (Framework) {
+    FreeUnitTestFramework (Framework);
+  }
+
+  return Status;
+}
+
+/**
+  Standard PEIM entry point for target based unit test execution from PEI.
+**/
+EFI_STATUS
+EFIAPI
+PeiEntryPoint (
+  IN EFI_PEI_FILE_HANDLE     FileHandle,
+  IN CONST EFI_PEI_SERVICES  **PeiServices
+  )
+{
+  return UefiTestMain ();
+}
+
+/**
+  Standard UEFI entry point for target based unit test execution from DXE, SMM,
+  UEFI Shell.
+**/
+EFI_STATUS
+EFIAPI
+DxeEntryPoint (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  return UefiTestMain ();
+}

--- a/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/Performance/CryptoPerfMainHost.c
+++ b/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/Performance/CryptoPerfMainHost.c
@@ -1,0 +1,30 @@
+/** @file
+  Host-based entry point for BaseCryptLib performance tests.
+
+  Note: When using BaseTimerLibNullTemplate, all timing results will be 0.
+  Use a platform-specific TimerLib for meaningful results.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "CryptoPerfLib.h"
+
+VOID
+EFIAPI
+ProcessLibraryConstructorList (
+  VOID
+  );
+
+/**
+  Standard POSIX C entry point for host based unit test execution.
+**/
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  ProcessLibraryConstructorList ();
+  return (int)UefiTestMain ();
+}

--- a/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/Performance/CryptoPerfTestApp.inf
+++ b/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/Performance/CryptoPerfTestApp.inf
@@ -1,0 +1,68 @@
+## @file
+# BaseCryptLib Performance Test built for execution in UEFI Shell.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 0x00010006
+  BASE_NAME      = BaseCryptLibPerfTestApp
+  FILE_GUID      = 4A8B21F7-6E52-4C85-A5B2-3C25E636A946
+  MODULE_TYPE    = UEFI_APPLICATION
+  VERSION_STRING = 1.0
+  ENTRY_POINT    = DxeEntryPoint
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  CryptoPerfMain.c
+  CryptoPerfTests.c
+  CryptoPerfLib.h
+  HashPerfTests.c
+  AesPerfTests.c
+  HmacPerfTests.c
+  RsaPerfTests.c
+  EcPerfTests.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  CryptoPkg/CryptoPkg.dec
+
+[LibraryClasses]
+  UefiApplicationEntryPoint
+  BaseLib
+  DebugLib
+  UnitTestLib
+  PrintLib
+  BaseCryptLib
+  TimerLib
+  BaseMemoryLib
+  MemoryAllocationLib
+
+[FixedPcd]
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceSha256Init                  ## CONSUMES
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceSha256HashAll               ## CONSUMES
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceSha384Init                  ## CONSUMES
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceSha384HashAll               ## CONSUMES
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceSha512Init                  ## CONSUMES
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceSha512HashAll               ## CONSUMES
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceAesGetContextSize           ## CONSUMES
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceAesInit                     ## CONSUMES
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceAesCbcEncrypt               ## CONSUMES
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceHmacSha256New               ## CONSUMES
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceHmacSha256Free              ## CONSUMES
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceHmacSha256SetKey            ## CONSUMES
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceHmacSha256Update            ## CONSUMES
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceHmacSha256Final             ## CONSUMES
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceRandomSeed                  ## CONSUMES
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceRandomBytes                 ## CONSUMES
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceRsaSetKey                   ## CONSUMES
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceRsaGetKey                   ## CONSUMES
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceRsaGenerateKey              ## CONSUMES
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceRsaPkcs1Sign                ## CONSUMES
+  gEfiCryptoPkgTokenSpaceGuid.PcdCryptoServiceRsaPkcs1Verify              ## CONSUMES

--- a/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/Performance/CryptoPerfTestHost.inf
+++ b/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/Performance/CryptoPerfTestHost.inf
@@ -1,0 +1,46 @@
+## @file
+# Host-based BaseCryptLib Performance Test.
+#
+# Note: When using BaseTimerLibNullTemplate, all timing results will be 0.
+# Use a real TimerLib implementation for meaningful measurements.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION    = 0x00010005
+  BASE_NAME      = BaseCryptLibPerfTestHost
+  FILE_GUID      = 8C1D3F52-9A47-4E2B-B6C8-7D4F1E2A5B39
+  MODULE_TYPE    = HOST_APPLICATION
+  VERSION_STRING = 1.0
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  CryptoPerfMain.c
+  CryptoPerfMainHost.c
+  CryptoPerfTests.c
+  CryptoPerfLib.h
+  HashPerfTests.c
+  AesPerfTests.c
+  HmacPerfTests.c
+  RsaPerfTests.c
+  EcPerfTests.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  CryptoPkg/CryptoPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+  BaseCryptLib
+  UnitTestLib
+  MmServicesTableLib
+  SynchronizationLib
+  TimerLib

--- a/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/Performance/CryptoPerfTests.c
+++ b/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/Performance/CryptoPerfTests.c
@@ -1,0 +1,71 @@
+/** @file
+  Performance test suite registration for BaseCryptLib.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "CryptoPerfLib.h"
+
+PERF_SUITE_DESC  mPerfSuiteDesc[] = {
+  //
+  // Title--------------------------------Package------------------------Sup--Tdn--TestNum-----------------TestDesc
+  //
+  { "Hash performance tests", "CryptoPkg.BaseCryptLib.Perf", NULL, NULL, &mHashPerfTestNum, mHashPerfTest },
+  { "AES performance tests",  "CryptoPkg.BaseCryptLib.Perf", NULL, NULL, &mAesPerfTestNum,  mAesPerfTest  },
+  { "HMAC performance tests", "CryptoPkg.BaseCryptLib.Perf", NULL, NULL, &mHmacPerfTestNum, mHmacPerfTest },
+  { "RSA performance tests",  "CryptoPkg.BaseCryptLib.Perf", NULL, NULL, &mRsaPerfTestNum,  mRsaPerfTest  },
+  { "EC performance tests",   "CryptoPkg.BaseCryptLib.Perf", NULL, NULL, &mEcPerfTestNum,   mEcPerfTest   },
+};
+
+EFI_STATUS
+EFIAPI
+CreatePerfTest (
+  IN     CHAR8                       *UnitTestName,
+  IN     CHAR8                       *UnitTestVersion,
+  IN OUT UNIT_TEST_FRAMEWORK_HANDLE  *Framework
+  )
+{
+  EFI_STATUS  Status;
+  UINTN       SuiteIndex;
+  UINTN       TestIndex;
+
+  if ((Framework == NULL) || (UnitTestVersion == NULL) || (UnitTestName == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = InitUnitTestFramework (Framework, UnitTestName, gEfiCallerBaseName, UnitTestVersion);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Failed in InitUnitTestFramework. Status = %r\n", Status));
+    return Status;
+  }
+
+  for (SuiteIndex = 0; SuiteIndex < ARRAY_SIZE (mPerfSuiteDesc); SuiteIndex++) {
+    UNIT_TEST_SUITE_HANDLE  Suite = NULL;
+    Status = CreateUnitTestSuite (
+               &Suite,
+               *Framework,
+               mPerfSuiteDesc[SuiteIndex].Title,
+               mPerfSuiteDesc[SuiteIndex].Package,
+               mPerfSuiteDesc[SuiteIndex].Sup,
+               mPerfSuiteDesc[SuiteIndex].Tdn
+               );
+    if (EFI_ERROR (Status)) {
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    for (TestIndex = 0; TestIndex < *mPerfSuiteDesc[SuiteIndex].TestNum; TestIndex++) {
+      AddTestCase (
+        Suite,
+        mPerfSuiteDesc[SuiteIndex].TestDesc[TestIndex].Description,
+        mPerfSuiteDesc[SuiteIndex].TestDesc[TestIndex].ClassName,
+        mPerfSuiteDesc[SuiteIndex].TestDesc[TestIndex].Func,
+        mPerfSuiteDesc[SuiteIndex].TestDesc[TestIndex].PreReq,
+        mPerfSuiteDesc[SuiteIndex].TestDesc[TestIndex].CleanUp,
+        mPerfSuiteDesc[SuiteIndex].TestDesc[TestIndex].Context
+        );
+    }
+  }
+
+  return EFI_SUCCESS;
+}

--- a/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/Performance/EcPerfTests.c
+++ b/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/Performance/EcPerfTests.c
@@ -1,0 +1,326 @@
+/** @file
+  EC performance benchmarks for BaseCryptLib.
+
+  Benchmarks EC P-256 key generation, ECDH key exchange,
+  and ECDSA sign/verify operations.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "CryptoPerfLib.h"
+
+//
+// P-256 sizes
+//
+#define EC_P256_PUB_KEY_SIZE  64
+#define EC_P256_HALF_SIZE     32
+#define EC_P256_SIG_SIZE      64
+
+UNIT_TEST_STATUS
+EFIAPI
+TestPerfEcGenerateKey (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  VOID     *Ec;
+  UINT8    PublicKey[EC_P256_PUB_KEY_SIZE];
+  UINTN    PublicKeySize;
+  BOOLEAN  Status;
+  UINTN    Index;
+  UINT64   StartTick;
+  UINT64   EndTick;
+
+  Status = RandomSeed (NULL, 0);
+  if (!Status) {
+    UT_LOG_WARNING ("RandomSeed failed, skipping EC keygen benchmark.");
+    return UNIT_TEST_PASSED;
+  }
+
+  //
+  // Verify it works
+  //
+  Ec = EcNewByNid (CRYPTO_NID_SECP256R1);
+  if (Ec == NULL) {
+    UT_LOG_WARNING ("EcNewByNid P-256 not supported, skipping benchmark.");
+    return UNIT_TEST_PASSED;
+  }
+
+  PublicKeySize = sizeof (PublicKey);
+  Status        = EcGenerateKey (Ec, PublicKey, &PublicKeySize);
+  EcFree (Ec);
+
+  if (!Status) {
+    UT_LOG_WARNING ("EcGenerateKey not supported, skipping benchmark.");
+    return UNIT_TEST_PASSED;
+  }
+
+  //
+  // Benchmark
+  //
+  StartTick = GetPerformanceCounter ();
+  for (Index = 0; Index < EC_ITERATIONS; Index++) {
+    Ec            = EcNewByNid (CRYPTO_NID_SECP256R1);
+    PublicKeySize = sizeof (PublicKey);
+    EcGenerateKey (Ec, PublicKey, &PublicKeySize);
+    EcFree (Ec);
+  }
+
+  EndTick = GetPerformanceCounter ();
+
+  PerfLogResult (
+    "EC P-256 KeyGen",
+    PerfElapsedNanoSeconds (StartTick, EndTick),
+    EC_ITERATIONS,
+    0
+    );
+
+  return UNIT_TEST_PASSED;
+}
+
+UNIT_TEST_STATUS
+EFIAPI
+TestPerfEcDhCompute (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  VOID     *Ec1;
+  VOID     *Ec2;
+  UINT8    Public1[EC_P256_PUB_KEY_SIZE];
+  UINTN    Public1Size;
+  UINT8    Public2[EC_P256_PUB_KEY_SIZE];
+  UINTN    Public2Size;
+  UINT8    Key[EC_P256_HALF_SIZE];
+  UINTN    KeySize;
+  BOOLEAN  Status;
+  UINTN    Index;
+  UINT64   StartTick;
+  UINT64   EndTick;
+
+  Status = RandomSeed (NULL, 0);
+  if (!Status) {
+    UT_LOG_WARNING ("RandomSeed failed, skipping ECDH benchmark.");
+    return UNIT_TEST_PASSED;
+  }
+
+  Ec1 = EcNewByNid (CRYPTO_NID_SECP256R1);
+  Ec2 = EcNewByNid (CRYPTO_NID_SECP256R1);
+  if ((Ec1 == NULL) || (Ec2 == NULL)) {
+    UT_LOG_WARNING ("EcNewByNid P-256 not supported, skipping ECDH benchmark.");
+    EcFree (Ec1);
+    EcFree (Ec2);
+    return UNIT_TEST_PASSED;
+  }
+
+  Public1Size = sizeof (Public1);
+  Status      = EcGenerateKey (Ec1, Public1, &Public1Size);
+  if (!Status) {
+    UT_LOG_WARNING ("EcGenerateKey failed, skipping ECDH benchmark.");
+    EcFree (Ec1);
+    EcFree (Ec2);
+    return UNIT_TEST_PASSED;
+  }
+
+  Public2Size = sizeof (Public2);
+  Status      = EcGenerateKey (Ec2, Public2, &Public2Size);
+  UT_ASSERT_TRUE (Status);
+
+  //
+  // Verify ECDH works
+  //
+  KeySize = sizeof (Key);
+  Status  = EcDhComputeKey (Ec1, Public2, Public2Size, NULL, Key, &KeySize);
+  if (!Status) {
+    UT_LOG_WARNING ("EcDhComputeKey not supported, skipping ECDH benchmark.");
+    EcFree (Ec1);
+    EcFree (Ec2);
+    return UNIT_TEST_PASSED;
+  }
+
+  //
+  // Benchmark: compute shared key repeatedly
+  //
+  StartTick = GetPerformanceCounter ();
+  for (Index = 0; Index < EC_ITERATIONS; Index++) {
+    KeySize = sizeof (Key);
+    EcDhComputeKey (Ec1, Public2, Public2Size, NULL, Key, &KeySize);
+  }
+
+  EndTick = GetPerformanceCounter ();
+
+  PerfLogResult (
+    "ECDH P-256 Compute",
+    PerfElapsedNanoSeconds (StartTick, EndTick),
+    EC_ITERATIONS,
+    0
+    );
+
+  EcFree (Ec1);
+  EcFree (Ec2);
+  return UNIT_TEST_PASSED;
+}
+
+UNIT_TEST_STATUS
+EFIAPI
+TestPerfEcDsaSign (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  VOID     *Ec;
+  UINT8    PublicKey[EC_P256_PUB_KEY_SIZE];
+  UINTN    PublicKeySize;
+  UINT8    HashValue[SHA256_DIGEST_SIZE];
+  UINT8    Signature[EC_P256_SIG_SIZE];
+  UINTN    SigSize;
+  BOOLEAN  Status;
+  UINTN    Index;
+  UINT64   StartTick;
+  UINT64   EndTick;
+
+  Status = RandomSeed (NULL, 0);
+  if (!Status) {
+    UT_LOG_WARNING ("RandomSeed failed, skipping ECDSA sign benchmark.");
+    return UNIT_TEST_PASSED;
+  }
+
+  Ec = EcNewByNid (CRYPTO_NID_SECP256R1);
+  if (Ec == NULL) {
+    UT_LOG_WARNING ("EcNewByNid P-256 not supported, skipping ECDSA sign benchmark.");
+    return UNIT_TEST_PASSED;
+  }
+
+  PublicKeySize = sizeof (PublicKey);
+  Status        = EcGenerateKey (Ec, PublicKey, &PublicKeySize);
+  if (!Status) {
+    UT_LOG_WARNING ("EcGenerateKey failed, skipping ECDSA sign benchmark.");
+    EcFree (Ec);
+    return UNIT_TEST_PASSED;
+  }
+
+  SetMem (HashValue, sizeof (HashValue), 0x42);
+
+  //
+  // Verify sign works
+  //
+  SigSize = sizeof (Signature);
+  Status  = EcDsaSign (Ec, CRYPTO_NID_SHA256, HashValue, sizeof (HashValue), Signature, &SigSize);
+  if (!Status) {
+    UT_LOG_WARNING ("EcDsaSign not supported, skipping benchmark.");
+    EcFree (Ec);
+    return UNIT_TEST_PASSED;
+  }
+
+  //
+  // Benchmark
+  //
+  StartTick = GetPerformanceCounter ();
+  for (Index = 0; Index < EC_ITERATIONS; Index++) {
+    SigSize = sizeof (Signature);
+    EcDsaSign (Ec, CRYPTO_NID_SHA256, HashValue, sizeof (HashValue), Signature, &SigSize);
+  }
+
+  EndTick = GetPerformanceCounter ();
+
+  PerfLogResult (
+    "ECDSA P-256 Sign",
+    PerfElapsedNanoSeconds (StartTick, EndTick),
+    EC_ITERATIONS,
+    0
+    );
+
+  EcFree (Ec);
+  return UNIT_TEST_PASSED;
+}
+
+UNIT_TEST_STATUS
+EFIAPI
+TestPerfEcDsaVerify (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  VOID     *Ec;
+  UINT8    PublicKey[EC_P256_PUB_KEY_SIZE];
+  UINTN    PublicKeySize;
+  UINT8    HashValue[SHA256_DIGEST_SIZE];
+  UINT8    Signature[EC_P256_SIG_SIZE];
+  UINTN    SigSize;
+  BOOLEAN  Status;
+  UINTN    Index;
+  UINT64   StartTick;
+  UINT64   EndTick;
+
+  Status = RandomSeed (NULL, 0);
+  if (!Status) {
+    UT_LOG_WARNING ("RandomSeed failed, skipping ECDSA verify benchmark.");
+    return UNIT_TEST_PASSED;
+  }
+
+  Ec = EcNewByNid (CRYPTO_NID_SECP256R1);
+  if (Ec == NULL) {
+    UT_LOG_WARNING ("EcNewByNid P-256 not supported, skipping ECDSA verify benchmark.");
+    return UNIT_TEST_PASSED;
+  }
+
+  PublicKeySize = sizeof (PublicKey);
+  Status        = EcGenerateKey (Ec, PublicKey, &PublicKeySize);
+  if (!Status) {
+    UT_LOG_WARNING ("EcGenerateKey failed, skipping ECDSA verify benchmark.");
+    EcFree (Ec);
+    return UNIT_TEST_PASSED;
+  }
+
+  SetMem (HashValue, sizeof (HashValue), 0x42);
+
+  //
+  // Create a signature to verify
+  //
+  SigSize = sizeof (Signature);
+  Status  = EcDsaSign (Ec, CRYPTO_NID_SHA256, HashValue, sizeof (HashValue), Signature, &SigSize);
+  if (!Status) {
+    UT_LOG_WARNING ("EcDsaSign failed, skipping ECDSA verify benchmark.");
+    EcFree (Ec);
+    return UNIT_TEST_PASSED;
+  }
+
+  //
+  // Verify it works
+  //
+  Status = EcDsaVerify (Ec, CRYPTO_NID_SHA256, HashValue, sizeof (HashValue), Signature, SigSize);
+  if (!Status) {
+    UT_LOG_WARNING ("EcDsaVerify not supported, skipping benchmark.");
+    EcFree (Ec);
+    return UNIT_TEST_PASSED;
+  }
+
+  //
+  // Benchmark
+  //
+  StartTick = GetPerformanceCounter ();
+  for (Index = 0; Index < EC_ITERATIONS; Index++) {
+    EcDsaVerify (Ec, CRYPTO_NID_SHA256, HashValue, sizeof (HashValue), Signature, SigSize);
+  }
+
+  EndTick = GetPerformanceCounter ();
+
+  PerfLogResult (
+    "ECDSA P-256 Verify",
+    PerfElapsedNanoSeconds (StartTick, EndTick),
+    EC_ITERATIONS,
+    0
+    );
+
+  EcFree (Ec);
+  return UNIT_TEST_PASSED;
+}
+
+PERF_TEST_DESC  mEcPerfTest[] = {
+  //
+  // -----Description--------------Class---------------------------------Function--------------Pre--Post--Context
+  //
+  { "PerfEcGenerateKey()", "CryptoPkg.BaseCryptLib.Perf.Ec", TestPerfEcGenerateKey, NULL, NULL, NULL },
+  { "PerfEcDhCompute()",  "CryptoPkg.BaseCryptLib.Perf.Ec", TestPerfEcDhCompute,  NULL, NULL, NULL },
+  { "PerfEcDsaSign()",    "CryptoPkg.BaseCryptLib.Perf.Ec", TestPerfEcDsaSign,    NULL, NULL, NULL },
+  { "PerfEcDsaVerify()",  "CryptoPkg.BaseCryptLib.Perf.Ec", TestPerfEcDsaVerify,  NULL, NULL, NULL },
+};
+
+UINTN  mEcPerfTestNum = ARRAY_SIZE (mEcPerfTest);

--- a/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/Performance/HashPerfTests.c
+++ b/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/Performance/HashPerfTests.c
@@ -1,0 +1,154 @@
+/** @file
+  Hash performance benchmarks for BaseCryptLib.
+
+  Benchmarks SHA-256, SHA-384, and SHA-512 bulk hashing throughput
+  using HashAll convenience functions on 1 MB data buffers.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "CryptoPerfLib.h"
+
+UNIT_TEST_STATUS
+EFIAPI
+TestPerfSha256 (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UINT8    *DataBuffer;
+  UINT8    Digest[SHA256_DIGEST_SIZE];
+  BOOLEAN  Status;
+  UINTN    Index;
+  UINT64   StartTick;
+  UINT64   EndTick;
+
+  DataBuffer = AllocatePool (PERF_DATA_SIZE);
+  UT_ASSERT_NOT_NULL (DataBuffer);
+  SetMem (DataBuffer, PERF_DATA_SIZE, 0xA5);
+
+  //
+  // Verify the operation works before benchmarking.
+  //
+  Status = Sha256HashAll (DataBuffer, PERF_DATA_SIZE, Digest);
+  if (!Status) {
+    UT_LOG_WARNING ("SHA-256 not supported, skipping benchmark.");
+    FreePool (DataBuffer);
+    return UNIT_TEST_PASSED;
+  }
+
+  //
+  // Benchmark
+  //
+  StartTick = GetPerformanceCounter ();
+  for (Index = 0; Index < HASH_ITERATIONS; Index++) {
+    Sha256HashAll (DataBuffer, PERF_DATA_SIZE, Digest);
+  }
+
+  EndTick = GetPerformanceCounter ();
+
+  PerfLogResult (
+    "SHA-256 HashAll",
+    PerfElapsedNanoSeconds (StartTick, EndTick),
+    HASH_ITERATIONS,
+    PERF_DATA_SIZE
+    );
+
+  FreePool (DataBuffer);
+  return UNIT_TEST_PASSED;
+}
+
+UNIT_TEST_STATUS
+EFIAPI
+TestPerfSha384 (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UINT8    *DataBuffer;
+  UINT8    Digest[SHA384_DIGEST_SIZE];
+  BOOLEAN  Status;
+  UINTN    Index;
+  UINT64   StartTick;
+  UINT64   EndTick;
+
+  DataBuffer = AllocatePool (PERF_DATA_SIZE);
+  UT_ASSERT_NOT_NULL (DataBuffer);
+  SetMem (DataBuffer, PERF_DATA_SIZE, 0xA5);
+
+  Status = Sha384HashAll (DataBuffer, PERF_DATA_SIZE, Digest);
+  if (!Status) {
+    UT_LOG_WARNING ("SHA-384 not supported, skipping benchmark.");
+    FreePool (DataBuffer);
+    return UNIT_TEST_PASSED;
+  }
+
+  StartTick = GetPerformanceCounter ();
+  for (Index = 0; Index < HASH_ITERATIONS; Index++) {
+    Sha384HashAll (DataBuffer, PERF_DATA_SIZE, Digest);
+  }
+
+  EndTick = GetPerformanceCounter ();
+
+  PerfLogResult (
+    "SHA-384 HashAll",
+    PerfElapsedNanoSeconds (StartTick, EndTick),
+    HASH_ITERATIONS,
+    PERF_DATA_SIZE
+    );
+
+  FreePool (DataBuffer);
+  return UNIT_TEST_PASSED;
+}
+
+UNIT_TEST_STATUS
+EFIAPI
+TestPerfSha512 (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  UINT8    *DataBuffer;
+  UINT8    Digest[SHA512_DIGEST_SIZE];
+  BOOLEAN  Status;
+  UINTN    Index;
+  UINT64   StartTick;
+  UINT64   EndTick;
+
+  DataBuffer = AllocatePool (PERF_DATA_SIZE);
+  UT_ASSERT_NOT_NULL (DataBuffer);
+  SetMem (DataBuffer, PERF_DATA_SIZE, 0xA5);
+
+  Status = Sha512HashAll (DataBuffer, PERF_DATA_SIZE, Digest);
+  if (!Status) {
+    UT_LOG_WARNING ("SHA-512 not supported, skipping benchmark.");
+    FreePool (DataBuffer);
+    return UNIT_TEST_PASSED;
+  }
+
+  StartTick = GetPerformanceCounter ();
+  for (Index = 0; Index < HASH_ITERATIONS; Index++) {
+    Sha512HashAll (DataBuffer, PERF_DATA_SIZE, Digest);
+  }
+
+  EndTick = GetPerformanceCounter ();
+
+  PerfLogResult (
+    "SHA-512 HashAll",
+    PerfElapsedNanoSeconds (StartTick, EndTick),
+    HASH_ITERATIONS,
+    PERF_DATA_SIZE
+    );
+
+  FreePool (DataBuffer);
+  return UNIT_TEST_PASSED;
+}
+
+PERF_TEST_DESC  mHashPerfTest[] = {
+  //
+  // -----Description--------Class--------------------------------------Function---------Pre--Post--Context
+  //
+  { "PerfSha256()", "CryptoPkg.BaseCryptLib.Perf.Hash", TestPerfSha256, NULL, NULL, NULL },
+  { "PerfSha384()", "CryptoPkg.BaseCryptLib.Perf.Hash", TestPerfSha384, NULL, NULL, NULL },
+  { "PerfSha512()", "CryptoPkg.BaseCryptLib.Perf.Hash", TestPerfSha512, NULL, NULL, NULL },
+};
+
+UINTN  mHashPerfTestNum = ARRAY_SIZE (mHashPerfTest);

--- a/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/Performance/HmacPerfTests.c
+++ b/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/Performance/HmacPerfTests.c
@@ -1,0 +1,91 @@
+/** @file
+  HMAC performance benchmarks for BaseCryptLib.
+
+  Benchmarks HMAC-SHA256 throughput on 1 MB data buffers.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "CryptoPerfLib.h"
+
+STATIC CONST UINT8  mHmacPerfKey[32] = {
+  0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
+  0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
+  0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
+  0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b
+};
+
+UNIT_TEST_STATUS
+EFIAPI
+TestPerfHmacSha256 (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  VOID     *HmacCtx;
+  UINT8    *DataBuffer;
+  UINT8    HmacValue[SHA256_DIGEST_SIZE];
+  BOOLEAN  Status;
+  UINTN    Index;
+  UINT64   StartTick;
+  UINT64   EndTick;
+
+  DataBuffer = AllocatePool (PERF_DATA_SIZE);
+  UT_ASSERT_NOT_NULL (DataBuffer);
+  SetMem (DataBuffer, PERF_DATA_SIZE, 0xA5);
+
+  HmacCtx = HmacSha256New ();
+  if (HmacCtx == NULL) {
+    UT_LOG_WARNING ("HMAC-SHA256 not supported, skipping benchmark.");
+    FreePool (DataBuffer);
+    return UNIT_TEST_PASSED;
+  }
+
+  //
+  // Verify it works
+  //
+  Status = HmacSha256SetKey (HmacCtx, mHmacPerfKey, sizeof (mHmacPerfKey));
+  if (!Status) {
+    UT_LOG_WARNING ("HMAC-SHA256 SetKey not supported, skipping benchmark.");
+    HmacSha256Free (HmacCtx);
+    FreePool (DataBuffer);
+    return UNIT_TEST_PASSED;
+  }
+
+  Status = HmacSha256Update (HmacCtx, DataBuffer, PERF_DATA_SIZE);
+  UT_ASSERT_TRUE (Status);
+  Status = HmacSha256Final (HmacCtx, HmacValue);
+  UT_ASSERT_TRUE (Status);
+
+  //
+  // Benchmark: SetKey + Update + Final per iteration
+  //
+  StartTick = GetPerformanceCounter ();
+  for (Index = 0; Index < HMAC_ITERATIONS; Index++) {
+    HmacSha256SetKey (HmacCtx, mHmacPerfKey, sizeof (mHmacPerfKey));
+    HmacSha256Update (HmacCtx, DataBuffer, PERF_DATA_SIZE);
+    HmacSha256Final (HmacCtx, HmacValue);
+  }
+
+  EndTick = GetPerformanceCounter ();
+
+  PerfLogResult (
+    "HMAC-SHA256",
+    PerfElapsedNanoSeconds (StartTick, EndTick),
+    HMAC_ITERATIONS,
+    PERF_DATA_SIZE
+    );
+
+  HmacSha256Free (HmacCtx);
+  FreePool (DataBuffer);
+  return UNIT_TEST_PASSED;
+}
+
+PERF_TEST_DESC  mHmacPerfTest[] = {
+  //
+  // -----Description-----------Class---------------------------------------Function-----------Pre--Post--Context
+  //
+  { "PerfHmacSha256()", "CryptoPkg.BaseCryptLib.Perf.Hmac", TestPerfHmacSha256, NULL, NULL, NULL },
+};
+
+UINTN  mHmacPerfTestNum = ARRAY_SIZE (mHmacPerfTest);

--- a/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/Performance/RsaPerfTests.c
+++ b/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/Performance/RsaPerfTests.c
@@ -1,0 +1,243 @@
+/** @file
+  RSA performance benchmarks for BaseCryptLib.
+
+  Benchmarks RSA-2048 key generation, PKCS1v1.5 sign, and verify.
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "CryptoPerfLib.h"
+
+#define RSA_PERF_MODULUS_LENGTH  2048
+
+STATIC CONST UINT8  mRsaPerfPublicExponent[] = { 0x01, 0x00, 0x01 };
+
+UNIT_TEST_STATUS
+EFIAPI
+TestPerfRsaGenerateKey (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  VOID     *Rsa;
+  BOOLEAN  Status;
+  UINTN    Index;
+  UINT64   StartTick;
+  UINT64   EndTick;
+
+  Status = RandomSeed (NULL, 0);
+  if (!Status) {
+    UT_LOG_WARNING ("RandomSeed failed, skipping RSA keygen benchmark.");
+    return UNIT_TEST_PASSED;
+  }
+
+  //
+  // Verify RSA keygen works
+  //
+  Rsa = RsaNew ();
+  if (Rsa == NULL) {
+    UT_LOG_WARNING ("RsaNew not supported, skipping benchmark.");
+    return UNIT_TEST_PASSED;
+  }
+
+  Status = RsaGenerateKey (
+             Rsa,
+             RSA_PERF_MODULUS_LENGTH,
+             mRsaPerfPublicExponent,
+             sizeof (mRsaPerfPublicExponent)
+             );
+  RsaFree (Rsa);
+
+  if (!Status) {
+    UT_LOG_WARNING ("RsaGenerateKey not supported for 2048-bit, skipping.");
+    return UNIT_TEST_PASSED;
+  }
+
+  //
+  // Benchmark
+  //
+  StartTick = GetPerformanceCounter ();
+  for (Index = 0; Index < RSA_KEYGEN_ITERATIONS; Index++) {
+    Rsa = RsaNew ();
+    RsaGenerateKey (
+      Rsa,
+      RSA_PERF_MODULUS_LENGTH,
+      mRsaPerfPublicExponent,
+      sizeof (mRsaPerfPublicExponent)
+      );
+    RsaFree (Rsa);
+  }
+
+  EndTick = GetPerformanceCounter ();
+
+  PerfLogResult (
+    "RSA-2048 KeyGen",
+    PerfElapsedNanoSeconds (StartTick, EndTick),
+    RSA_KEYGEN_ITERATIONS,
+    0
+    );
+
+  return UNIT_TEST_PASSED;
+}
+
+UNIT_TEST_STATUS
+EFIAPI
+TestPerfRsaPkcs1Sign (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  VOID     *Rsa;
+  UINT8    HashValue[SHA256_DIGEST_SIZE];
+  UINT8    Signature[RSA_PERF_MODULUS_LENGTH / 8];
+  UINTN    SigSize;
+  BOOLEAN  Status;
+  UINTN    Index;
+  UINT64   StartTick;
+  UINT64   EndTick;
+
+  Status = RandomSeed (NULL, 0);
+  if (!Status) {
+    UT_LOG_WARNING ("RandomSeed failed, skipping RSA sign benchmark.");
+    return UNIT_TEST_PASSED;
+  }
+
+  Rsa = RsaNew ();
+  UT_ASSERT_NOT_NULL (Rsa);
+
+  Status = RsaGenerateKey (
+             Rsa,
+             RSA_PERF_MODULUS_LENGTH,
+             mRsaPerfPublicExponent,
+             sizeof (mRsaPerfPublicExponent)
+             );
+  if (!Status) {
+    UT_LOG_WARNING ("RsaGenerateKey failed, skipping RSA sign benchmark.");
+    RsaFree (Rsa);
+    return UNIT_TEST_PASSED;
+  }
+
+  SetMem (HashValue, sizeof (HashValue), 0x42);
+
+  //
+  // Verify sign works
+  //
+  SigSize = sizeof (Signature);
+  Status  = RsaPkcs1Sign (Rsa, HashValue, SHA256_DIGEST_SIZE, Signature, &SigSize);
+  if (!Status) {
+    UT_LOG_WARNING ("RsaPkcs1Sign not supported, skipping benchmark.");
+    RsaFree (Rsa);
+    return UNIT_TEST_PASSED;
+  }
+
+  //
+  // Benchmark
+  //
+  StartTick = GetPerformanceCounter ();
+  for (Index = 0; Index < RSA_SIGN_ITERATIONS; Index++) {
+    SigSize = sizeof (Signature);
+    RsaPkcs1Sign (Rsa, HashValue, SHA256_DIGEST_SIZE, Signature, &SigSize);
+  }
+
+  EndTick = GetPerformanceCounter ();
+
+  PerfLogResult (
+    "RSA-2048 PKCS1v1.5 Sign",
+    PerfElapsedNanoSeconds (StartTick, EndTick),
+    RSA_SIGN_ITERATIONS,
+    0
+    );
+
+  RsaFree (Rsa);
+  return UNIT_TEST_PASSED;
+}
+
+UNIT_TEST_STATUS
+EFIAPI
+TestPerfRsaPkcs1Verify (
+  IN UNIT_TEST_CONTEXT  Context
+  )
+{
+  VOID     *Rsa;
+  UINT8    HashValue[SHA256_DIGEST_SIZE];
+  UINT8    Signature[RSA_PERF_MODULUS_LENGTH / 8];
+  UINTN    SigSize;
+  BOOLEAN  Status;
+  UINTN    Index;
+  UINT64   StartTick;
+  UINT64   EndTick;
+
+  Status = RandomSeed (NULL, 0);
+  if (!Status) {
+    UT_LOG_WARNING ("RandomSeed failed, skipping RSA verify benchmark.");
+    return UNIT_TEST_PASSED;
+  }
+
+  Rsa = RsaNew ();
+  UT_ASSERT_NOT_NULL (Rsa);
+
+  Status = RsaGenerateKey (
+             Rsa,
+             RSA_PERF_MODULUS_LENGTH,
+             mRsaPerfPublicExponent,
+             sizeof (mRsaPerfPublicExponent)
+             );
+  if (!Status) {
+    UT_LOG_WARNING ("RsaGenerateKey failed, skipping RSA verify benchmark.");
+    RsaFree (Rsa);
+    return UNIT_TEST_PASSED;
+  }
+
+  SetMem (HashValue, sizeof (HashValue), 0x42);
+
+  //
+  // Create a signature to verify
+  //
+  SigSize = sizeof (Signature);
+  Status  = RsaPkcs1Sign (Rsa, HashValue, SHA256_DIGEST_SIZE, Signature, &SigSize);
+  if (!Status) {
+    UT_LOG_WARNING ("RsaPkcs1Sign failed, skipping RSA verify benchmark.");
+    RsaFree (Rsa);
+    return UNIT_TEST_PASSED;
+  }
+
+  //
+  // Verify it works
+  //
+  Status = RsaPkcs1Verify (Rsa, HashValue, SHA256_DIGEST_SIZE, Signature, SigSize);
+  if (!Status) {
+    UT_LOG_WARNING ("RsaPkcs1Verify not supported, skipping benchmark.");
+    RsaFree (Rsa);
+    return UNIT_TEST_PASSED;
+  }
+
+  //
+  // Benchmark
+  //
+  StartTick = GetPerformanceCounter ();
+  for (Index = 0; Index < RSA_VERIFY_ITERATIONS; Index++) {
+    RsaPkcs1Verify (Rsa, HashValue, SHA256_DIGEST_SIZE, Signature, SigSize);
+  }
+
+  EndTick = GetPerformanceCounter ();
+
+  PerfLogResult (
+    "RSA-2048 PKCS1v1.5 Verify",
+    PerfElapsedNanoSeconds (StartTick, EndTick),
+    RSA_VERIFY_ITERATIONS,
+    0
+    );
+
+  RsaFree (Rsa);
+  return UNIT_TEST_PASSED;
+}
+
+PERF_TEST_DESC  mRsaPerfTest[] = {
+  //
+  // -----Description----------------Class----------------------------------Function-------------------Pre--Post--Context
+  //
+  { "PerfRsaGenerateKey()",  "CryptoPkg.BaseCryptLib.Perf.Rsa", TestPerfRsaGenerateKey,  NULL, NULL, NULL },
+  { "PerfRsaPkcs1Sign()",   "CryptoPkg.BaseCryptLib.Perf.Rsa", TestPerfRsaPkcs1Sign,   NULL, NULL, NULL },
+  { "PerfRsaPkcs1Verify()", "CryptoPkg.BaseCryptLib.Perf.Rsa", TestPerfRsaPkcs1Verify, NULL, NULL, NULL },
+};
+
+UINTN  mRsaPerfTestNum = ARRAY_SIZE (mRsaPerfTest);

--- a/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/TestBaseCryptLibHost.inf
+++ b/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/TestBaseCryptLibHost.inf
@@ -55,3 +55,4 @@
   UnitTestLib
   MmServicesTableLib
   SynchronizationLib
+  TimerLib

--- a/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/UnitTestMain.c
+++ b/CryptoPkg/Test/UnitTest/Library/BaseCryptLib/UnitTestMain.c
@@ -35,7 +35,24 @@ UefiTestMain (
   //
   // Execute the tests.
   //
-  Status = RunAllTestSuites (Framework);
+  UINT64  StartTick;
+  UINT64  EndTick;
+  UINT64  ElapsedNs;
+
+  StartTick = GetPerformanceCounter ();
+  Status    = RunAllTestSuites (Framework);
+  EndTick   = GetPerformanceCounter ();
+
+  //
+  // The performance counter may count up or down, so take the absolute delta.
+  //
+  if (EndTick >= StartTick) {
+    ElapsedNs = GetTimeInNanoSecond (EndTick - StartTick);
+  } else {
+    ElapsedNs = GetTimeInNanoSecond (StartTick - EndTick);
+  }
+
+  DEBUG ((DEBUG_INFO, "All test suites completed in %lu ms\n", ElapsedNs / 1000000));
 
 Done:
   if (Framework) {


### PR DESCRIPTION
## Description


Add a dedicated performance benchmark application that measures throughput and latency of key BaseCryptLib operations including SHA-256/384/512 hashing, AES-CBC/GCM encryption, HMAC-SHA256, RSA-2048 key generation/sign/verify, and EC P-256 key generation/ECDH/ECDSA sign/verify.

Also add elapsed time reporting to the existing BaseCryptLib unit test runner using TimerLib.

New files under Performance/:
- CryptoPerfTestApp.inf (UEFI_APPLICATION)
- CryptoPerfTestHost.inf (HOST_APPLICATION)
- CryptoPerfMain.c, CryptoPerfTests.c, CryptoPerfLib.h
- HashPerfTests.c, AesPerfTests.c, HmacPerfTests.c
- RsaPerfTests.c, EcPerfTests.c


For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
