### PR TITLE
UefiCpuPkg: ArmMmuLib: Check if Block Split Following Page Alloc

### DIFF
--- a/UefiCpuPkg/Library/ArmMmuLib/AArch64/ArmMmuLibCore.c
+++ b/UefiCpuPkg/Library/ArmMmuLib/AArch64/ArmMmuLibCore.c
@@ -277,11 +277,14 @@ UpdateRegionMappingRecursive (
   VOID        *TranslationTable;
   EFI_STATUS  Status;
   BOOLEAN     NextTableIsLive;
+  VOID        *TableToFree; // MU_CHANGE: Fix Split During Alloc
 
   ASSERT (((RegionStart | RegionEnd) & EFI_PAGE_MASK) == 0);
 
   BlockShift = (Level + 1) * BITS_PER_LEVEL + MIN_T0SZ;
   BlockMask  = MAX_UINT64 >> BlockShift;
+
+  TableToFree = NULL; // MU_CHANGE: Fix Split During Alloc
 
   DEBUG ((
     DEBUG_VERBOSE,
@@ -337,44 +340,61 @@ UpdateRegionMappingRecursive (
           return EFI_OUT_OF_RESOURCES;
         }
 
-        if (!ArmMmuEnabled ()) {
+        // MU_CHANGE BEGIN: Fix Split During Alloc
+        // Allocating a page may have split this block if a guard page
+        // was allocated in this block. Check if this is already split
+        // and if so skip the splitting logic
+        //
+        if (IsTableEntry (*Entry, Level)) {
           //
-          // Make sure we are not inadvertently hitting in the caches
-          // when populating the page tables.
+          // Don't free the page table here, we may end up recreating the
+          // large page
           //
-          InvalidateDataCacheRange (TranslationTable, EFI_PAGE_SIZE);
-        }
-
-        ZeroMem (TranslationTable, EFI_PAGE_SIZE);
-
-        if (IsBlockEntry (*Entry, Level)) {
-          //
-          // We are splitting an existing block entry, so we have to populate
-          // the new table with the attributes of the block entry it replaces.
-          //
-          Status = UpdateRegionMappingRecursive (
-                     RegionStart & ~BlockMask,
-                     (RegionStart | BlockMask) + 1,
-                     *Entry & TT_ATTRIBUTES_MASK,
-                     0,
-                     TranslationTable,
-                     Level + 1,
-                     FALSE,
-                     FALSE,
-                     Lpa2Enabled
-                     );
-          if (EFI_ERROR (Status)) {
+          TableToFree      = TranslationTable;
+          TranslationTable = (VOID *)GetOutputAddress (*Entry, Lpa2Enabled);
+          NextTableIsLive  = TableIsLive;
+        } else {
+          if (!ArmMmuEnabled ()) {
             //
-            // The range we passed to UpdateRegionMappingRecursive () is block
-            // aligned, so it is guaranteed that no further pages were allocated
-            // by it, and so we only have to free the page we allocated here.
+            // Make sure we are not inadvertently hitting in the caches
+            // when populating the page tables.
             //
-            FreePages (TranslationTable, 1);
-            return Status;
+            InvalidateDataCacheRange (TranslationTable, EFI_PAGE_SIZE);
           }
+
+          ZeroMem (TranslationTable, EFI_PAGE_SIZE);
+
+          if (IsBlockEntry (*Entry, Level)) {
+            //
+            // We are splitting an existing block entry, so we have to populate
+            // the new table with the attributes of the block entry it replaces.
+            //
+            Status = UpdateRegionMappingRecursive (
+                       RegionStart & ~BlockMask,
+                       (RegionStart | BlockMask) + 1,
+                       *Entry & TT_ATTRIBUTES_MASK,
+                       0,
+                       TranslationTable,
+                       Level + 1,
+                       FALSE,
+                       FALSE,
+                       Lpa2Enabled
+                       );
+            if (EFI_ERROR (Status)) {
+              //
+              // The range we passed to UpdateRegionMappingRecursive () is block
+              // aligned, so it is guaranteed that no further pages were allocated
+              // by it, and so we only have to free the page we allocated here.
+              //
+              FreePages (TranslationTable, 1);
+              return Status;
+            }
+          }
+
+          NextTableIsLive = FALSE;
         }
 
-        NextTableIsLive = FALSE;
+        // MU_CHANGE END: Fix Split During Alloc
       } else {
         TranslationTable = (VOID *)GetOutputAddress (*Entry, Lpa2Enabled);
         NextTableIsLive  = TableIsLive;
@@ -431,6 +451,17 @@ UpdateRegionMappingRecursive (
       ReplaceTableEntry (Entry, EntryValue, RegionStart, BlockMask, FALSE);
     }
   }
+
+  // MU_CHANGE BEGIN: Fix Split During Alloc
+  // We may have left an orphaned page table page if we discovered a
+  // recursive call already split a block.
+  //
+  if (TableToFree != NULL) {
+    FreePages (TableToFree, 1);
+    TableToFree = NULL;
+  }
+
+  // MU_CHANGE END: Fix Split During Alloc
 
   return EFI_SUCCESS;
 }


### PR DESCRIPTION
## Description

Currently, there is a bug in UpdateRegionMappingRecursive() when guard pages are enabled and a large page is being split.

The code checks whether the page table is a block or table and seeing that it is a block, allocates a new page table for the next level. However, when it does this, it will call an additional recursive call into the page table updating logic to make sure the new page table page is mapped. In addition, when guard pages are enabled, it will mark the guard page as RP. If the guard page is in the same block as we are already trying to split, the recursive call will split the block and mark the guard page as RP.

When we return to the original call, it will fill out the now orphaned page table but never install it into the page table hierarchy (and if it did, it would lose the guard page). This has been observed to cause a driver's code section to still have NX set on it and so crash when trying to execute.

This commit resolves the issue by checking if the block has already been split when we return from the new page table allocation. If it has, we simply update the existing table mapping instead of trying to split the block.

The allocated page table page cannot be immediately freed, because this might trigger the block to get re-merged, so a reference to it is held until the end of updating this level and subsequent levels, when it can be safely freed.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on a physical ARM64 platform with NX and page guard enabled. System crashes before this change and boots with it.

## Integration Instructions

N/A.
