### PR TITLE
MdeModulePkg: Signal PreReadyToBoot

### DIFF
--- a/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
+++ b/MdeModulePkg/Library/UefiBootManagerLib/BmBoot.c
@@ -1962,6 +1962,9 @@ EfiBootManagerBoot (
     DEBUG ((DEBUG_INFO, "[Bds] Booting Boot Manager Menu.\n"));
     BmStopHotkeyService (NULL, NULL);
   } else {
+    PERF_EVENT_SIGNAL_BEGIN (&gEfiEventPreReadyToBootGuid); // MU_CHANGE
+    EfiEventGroupSignal (&gEfiEventPreReadyToBootGuid);     // MU_CHANGE
+    PERF_EVENT_SIGNAL_END (&gEfiEventPreReadyToBootGuid);   // MU_CHANGE
     PERF_EVENT_SIGNAL_BEGIN (&gEfiEventReadyToBootGuid);    // MU_CHANGE
     EfiSignalEventReadyToBoot ();
     PERF_EVENT_SIGNAL_END (&gEfiEventReadyToBootGuid);       // MU_CHANGE

--- a/MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
+++ b/MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
@@ -87,6 +87,7 @@
   gEfiDiskInfoScsiInterfaceGuid                 ## SOMETIMES_CONSUMES ## GUID
   gEfiDiskInfoSdMmcInterfaceGuid                ## SOMETIMES_CONSUMES ## GUID
   gEfiDiskInfoUfsInterfaceGuid                  ## SOMETIMES_CONSUMES ## GUID
+  gEfiEventPreReadyToBootGuid                   ## PRODUCES   ##MU_CHANGE
   gEfiEventReadyToBootGuid                      # MU_CHANGE
 
 [Protocols]


### PR DESCRIPTION
## Description

Signal the PreReadyToBoot Event prior to ready to
boot. Missed during dropping PostReadyToBoot event during 202511 integration.

This is used by platforms which need to avoid
the flurry of events signaled on ReadyToBoot event.

- [X] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Platform relying on PreReadyToBootEvent failed to signal event. 

## Integration Instructions
No Integration necessary.