### PR TITLE
[CHERRY-PICK] BaseTools/Plugin: Add lcov error tolerance for vendored source trees

### DIFF
--- a/BaseTools/Plugin/HostBasedUnitTestRunner/HostBasedUnitTestRunner.py
+++ b/BaseTools/Plugin/HostBasedUnitTestRunner/HostBasedUnitTestRunner.py
@@ -214,8 +214,13 @@ class HostBasedUnitTestRunner(IUefiBuildPlugin):
         logging.info(f"Got lcov version {lcov_version_major}")
 
         # Generate base code coverage for all source files
-        # `--ignore-errors mismatch` needed to make lcov v2.0+/gcov work.
-        lcov_error_settings = "--ignore-errors mismatch" if lcov_version_major >= 2 else ""
+        # lcov v2.0+ with gcov requires ignoring several non-fatal error
+        # classes that commonly occur with large vendored third-party trees:
+        #   mismatch - gcov/gcno version or function line mismatches
+        #   source   - source files not found or newer than gcno notes
+        #   format   - unexpected gcov output (e.g. line numbers beyond EOF)
+        #   gcov     - gcov tool returned with a non-zero return code
+        lcov_error_settings = "--ignore-errors mismatch,source,format,gcov" if lcov_version_major >= 2 else ""
         ret = RunCmd("lcov", f"--no-external --capture --initial --directory {buildOutputBase} --output-file {buildOutputBase}/cov-base.info --rc lcov_branch_coverage=1 {lcov_error_settings}")
         if ret != 0:
             logging.error("UnitTest Coverage: Failed to build initial coverage data.")


### PR DESCRIPTION
## Description

lcov v2.0+ treats several gcov/source-related conditions as fatal errors that were previously warnings in v1.x. This causes coverage capture to abort when the build tree includes vendored third-party sources (e.g. OpenSSL) that produce gcov mismatches, missing source references, unexpected gcov output, or non-zero gcov return codes.

(cherry picked from commit 233eddb8e30d137597119a80a473c449cba3e351)

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

OpensslPkg

## Integration Instructions

N/A