### PR TITLE
[CHERRY-PICK] Replace mu change patches with edk2 commits

### DIFF
--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
@@ -23,6 +23,7 @@
 #include <Library/DebugLib.h>
 #include <Library/HobLib.h>
 #include <Library/PcdLib.h>
+#include <Library/SafeIntLib.h>
 
 #include <IndustryStandard/ArmFfaSvc.h>
 #include <IndustryStandard/ArmFfaPartInfo.h>
@@ -509,6 +510,46 @@ ErrorHandler:
   }
 
   return Status;
+}
+
+/**
+  Invoked by an endpoint to yield control back to the component
+  that called it. This prevents long running transactions from
+  being caught up in the secure world. Endpoint will need to be
+  invoked with FFA_RUN after the specified timeout.
+
+  @param [in]   TimeoutUs    The timeout indicating the time in which
+                             the endpoint is required to be run in
+                             microseconds.
+
+  @return EFI_SUCCESS
+  @return Other              Error
+
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaLibYield (
+  IN  UINT64  TimeoutUs
+  )
+{
+  ARM_FFA_ARGS   FfaArgs;
+  UINT64         TimeoutNs;
+  RETURN_STATUS  ReturnStatus;
+
+  ZeroMem (&FfaArgs, sizeof (ARM_FFA_ARGS));
+
+  ReturnStatus = SafeUint64Mult (TimeoutUs, 1000, &TimeoutNs);
+  if (ReturnStatus != RETURN_SUCCESS) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  FfaArgs.Arg0 = ARM_FID_FFA_YIELD;
+  FfaArgs.Arg2 = (UINT32)TimeoutNs;
+  FfaArgs.Arg3 = (UINT32)(TimeoutNs >> 32);
+
+  ArmCallFfa (&FfaArgs);
+
+  return FfaArgsToEfiStatus (&FfaArgs);
 }
 
 /**

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
@@ -23,7 +23,6 @@
 #include <Library/DebugLib.h>
 #include <Library/HobLib.h>
 #include <Library/PcdLib.h>
-#include <Library/TimerLib.h>  // MU_CHANGE: Handle FFA_YIELD with timeout
 
 #include <IndustryStandard/ArmFfaSvc.h>
 #include <IndustryStandard/ArmFfaPartInfo.h>
@@ -124,7 +123,6 @@ FfaArgsToEfiStatus (
   )
 {
   UINT32  FfaStatus;
-  UINT64  Timeout;  // MU_CHANGE: Handle FFA_YIELD with timeout
 
   if (FfaArgs == NULL) {
     FfaStatus = ARM_FFA_RET_INVALID_PARAMETERS;
@@ -144,22 +142,6 @@ FfaArgsToEfiStatus (
     FfaStatus = ARM_FFA_RET_NOT_SUPPORTED;
   } else if ((FfaArgs->Arg0 == ARM_FID_FFA_INTERRUPT) || (FfaArgs->Arg0 == ARM_FID_FFA_YIELD)) {
     FfaStatus = ARM_FFA_RET_INTERRUPTED;
-    // MU_CHANGE starts: Handle FFA_YIELD with timeout
-  } else if (FfaArgs->Arg0 == ARM_FID_FFA_YIELD) {
-    /*
-    * If the FF-A ABI indicates that the call was yielded, we need to pull the
-    * timeout period from Arg2 and Arg3.
-    */
-    Timeout = LShiftU64 (FfaArgs->Arg3, 32) | FfaArgs->Arg2;
-    if (Timeout != 0) {
-      /*
-      * If the timeout is non-zero, we handle the delay here.
-      */
-      NanoSecondDelay (Timeout);
-    }
-
-    FfaStatus = ARM_FFA_RET_INTERRUPTED;
-    // MU_CHANGE ends: Handle FFA_YIELD with timeout
   } else {
     FfaStatus = ARM_FFA_RET_SUCCESS;
   }

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
@@ -23,8 +23,7 @@
 #include <Library/DebugLib.h>
 #include <Library/HobLib.h>
 #include <Library/PcdLib.h>
-#include <Library/TimerLib.h>   // MU_CHANGE: Handle FFA_YIELD with timeout
-#include <Library/SafeIntLib.h> // MU_CHANGE: Yield conversion from us to ns
+#include <Library/TimerLib.h>  // MU_CHANGE: Handle FFA_YIELD with timeout
 
 #include <IndustryStandard/ArmFfaSvc.h>
 #include <IndustryStandard/ArmFfaPartInfo.h>
@@ -529,49 +528,6 @@ ErrorHandler:
 
   return Status;
 }
-
-// MU_CHANGE - [BEGIN]
-
-/**
- * Invoked by an endpoint to yield control back to the component
- * that called it. This prevents long running transactions from
- * being caught up in the secure world. Endpoint will need to be
- * invoked with FFA_RUN after the specified timeout.
- *
- * @param [in]   TimeoutUs    The timeout indicating the time in which
- *                            the endpoint is required to be run in
- *                            microseconds.
- *
- * @return EFI_SUCCESS
- * @return Other              Error
- */
-EFI_STATUS
-EFIAPI
-ArmFfaLibYield (
-  IN  UINT64  TimeoutUs
-  )
-{
-  ARM_FFA_ARGS   FfaArgs;
-  UINT64         TimeoutNs;
-  RETURN_STATUS  ReturnStatus;
-
-  ZeroMem (&FfaArgs, sizeof (ARM_FFA_ARGS));
-
-  ReturnStatus = SafeUint64Mult (TimeoutUs, 1000, &TimeoutNs);
-  if (ReturnStatus != RETURN_SUCCESS) {
-    return EFI_INVALID_PARAMETER;
-  }
-
-  FfaArgs.Arg0 = ARM_FID_FFA_YIELD;
-  FfaArgs.Arg2 = (UINT32)TimeoutNs;
-  FfaArgs.Arg3 = (UINT32)(TimeoutNs >> 32);
-
-  ArmCallFfa (&FfaArgs);
-
-  return FfaArgsToEfiStatus (&FfaArgs);
-}
-
-// MU_CHANGE - [END]
 
 /**
   Get number of Partitions via registers.

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaDxeLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaDxeLib.inf
@@ -34,6 +34,7 @@
   DebugLib
   HobLib
   MemoryAllocationLib
+  SafeIntLib
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaDxeLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaDxeLib.inf
@@ -34,8 +34,6 @@
   DebugLib
   HobLib
   MemoryAllocationLib
-  SafeIntLib # MU_CHANGE
-  TimerLib  # MU_CHANGE
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.inf
@@ -34,6 +34,7 @@
   DebugLib
   HobLib
   MemoryAllocationLib
+  SafeIntLib
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaPeiLib.inf
@@ -34,8 +34,6 @@
   DebugLib
   HobLib
   MemoryAllocationLib
-  SafeIntLib # MU_CHANGE
-  TimerLib  # MU_CHANGE
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecLib.inf
@@ -34,6 +34,7 @@
   DebugLib
   HobLib
   MemoryAllocationLib
+  SafeIntLib
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaSecLib.inf
@@ -34,7 +34,6 @@
   DebugLib
   HobLib
   MemoryAllocationLib
-  TimerLib  # MU_CHANGE
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf
@@ -36,6 +36,7 @@
   HobLib
   MemoryAllocationLib
   MmServicesTableLib
+  SafeIntLib
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf
@@ -36,7 +36,6 @@
   HobLib
   MemoryAllocationLib
   MmServicesTableLib
-  TimerLib  # MU_CHANGE
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.inf
@@ -36,6 +36,7 @@
   HobLib
   MemoryAllocationLib
   MmServicesTableLib
+  SafeIntLib
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.inf
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.inf
@@ -36,7 +36,6 @@
   HobLib
   MemoryAllocationLib
   MmServicesTableLib
-  TimerLib  # MU_CHANGE
 
 [Pcd]
   gEfiMdeModulePkgTokenSpaceGuid.PcdFfaLibConduitSmc

--- a/MdePkg/Include/Library/ArmFfaLib.h
+++ b/MdePkg/Include/Library/ArmFfaLib.h
@@ -343,6 +343,26 @@ ArmFfaLibSpmIdGet (
   );
 
 /**
+  Invoked by an endpoint to yield control back to the component
+  that called it. This prevents long running transactions from
+  being caught up in the secure world. Endpoint will need to be
+  invoked with FFA_RUN after the specified timeout.
+
+  @param [in]   TimeoutUs    The timeout indicating the time in which
+                             the endpoint is required to be run in
+                             microseconds.
+
+  @return EFI_SUCCESS
+  @return Other              Error
+
+**/
+EFI_STATUS
+EFIAPI
+ArmFfaLibYield (
+  IN  UINT64  TimeoutUs
+  );
+
+/**
   Restore context which interrupted with FFA_INTERRUPT (EFI_INTERRUPT_PENDING).
 
   @param [in]   PartId       Partition id

--- a/MdePkg/Include/Library/ArmFfaLib.h
+++ b/MdePkg/Include/Library/ArmFfaLib.h
@@ -342,29 +342,6 @@ ArmFfaLibSpmIdGet (
   OUT UINT16  *SpmPartId
   );
 
-// MU_CHANGE - [BEGIN]
-
-/**
- * Invoked by an endpoint to yield control back to the component
- * that called it. This prevents long running transactions from
- * being caught up in the secure world. Endpoint will need to be
- * invoked with FFA_RUN after the specified timeout.
- *
- * @param [in]   TimeoutUs    The timeout indicating the time in which
- *                            the endpoint is required to be run in
- *                            microseconds.
- *
- * @return EFI_SUCCESS
- * @return Other              Error
- */
-EFI_STATUS
-EFIAPI
-ArmFfaLibYield (
-  IN  UINT64  TimeoutUs
-  );
-
-// MU_CHANGE - [END]
-
 /**
   Restore context which interrupted with FFA_INTERRUPT (EFI_INTERRUPT_PENDING).
 


### PR DESCRIPTION
## Description

This change reverts two commits. One of them was upstreamed into edk2 2511 but was transformed during the upstreaming process. The other was upstreamed into edk2 later than 2511 but never cherry-picked back into Mu, and it contains a bug fix for the original Mu change.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This does not involve functional changes. But tested on physical ARM platforms and booted to Windows desktop.

## Integration Instructions

N/A
