### PR TITLE
[2502] MdeModulePkg/Variable: Do not produce RT cache HOB when DXE RT cache is allocated

### DIFF
--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -922,8 +922,7 @@
 
   # MU_CHANGE [BEGIN] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
   ## Indicates whether to allocate variable runtime cache buffers in PEI or DXE phase.<BR><BR>
-  #  When TRUE, buffers are allocated as EfiBootServicesData in PEI and migrated to
-  #  EfiRuntimeServicesData in DXE to prevent runtime memory fragmentation.<BR>
+  #  When TRUE,the Variable RT cache HOB is not produced and PEI and the cache is allocated in DXE.<BR>
   #  When FALSE, buffers are allocated directly as EfiRuntimeServicesData in PEI
   #  (original behavior).<BR><BR>
   #  This should only be set to TRUE on platforms that can unblock MM memory in DXE such as those

--- a/MdeModulePkg/Universal/Variable/Pei/Variable.c
+++ b/MdeModulePkg/Universal/Variable/Pei/Variable.c
@@ -67,8 +67,19 @@ PeimInitializeVariableServices (
   )
 {
   if (FeaturePcdGet (PcdEnableVariableRuntimeCache)) {
-    PeiServicesNotifyPpi (&mPostMemNotifyList);
+    // MU_CHANGE [BEGIN] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
+    //
+    // The Variable Runtime Cache HOB is not used by the Variable PEIM itself. It provides a mechanism for Standalone
+    // MM environments to have a RT buffer that is unblocked prior to post-mem MM IPL. To prevent making a breaking
+    // change, the name PcdMigrateVariableRuntimeCacheBufferAllocation is retained for the PCD, but it doesn't need to
+    // migrate as much as allocate a new RT cache buffer in DXE instead of PEI for environments that support that.
+    // This
+    if (!PcdGetBool (PcdMigrateVariableRuntimeCacheBufferAllocation)) {
+      PeiServicesNotifyPpi (&mPostMemNotifyList);
+    }
   }
+
+  // MU_CHANGE [END] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
 
   return PeiServicesInstallPpi (&mPpiListVariable);
 }
@@ -1455,31 +1466,19 @@ BuildVariableRuntimeCacheInfoHob (
 
   ZeroMem (&TempHobBuffer, sizeof (VARIABLE_RUNTIME_CACHE_INFO));
 
-  // MU_CHANGE [BEGIN] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
-  Pages = EFI_SIZE_TO_PAGES (sizeof (CACHE_INFO_FLAG));
-
-  if (PcdGetBool (PcdMigrateVariableRuntimeCacheBufferAllocation)) {
-    //
-    // AllocatePages for CACHE_INFO_FLAG buffer (will be relocated to runtime by DXE).
-    //
-    Buffer = AllocatePages (Pages);
-    ASSERT (Buffer != NULL);
-  } else {
-    //
-    // AllocateRuntimePages for CACHE_INFO_FLAG and unblock it.
-    //
-    Buffer = AllocateRuntimePages (Pages);
-    ASSERT (Buffer != NULL);
-    Status = MmUnblockMemoryRequest (
-               (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
-               Pages
-               );
-    if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-      return Status;
-    }
+  //
+  // AllocateRuntimePages for CACHE_INFO_FLAG and unblock it.
+  //
+  Pages  = EFI_SIZE_TO_PAGES (sizeof (CACHE_INFO_FLAG));
+  Buffer = AllocateRuntimePages (Pages);
+  ASSERT (Buffer != NULL);
+  Status = MmUnblockMemoryRequest (
+             (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
+             Pages
+             );
+  if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+    return Status;
   }
-
-  // MU_CHANGE [END]
 
   TempHobBuffer.CacheInfoFlagBuffer = (UINTN)Buffer;
   DEBUG ((
@@ -1489,36 +1488,25 @@ BuildVariableRuntimeCacheInfoHob (
     Pages
     ));
 
-  // MU_CHANGE [BEGIN] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
+  //
+  // AllocateRuntimePages for VolatileCache and unblock it.
+  //
   BufferSize = PcdGet32 (PcdVariableStoreSize);
   if (BufferSize > 0) {
-    Pages = EFI_SIZE_TO_PAGES (BufferSize);
-    if (PcdGetBool (PcdMigrateVariableRuntimeCacheBufferAllocation)) {
-      //
-      // AllocatePages for VolatileCache buffer (will be relocated to runtime by DXE).
-      //
-      Buffer = AllocatePages (Pages);
-      ASSERT (Buffer != NULL);
-    } else {
-      //
-      // AllocateRuntimePages for VolatileCache and unblock it.
-      //
-      Buffer = AllocateRuntimePages (Pages);
-      ASSERT (Buffer != NULL);
-      Status = MmUnblockMemoryRequest (
-                 (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
-                 Pages
-                 );
-      if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-        return Status;
-      }
+    Pages  = EFI_SIZE_TO_PAGES (BufferSize);
+    Buffer = AllocateRuntimePages (Pages);
+    ASSERT (Buffer != NULL);
+    Status = MmUnblockMemoryRequest (
+               (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
+               Pages
+               );
+    if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+      return Status;
     }
 
     TempHobBuffer.RuntimeVolatileCacheBuffer = (UINTN)Buffer;
     TempHobBuffer.RuntimeVolatileCachePages  = Pages;
   }
-
-  // MU_CHANGE [END]
 
   DEBUG ((
     DEBUG_INFO,
@@ -1527,36 +1515,25 @@ BuildVariableRuntimeCacheInfoHob (
     TempHobBuffer.RuntimeVolatileCachePages
     ));
 
-  // MU_CHANGE [BEGIN] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
+  //
+  // AllocateRuntimePages for NVCache and unblock it.
+  //
   BufferSize = CalculateNvVariableCacheSize (&NvAuthFlag);
   if (BufferSize > 0) {
-    Pages = EFI_SIZE_TO_PAGES (BufferSize);
-    if (PcdGetBool (PcdMigrateVariableRuntimeCacheBufferAllocation)) {
-      //
-      // AllocatePages for NVCache buffer (will be relocated to runtime by DXE).
-      //
-      Buffer = AllocatePages (Pages);
-      ASSERT (Buffer != NULL);
-    } else {
-      //
-      // AllocateRuntimePages for NVCache and unblock it.
-      //
-      Buffer = AllocateRuntimePages (Pages);
-      ASSERT (Buffer != NULL);
-      Status = MmUnblockMemoryRequest (
-                 (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
-                 Pages
-                 );
-      if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-        return Status;
-      }
+    Pages  = EFI_SIZE_TO_PAGES (BufferSize);
+    Buffer = AllocateRuntimePages (Pages);
+    ASSERT (Buffer != NULL);
+    Status = MmUnblockMemoryRequest (
+               (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
+               Pages
+               );
+    if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+      return Status;
     }
 
     TempHobBuffer.RuntimeNvCacheBuffer = (UINTN)Buffer;
     TempHobBuffer.RuntimeNvCachePages  = Pages;
   }
-
-  // MU_CHANGE [END]
 
   DEBUG ((
     DEBUG_INFO,
@@ -1565,36 +1542,25 @@ BuildVariableRuntimeCacheInfoHob (
     TempHobBuffer.RuntimeNvCachePages
     ));
 
-  // MU_CHANGE [BEGIN] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
+  //
+  // AllocateRuntimePages for HobCache and unblock it.
+  //
   BufferSize = CalculateHobVariableCacheSize (NvAuthFlag);
   if (BufferSize > 0) {
-    Pages = EFI_SIZE_TO_PAGES (BufferSize);
-    if (PcdGetBool (PcdMigrateVariableRuntimeCacheBufferAllocation)) {
-      //
-      // AllocatePages for HobCache buffer (will be relocated to runtime by DXE).
-      //
-      Buffer = AllocatePages (Pages);
-      ASSERT (Buffer != NULL);
-    } else {
-      //
-      // AllocateRuntimePages for HobCache and unblock it.
-      //
-      Buffer = AllocateRuntimePages (Pages);
-      ASSERT (Buffer != NULL);
-      Status = MmUnblockMemoryRequest (
-                 (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
-                 Pages
-                 );
-      if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-        return Status;
-      }
+    Pages  = EFI_SIZE_TO_PAGES (BufferSize);
+    Buffer = AllocateRuntimePages (Pages);
+    ASSERT (Buffer != NULL);
+    Status = MmUnblockMemoryRequest (
+               (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
+               Pages
+               );
+    if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+      return Status;
     }
 
     TempHobBuffer.RuntimeHobCacheBuffer = (UINTN)Buffer;
     TempHobBuffer.RuntimeHobCachePages  = Pages;
   }
-
-  // MU_CHANGE [END]
 
   DEBUG ((
     DEBUG_INFO,

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
@@ -1578,8 +1578,7 @@ InitVariableCache (
   UINTN                        AllocatedNvCacheSize;
   UINTN                        AllocatedVolatileCacheSize;
   VARIABLE_RUNTIME_CACHE_INFO  *VariableRuntimeCacheInfo;
-  // MU_CHANGE [BEGIN] - Add variables for runtime buffer relocation from DXE
-  VOID   *RuntimeBuffer;
+  // MU_CHANGE [BEGIN] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
   UINTN  Pages;
 
   // Storage for temporary allocations - only commit to mVariableRtCacheInfo if ALL succeed
@@ -1589,7 +1588,7 @@ InitVariableCache (
   EFI_PHYSICAL_ADDRESS  TempVolatileCacheBuffer         = 0;
   BOOLEAN               AllRtBufferAllocationsSucceeded = TRUE;
 
-  // MU_CHANGE [END]
+  // MU_CHANGE [END] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
 
   //
   // Get needed runtime cache buffer size and check if auth variables are to be used from SMM
@@ -1601,20 +1600,35 @@ InitVariableCache (
               &mVariableAuthFormat
               );
   if (!EFI_ERROR (Status)) {
-    VariableRuntimeCacheInfo   = GET_GUID_HOB_DATA (RuntimeCacheInfoGuidHob);
-    AllocatedHobCacheSize      = EFI_PAGES_TO_SIZE ((UINTN)VariableRuntimeCacheInfo->RuntimeHobCachePages);
-    AllocatedNvCacheSize       = EFI_PAGES_TO_SIZE ((UINTN)VariableRuntimeCacheInfo->RuntimeNvCachePages);
-    AllocatedVolatileCacheSize = EFI_PAGES_TO_SIZE ((UINTN)VariableRuntimeCacheInfo->RuntimeVolatileCachePages);
-
-    ASSERT (
-      (AllocatedHobCacheSize >= ExpectedHobCacheSize) &&
-      (AllocatedNvCacheSize >= ExpectedNvCacheSize) &&
-      (AllocatedVolatileCacheSize >= ExpectedVolatileCacheSize)
-      );
-
-    CopyMem (&mVariableRtCacheInfo, VariableRuntimeCacheInfo, sizeof (VARIABLE_RUNTIME_CACHE_INFO));
-
     // MU_CHANGE [BEGIN] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
+    if (PcdGetBool (PcdMigrateVariableRuntimeCacheBufferAllocation)) {
+      ZeroMem (&mVariableRtCacheInfo, sizeof (mVariableRtCacheInfo));
+      AllocatedHobCacheSize      = ExpectedHobCacheSize;
+      AllocatedNvCacheSize       = ExpectedNvCacheSize;
+      AllocatedVolatileCacheSize = ExpectedVolatileCacheSize;
+
+      mVariableRtCacheInfo.RuntimeHobCachePages      = EFI_SIZE_TO_PAGES (ExpectedHobCacheSize);
+      mVariableRtCacheInfo.RuntimeNvCachePages       = EFI_SIZE_TO_PAGES (ExpectedNvCacheSize);
+      mVariableRtCacheInfo.RuntimeVolatileCachePages = EFI_SIZE_TO_PAGES (ExpectedVolatileCacheSize);
+    } else {
+      if (RuntimeCacheInfoGuidHob == NULL) {
+        return EFI_INVALID_PARAMETER;
+      }
+
+      VariableRuntimeCacheInfo   = GET_GUID_HOB_DATA (RuntimeCacheInfoGuidHob);
+      AllocatedHobCacheSize      = EFI_PAGES_TO_SIZE ((UINTN)VariableRuntimeCacheInfo->RuntimeHobCachePages);
+      AllocatedNvCacheSize       = EFI_PAGES_TO_SIZE ((UINTN)VariableRuntimeCacheInfo->RuntimeNvCachePages);
+      AllocatedVolatileCacheSize = EFI_PAGES_TO_SIZE ((UINTN)VariableRuntimeCacheInfo->RuntimeVolatileCachePages);
+
+      ASSERT (
+        (AllocatedHobCacheSize >= ExpectedHobCacheSize) &&
+        (AllocatedNvCacheSize >= ExpectedNvCacheSize) &&
+        (AllocatedVolatileCacheSize >= ExpectedVolatileCacheSize)
+        );
+
+      CopyMem (&mVariableRtCacheInfo, VariableRuntimeCacheInfo, sizeof (VARIABLE_RUNTIME_CACHE_INFO));
+    }
+
     if (PcdGetBool (PcdMigrateVariableRuntimeCacheBufferAllocation)) {
       //
       // Relocate runtime cache buffers from boot services to runtime services
@@ -1622,30 +1636,28 @@ InitVariableCache (
       //
       // Relocate CacheInfoFlag buffer from boot services to runtime services
       //
-      if (mVariableRtCacheInfo.CacheInfoFlagBuffer != 0) {
-        Pages  = EFI_SIZE_TO_PAGES (sizeof (CACHE_INFO_FLAG));
-        Status = gBS->AllocatePages (
-                        AllocateAnyPages,
-                        EfiRuntimeServicesData,
-                        Pages,
-                        &TempCacheInfoBuffer
-                        );
-        if (EFI_ERROR (Status)) {
-          DEBUG ((DEBUG_WARN, "Failed to allocate runtime CacheInfoFlag buffer: %r\n", Status));
+      Pages  = EFI_SIZE_TO_PAGES (sizeof (CACHE_INFO_FLAG));
+      Status = gBS->AllocatePages (
+                      AllocateAnyPages,
+                      EfiRuntimeServicesData,
+                      Pages,
+                      &TempCacheInfoBuffer
+                      );
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_WARN, "Failed to allocate runtime CacheInfoFlag buffer: %r\n", Status));
+        AllRtBufferAllocationsSucceeded = FALSE;
+      } else {
+        Status = MmUnblockMemoryRequest (TempCacheInfoBuffer, Pages);
+        if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_WARN, "Failed to unblock CacheInfoFlag buffer: %r\n", Status));
+          gBS->FreePages (TempCacheInfoBuffer, Pages);
+          TempCacheInfoBuffer             = 0;
           AllRtBufferAllocationsSucceeded = FALSE;
-        } else {
-          Status = MmUnblockMemoryRequest (TempCacheInfoBuffer, Pages);
-          if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-            DEBUG ((DEBUG_WARN, "Failed to unblock CacheInfoFlag buffer: %r\n", Status));
-            gBS->FreePages (TempCacheInfoBuffer, Pages);
-            TempCacheInfoBuffer             = 0;
-            AllRtBufferAllocationsSucceeded = FALSE;
-          }
         }
       }
 
-      if (AllRtBufferAllocationsSucceeded && (mVariableRtCacheInfo.RuntimeHobCacheBuffer != 0) && (AllocatedHobCacheSize > 0)) {
-        Pages  = EFI_SIZE_TO_PAGES (AllocatedHobCacheSize);
+      if (AllRtBufferAllocationsSucceeded && (mVariableRtCacheInfo.RuntimeHobCachePages > 0)) {
+        Pages  = (UINTN)mVariableRtCacheInfo.RuntimeHobCachePages;
         Status = gBS->AllocatePages (
                         AllocateAnyPages,
                         EfiRuntimeServicesData,
@@ -1666,8 +1678,8 @@ InitVariableCache (
         }
       }
 
-      if (AllRtBufferAllocationsSucceeded && (mVariableRtCacheInfo.RuntimeNvCacheBuffer != 0) && (AllocatedNvCacheSize > 0)) {
-        Pages  = EFI_SIZE_TO_PAGES (AllocatedNvCacheSize);
+      if (AllRtBufferAllocationsSucceeded && (mVariableRtCacheInfo.RuntimeNvCachePages > 0)) {
+        Pages  = (UINTN)mVariableRtCacheInfo.RuntimeNvCachePages;
         Status = gBS->AllocatePages (
                         AllocateAnyPages,
                         EfiRuntimeServicesData,
@@ -1688,8 +1700,8 @@ InitVariableCache (
         }
       }
 
-      if (AllRtBufferAllocationsSucceeded && (mVariableRtCacheInfo.RuntimeVolatileCacheBuffer != 0) && (AllocatedVolatileCacheSize > 0)) {
-        Pages  = EFI_SIZE_TO_PAGES (AllocatedVolatileCacheSize);
+      if (AllRtBufferAllocationsSucceeded && (mVariableRtCacheInfo.RuntimeVolatileCachePages > 0)) {
+        Pages  = (UINTN)mVariableRtCacheInfo.RuntimeVolatileCachePages;
         Status = gBS->AllocatePages (
                         AllocateAnyPages,
                         EfiRuntimeServicesData,
@@ -1721,33 +1733,25 @@ InitVariableCache (
         }
 
         if (TempCacheInfoBuffer != 0) {
-          RuntimeBuffer = (VOID *)(UINTN)TempCacheInfoBuffer;
-          CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.CacheInfoFlagBuffer, sizeof (CACHE_INFO_FLAG));
           mVariableRtCacheInfo.CacheInfoFlagBuffer = TempCacheInfoBuffer;
         }
 
         if (TempHobCacheBuffer != 0) {
-          RuntimeBuffer = (VOID *)(UINTN)TempHobCacheBuffer;
-          CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeHobCacheBuffer, AllocatedHobCacheSize);
           mVariableRtCacheInfo.RuntimeHobCacheBuffer = TempHobCacheBuffer;
-          InitVariableStoreHeader (RuntimeBuffer, AllocatedHobCacheSize);
+          InitVariableStoreHeader ((VOID *)(UINTN)TempHobCacheBuffer, AllocatedHobCacheSize);
         }
 
         if (TempNvCacheBuffer != 0) {
-          RuntimeBuffer = (VOID *)(UINTN)TempNvCacheBuffer;
-          CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeNvCacheBuffer, AllocatedNvCacheSize);
           mVariableRtCacheInfo.RuntimeNvCacheBuffer = TempNvCacheBuffer;
-          InitVariableStoreHeader (RuntimeBuffer, AllocatedNvCacheSize);
+          InitVariableStoreHeader ((VOID *)(UINTN)TempNvCacheBuffer, AllocatedNvCacheSize);
         }
 
         if (TempVolatileCacheBuffer != 0) {
-          RuntimeBuffer = (VOID *)(UINTN)TempVolatileCacheBuffer;
-          CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeVolatileCacheBuffer, AllocatedVolatileCacheSize);
           mVariableRtCacheInfo.RuntimeVolatileCacheBuffer = TempVolatileCacheBuffer;
-          InitVariableStoreHeader (RuntimeBuffer, AllocatedVolatileCacheSize);
+          InitVariableStoreHeader ((VOID *)(UINTN)TempVolatileCacheBuffer, AllocatedVolatileCacheSize);
         }
 
-        DEBUG ((DEBUG_INFO, "Runtime variable cache buffers successfully relocated\n"));
+        DEBUG ((DEBUG_INFO, "Runtime variable cache buffers successfully allocated in DXE.\n"));
       } else {
         //
         // One or more allocations failed - clean up any successful allocations
@@ -1906,7 +1910,9 @@ SmmVariableReady (
   mVariableBufferPhysical = mVariableBuffer;
 
   GuidHob = GetFirstGuidHob (&gEdkiiVariableRuntimeCacheInfoHobGuid);
-  if (GuidHob != NULL) {
+  // MU_CHANGE [BEGIN] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
+  if ((GuidHob != NULL) || FeaturePcdGet (PcdEnableVariableRuntimeCache)) {
+    // MU_CHANGE [END] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
     mIsRuntimeCacheEnabled = TRUE;
     DEBUG ((DEBUG_INFO, "Variable driver runtime cache is enabled.\n"));
 

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf
@@ -87,6 +87,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdAllowVariablePolicyEnforcementDisable     ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdTcgPfpMeasurementRevision                 ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdEnableSpdmDeviceAuthentication             ## PRODUCES AND CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdEnableVariableRuntimeCache                   ## CONSUMES  # MU_CHANGE
   gEfiMdeModulePkgTokenSpaceGuid.PcdMigrateVariableRuntimeCacheBufferAllocation  ## CONSUMES  # MU_CHANGE
 
 [Guids]


### PR DESCRIPTION
## Description

The UEFI variable driver has a runtime cache that is used to reduce
the number of MMIs to service variable requests.

Originally, this cache was allocated in the RT DXE variable driver
when setting up its in-memory variable store and used to cache
variables the RT layer through OS runtime. Since the variable cache
is shared between MM, this included MM unblock being added to when
the cache buffer was allocated.

Over time, two x86 Standalone MM cores came into existence - the Mu
MM Supervisor and the edk2 Standalone MM core in StandaloneMmPkg.
Because the UEFI variable code is maintained in edk2, it naturally
was updated to solely support the edk2 Standalone MM core.

This included removing the runtime cache allocation in
VariableSmmRuntimeDxe and instead allocating runtime buffers in the
VariablePei module and passing those allocations to
VarriableSmmRuntimeDxe through gEdkiiVariableRuntimeCacheInfoHobGuid
(a new HOB). This is because the edk2 Standalone MM core needs these
allocations made prior to MM IPL and does not support MM unblock in
DXE.

This fundamentally violates the principle of memory bins which are a
way to maintain runtime memory allocations in a stable location across
S4 suspend and resume since the allocations are made in PEI before the
bins are established in DXE load.

Since the Mu MM Supervisor does support MM unblock in DXE, this now
imposed the hibernation issue onto the Mu MM Supervisor platforms
without any benefit. edk2 code optimized around the HOB solution, for
example, no longer checking PcdEnableVariableRuntimeCache in the DXE
code and using the HOB presence behind the PCD check in the PEI code
to determine whether to activate the runtime cache in DXE.

In response, PcdMigrateVariableRuntimeCacheBufferAllocation was
added to the Mu variable driver to support allocating the runtime
buffer in DXE and unblocking it to essentially keep hibernate and
MM support the same as before the edk2 Standalone MM variable change.

This change is a 2502-specific refactor of that solution to remove
some unnecessary complexity and prevent any potential for a non-RT
buffer to be unblocked in PEI. To keep the change backward compatible,
PcdMigrateVariableRuntimeCacheBufferAllocation is retained and has the
same functional purpose (allocating and unblocking in DXE), but no
longer produces gEdkiiVariableRuntimeCacheInfoHobGuid at all when the
PCD is true.

This is meant to be a steady state for 2502 code to satisfy both
MM paradigms aligning with edk2 behavior by default (since
PcdMigrateVariableRuntimeCacheBufferAllocation is false by default).

Mu 2511 should be able to remove the DXE allocation entirely and
allocate and unblock the runtime cache buffer using runtime memory
in PEI with PEI memory buckets.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- QEMU Q35 with:
  - Config 1 (normal Q35 state w/ Mu MM Supervisor)
    - PcdEnableVariableRuntimeCache = TRUE
    - PcdMigrateVariableRuntimeCacheBufferAllocation = TRUE
  - Config 2
    - PcdEnableVariableRuntimeCache = TRUE
    - PcdMigrateVariableRuntimeCacheBufferAllocation = FALSE
- QEMU SBSA:
  - PcdEnableVariableRuntimeCache = FALSE
- Intel client platform
    - PcdEnableVariableRuntimeCache = TRUE
    - PcdMigrateVariableRuntimeCacheBufferAllocation = TRUE

## Integration Instructions

- Mu MM Supervisor platforms should:
  - Enable PcdEnableVariableRuntimeCache
  - Enable PcdMigrateVariableRuntimeCacheBufferAllocation
- edk2 Standalone MM core platforms should:
  - Enable PcdEnableVariableRuntimeCache
  - Disable PcdMigrateVariableRuntimeCacheBufferAllocation