### PR TITLE
Support reblock

### DIFF
--- a/MdeModulePkg/Universal/Variable/Pei/Variable.c
+++ b/MdeModulePkg/Universal/Variable/Pei/Variable.c
@@ -1479,13 +1479,14 @@ BuildVariableRuntimeCacheInfoHob (
     //
     Buffer = AllocateRuntimePages (Pages);
     ASSERT (Buffer != NULL);
-    Status = MmUnblockMemoryRequest (
-               (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
-               Pages
-               );
-    if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-      return Status;
-    }
+  }
+
+  Status = MmUnblockMemoryRequest (
+              (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
+              Pages
+              );
+  if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+    return Status;
   }
 
   // MU_CHANGE [END]
@@ -1514,13 +1515,14 @@ BuildVariableRuntimeCacheInfoHob (
       //
       Buffer = AllocateRuntimePages (Pages);
       ASSERT (Buffer != NULL);
-      Status = MmUnblockMemoryRequest (
-                 (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
-                 Pages
-                 );
-      if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-        return Status;
-      }
+    }
+
+    Status = MmUnblockMemoryRequest (
+                (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
+                Pages
+                );
+    if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+      return Status;
     }
 
     TempHobBuffer.RuntimeVolatileCacheBuffer = (UINTN)Buffer;
@@ -1552,13 +1554,14 @@ BuildVariableRuntimeCacheInfoHob (
       //
       Buffer = AllocateRuntimePages (Pages);
       ASSERT (Buffer != NULL);
-      Status = MmUnblockMemoryRequest (
-                 (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
-                 Pages
-                 );
-      if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-        return Status;
-      }
+    }
+
+    Status = MmUnblockMemoryRequest (
+                (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
+                Pages
+                );
+    if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+      return Status;
     }
 
     TempHobBuffer.RuntimeNvCacheBuffer = (UINTN)Buffer;
@@ -1590,13 +1593,14 @@ BuildVariableRuntimeCacheInfoHob (
       //
       Buffer = AllocateRuntimePages (Pages);
       ASSERT (Buffer != NULL);
-      Status = MmUnblockMemoryRequest (
-                 (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
-                 Pages
-                 );
-      if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-        return Status;
-      }
+    }
+
+    Status = MmUnblockMemoryRequest (
+                (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
+                Pages
+                );
+    if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+      return Status;
     }
 
     TempHobBuffer.RuntimeHobCacheBuffer = (UINTN)Buffer;

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
@@ -1813,12 +1813,14 @@ InitVariableCache (
         if (TempCacheInfoBuffer != 0) {
           RuntimeBuffer = (VOID *)(UINTN)TempCacheInfoBuffer;
           CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.CacheInfoFlagBuffer, sizeof (CACHE_INFO_FLAG));
+          MmReblockMemoryRequest (mVariableRtCacheInfo.CacheInfoFlagBuffer, EFI_SIZE_TO_PAGES (sizeof (CACHE_INFO_FLAG)));
           mVariableRtCacheInfo.CacheInfoFlagBuffer = TempCacheInfoBuffer;
         }
 
         if (TempHobCacheBuffer != 0) {
           RuntimeBuffer = (VOID *)(UINTN)TempHobCacheBuffer;
           CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeHobCacheBuffer, AllocatedHobCacheSize);
+          MmReblockMemoryRequest (mVariableRtCacheInfo.RuntimeHobCacheBuffer, EFI_SIZE_TO_PAGES (AllocatedHobCacheSize));
           mVariableRtCacheInfo.RuntimeHobCacheBuffer = TempHobCacheBuffer;
           InitVariableStoreHeader (RuntimeBuffer, AllocatedHobCacheSize);
         }
@@ -1826,6 +1828,7 @@ InitVariableCache (
         if (TempNvCacheBuffer != 0) {
           RuntimeBuffer = (VOID *)(UINTN)TempNvCacheBuffer;
           CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeNvCacheBuffer, AllocatedNvCacheSize);
+          MmReblockMemoryRequest (mVariableRtCacheInfo.RuntimeNvCacheBuffer, EFI_SIZE_TO_PAGES (AllocatedNvCacheSize));
           mVariableRtCacheInfo.RuntimeNvCacheBuffer = TempNvCacheBuffer;
           InitVariableStoreHeader (RuntimeBuffer, AllocatedNvCacheSize);
         }
@@ -1833,6 +1836,7 @@ InitVariableCache (
         if (TempVolatileCacheBuffer != 0) {
           RuntimeBuffer = (VOID *)(UINTN)TempVolatileCacheBuffer;
           CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeVolatileCacheBuffer, AllocatedVolatileCacheSize);
+          MmReblockMemoryRequest (mVariableRtCacheInfo.RuntimeVolatileCacheBuffer, EFI_SIZE_TO_PAGES (AllocatedVolatileCacheSize));
           mVariableRtCacheInfo.RuntimeVolatileCacheBuffer = TempVolatileCacheBuffer;
           InitVariableStoreHeader (RuntimeBuffer, AllocatedVolatileCacheSize);
         }

--- a/MdePkg/Include/Library/MmUnblockMemoryLib.h
+++ b/MdePkg/Include/Library/MmUnblockMemoryLib.h
@@ -41,4 +41,33 @@ MmUnblockMemoryRequest (
   IN UINT64            NumberOfPages
   );
 
+// MU_CHANGE Starts: MM_SUPV: Added reblock API as well, which is the reverse operation of unblock.
+/**
+  This API provides a way to reblock certain data pages to be inaccessible inside MM environment.
+  The reblock operation is the reverse of unblock operation, which means the input address and page
+  number should be already unblocked before, otherwise the reblock request will be rejected.
+
+  @param  ReblockAddress              The address of buffer caller requests to reblock, the address
+                                      has to be page aligned.
+  @param  NumberOfPages               The number of pages requested to be reblocked from MM
+                                      environment.
+
+  @retval RETURN_SUCCESS              The request goes through successfully.
+  @retval RETURN_NOT_AVAILABLE_YET    The requested functionality is not produced yet.
+  @retval RETURN_UNSUPPORTED          The requested functionality is not supported on current platform.
+  @retval RETURN_SECURITY_VIOLATION   The requested address failed to pass security check for
+                                      reblocking.
+  @retval RETURN_INVALID_PARAMETER    Input address either NULL pointer or not page aligned.
+  @retval RETURN_ACCESS_DENIED        The request is rejected due to system has passed certain boot
+                                      phase.
+
+**/
+RETURN_STATUS
+EFIAPI
+MmReblockMemoryRequest (
+  IN PHYSICAL_ADDRESS  ReblockAddress,
+  IN UINT64            NumberOfPages
+  );
+// MU_CHANGE Ends: MM_SUPV: Added reblock API as well, which is the reverse operation of unblock.
+
 #endif // MM_UNBLOCK_MEMORY_LIB_H_


### PR DESCRIPTION
## Description

Current method of migrating MM accessible buffers is leaving the previously unblocked buffers unblocked, which will pose the risk of failing DRTM validation.

This change adds a new interface to support reblock pages to mitigate the issue.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested using QEMU Q35 and booted to UEFI shell.

## Integration Instructions

Call `MmReblockMemoryRequest` after the old buffer is being replaced.