### PR TITLE
[Cherry-Pick] BaseTools: Only check for GCC prefixes when targeting

### DIFF
--- a/BaseTools/Plugin/LinuxGccToolChain/LinuxGccToolChain.py
+++ b/BaseTools/Plugin/LinuxGccToolChain/LinuxGccToolChain.py
@@ -37,23 +37,26 @@ class LinuxGccToolChain(IUefiBuildPlugin):
             if "GCC5" in thebuilder.env.GetValue("TOOL_CHAIN_TAG"):
                 toolchain = "GCC5"
 
-            # Start with AARACH64 compiler
-            ret = self._check_aarch64(toolchain)
-            if ret != 0:
-                self.Logger.critical("Failed in check aarch64")
-                return ret
+            # Start with AAACH64 compiler
+            if "AARCH64" in thebuilder.env.GetValue("TARGET_ARCH", "AARCH64"):
+                ret = self._check_aarch64(toolchain)
+                if ret != 0:
+                    self.Logger.critical("Failed in check aarch64")
+                    return ret
 
             # Check RISCV64 compiler
-            ret = self._check_riscv64(toolchain)
-            if ret != 0:
-                self.Logger.critical("Failed in check riscv64")
-                return ret
+            if "RISCV64" in thebuilder.env.GetValue("TARGET_ARCH", "RISCV64"):
+                ret = self._check_riscv64(toolchain)
+                if ret != 0:
+                    self.Logger.critical("Failed in check riscv64")
+                    return ret
 
             # Check LoongArch64 compiler
-            ret = self._check_loongarch64(toolchain)
-            if ret != 0:
-                self.Logger.critical("Failed in check loongarch64")
-                return ret
+            if "LOONGARCH64" in thebuilder.env.GetValue("TARGET_ARCH", "LOONGARCH64"):
+                ret = self._check_loongarch64(toolchain)
+                if ret != 0:
+                    self.Logger.critical("Failed in check loongarch64")
+                    return ret
 
         return 0
 


### PR DESCRIPTION
## Description

LinuxGccToolChain is checking for the environment variable GCC_AARCH64_PREFIX when GCC_AARCH64_INSTALL is set in the environment variables. GCC_AARCH64_INSTALL is set when any gcc aarch64 compiler is installed (i.e. aarch64-none-elf, aarch64-linux-gnu, aarch64-unknown-elf all result in a GCC_AARCH64_INSTALL environment variable).

When compiling for an X86 target, if an AARCH64 tool chain is installed in the system, this will result in an error due to the GCC_AARCH64_PREFIX not being set.

Add a check based upon TARGET_ARCH and and only verify the prefixes when attempting to build AARCH64.

Replicate the same check for RISCV and LOONGARCH64 architectures as well.


(cherry picked from commit b7cf7e465c402f9b32dcadc791ba37f2db750522)

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Ubuntu WSL with aarch64 compiler installed building X64 target failed. Passed after change.

## Integration Instructions
No integration necessary.