### PR TITLE
SecurityPkg: Remove Globals from HashLibTpm2PeilessSec

### DIFF
--- a/SecurityPkg/Include/Library/Tpm2HelpLib.h
+++ b/SecurityPkg/Include/Library/Tpm2HelpLib.h
@@ -39,6 +39,7 @@ GetHashMaskFromAlgo (
   );
 
 // MU_CHANGE - [BEGIN]
+
 /**
   Get hash algorithm from mask.
 
@@ -73,8 +74,9 @@ GetHashInfoSize (
 UINT32
 EFIAPI
 GetHashMaskAtIndex (
-  IN UINT32 Index
+  IN UINT32  Index
   );
+
 // MU_CHANGE - [END]
 
 /**

--- a/SecurityPkg/Include/Library/Tpm2HelpLib.h
+++ b/SecurityPkg/Include/Library/Tpm2HelpLib.h
@@ -38,6 +38,45 @@ GetHashMaskFromAlgo (
   IN TPMI_ALG_HASH  HashAlgo
   );
 
+// MU_CHANGE - [BEGIN]
+/**
+  Get hash algorithm from mask.
+
+  @param[in] HashMask   Hash mask
+
+  @return Hash algorithm
+**/
+TPMI_ALG_HASH
+EFIAPI
+GetHashAlgoFromMask (
+  IN UINT32  HashMask
+  );
+
+/**
+  Get internal hash info size.
+
+  @return Hash info size
+**/
+UINTN
+EFIAPI
+GetHashInfoSize (
+  VOID
+  );
+
+/**
+  Get hash mask at specified index.
+
+  @param[in] Index   Index requested
+
+  @return Hash mask at the specified index
+**/
+UINT32
+EFIAPI
+GetHashMaskAtIndex (
+  IN UINT32 Index
+  );
+// MU_CHANGE - [END]
+
 /**
   Copy AuthSessionIn to TPM2 command buffer.
 

--- a/SecurityPkg/Include/Library/Tpm2HelpLib.h
+++ b/SecurityPkg/Include/Library/Tpm2HelpLib.h
@@ -1,4 +1,5 @@
 /** @file
+  MU_CHANGE
   Definitions for TPM2 helper functions
 
 Copyright (c), Microsoft Corporation.
@@ -38,8 +39,6 @@ GetHashMaskFromAlgo (
   IN TPMI_ALG_HASH  HashAlgo
   );
 
-// MU_CHANGE - [BEGIN]
-
 /**
   Get hash algorithm from mask.
 
@@ -49,7 +48,7 @@ GetHashMaskFromAlgo (
 **/
 TPMI_ALG_HASH
 EFIAPI
-GetHashAlgoFromMask (
+Tpm2GetHashAlgoFromMask (
   IN UINT32  HashMask
   );
 
@@ -60,7 +59,7 @@ GetHashAlgoFromMask (
 **/
 UINTN
 EFIAPI
-GetHashInfoSize (
+Tpm2GetHashInfoSize (
   VOID
   );
 
@@ -73,11 +72,9 @@ GetHashInfoSize (
 **/
 UINT32
 EFIAPI
-GetHashMaskAtIndex (
+Tpm2GetHashMaskAtIndex (
   IN UINT32  Index
   );
-
-// MU_CHANGE - [END]
 
 /**
   Copy AuthSessionIn to TPM2 command buffer.

--- a/SecurityPkg/Library/HashLibTpm2/HashLibTpm2PeilessSecLib.c
+++ b/SecurityPkg/Library/HashLibTpm2/HashLibTpm2PeilessSecLib.c
@@ -94,6 +94,7 @@ GetTransferList (
 }
 
 // MU_CHANGE - [BEGIN]
+
 /**
   Get supported hash bitmap
 
@@ -109,7 +110,7 @@ STATIC
 EFI_STATUS
 EFIAPI
 GetSupportedHashBitmap (
-  OUT UINT32 *SupportedHashBitmap
+  OUT UINT32  *SupportedHashBitmap
   )
 {
   EFI_STATUS                       Status;
@@ -143,8 +144,11 @@ GetSupportedHashBitmap (
     return Status;
   }
 
+  // NOTE: TpmHashBitmap is what the TPM supports, PcrHashBitmap is what is currently active
+  DEBUG ((DEBUG_INFO, "TpmHashBitmap: %x, PcrHashBitmap: %x\n", TpmHashBitmap, PcrHashBitmap));
+
   UseTlHashBitmap = FALSE;
-  Status = GetTransferList (&TransferList);
+  Status          = GetTransferList (&TransferList);
   if (EFI_ERROR (Status)) {
     DEBUG ((DEBUG_ERROR, "%a: Unable to acquire Transfer list...\n", __func__));
     goto Exit;
@@ -175,6 +179,12 @@ GetSupportedHashBitmap (
     *SupportedHashBitmap |= GetHashMaskFromAlgo (DigestSize[Idx].algorithmId);
   }
 
+  // The active PCR banks should match what is reported in the TCG event log
+  if (PcrHashBitmap != *SupportedHashBitmap) {
+    DEBUG ((DEBUG_ERROR, "Active PCRs & Transfer List mismatch!\n"));
+    UseTlHashBitmap = FALSE;
+  }
+
 Exit:
   if (!UseTlHashBitmap) {
     // Use the information from the TPM to update the supported hash bitmap
@@ -193,6 +203,7 @@ Exit:
 }
 
 #if 0
+
 /**
   The function get algorithm from hash mask info.
 
@@ -297,6 +308,7 @@ ClearSequenceHandles (
     mTpm2HashMask[Idx].SequenceHandle = BAD_SEQ_HANDLE;
   }
 }
+
 #endif
 // MU_CHANGE - [END]
 
@@ -315,16 +327,16 @@ HashStart (
   OUT HASH_HANDLE  *HashHandle
   )
 {
-  EFI_STATUS   Status;
-  TPM_ALG_ID   AlgoId;
-  UINT32       Idx;
+  EFI_STATUS  Status;
+  TPM_ALG_ID  AlgoId;
+  UINT32      Idx;
   // MU_CHANGE - [BEGIN]
   UINT32       SupportedHashBitmap;
   HASH_HANDLE  *HashCtx;
   UINTN        HashInfoSize;
 
   SupportedHashBitmap = 0;
-  Status = GetSupportedHashBitmap(&SupportedHashBitmap);
+  Status              = GetSupportedHashBitmap (&SupportedHashBitmap);
   if (EFI_ERROR (Status)) {
     return Status;
   }
@@ -333,23 +345,23 @@ HashStart (
     return EFI_DEVICE_ERROR;
   }
 
-  HashInfoSize = GetHashInfoSize();
-  HashCtx = AllocatePool (HashInfoSize * sizeof (HASH_HANDLE));
+  HashInfoSize = GetHashInfoSize ();
+  HashCtx      = AllocatePool (HashInfoSize * sizeof (HASH_HANDLE));
   if (HashCtx == NULL) {
     return EFI_OUT_OF_RESOURCES;
   }
 
   for (Idx = 0; Idx < HashInfoSize; Idx++) {
-    if ((GetHashMaskAtIndex(Idx) & SupportedHashBitmap) == 0) {
+    if ((GetHashMaskAtIndex (Idx) & SupportedHashBitmap) == 0) {
       continue;
     }
 
-    AlgoId = GetHashAlgoFromMask (GetHashMaskAtIndex(Idx));
+    AlgoId = GetHashAlgoFromMask (GetHashMaskAtIndex (Idx));
     if (AlgoId == TPM_ALG_ERROR) {
       return EFI_UNSUPPORTED;
     }
 
-    Status = Tpm2HashSequenceStart (AlgoId, (TPMI_DH_OBJECT*)&HashCtx[Idx]);
+    Status = Tpm2HashSequenceStart (AlgoId, (TPMI_DH_OBJECT *)&HashCtx[Idx]);
     if (EFI_ERROR (Status)) {
       return Status;
     }
@@ -379,19 +391,19 @@ HashUpdate (
   IN UINTN        DataToHashLen
   )
 {
-  EFI_STATUS        Status;
-  UINT32            Idx;
-  //UINT32            HashMask; // MU_CHANGE
+  EFI_STATUS  Status;
+  UINT32      Idx;
+  // UINT32            HashMask; // MU_CHANGE
   UINT8             *Buffer;
   UINT64            HashLen;
   TPM2B_MAX_BUFFER  HashBuffer;
   // MU_CHANGE - [BEGIN]
-  UINT32            SupportedHashBitmap;
-  HASH_HANDLE       *HashCtx;
-  UINTN             HashInfoSize;
+  UINT32       SupportedHashBitmap;
+  HASH_HANDLE  *HashCtx;
+  UINTN        HashInfoSize;
 
   SupportedHashBitmap = 0;
-  Status = GetSupportedHashBitmap(&SupportedHashBitmap);
+  Status              = GetSupportedHashBitmap (&SupportedHashBitmap);
   // MU_CHANGE - [END]
   if (EFI_ERROR (Status)) {
     return Status;
@@ -402,11 +414,11 @@ HashUpdate (
     return EFI_DEVICE_ERROR;
   }
 
-  HashCtx = (HASH_HANDLE*)HashHandle;
+  HashCtx = (HASH_HANDLE *)HashHandle;
 
-  HashInfoSize = GetHashInfoSize();
+  HashInfoSize = GetHashInfoSize ();
   for (Idx = 0; Idx < HashInfoSize; Idx++) {
-    if ((GetHashMaskAtIndex(Idx) & SupportedHashBitmap) == 0) {
+    if ((GetHashMaskAtIndex (Idx) & SupportedHashBitmap) == 0) {
       // MU_CHANGE - [END]
       continue;
     }
@@ -457,39 +469,42 @@ HashCompleteAndExtend (
   OUT TPML_DIGEST_VALUES  *DigestList
   )
 {
-  EFI_STATUS        Status;
-  UINT32            Idx;
-  UINT32            DigestIdx;
-  //UINT32            HashMask; // MU_CHANGE
+  EFI_STATUS  Status;
+  UINT32      Idx;
+  UINT32      DigestIdx;
+  // UINT32            HashMask; // MU_CHANGE
   UINT8             *Buffer;
   UINT64            HashLen;
   TPM2B_MAX_BUFFER  HashBuffer;
   TPM_ALG_ID        AlgoId;
   TPM2B_DIGEST      Result;
   // MU_CHANGE - [BEGIN]
-  UINT32            SupportedHashBitmap;
-  HASH_HANDLE       *HashCtx;
-  UINTN             HashInfoSize;
+  UINT32       SupportedHashBitmap;
+  HASH_HANDLE  *HashCtx;
+  UINTN        HashInfoSize;
 
   SupportedHashBitmap = 0;
-  Status = GetSupportedHashBitmap(&SupportedHashBitmap);
+  Status              = GetSupportedHashBitmap (&SupportedHashBitmap);
   if (EFI_ERROR (Status)) {
-    goto Error;
+    return Status;
   }
 
   if (SupportedHashBitmap == 0) {
     return EFI_DEVICE_ERROR;
   }
+
   // MU_CHANGE - [END]
 
   ZeroMem (DigestList, sizeof (*DigestList));
   DigestList->count = HASH_COUNT;
   DigestIdx         = 0;
-  HashCtx           = (HASH_HANDLE*)HashHandle; // MU_CHANGE
+  HashCtx           = (HASH_HANDLE *)HashHandle; // MU_CHANGE
 
-  HashInfoSize = GetHashInfoSize();
-  for (Idx = 0; Idx < HashInfoSize; Idx++) { // MU_CHANGE
-    if ((GetHashMaskAtIndex(Idx) & SupportedHashBitmap) == 0) { // MU_CHANGE
+  HashInfoSize = GetHashInfoSize ();
+  for (Idx = 0; Idx < HashInfoSize; Idx++) {
+    // MU_CHANGE
+    if ((GetHashMaskAtIndex (Idx) & SupportedHashBitmap) == 0) {
+      // MU_CHANGE
       continue;
     }
 
@@ -515,11 +530,12 @@ HashCompleteAndExtend (
     }
 
     // MU_CHANGE - [BEGIN]
-    AlgoId = GetHashAlgoFromMask (GetHashMaskAtIndex(Idx));
+    AlgoId = GetHashAlgoFromMask (GetHashMaskAtIndex (Idx));
     if (AlgoId == TPM_ALG_ERROR) {
       Status = EFI_UNSUPPORTED;
       goto Error;
     }
+
     // MU_CHANGE - [END]
 
     // Copy the result of hash.
@@ -570,13 +586,13 @@ HashAndExtend (
   UINT32            Idx;
   UINT32            DigestIdx;
   UINT32            SupportedHashBitmap; // MU_CHANGE
-  UINT32            HashInfoSize; // MU_CHANGE
+  UINT32            HashInfoSize;        // MU_CHANGE
 
   DEBUG ((DEBUG_VERBOSE, "\n HashAndExtend Entry \n"));
 
   // MU_CHANGE - [BEGIN]
   SupportedHashBitmap = 0;
-  Status = GetSupportedHashBitmap (&SupportedHashBitmap);
+  Status              = GetSupportedHashBitmap (&SupportedHashBitmap);
   if (EFI_ERROR (Status)) {
     return Status;
   }
@@ -584,24 +600,28 @@ HashAndExtend (
   if (SupportedHashBitmap == 0x00) {
     return EFI_DEVICE_ERROR;
   }
+
   // MU_CHANGE - [END]
 
   ZeroMem (DigestList, sizeof (*DigestList));
   DigestList->count = HASH_COUNT;
   DigestIdx         = 0;
 
-  HashInfoSize = GetHashInfoSize(); // MU_CHANGE
-  for (Idx = 0; Idx < HashInfoSize; Idx++) { // MU_CHANGE
-    if ((GetHashMaskAtIndex(Idx) & SupportedHashBitmap) == 0) { // MU_CHANGE
+  HashInfoSize = GetHashInfoSize (); // MU_CHANGE
+  for (Idx = 0; Idx < HashInfoSize; Idx++) {
+    // MU_CHANGE
+    if ((GetHashMaskAtIndex (Idx) & SupportedHashBitmap) == 0) {
+      // MU_CHANGE
       continue;
     }
 
     // MU_CHANGE - [BEGIN]
-    DEBUG ((DEBUG_INFO, "Hashing with Mask: %x\n", GetHashMaskAtIndex(Idx)));
-    AlgoId = GetHashAlgoFromMask (GetHashMaskAtIndex(Idx));
+    DEBUG ((DEBUG_INFO, "Hashing with Mask: %x\n", GetHashMaskAtIndex (Idx)));
+    AlgoId = GetHashAlgoFromMask (GetHashMaskAtIndex (Idx));
     if (AlgoId == TPM_ALG_ERROR) {
       return EFI_UNSUPPORTED;
     }
+
     // MU_CHANGE - [END]
 
     Status = Tpm2HashSequenceStart (AlgoId, &SequenceHandle);
@@ -644,7 +664,7 @@ HashAndExtend (
   DigestList->count = DigestIdx;
 
   DEBUG ((DEBUG_INFO, "Extending to PCR%d\n", PcrIndex)); // MU_CHANGE
-  Status = Tpm2PcrExtend (PcrIndex,DigestList); // MU_CHANGE
+  Status = Tpm2PcrExtend (PcrIndex, DigestList);          // MU_CHANGE
   if (EFI_ERROR (Status)) {
     return EFI_DEVICE_ERROR;
   }
@@ -675,6 +695,7 @@ RegisterHashInterfaceLib (
 
 // MU_CHANGE - [BEGIN]
 #if 0
+
 /**
   Constructor of HashLibTpm2PeilessSecLibConstructor.
 
@@ -751,5 +772,6 @@ HasLibTpm2PeilessSecLibConstructor (
 DisableHandler:
   return EFI_SUCCESS;
 }
+
 #endif
 // MU_CHANGE - [END]

--- a/SecurityPkg/Library/HashLibTpm2/HashLibTpm2PeilessSecLib.c
+++ b/SecurityPkg/Library/HashLibTpm2/HashLibTpm2PeilessSecLib.c
@@ -1,7 +1,7 @@
 /** @file
   // MU_CHANGE
   This library is the PeilessSec version of the HashLib. It will
-  initate a hash on each supported hash algorithm via the TPM or
+  initiate a hash on each supported hash algorithm via the TPM or
   TransferList.
 
   Copyright (c) 2025, Arm Limited. All rights reserved.<BR>
@@ -126,8 +126,6 @@ GetSupportedHashBitmap (
   UINT32                           PcrHashBitmap;
   BOOLEAN                          UseTlHashBitmap;
 
-  DEBUG ((DEBUG_INFO, "%a - Entry\n", __func__));
-
   if (SupportedHashBitmap == NULL) {
     return EFI_INVALID_PARAMETER;
   }
@@ -196,8 +194,6 @@ Exit:
   if (*SupportedHashBitmap == 0x00) {
     DEBUG ((DEBUG_ERROR, "%a: No supported Hash algorithm with event log Spec...!\n", __func__));
   }
-
-  DEBUG ((DEBUG_INFO, "%a - Exit\n", __func__));
 
   return EFI_SUCCESS;
 }
@@ -345,18 +341,18 @@ HashStart (
     return EFI_DEVICE_ERROR;
   }
 
-  HashInfoSize = GetHashInfoSize ();
+  HashInfoSize = Tpm2GetHashInfoSize ();
   HashCtx      = AllocatePool (HashInfoSize * sizeof (HASH_HANDLE));
   if (HashCtx == NULL) {
     return EFI_OUT_OF_RESOURCES;
   }
 
   for (Idx = 0; Idx < HashInfoSize; Idx++) {
-    if ((GetHashMaskAtIndex (Idx) & SupportedHashBitmap) == 0) {
+    if ((Tpm2GetHashMaskAtIndex (Idx) & SupportedHashBitmap) == 0) {
       continue;
     }
 
-    AlgoId = GetHashAlgoFromMask (GetHashMaskAtIndex (Idx));
+    AlgoId = Tpm2GetHashAlgoFromMask (Tpm2GetHashMaskAtIndex (Idx));
     if (AlgoId == TPM_ALG_ERROR) {
       return EFI_UNSUPPORTED;
     }
@@ -416,9 +412,9 @@ HashUpdate (
 
   HashCtx = (HASH_HANDLE *)HashHandle;
 
-  HashInfoSize = GetHashInfoSize ();
+  HashInfoSize = Tpm2GetHashInfoSize ();
   for (Idx = 0; Idx < HashInfoSize; Idx++) {
-    if ((GetHashMaskAtIndex (Idx) & SupportedHashBitmap) == 0) {
+    if ((Tpm2GetHashMaskAtIndex (Idx) & SupportedHashBitmap) == 0) {
       // MU_CHANGE - [END]
       continue;
     }
@@ -500,10 +496,10 @@ HashCompleteAndExtend (
   DigestIdx         = 0;
   HashCtx           = (HASH_HANDLE *)HashHandle; // MU_CHANGE
 
-  HashInfoSize = GetHashInfoSize ();
+  HashInfoSize = Tpm2GetHashInfoSize ();
   for (Idx = 0; Idx < HashInfoSize; Idx++) {
     // MU_CHANGE
-    if ((GetHashMaskAtIndex (Idx) & SupportedHashBitmap) == 0) {
+    if ((Tpm2GetHashMaskAtIndex (Idx) & SupportedHashBitmap) == 0) {
       // MU_CHANGE
       continue;
     }
@@ -530,7 +526,7 @@ HashCompleteAndExtend (
     }
 
     // MU_CHANGE - [BEGIN]
-    AlgoId = GetHashAlgoFromMask (GetHashMaskAtIndex (Idx));
+    AlgoId = Tpm2GetHashAlgoFromMask (Tpm2GetHashMaskAtIndex (Idx));
     if (AlgoId == TPM_ALG_ERROR) {
       Status = EFI_UNSUPPORTED;
       goto Error;
@@ -607,17 +603,17 @@ HashAndExtend (
   DigestList->count = HASH_COUNT;
   DigestIdx         = 0;
 
-  HashInfoSize = GetHashInfoSize (); // MU_CHANGE
+  HashInfoSize = Tpm2GetHashInfoSize (); // MU_CHANGE
   for (Idx = 0; Idx < HashInfoSize; Idx++) {
     // MU_CHANGE
-    if ((GetHashMaskAtIndex (Idx) & SupportedHashBitmap) == 0) {
+    if ((Tpm2GetHashMaskAtIndex (Idx) & SupportedHashBitmap) == 0) {
       // MU_CHANGE
       continue;
     }
 
     // MU_CHANGE - [BEGIN]
-    DEBUG ((DEBUG_INFO, "Hashing with Mask: %x\n", GetHashMaskAtIndex (Idx)));
-    AlgoId = GetHashAlgoFromMask (GetHashMaskAtIndex (Idx));
+    DEBUG ((DEBUG_INFO, "Hashing with Mask: %x\n", Tpm2GetHashMaskAtIndex (Idx)));
+    AlgoId = Tpm2GetHashAlgoFromMask (Tpm2GetHashMaskAtIndex (Idx));
     if (AlgoId == TPM_ALG_ERROR) {
       return EFI_UNSUPPORTED;
     }

--- a/SecurityPkg/Library/HashLibTpm2/HashLibTpm2PeilessSecLib.c
+++ b/SecurityPkg/Library/HashLibTpm2/HashLibTpm2PeilessSecLib.c
@@ -1,6 +1,11 @@
 /** @file
+  // MU_CHANGE
+  This library is the PeilessSec version of the HashLib. It will
+  initate a hash on each supported hash algorithm via the TPM or
+  TransferList.
 
   Copyright (c) 2025, Arm Limited. All rights reserved.<BR>
+  Copyright (c), Microsoft Corporation // MU_CHANGE
 
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -23,7 +28,10 @@
 #include <Library/HobLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/PrintLib.h>
+// MU_CHANGE - [BEGIN]
+#include <Library/Tpm2HelpLib.h>
 
+#if 0
 #define HASH_ALG_ERROR   0x00
 #define BAD_SEQ_HANDLE   0xFFFFFFFF
 #define BAD_HASH_HANDLE  0x00
@@ -43,6 +51,8 @@ STATIC TPM2_HASH_MASK  mTpm2HashMask[] = {
 
 STATIC UINT32   mSupportedHashBitmap;
 STATIC BOOLEAN  mHashLibDisabled;
+#endif
+// MU_CHANGE - [END]
 
 /**
   Get transfer list header.
@@ -83,6 +93,106 @@ GetTransferList (
   return EFI_SUCCESS;
 }
 
+// MU_CHANGE - [BEGIN]
+/**
+  Get supported hash bitmap
+
+  @param[out] SupportedHashBitmap
+
+  @retval EFI_SUCCESS            Bitmap populated
+  @retval EFI_INVALID_PARAMETER  Invalid pointer
+  @retval EFI_NOT_FOUND          Error accessing data
+  @retval EFI_DEVICE_ERROR       TPM device error
+
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+GetSupportedHashBitmap (
+  OUT UINT32 *SupportedHashBitmap
+  )
+{
+  EFI_STATUS                       Status;
+  TRANSFER_LIST_HEADER             *TransferList;
+  VOID                             *EventLog;
+  UINTN                            EventLogSize;
+  TCG_PCR_EVENT                    *TcgPcrEvent;
+  TCG_EfiSpecIDEventStruct         *TcgEfiSpecIdEventStruct;
+  TCG_EfiSpecIdEventAlgorithmSize  *DigestSize;
+  UINTN                            Idx;
+  UINT32                           NumberOfAlgorithms;
+  UINT32                           TpmHashBitmap;
+  UINT32                           PcrHashBitmap;
+  BOOLEAN                          UseTlHashBitmap;
+
+  DEBUG ((DEBUG_INFO, "%a - Entry\n", __func__));
+
+  if (SupportedHashBitmap == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = Tpm2RequestUseTpm ();
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: TPM2 not detected!\n", __func__));
+    return Status;
+  }
+
+  Status = Tpm2GetCapabilitySupportedAndActivePcrs (&TpmHashBitmap, &PcrHashBitmap);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Failed to get Tpm capability... Status: %r\n", __func__, Status));
+    return Status;
+  }
+
+  UseTlHashBitmap = FALSE;
+  Status = GetTransferList (&TransferList);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: Unable to acquire Transfer list...\n", __func__));
+    goto Exit;
+  }
+
+  if (TransferListCheckHeader (TransferList) == TRANSFER_LIST_OPS_INVALID) {
+    DEBUG ((DEBUG_ERROR, "%a: Invalid Transfer list...\n", __func__));
+    goto Exit;
+  }
+
+  Status = TransferListGetEventLog (TransferList, &EventLog, &EventLogSize, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: No data for TPM event log...\n", __func__));
+    goto Exit;
+  }
+
+  UseTlHashBitmap         = TRUE;
+  TcgPcrEvent             = (TCG_PCR_EVENT *)EventLog;
+  TcgEfiSpecIdEventStruct = (TCG_EfiSpecIDEventStruct *)
+                            (EventLog + OFFSET_OF (TCG_PCR_EVENT, Event));
+
+  CopyMem (&NumberOfAlgorithms, TcgEfiSpecIdEventStruct + 1, sizeof (NumberOfAlgorithms));
+  DigestSize = (TCG_EfiSpecIdEventAlgorithmSize *)((UINT8 *)TcgEfiSpecIdEventStruct + sizeof (*TcgEfiSpecIdEventStruct) + sizeof (NumberOfAlgorithms));
+  DEBUG ((DEBUG_INFO, "%a: Transfer list TPM event log available\n", __func__));
+
+  // Update the supported hash bitmap based on the info from the TCG event log
+  for (Idx = 0; Idx < NumberOfAlgorithms; Idx++) {
+    *SupportedHashBitmap |= GetHashMaskFromAlgo (DigestSize[Idx].algorithmId);
+  }
+
+Exit:
+  if (!UseTlHashBitmap) {
+    // Use the information from the TPM to update the supported hash bitmap
+    *SupportedHashBitmap = TpmHashBitmap;
+    DEBUG ((DEBUG_INFO, "%a: No Transfer List or TPM event log available\n", __func__));
+  }
+
+  *SupportedHashBitmap &= PcrHashBitmap;
+  if (*SupportedHashBitmap == 0x00) {
+    DEBUG ((DEBUG_ERROR, "%a: No supported Hash algorithm with event log Spec...!\n", __func__));
+  }
+
+  DEBUG ((DEBUG_INFO, "%a - Exit\n", __func__));
+
+  return EFI_SUCCESS;
+}
+
+#if 0
 /**
   The function get algorithm from hash mask info.
 
@@ -187,6 +297,8 @@ ClearSequenceHandles (
     mTpm2HashMask[Idx].SequenceHandle = BAD_SEQ_HANDLE;
   }
 }
+#endif
+// MU_CHANGE - [END]
 
 /**
   Start hash sequence.
@@ -206,45 +318,45 @@ HashStart (
   EFI_STATUS   Status;
   TPM_ALG_ID   AlgoId;
   UINT32       Idx;
-  UINT32       HashMask;
-  HASH_HANDLE  Handle;
+  // MU_CHANGE - [BEGIN]
+  UINT32       SupportedHashBitmap;
+  HASH_HANDLE  *HashCtx;
+  UINTN        HashInfoSize;
 
-  if (mHashLibDisabled) {
-    return EFI_UNSUPPORTED;
+  SupportedHashBitmap = 0;
+  Status = GetSupportedHashBitmap(&SupportedHashBitmap);
+  if (EFI_ERROR (Status)) {
+    return Status;
   }
 
-  Handle = BAD_HASH_HANDLE;
+  if (SupportedHashBitmap == 0) {
+    return EFI_DEVICE_ERROR;
+  }
 
-  for (Idx = 0; Idx < ARRAY_SIZE (mTpm2HashMask); Idx++) {
-    HashMask = 1 << Idx;
+  HashInfoSize = GetHashInfoSize();
+  HashCtx = AllocatePool (HashInfoSize * sizeof (HASH_HANDLE));
+  if (HashCtx == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
 
-    if ((mSupportedHashBitmap & HashMask) == 0x00) {
+  for (Idx = 0; Idx < HashInfoSize; Idx++) {
+    if ((GetHashMaskAtIndex(Idx) & SupportedHashBitmap) == 0) {
       continue;
     }
 
-    if (mTpm2HashMask[Idx].SequenceHandle != BAD_SEQ_HANDLE) {
-      Status = EFI_ALREADY_STARTED;
-      Handle = BAD_HASH_HANDLE;
-      goto ErrorHandler;
+    AlgoId = GetHashAlgoFromMask (GetHashMaskAtIndex(Idx));
+    if (AlgoId == TPM_ALG_ERROR) {
+      return EFI_UNSUPPORTED;
     }
 
-    AlgoId = Tpm2GetAlgoFromHashMask (HashMask);
-    ASSERT (AlgoId != TPM_ALG_ERROR);
-
-    Status =  Tpm2HashSequenceStart (AlgoId, &mTpm2HashMask[Idx].SequenceHandle);
+    Status = Tpm2HashSequenceStart (AlgoId, (TPMI_DH_OBJECT*)&HashCtx[Idx]);
     if (EFI_ERROR (Status)) {
-      Handle = BAD_HASH_HANDLE;
-      goto ErrorHandler;
+      return Status;
     }
-
-    Handle |= HashMask;
   }
 
-ErrorHandler:
-  *HashHandle = Handle;
-  if (Handle == BAD_HASH_HANDLE) {
-    ClearSequenceHandles ();
-  }
+  *HashHandle = (HASH_HANDLE)HashCtx;
+  // MU_CHANGE - [END]
 
   return Status;
 }
@@ -269,24 +381,33 @@ HashUpdate (
 {
   EFI_STATUS        Status;
   UINT32            Idx;
-  UINT32            HashMask;
+  //UINT32            HashMask; // MU_CHANGE
   UINT8             *Buffer;
   UINT64            HashLen;
   TPM2B_MAX_BUFFER  HashBuffer;
+  // MU_CHANGE - [BEGIN]
+  UINT32            SupportedHashBitmap;
+  HASH_HANDLE       *HashCtx;
+  UINTN             HashInfoSize;
 
-  if (mHashLibDisabled) {
-    return EFI_UNSUPPORTED;
-  }
-
-  Status = ValidateHashHandle (HashHandle);
+  SupportedHashBitmap = 0;
+  Status = GetSupportedHashBitmap(&SupportedHashBitmap);
+  // MU_CHANGE - [END]
   if (EFI_ERROR (Status)) {
     return Status;
   }
 
-  for (Idx = 0; Idx < ARRAY_SIZE (mTpm2HashMask); Idx++) {
-    HashMask = 1 << Idx;
+  // MU_CHANGE - [BEGIN]
+  if (SupportedHashBitmap == 0) {
+    return EFI_DEVICE_ERROR;
+  }
 
-    if ((HashHandle & HashMask) == 0x00) {
+  HashCtx = (HASH_HANDLE*)HashHandle;
+
+  HashInfoSize = GetHashInfoSize();
+  for (Idx = 0; Idx < HashInfoSize; Idx++) {
+    if ((GetHashMaskAtIndex(Idx) & SupportedHashBitmap) == 0) {
+      // MU_CHANGE - [END]
       continue;
     }
 
@@ -296,7 +417,7 @@ HashUpdate (
       CopyMem (HashBuffer.buffer, Buffer, sizeof (HashBuffer.buffer));
       Buffer += sizeof (HashBuffer.buffer);
 
-      Status = Tpm2SequenceUpdate (mTpm2HashMask[Idx].SequenceHandle, &HashBuffer);
+      Status = Tpm2SequenceUpdate ((TPMI_DH_OBJECT)HashCtx[Idx], &HashBuffer); // MU_CHANGE
       if (EFI_ERROR (Status)) {
         return EFI_DEVICE_ERROR;
       }
@@ -305,7 +426,7 @@ HashUpdate (
     // Last one
     HashBuffer.size = (UINT16)HashLen;
     CopyMem (HashBuffer.buffer, Buffer, (UINTN)HashLen);
-    Status = Tpm2SequenceUpdate (mTpm2HashMask[Idx].SequenceHandle, &HashBuffer);
+    Status = Tpm2SequenceUpdate ((TPMI_DH_OBJECT)HashCtx[Idx], &HashBuffer); // MU_CHANGE
     if (EFI_ERROR (Status)) {
       return EFI_DEVICE_ERROR;
     }
@@ -339,30 +460,36 @@ HashCompleteAndExtend (
   EFI_STATUS        Status;
   UINT32            Idx;
   UINT32            DigestIdx;
-  UINT32            HashMask;
+  //UINT32            HashMask; // MU_CHANGE
   UINT8             *Buffer;
   UINT64            HashLen;
   TPM2B_MAX_BUFFER  HashBuffer;
   TPM_ALG_ID        AlgoId;
   TPM2B_DIGEST      Result;
+  // MU_CHANGE - [BEGIN]
+  UINT32            SupportedHashBitmap;
+  HASH_HANDLE       *HashCtx;
+  UINTN             HashInfoSize;
 
-  if (mHashLibDisabled) {
-    return EFI_UNSUPPORTED;
-  }
-
-  Status = ValidateHashHandle (HashHandle);
+  SupportedHashBitmap = 0;
+  Status = GetSupportedHashBitmap(&SupportedHashBitmap);
   if (EFI_ERROR (Status)) {
-    return Status;
+    goto Error;
   }
+
+  if (SupportedHashBitmap == 0) {
+    return EFI_DEVICE_ERROR;
+  }
+  // MU_CHANGE - [END]
 
   ZeroMem (DigestList, sizeof (*DigestList));
   DigestList->count = HASH_COUNT;
   DigestIdx         = 0;
+  HashCtx           = (HASH_HANDLE*)HashHandle; // MU_CHANGE
 
-  for (Idx = 0; Idx < ARRAY_SIZE (mTpm2HashMask); Idx++) {
-    HashMask = 1 << Idx;
-
-    if ((HashHandle & HashMask) == 0x00) {
+  HashInfoSize = GetHashInfoSize();
+  for (Idx = 0; Idx < HashInfoSize; Idx++) { // MU_CHANGE
+    if ((GetHashMaskAtIndex(Idx) & SupportedHashBitmap) == 0) { // MU_CHANGE
       continue;
     }
 
@@ -372,9 +499,9 @@ HashCompleteAndExtend (
       CopyMem (HashBuffer.buffer, Buffer, sizeof (HashBuffer.buffer));
       Buffer += sizeof (HashBuffer.buffer);
 
-      Status = Tpm2SequenceUpdate (mTpm2HashMask[Idx].SequenceHandle, &HashBuffer);
+      Status = Tpm2SequenceUpdate ((TPMI_DH_OBJECT)HashCtx[Idx], &HashBuffer); // MU_CHANGE
       if (EFI_ERROR (Status)) {
-        return EFI_DEVICE_ERROR;
+        goto Error; // MU_CHANGE
       }
     }
 
@@ -382,17 +509,18 @@ HashCompleteAndExtend (
     HashBuffer.size = (UINT16)HashLen;
     CopyMem (HashBuffer.buffer, Buffer, (UINTN)HashLen);
 
-    Status = Tpm2SequenceComplete (
-               mTpm2HashMask[Idx].SequenceHandle,
-               &HashBuffer,
-               &Result
-               );
+    Status = Tpm2SequenceComplete ((TPMI_DH_OBJECT)HashCtx[Idx], &HashBuffer, &Result); // MU_CHANGE
     if (EFI_ERROR (Status)) {
-      return EFI_DEVICE_ERROR;
+      goto Error; // MU_CHANGE
     }
 
-    AlgoId = Tpm2GetAlgoFromHashMask (HashMask);
-    ASSERT (AlgoId != TPM_ALG_ERROR);
+    // MU_CHANGE - [BEGIN]
+    AlgoId = GetHashAlgoFromMask (GetHashMaskAtIndex(Idx));
+    if (AlgoId == TPM_ALG_ERROR) {
+      Status = EFI_UNSUPPORTED;
+      goto Error;
+    }
+    // MU_CHANGE - [END]
 
     // Copy the result of hash.
     CopyMem (&DigestList->digests[DigestIdx].digest, Result.buffer, Result.size);
@@ -402,17 +530,14 @@ HashCompleteAndExtend (
 
   DigestList->count = DigestIdx;
 
-  Status = Tpm2PcrExtend (
-             PcrIndex,
-             DigestList
-             );
-  if (EFI_ERROR (Status)) {
-    return EFI_DEVICE_ERROR;
-  }
+  // MU_CHANGE - [BEGIN]
+  Status = Tpm2PcrExtend (PcrIndex, DigestList);
 
-  ClearSequenceHandles ();
+Error:
+  FreePool (HashCtx);
 
-  return EFI_SUCCESS;
+  return Status;
+  // MU_CHANGE - [END]
 }
 
 /**
@@ -444,32 +569,40 @@ HashAndExtend (
   TPM_ALG_ID        AlgoId;
   UINT32            Idx;
   UINT32            DigestIdx;
-  UINT32            HashMask;
-
-  if (mHashLibDisabled) {
-    return EFI_UNSUPPORTED;
-  }
+  UINT32            SupportedHashBitmap; // MU_CHANGE
+  UINT32            HashInfoSize; // MU_CHANGE
 
   DEBUG ((DEBUG_VERBOSE, "\n HashAndExtend Entry \n"));
 
-  if (mSupportedHashBitmap == 0x00) {
+  // MU_CHANGE - [BEGIN]
+  SupportedHashBitmap = 0;
+  Status = GetSupportedHashBitmap (&SupportedHashBitmap);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  if (SupportedHashBitmap == 0x00) {
     return EFI_DEVICE_ERROR;
   }
+  // MU_CHANGE - [END]
 
   ZeroMem (DigestList, sizeof (*DigestList));
   DigestList->count = HASH_COUNT;
   DigestIdx         = 0;
 
-  for (Idx = 0; Idx < ARRAY_SIZE (mTpm2HashMask); Idx++) {
-    HashMask = 1 << Idx;
-
-    if ((mSupportedHashBitmap & HashMask) == 0x00) {
+  HashInfoSize = GetHashInfoSize(); // MU_CHANGE
+  for (Idx = 0; Idx < HashInfoSize; Idx++) { // MU_CHANGE
+    if ((GetHashMaskAtIndex(Idx) & SupportedHashBitmap) == 0) { // MU_CHANGE
       continue;
     }
 
-    SequenceHandle = BAD_SEQ_HANDLE; // Know bad value
-    AlgoId         = Tpm2GetAlgoFromHashMask (HashMask);
-    ASSERT (AlgoId != TPM_ALG_ERROR);
+    // MU_CHANGE - [BEGIN]
+    DEBUG ((DEBUG_INFO, "Hashing with Mask: %x\n", GetHashMaskAtIndex(Idx)));
+    AlgoId = GetHashAlgoFromMask (GetHashMaskAtIndex(Idx));
+    if (AlgoId == TPM_ALG_ERROR) {
+      return EFI_UNSUPPORTED;
+    }
+    // MU_CHANGE - [END]
 
     Status = Tpm2HashSequenceStart (AlgoId, &SequenceHandle);
     if (EFI_ERROR (Status)) {
@@ -477,6 +610,7 @@ HashAndExtend (
     }
 
     DEBUG ((DEBUG_VERBOSE, "\n Tpm2HashSequenceStart Success \n"));
+    DEBUG ((DEBUG_INFO, "Hashing %d bytes of data\n", DataToHashLen)); // MU_CHANGE
 
     Buffer = (UINT8 *)(UINTN)DataToHash;
     for (HashLen = DataToHashLen; HashLen > sizeof (HashBuffer.buffer); HashLen -= sizeof (HashBuffer.buffer)) {
@@ -495,11 +629,7 @@ HashAndExtend (
     HashBuffer.size = (UINT16)HashLen;
     CopyMem (HashBuffer.buffer, Buffer, (UINTN)HashLen);
 
-    Status = Tpm2SequenceComplete (
-               SequenceHandle,
-               &HashBuffer,
-               &Result
-               );
+    Status = Tpm2SequenceComplete (SequenceHandle, &HashBuffer, &Result); // MU_CHANGE
     if (EFI_ERROR (Status)) {
       return EFI_DEVICE_ERROR;
     }
@@ -513,10 +643,8 @@ HashAndExtend (
 
   DigestList->count = DigestIdx;
 
-  Status = Tpm2PcrExtend (
-             PcrIndex,
-             DigestList
-             );
+  DEBUG ((DEBUG_INFO, "Extending to PCR%d\n", PcrIndex)); // MU_CHANGE
+  Status = Tpm2PcrExtend (PcrIndex,DigestList); // MU_CHANGE
   if (EFI_ERROR (Status)) {
     return EFI_DEVICE_ERROR;
   }
@@ -545,6 +673,8 @@ RegisterHashInterfaceLib (
   return EFI_UNSUPPORTED;
 }
 
+// MU_CHANGE - [BEGIN]
+#if 0
 /**
   Constructor of HashLibTpm2PeilessSecLibConstructor.
 
@@ -621,3 +751,5 @@ HasLibTpm2PeilessSecLibConstructor (
 DisableHandler:
   return EFI_SUCCESS;
 }
+#endif
+// MU_CHANGE - [END]

--- a/SecurityPkg/Library/HashLibTpm2/HashLibTpm2PeilessSecLib.inf
+++ b/SecurityPkg/Library/HashLibTpm2/HashLibTpm2PeilessSecLib.inf
@@ -14,7 +14,7 @@
   MODULE_TYPE                    = BASE
   VERSION_STRING                 = 1.0
   LIBRARY_CLASS                  = HashLib|SEC
-  CONSTRUCTOR                    = HasLibTpm2PeilessSecLibConstructor
+  #CONSTRUCTOR                    = HasLibTpm2PeilessSecLibConstructor # MU_CHANGE
 
 #
 # The following information is for reference only and not required by the build tools.
@@ -42,6 +42,7 @@
   PrePiLib
   Tpm2DeviceLib
   Tpm2CommandLib
+  Tpm2HelpLib # MU_CHANGE
 
 [Guids]
   gTpmErrorHobGuid

--- a/SecurityPkg/Library/Tpm2HelpLib/Tpm2Help.c
+++ b/SecurityPkg/Library/Tpm2HelpLib/Tpm2Help.c
@@ -105,6 +105,7 @@ GetHashMaskFromAlgo (
 }
 
 // MU_CHANGE - [BEGIN]
+
 /**
   Get hash algorithm from mask.
 
@@ -153,11 +154,12 @@ GetHashInfoSize (
 UINT32
 EFIAPI
 GetHashMaskAtIndex (
-  IN UINT32 Index
+  IN UINT32  Index
   )
 {
   return mHashInfo[Index].HashMask;
 }
+
 // MU_CHANGE - [END]
 
 /**

--- a/SecurityPkg/Library/Tpm2HelpLib/Tpm2Help.c
+++ b/SecurityPkg/Library/Tpm2HelpLib/Tpm2Help.c
@@ -104,6 +104,62 @@ GetHashMaskFromAlgo (
   return 0;
 }
 
+// MU_CHANGE - [BEGIN]
+/**
+  Get hash algorithm from mask.
+
+  @param[in] HashMask   Hash mask
+
+  @return Hash algorithm
+**/
+TPMI_ALG_HASH
+EFIAPI
+GetHashAlgoFromMask (
+  IN UINT32  HashMask
+  )
+{
+  UINTN  Index;
+
+  for (Index = 0; Index < sizeof (mHashInfo)/sizeof (mHashInfo[0]); Index++) {
+    if (mHashInfo[Index].HashMask == HashMask) {
+      return mHashInfo[Index].HashAlgo;
+    }
+  }
+
+  return 0;
+}
+
+/**
+  Get internal hash info size.
+
+  @return Hash info size
+**/
+UINTN
+EFIAPI
+GetHashInfoSize (
+  VOID
+  )
+{
+  return ARRAY_SIZE (mHashInfo);
+}
+
+/**
+  Get hash mask at specified index.
+
+  @param[in] Index   Index requested
+
+  @return Hash mask at the specified index
+**/
+UINT32
+EFIAPI
+GetHashMaskAtIndex (
+  IN UINT32 Index
+  )
+{
+  return mHashInfo[Index].HashMask;
+}
+// MU_CHANGE - [END]
+
 /**
   Copy AuthSessionIn to TPM2 command buffer.
 

--- a/SecurityPkg/Library/Tpm2HelpLib/Tpm2Help.c
+++ b/SecurityPkg/Library/Tpm2HelpLib/Tpm2Help.c
@@ -1,4 +1,5 @@
 /** @file
+  MU_CHANGE
   Implement TPM2 help.
 
 Copyright (c), Microsoft Corporation.
@@ -104,8 +105,6 @@ GetHashMaskFromAlgo (
   return 0;
 }
 
-// MU_CHANGE - [BEGIN]
-
 /**
   Get hash algorithm from mask.
 
@@ -115,7 +114,7 @@ GetHashMaskFromAlgo (
 **/
 TPMI_ALG_HASH
 EFIAPI
-GetHashAlgoFromMask (
+Tpm2GetHashAlgoFromMask (
   IN UINT32  HashMask
   )
 {
@@ -127,7 +126,7 @@ GetHashAlgoFromMask (
     }
   }
 
-  return 0;
+  return TPM_ALG_ERROR;
 }
 
 /**
@@ -137,7 +136,7 @@ GetHashAlgoFromMask (
 **/
 UINTN
 EFIAPI
-GetHashInfoSize (
+Tpm2GetHashInfoSize (
   VOID
   )
 {
@@ -153,14 +152,12 @@ GetHashInfoSize (
 **/
 UINT32
 EFIAPI
-GetHashMaskAtIndex (
+Tpm2GetHashMaskAtIndex (
   IN UINT32  Index
   )
 {
   return mHashInfo[Index].HashMask;
 }
-
-// MU_CHANGE - [END]
 
 /**
   Copy AuthSessionIn to TPM2 command buffer.


### PR DESCRIPTION
## Description

Updated the HashLibTpm2PeilessSec library to no longer use globals in SEC. When enabled on SBSA, this was causing a hang as functions attempted to set RO memory. Changed the code to query the relevant information each time it was needed either through the TPM or Transfer List. Added new helper functions to Tpm2Help which removes the need to have a duplicate hash struct.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Built with the PeilessSecMeasureLib not set to the NULL instance on QEMU SBSA with the TPM enabled. Verified the library measure the FV and CRTM version.

## Integration Instructions

It is better for us to continue using the NULL instance of the PeilessSecMeasureLib as the time it took to measure the FV was ~15 mins on QEMU SBSA with TPM support.