### PR TITLE
mu-pr-validation-pending.yml: Temporarily disable commit status upates

### DIFF
--- a/.github/workflows/mu-pr-validation-pending.yml
+++ b/.github/workflows/mu-pr-validation-pending.yml
@@ -86,6 +86,7 @@ jobs:
             }
 
       - name: Set Pending Commit Status
+        if: false  # TODO: Requires commit status write permission to be accepted at the org level first
         uses: actions/github-script@v8
         with:
           github-token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Description

The Mu Automation GitHub app requires a permission update to be accepted by a microsoft org admin. Until that happens, disable the calling the GitHub API to update the commit status.

This will still run validation and post PR comments. The pass/fail result just won't be reported in the status check area of the PR until the permission is allowed.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- N/A

## Integration Instructions

- N/A
