### PR TITLE
MdeModulePkg/NvmExpressDxe: Add NVMe namespace filtering PCD

### DIFF
--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.c
@@ -418,14 +418,14 @@ Exit:
   Discover all Nvm Express device namespaces, and create child handles for them with BlockIo
   and DiskInfo protocol instances.
 
-  When PcdNvmeNamespaceFilter is set to TRUE, it limits NVMe namespace enumeration.
-  When TRUE, only the first namespace (NSID 1) is discovered and
-  enumerated. When FALSE (default), all namespaces are enumerated
-  as before.
-
   // MU_CHANGE [BEGIN] - NVMe namespace filtering
+  When PcdNvmeNamespaceFilterId is 0, all namespaces are enumerated.
+  When non-zero, only the namespace matching the specified NSID is
+  discovered and enumerated.
+
   @param[in] Private          The pointer to the NVME_CONTROLLER_PRIVATE_DATA data structure.
-  @param[in] FilteringEnabled If TRUE, only discover the first namespace. If FALSE, discover all namespaces.
+  @param[in] FilterNsId       If 0, discover all namespaces. If non-zero, only discover the namespace
+                              with this NSID.
 
   @retval EFI_SUCCESS         All the namespaces in the device are successfully enumerated.
   @return Others              Some error occurs when enumerating the namespaces.
@@ -434,7 +434,7 @@ Exit:
 EFI_STATUS
 DiscoverAllNamespaces (
   IN NVME_CONTROLLER_PRIVATE_DATA  *Private,
-  IN BOOLEAN                       FilteringEnabled
+  IN UINT32                        FilterNsId
   )
 // MU_CHANGE [END] - NVMe namespace filtering
 {
@@ -445,8 +445,7 @@ DiscoverAllNamespaces (
   NamespaceId = 0xFFFFFFFF;
   Passthru    = &Private->Passthru;
 
-  // MU_CHANGE [BEGIN] - NVMe namespace filtering
-  do {
+  while (TRUE) {
     Status = Passthru->GetNextNamespace (
                          Passthru,
                          (UINT32 *)&NamespaceId
@@ -456,6 +455,13 @@ DiscoverAllNamespaces (
       break;
     }
 
+    // MU_CHANGE [BEGIN] - NVMe namespace filtering
+    if ((FilterNsId != 0) && (NamespaceId != FilterNsId)) {
+      continue;
+    }
+
+    // MU_CHANGE [END] - NVMe namespace filtering
+
     Status = EnumerateNvmeDevNamespace (
                Private,
                NamespaceId
@@ -464,9 +470,14 @@ DiscoverAllNamespaces (
     if (EFI_ERROR (Status)) {
       continue;
     }
-  } while (!FilteringEnabled);
 
-  // MU_CHANGE [END] - NVMe namespace filtering
+    // MU_CHANGE [BEGIN] - NVMe namespace filtering
+    if (FilterNsId != 0) {
+      break;
+    }
+
+    // MU_CHANGE [END] - NVMe namespace filtering
+  }
 
   return EFI_SUCCESS;
 }
@@ -1137,7 +1148,7 @@ NvmExpressDriverBindingStart (
   // MU_CHANGE [END] - Allocate IO Queue Buffer
 
   EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL  *Passthru;
-  BOOLEAN                             FilteringEnabled; // MU_CHANGE - NVMe namespace filtering
+  UINT32                              FilterNsId; // MU_CHANGE - NVMe namespace filtering
 
   DEBUG ((DEBUG_INFO, "NvmExpressDriverBindingStart: start\n"));
 
@@ -1329,7 +1340,7 @@ NvmExpressDriverBindingStart (
   }
 
   // MU_CHANGE [BEGIN] - NVMe namespace filtering
-  FilteringEnabled = PcdGetBool (PcdNvmeNamespaceFilter);
+  FilterNsId = PcdGet32 (PcdNvmeNamespaceFilterId);
   // MU_CHANGE [END] - NVMe namespace filtering
 
   if (RemainingDevicePath == NULL) {
@@ -1339,7 +1350,7 @@ NvmExpressDriverBindingStart (
     // MU_CHANGE [BEGIN] - NVMe namespace filtering
     Status = DiscoverAllNamespaces (
                Private,
-               FilteringEnabled
+               FilterNsId
                );
     // MU_CHANGE [END] - NVMe namespace filtering
   } else if (!IsDevicePathEnd (RemainingDevicePath)) {
@@ -1354,12 +1365,8 @@ NvmExpressDriverBindingStart (
 
     if (!EFI_ERROR (Status)) {
       // MU_CHANGE [BEGIN] - NVMe namespace filtering
-      // When PcdNvmeNamespaceFilter is set to TRUE, it limits NVMe namespace enumeration.
-      // When TRUE, only the first namespace (NSID 1) is discovered and
-      // enumerated. When FALSE (default), all namespaces are enumerated
-      // as before.
-      if (!FilteringEnabled ||
-          (NamespaceId == NVME_FIRST_NSID))
+      if ((FilterNsId == 0) ||
+          (NamespaceId == FilterNsId))
       {
         Status = EnumerateNvmeDevNamespace (
                    Private,

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.c
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.c
@@ -418,16 +418,25 @@ Exit:
   Discover all Nvm Express device namespaces, and create child handles for them with BlockIo
   and DiskInfo protocol instances.
 
-  @param[in] Private         The pointer to the NVME_CONTROLLER_PRIVATE_DATA data structure.
+  When PcdNvmeNamespaceFilter is set to TRUE, it limits NVMe namespace enumeration.
+  When TRUE, only the first namespace (NSID 1) is discovered and
+  enumerated. When FALSE (default), all namespaces are enumerated
+  as before.
 
-  @retval EFI_SUCCESS        All the namespaces in the device are successfully enumerated.
-  @return Others             Some error occurs when enumerating the namespaces.
+  // MU_CHANGE [BEGIN] - NVMe namespace filtering
+  @param[in] Private          The pointer to the NVME_CONTROLLER_PRIVATE_DATA data structure.
+  @param[in] FilteringEnabled If TRUE, only discover the first namespace. If FALSE, discover all namespaces.
+
+  @retval EFI_SUCCESS         All the namespaces in the device are successfully enumerated.
+  @return Others              Some error occurs when enumerating the namespaces.
 
 **/
 EFI_STATUS
 DiscoverAllNamespaces (
-  IN NVME_CONTROLLER_PRIVATE_DATA  *Private
+  IN NVME_CONTROLLER_PRIVATE_DATA  *Private,
+  IN BOOLEAN                       FilteringEnabled
   )
+// MU_CHANGE [END] - NVMe namespace filtering
 {
   EFI_STATUS                          Status;
   UINT32                              NamespaceId;
@@ -436,7 +445,8 @@ DiscoverAllNamespaces (
   NamespaceId = 0xFFFFFFFF;
   Passthru    = &Private->Passthru;
 
-  while (TRUE) {
+  // MU_CHANGE [BEGIN] - NVMe namespace filtering
+  do {
     Status = Passthru->GetNextNamespace (
                          Passthru,
                          (UINT32 *)&NamespaceId
@@ -454,7 +464,9 @@ DiscoverAllNamespaces (
     if (EFI_ERROR (Status)) {
       continue;
     }
-  }
+  } while (!FilteringEnabled);
+
+  // MU_CHANGE [END] - NVMe namespace filtering
 
   return EFI_SUCCESS;
 }
@@ -1125,6 +1137,7 @@ NvmExpressDriverBindingStart (
   // MU_CHANGE [END] - Allocate IO Queue Buffer
 
   EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL  *Passthru;
+  BOOLEAN                             FilteringEnabled; // MU_CHANGE - NVMe namespace filtering
 
   DEBUG ((DEBUG_INFO, "NvmExpressDriverBindingStart: start\n"));
 
@@ -1315,13 +1328,20 @@ NvmExpressDriverBindingStart (
     Private = NVME_CONTROLLER_PRIVATE_DATA_FROM_PASS_THRU (Passthru);
   }
 
+  // MU_CHANGE [BEGIN] - NVMe namespace filtering
+  FilteringEnabled = PcdGetBool (PcdNvmeNamespaceFilter);
+  // MU_CHANGE [END] - NVMe namespace filtering
+
   if (RemainingDevicePath == NULL) {
     //
     // Enumerate all NVME namespaces in the controller
     //
+    // MU_CHANGE [BEGIN] - NVMe namespace filtering
     Status = DiscoverAllNamespaces (
-               Private
+               Private,
+               FilteringEnabled
                );
+    // MU_CHANGE [END] - NVMe namespace filtering
   } else if (!IsDevicePathEnd (RemainingDevicePath)) {
     //
     // Enumerate the specified NVME namespace
@@ -1333,10 +1353,21 @@ NvmExpressDriverBindingStart (
                                  );
 
     if (!EFI_ERROR (Status)) {
-      Status = EnumerateNvmeDevNamespace (
-                 Private,
-                 NamespaceId
-                 );
+      // MU_CHANGE [BEGIN] - NVMe namespace filtering
+      // When PcdNvmeNamespaceFilter is set to TRUE, it limits NVMe namespace enumeration.
+      // When TRUE, only the first namespace (NSID 1) is discovered and
+      // enumerated. When FALSE (default), all namespaces are enumerated
+      // as before.
+      if (!FilteringEnabled ||
+          (NamespaceId == NVME_FIRST_NSID))
+      {
+        Status = EnumerateNvmeDevNamespace (
+                   Private,
+                   NamespaceId
+                   );
+      }
+
+      // MU_CHANGE [END] - NVMe namespace filtering
     }
   }
 

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.h
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.h
@@ -152,10 +152,6 @@ extern EFI_DRIVER_SUPPORTED_EFI_VERSION_PROTOCOL  gNvmExpressDriverSupportedEfiV
 
 #define NVME_CONTROLLER_ID  0
 
-// MU_CHANGE [BEGIN] - NVMe namespace filtering
-#define NVME_FIRST_NSID  0x00000001
-// MU_CHANGE [END] - NVMe namespace filtering
-
 //
 // Time out value for Nvme transaction execution
 //

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.h
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.h
@@ -152,6 +152,10 @@ extern EFI_DRIVER_SUPPORTED_EFI_VERSION_PROTOCOL  gNvmExpressDriverSupportedEfiV
 
 #define NVME_CONTROLLER_ID  0
 
+// MU_CHANGE [BEGIN] - NVMe namespace filtering
+#define NVME_FIRST_NSID  0x00000001
+// MU_CHANGE [END] - NVMe namespace filtering
+
 //
 // Time out value for Nvme transaction execution
 //

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressDxe.inf
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressDxe.inf
@@ -81,6 +81,9 @@
   ## MU_CHANGE [BEGIN] - Support alternative hardware queue sizes in NVME driver
   gEfiMdeModulePkgTokenSpaceGuid.PcdSupportAlternativeQueueSize ## CONSUMES
   ## MU_CHANGE [END] - Support alternative hardware queue sizes in NVME driver
+  ## MU_CHANGE [BEGIN] - NVMe namespace filtering
+  gEfiMdeModulePkgTokenSpaceGuid.PcdNvmeNamespaceFilter         ## CONSUMES
+  ## MU_CHANGE [END] - NVMe namespace filtering
 
 # [Event]
 # EVENT_TYPE_RELATIVE_TIMER ## SOMETIMES_CONSUMES

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressDxe.inf
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressDxe.inf
@@ -82,7 +82,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdSupportAlternativeQueueSize ## CONSUMES
   ## MU_CHANGE [END] - Support alternative hardware queue sizes in NVME driver
   ## MU_CHANGE [BEGIN] - NVMe namespace filtering
-  gEfiMdeModulePkgTokenSpaceGuid.PcdNvmeNamespaceFilter         ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdNvmeNamespaceFilterId         ## CONSUMES
   ## MU_CHANGE [END] - NVMe namespace filtering
 
 # [Event]

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/Readme.md
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/Readme.md
@@ -1,0 +1,326 @@
+# NvmExpressDxe
+
+## Overview
+
+NvmExpressDxe is a UEFI driver that manages NVM Express (NVMe) non-volatile memory subsystems
+connected over PCI. It follows the UEFI Driver Model and the NVM Express specification to
+discover, initialize, and provide block-level access to NVMe storage devices during the UEFI
+boot phase.
+
+## Module Details
+
+| Field | Value |
+|---|---|
+| **Module Type** | UEFI_DRIVER |
+| **INF GUID** | `5BE3BDF4-53CF-46a3-A6A9-73C34A6E5EE3` |
+| **Entry Point** | `NvmExpressDriverEntry` |
+| **Unload** | `NvmExpressUnload` |
+| **Architectures** | IA32, X64 |
+
+## What This Module Does
+
+### Driver Binding
+
+The driver implements the standard UEFI Driver Binding Protocol (`Supported`, `Start`, `Stop`)
+to attach to PCI devices with class code Mass Storage / NVM (0x01/0x08) and NVMHCI programming
+interface (0x02).
+
+### Controller Initialization
+
+During `Start`, the driver:
+
+1. Opens the `EFI_PCI_IO_PROTOCOL` on the controller handle.
+2. Reads the NVMe Controller Capabilities register (`CAP`) and validates NVM command set support.
+3. Allocates DMA-accessible buffers for admin submission/completion queues.
+4. Disables the controller, programs the Admin Queue Attributes (`AQA`), Admin Submission Queue
+   Base Address (`ASQ`), and Admin Completion Queue Base Address (`ACQ`), then re-enables the
+   controller.
+5. Sends Identify Controller to retrieve controller metadata (serial number, model, capabilities).
+6. Uses the Set Features command (Number of Queues) to negotiate I/O queue pairs with the
+   controller.
+7. Allocates DMA-accessible buffers for I/O submission/completion queues and creates the I/O
+   queue pairs via Create I/O Completion Queue and Create I/O Submission Queue admin commands.
+8. Enumerates NVMe namespaces and creates child handles for each discovered namespace.
+
+### Protocols Produced (per controller)
+
+| Protocol | Purpose |
+|---|---|
+| `EFI_NVM_EXPRESS_PASS_THRU_PROTOCOL` | Raw NVMe command passthrough for admin and I/O commands. Installed on the controller handle. |
+| `EFI_DRIVER_SUPPORTED_EFI_VERSION_PROTOCOL` | Declares the EFI specification version the driver supports. Installed on the driver image handle at entry point. |
+
+### Protocols Produced (per namespace)
+
+| Protocol | Purpose |
+|---|---|
+| `EFI_BLOCK_IO_PROTOCOL` | Synchronous block read/write/flush/reset operations. |
+| `EFI_BLOCK_IO2_PROTOCOL` | Asynchronous (non-blocking) block I/O operations. Only installed when the controller allocates more than one I/O queue pair. |
+| `EFI_DISK_INFO_PROTOCOL` | Exposes NVMe Identify Namespace data for disk information queries. |
+| `EFI_STORAGE_SECURITY_COMMAND_PROTOCOL` | Security Send/Receive commands (if the controller supports OACS bit 0). |
+| `MEDIA_SANITIZE_PROTOCOL` | Media Clear, Purge, and Format operations mapped to NVMe Format NVM and Sanitize admin commands per NIST SP 800-88 guidelines. |
+
+### Protocols Consumed
+
+| Protocol | Purpose |
+|---|---|
+| `EFI_PCI_IO_PROTOCOL` | PCI BAR memory access, DMA buffer allocation, and bus master mapping. |
+| `EFI_DEVICE_PATH_PROTOCOL` | Device path construction for namespace child handles. |
+| `EFI_RESET_NOTIFICATION_PROTOCOL` | Registers a shutdown callback to gracefully shut down all NVMe controllers before platform reset. |
+
+### Asynchronous I/O
+
+The driver uses a periodic timer event (`NVME_HC_ASYNC_TIMER`, 1 ms) to poll the async I/O
+completion queue and process completed asynchronous requests. The `BlockIo2` protocol is only
+installed when the controller has allocated at least two I/O queue pairs (one for blocking, one
+for async).
+
+### Controller Reset
+
+On command timeout, the driver performs a full controller reset: disable, re-program admin queues,
+re-enable, re-identify, re-negotiate queue count, and re-create I/O queues—all while preserving
+allocated DMA buffers.
+
+### Shutdown Notification
+
+The driver registers with `EFI_RESET_NOTIFICATION_PROTOCOL` to issue NVMe shutdown notifications
+(CC.SHN) to all managed controllers before a platform reset, ensuring data integrity.
+
+## Source Files
+
+| File | Description |
+|---|---|
+| `NvmExpress.c` | Driver entry point, driver binding, namespace enumeration, queue cleanup. |
+| `NvmExpress.h` | Main header: data structures, constants, macros, function declarations. |
+| `NvmExpressHci.c` | HCI register access, controller init/reset, admin and I/O queue creation. |
+| `NvmExpressHci.h` | HCI function declarations. |
+| `NvmExpressPassthru.c` | NVM Express PassThru protocol implementation (blocking and async). |
+| `NvmExpressBlockIo.c` | BlockIo and BlockIo2 protocol implementations. |
+| `NvmExpressBlockIo.h` | BlockIo/BlockIo2 function declarations. |
+| `NvmExpressDiskInfo.c` | DiskInfo protocol implementation. |
+| `NvmExpressDiskInfo.h` | DiskInfo function declarations. |
+| `NvmExpressMediaSanitize.c` | Media Sanitize protocol: Clear, Purge, Format via NVMe commands. |
+| `NvmExpressMediaSanitize.h` | Media Sanitize function declarations and types. |
+| `ComponentName.c` | Component Name and Component Name2 protocol implementations. |
+| `UnitTest/MediaSanitizeUnitTest.c` | Host-based unit tests for the Media Sanitize functionality. |
+
+---
+
+## MU_CHANGE Summary
+
+This section documents all Microsoft (Project Mu) changes made to the upstream EDK2 NvmExpressDxe
+driver. Each change is tagged in the source with `// MU_CHANGE` comments.
+
+### 1. Allocate IO Queue Buffer
+
+**Tag:** `MU_CHANGE - Allocate IO Queue Buffer`
+
+**Files:** `NvmExpress.h`, `NvmExpress.c`, `NvmExpressHci.h`, `NvmExpressHci.c`, `NvmExpressBlockIo.c`, `NvmExpressPassthru.c`
+
+**What changed:**
+
+The upstream driver allocates a single flat 6-page DMA buffer at `DriverBindingStart` time and
+carves fixed 4 KiB regions out of it for all six queues (admin SQ, admin CQ, I/O SQ #1, I/O CQ #1,
+I/O SQ #2, I/O CQ #2). This MU change replaces that approach with a split allocation model:
+
+- **Admin queues** are allocated separately based on the actual admin queue entry size and count
+  derived from controller capabilities (via `NVME_SQ_SIZE_IN_PAGES` / `NVME_CQ_SIZE_IN_PAGES`
+  macros).
+- **I/O queues** are allocated in a separate DMA buffer (`IoQueueBuffer` / `IoQueueBufferPciAddr`)
+  whose size is computed dynamically based on the negotiated number of I/O queue pairs and their
+  entry sizes.
+- A new structure `NVME_QUEUE_SIZE_DATA` (with `NumberOfEntries` and `EntrySize` fields) is added
+  to track per-queue sizing metadata in the controller private data.
+- Queue buffer page counts are computed using macros (`NVME_SQ_SIZE_IN_PAGES`,
+  `NVME_CQ_SIZE_IN_PAGES`) that use the actual entry size (as a power of 2) rather than assuming
+  fixed 4 KiB pages.
+- New functions are introduced:
+  - `NvmeControllerInitAdminQueues()` — initializes admin queue buffer pointers and programs ASQ/ACQ.
+  - `NvmeControllerInitIoQueues()` — initializes I/O queue buffer pointers and creates I/O CQ/SQ.
+  - `NvmExpressDriverCleanUpQueues()` — unmaps and frees both admin and I/O queue DMA buffers.
+  - `NvmeControllerReset()` — performs a full controller reset reusing existing buffer allocations.
+  - `ReadNvmeAdminQueueAttributes()` — reads the AQA register for validation during reset.
+- The `NvmeEnableController()` function now accepts `IoSqEs` and `IoCqEs` parameters to program
+  the correct queue entry sizes into `CC.IOSQES` and `CC.IOCQES`.
+- Page mask operations on queue base addresses are removed since buffers allocated via
+  `AllocatePages` are already page-aligned.
+
+**Why it's needed:**
+
+The fixed 6-page allocation is insufficient when queue sizes exceed 1 entry (i.e., when using
+alternative queue sizes like 255 entries). The dynamic allocation supports variable queue entry
+counts and entry sizes, allows the admin and I/O queues to be managed independently, and enables
+proper cleanup and reset without leaking DMA memory. Separating the I/O queue buffer also means
+the driver can scale the allocation based on how many queue pairs the controller actually grants.
+
+---
+
+### 2. Request Number of Queues from Controller
+
+**Tag:** `MU_CHANGE - Request Number of Queues from Controller`
+
+**Files:** `NvmExpress.h`, `NvmExpress.c`, `NvmExpressHci.c`
+
+**What changed:**
+
+- A new function `NvmeSetFeaturesNumberOfQueues()` is added. It sends the NVMe Set Features
+  command (Feature ID: Number of Queues) to request the desired number of I/O queue pairs from
+  the controller. The controller may allocate fewer pairs than requested; the driver stores the
+  actual granted count in `Private->NumberOfIoQueuePairs`.
+- The maximum number of queue pairs the driver requests is defined by `NVME_MAX_QUEUES` (3 total:
+  1 admin + 2 I/O), meaning the driver requests up to 2 I/O queue pairs.
+- The `NVME_SUPPORT_BLOCKIO2()` macro checks whether the controller allocated more than 1 I/O
+  queue pair. If not, the `BlockIo2` protocol and async timer event are **not** installed.
+- `NvmeCreateIoCompletionQueue()` and `NvmeCreateIoSubmissionQueue()` loop from index 1 to
+  `NumberOfIoQueuePairs` instead of using hardcoded indices.
+- `BlockIo2` protocol installation/uninstallation in `EnumerateNvmeDevNamespace()` and
+  `UnregisterNvmeNamespace()` is made conditional on `NVME_SUPPORT_BLOCKIO2()`.
+
+**Why it's needed:**
+
+The upstream driver assumes every controller supports exactly two I/O queue pairs. Some NVMe
+controllers (especially embedded or resource-constrained ones) may only support a single I/O
+queue pair. By querying the controller via Set Features and gracefully degrading (skipping
+`BlockIo2` when only one queue pair is available), the driver avoids failures on controllers that
+cannot satisfy a two-queue-pair request and correctly reflects the controller's actual capabilities.
+
+---
+
+### 3. Support Alternative Hardware Queue Sizes in NVME Driver
+
+**Tag:** `MU_CHANGE - Support alternative hardware queue sizes in NVME driver`
+
+**Files:** `NvmExpress.h`, `NvmExpress.c`, `NvmExpressDxe.inf`, `NvmExpressHci.c`, `NvmExpressPassthru.c`
+
+**What changed:**
+
+- A PCD `PcdSupportAlternativeQueueSize` (Boolean) is consumed. When `TRUE`, the driver uses a
+  maximum queue size of 255 entries (`NVME_ALTERNATIVE_MAX_QUEUE_SIZE`) instead of the default
+  sizes (1 for sync, 63/255 for async).
+- Queue creation (`NvmeCreateIoCompletionQueue`, `NvmeCreateIoSubmissionQueue`) uses
+  `MIN(NVME_ALTERNATIVE_MAX_QUEUE_SIZE, Cap.Mqes)` for all queues when the PCD is enabled.
+- Admin queue sizes (`AQA.ASQS`, `AQA.ACQS`) also use the alternative size when the PCD is set.
+- Passthrough command handling (`NvmExpressPassThru`) adjusts queue head/tail pointer arithmetic
+  to use modular wrap-around (instead of XOR toggle) when the alternative queue size is active,
+  supporting queue depths greater than 1.
+- The async task list processor (`ProcessAsyncTaskList`) similarly uses the alternative queue size
+  for completion queue head management.
+
+**Why it's needed:**
+
+Some NVMe hardware implementations require a minimum queue depth greater than 1 (e.g., 255
+entries). The upstream driver defaults to queue sizes of 1 for synchronous I/O and uses XOR-based
+head/tail toggling which only works with 2-entry queues (0 and 1). When hardware requires deeper
+queues, this feature enables proper modular arithmetic for queue management and allocates
+appropriately sized buffers. This is controlled by a PCD so platforms that don't need it retain the
+original behavior.
+
+---
+
+### 4. NVMe Namespace Filtering
+
+**Tag:** `MU_CHANGE - NVMe namespace filtering`
+
+**Files:** `NvmExpress.h`, `NvmExpress.c`, `NvmExpressDxe.inf`
+
+**What changed:**
+
+- A PCD `PcdNvmeNamespaceFilter` (Boolean) is consumed. When `TRUE`, namespace discovery is
+  limited to only the first namespace (NSID 1).
+- A constant `NVME_FIRST_NSID` (0x00000001) is defined.
+- `DiscoverAllNamespaces()` takes a new `FilteringEnabled` parameter. When set, the loop breaks
+  after enumerating the first namespace instead of iterating through all namespaces.
+- In the `RemainingDevicePath` path, if filtering is enabled and the requested `NamespaceId` is
+  not `NVME_FIRST_NSID`, the namespace is skipped.
+
+**Why it's needed:**
+
+In some platform or test configurations, it is desirable to restrict which NVMe namespaces are
+exposed to the UEFI environment. For example, a system with a multi-namespace NVMe device may
+only want the boot namespace (typically NSID 1) available during boot to reduce enumeration time,
+limit attack surface, or avoid exposing non-boot partitions. This PCD-controlled filter provides
+that capability without modifying the driver at build time.
+
+---
+
+### 5. Use the Mqes Value from the Cap Register
+
+**Tag:** `MU_CHANGE - Use the Mqes value from the Cap register`
+
+**Files:** `NvmExpressHci.c`
+
+**What changed:**
+
+- When creating I/O completion and submission queues, the queue size is clamped to
+  `MIN(requested_size, Cap.Mqes)` instead of using the requested size directly.
+
+**Why it's needed:**
+
+The NVMe `CAP.MQES` field reports the maximum queue entries supported by the controller. If the
+driver requests a queue larger than what the controller supports, the behavior is undefined or the
+command fails. By clamping queue sizes to `MQES`, the driver respects the controller's hardware
+limits and avoids creating oversized queues.
+
+---
+
+### 6. Correct Cap Parameter Modifier
+
+**Tag:** `MU_CHANGE - Correct Cap parameter modifier`
+
+**Files:** `NvmExpressHci.c`
+
+**What changed:**
+
+- The `ReadNvmeControllerCapabilities()` function signature is corrected so that the `Cap`
+  parameter uses the `OUT` modifier instead of `IN`, reflecting that the function writes to (not
+  reads from) this parameter.
+
+**Why it's needed:**
+
+A correctness fix. The `Cap` parameter is an output of `ReadNvmeControllerCapabilities()`—the
+function reads the hardware register and writes the result into the caller's buffer. Marking it
+`IN` was semantically incorrect and could mislead static analysis tools or code reviewers.
+
+---
+
+### 7. Improve NVMe Controller Init Robustness
+
+**Tag:** `MU_CHANGE - Improve NVMe controller init robustness`
+
+**Files:** `NvmExpressHci.c`
+
+**What changed:**
+
+- At the start of `NvmeControllerInit()` (and `NvmeControllerReset()`), the driver reads the PCI
+  Vendor ID and Device ID. If either returns `0xFFFF` (`NVME_INVALID_VID_DID`), the function
+  returns `EFI_DEVICE_ERROR` immediately.
+- The assertion on `Cap.Mpsmin` is replaced with a conditional check and `EFI_DEVICE_ERROR` return,
+  so the driver fails gracefully instead of asserting if the controller reports an unsupported
+  minimum page size.
+
+**Why it's needed:**
+
+If an NVMe controller has been surprise-removed (hot-unplug), is behind a failed PCIe link, or
+is otherwise inaccessible, PCI config reads return all-ones (`0xFFFF`). Without this check, the
+driver would proceed to access invalid MMIO space, potentially causing system hangs or crashes.
+The `Mpsmin` check change prevents a hard assert in production builds if the controller reports an
+unexpected minimum memory page size, instead returning a clean error.
+
+---
+
+### 8. Remove Page Mask
+
+**Tag:** `MU_CHANGE - Remove Page Mask` / `MU_CHANGE - Remove the page mask since the buffer is allocated using AllocatePages`
+
+**Files:** `NvmExpressHci.c`
+
+**What changed:**
+
+- The page-alignment mask operations (`& ~(EFI_PAGE_SIZE - 1)`) on the admin submission queue
+  (ASQ) and admin completion queue (ACQ) base addresses are removed.
+
+**Why it's needed:**
+
+Since the admin queue buffers are allocated using `PciIo->AllocateBuffer()` with
+`AllocateAnyPages`, the returned addresses are already guaranteed to be page-aligned. Applying a
+page mask is redundant and was removed for clarity. This is part of the broader Allocate IO Queue
+Buffer refactoring.

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/Readme.md
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/Readme.md
@@ -7,16 +7,6 @@ connected over PCI. It follows the UEFI Driver Model and the NVM Express specifi
 discover, initialize, and provide block-level access to NVMe storage devices during the UEFI
 boot phase.
 
-## Module Details
-
-| Field | Value |
-|---|---|
-| **Module Type** | UEFI_DRIVER |
-| **INF GUID** | `5BE3BDF4-53CF-46a3-A6A9-73C34A6E5EE3` |
-| **Entry Point** | `NvmExpressDriverEntry` |
-| **Unload** | `NvmExpressUnload` |
-| **Architectures** | IA32, X64 |
-
 ## What This Module Does
 
 ### Driver Binding
@@ -84,26 +74,6 @@ allocated DMA buffers.
 
 The driver registers with `EFI_RESET_NOTIFICATION_PROTOCOL` to issue NVMe shutdown notifications
 (CC.SHN) to all managed controllers before a platform reset, ensuring data integrity.
-
-## Source Files
-
-| File | Description |
-|---|---|
-| `NvmExpress.c` | Driver entry point, driver binding, namespace enumeration, queue cleanup. |
-| `NvmExpress.h` | Main header: data structures, constants, macros, function declarations. |
-| `NvmExpressHci.c` | HCI register access, controller init/reset, admin and I/O queue creation. |
-| `NvmExpressHci.h` | HCI function declarations. |
-| `NvmExpressPassthru.c` | NVM Express PassThru protocol implementation (blocking and async). |
-| `NvmExpressBlockIo.c` | BlockIo and BlockIo2 protocol implementations. |
-| `NvmExpressBlockIo.h` | BlockIo/BlockIo2 function declarations. |
-| `NvmExpressDiskInfo.c` | DiskInfo protocol implementation. |
-| `NvmExpressDiskInfo.h` | DiskInfo function declarations. |
-| `NvmExpressMediaSanitize.c` | Media Sanitize protocol: Clear, Purge, Format via NVMe commands. |
-| `NvmExpressMediaSanitize.h` | Media Sanitize function declarations and types. |
-| `ComponentName.c` | Component Name and Component Name2 protocol implementations. |
-| `UnitTest/MediaSanitizeUnitTest.c` | Host-based unit tests for the Media Sanitize functionality. |
-
----
 
 ## MU_CHANGE Summary
 
@@ -224,21 +194,21 @@ original behavior.
 
 **What changed:**
 
-- A PCD `PcdNvmeNamespaceFilter` (Boolean) is consumed. When `TRUE`, namespace discovery is
-  limited to only the first namespace (NSID 1).
-- A constant `NVME_FIRST_NSID` (0x00000001) is defined.
-- `DiscoverAllNamespaces()` takes a new `FilteringEnabled` parameter. When set, the loop breaks
-  after enumerating the first namespace instead of iterating through all namespaces.
-- In the `RemainingDevicePath` path, if filtering is enabled and the requested `NamespaceId` is
-  not `NVME_FIRST_NSID`, the namespace is skipped.
+- A PCD `PcdNvmeNamespaceFilterId` (UINT32) is consumed. When `0` (default), all namespaces are
+  enumerated as in the upstream behavior. When non-zero, namespace discovery is restricted to the
+  single namespace whose NSID matches the PCD value.
+- `DiscoverAllNamespaces()` takes a new `FilterNsId` parameter. When non-zero, `GetNextNamespace`
+  is iterated and only the matching NSID is enumerated; the loop then exits.
+- In the `RemainingDevicePath` path, if filtering is enabled and the requested `NamespaceId` does
+  not match `FilterNsId`, the namespace is skipped.
 
 **Why it's needed:**
 
 In some platform or test configurations, it is desirable to restrict which NVMe namespaces are
 exposed to the UEFI environment. For example, a system with a multi-namespace NVMe device may
-only want the boot namespace (typically NSID 1) available during boot to reduce enumeration time,
-limit attack surface, or avoid exposing non-boot partitions. This PCD-controlled filter provides
-that capability without modifying the driver at build time.
+only want a specific boot namespace available during boot to reduce enumeration time, limit
+attack surface, or avoid exposing non-boot partitions. This PCD-controlled filter provides that
+capability without modifying the driver at build time.
 
 ---
 

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -1394,6 +1394,11 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdSupportAlternativeQueueSize|FALSE|BOOLEAN|0x40000151
   # MU_CHANGE [END]
 
+  # MU_CHANGE [BEGIN] - NVMe namespace filtering
+  # When TRUE, only the first NVMe namespace is enumerated. When FALSE, all namespaces are discovered.
+  gEfiMdeModulePkgTokenSpaceGuid.PcdNvmeNamespaceFilter|FALSE|BOOLEAN|0x40000153
+  # MU_CHANGE [END] - NVMe namespace filtering
+
   ## Specifies the page count allocated for the MM communication buffer.
   # @Prompt Defines the page allocation for the MM communication buffer; default is 128 pages (512KB).
   gEfiMdeModulePkgTokenSpaceGuid.PcdMmCommBufferPages|128|UINT32|0x30001061

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -1394,11 +1394,6 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdSupportAlternativeQueueSize|FALSE|BOOLEAN|0x40000151
   # MU_CHANGE [END]
 
-  # MU_CHANGE [BEGIN] - NVMe namespace filtering
-  # When TRUE, only the first NVMe namespace is enumerated. When FALSE, all namespaces are discovered.
-  gEfiMdeModulePkgTokenSpaceGuid.PcdNvmeNamespaceFilter|FALSE|BOOLEAN|0x40000153
-  # MU_CHANGE [END] - NVMe namespace filtering
-
   ## Specifies the page count allocated for the MM communication buffer.
   # @Prompt Defines the page allocation for the MM communication buffer; default is 128 pages (512KB).
   gEfiMdeModulePkgTokenSpaceGuid.PcdMmCommBufferPages|128|UINT32|0x30001061
@@ -2600,6 +2595,12 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdLoadFixAddressSmmCodePageNumber|0|UINT32|0x0000002c
 
 [PcdsDynamic, PcdsDynamicEx]
+  # MU_CHANGE [BEGIN] - NVMe namespace filtering
+  ## When TRUE, only the first NVMe namespace is enumerated. When FALSE, all namespaces are discovered.
+  # @Prompt Enable NVMe namespace filtering to only use NSID 1.
+  gEfiMdeModulePkgTokenSpaceGuid.PcdNvmeNamespaceFilter|FALSE|BOOLEAN|0x40000153
+  # MU_CHANGE [END] - NVMe namespace filtering
+
   ## This dynamic PCD hold an address to point to private data structure used in DxeS3BootScriptLib library
   #  instance which records the S3 boot script table start address, length, etc. To introduce this PCD is
   #  only for DxeS3BootScriptLib instance implementation purpose. The platform developer should make sure the

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -2596,9 +2596,10 @@
 
 [PcdsDynamic, PcdsDynamicEx]
   # MU_CHANGE [BEGIN] - NVMe namespace filtering
-  ## When TRUE, only the first NVMe namespace is enumerated. When FALSE, all namespaces are discovered.
-  # @Prompt Enable NVMe namespace filtering to only use NSID 1.
-  gEfiMdeModulePkgTokenSpaceGuid.PcdNvmeNamespaceFilter|FALSE|BOOLEAN|0x40000153
+  ## When 0, all NVMe namespaces are enumerated. When non-zero, only the namespace
+  ## with the specified NSID is discovered and enumerated. Valid range: 0 to 0xFFFFFFFE.
+  # @Prompt NVMe namespace ID filter (0 = disabled, non-zero = target NSID).
+  gEfiMdeModulePkgTokenSpaceGuid.PcdNvmeNamespaceFilterId|0x0|UINT32|0x40000153
   # MU_CHANGE [END] - NVMe namespace filtering
 
   ## This dynamic PCD hold an address to point to private data structure used in DxeS3BootScriptLib library


### PR DESCRIPTION
## Description

Add PcdNvmeNamespaceFilterId to control NVMe namespace enumeration.
When != 0, only the specified NSID is discovered and enumerated. When 0 (default), all namespaces are enumerated as before.

This improves security on NVMe devices with multiple namespaces.
Without filtering, UEFI enumerates all namespaces and an attacker could place malicious boot media in a secondary namespace. By restricting enumeration to only the first namespace, we ensure the system boots exclusively from the intended namespace and prevents exploitation of additional namespaces as an attack vector.

Changes:
- NvmExpress.c: Add FilteringEnabled parameter to DiscoverAllNamespaces, EnumerateNvmeDevNamespace with namespace ID check when filtering
- NvmExpressDxe.inf: Add PcdNvmeNamespaceFilterId to [Pcd] section
- MdeModulePkg.dec: Define PcdNvmeNamespaceFilterId (default 0)

Ref: microsoft/mu_msvm@9337285

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on:
- OpenVMM platform where namespace filtering is required and successfully booted to OS via DDA NVMe with Namespace filtering on & off.
- Physical platform and booted to OS with physical NVMe with Namespace filtering on & off.
- Qemu Q35 by booting to OS via NVMe with Namespace filtering on & off:

  Modified `QemuCommandBuilder.py` with the following:
  ```
  elif device == "ssd" and self._architecture == QemuArchitecture.Q35:
      # Create NVMe controller with 2 namespaces for testing namespace filtering
      # NS1: boot media, NS2: empty 1GB drive
      self._args.extend([
          "-drive",
          f"file={path},format={format},if=none,id=nvme_ns1",
          "-drive",
          "if=none,id=nvme_ns2,format=raw,file.driver=null-co,file.size=1G",
          "-device",
          "nvme,id=nvme0,serial=nvme-1",
          "-device",
          "nvme-ns,drive=nvme_ns1,bus=nvme0,nsid=1",
          "-device",
          "nvme-ns,drive=nvme_ns2,bus=nvme0,nsid=2",
      ])
  ```

With this change, we have added 2 NVMe namespaces nsid 1 & 2, and we have added 2 boot media, 1 with the real OS and 2 with an empty drive. Also, I tried to put the real boot media on nsid 2, and emptry drive in nsid 1, selected nsid 2 as the filter, and was able to successfully boot to OS.

With `PcdNvmeNamespaceFilterId == 1 || PcdNvmeNamespaceFilterId == 2` we only enumerate target NSID and successfully boot to OS.

With `PcdNvmeNamespaceFilterId == 0` we enumerate both the namespaces as defined above and also successfully boot to OS.

## Integration Instructions

Set PcdNvmeNamespaceFilterId to the desired NSID when required at the platform dsc.