### PR TITLE
[SQUASH ON REBASE] [REBASE & FF] ArmPlatformPkg: MemoryInitPeiLib: Update Resc Desc V2 HOB

### DIFF
--- a/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.c
+++ b/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.c
@@ -139,16 +139,16 @@ MemoryPeim (
 
     // Search for System Memory Hob that contains the firmware
     NextHob.Raw = GetHobList ();
-    while ((NextHob.Raw = GetNextHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR, NextHob.Raw)) != NULL) {
-      if ((NextHob.ResourceDescriptor->ResourceType == EFI_RESOURCE_SYSTEM_MEMORY) &&
-          (PcdGet64 (PcdFdBaseAddress) >= NextHob.ResourceDescriptor->PhysicalStart) &&
-          (FdTop <= NextHob.ResourceDescriptor->PhysicalStart + NextHob.ResourceDescriptor->ResourceLength))
+    while ((NextHob.Raw = GetNextHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR2, NextHob.Raw)) != NULL) {
+      if ((NextHob.ResourceDescriptorV2->V1.ResourceType == EFI_RESOURCE_SYSTEM_MEMORY) &&
+          (PcdGet64 (PcdFdBaseAddress) >= NextHob.ResourceDescriptorV2->V1.PhysicalStart) &&
+          (FdTop <= NextHob.ResourceDescriptorV2->V1.PhysicalStart + NextHob.ResourceDescriptorV2->V1.ResourceLength))
       {
-        ResourceAttributes = NextHob.ResourceDescriptor->ResourceAttribute;
-        ResourceLength     = NextHob.ResourceDescriptor->ResourceLength;
-        ResourceTop        = NextHob.ResourceDescriptor->PhysicalStart + ResourceLength;
+        ResourceAttributes = NextHob.ResourceDescriptorV2->V1.ResourceAttribute;
+        ResourceLength     = NextHob.ResourceDescriptorV2->V1.ResourceLength;
+        ResourceTop        = NextHob.ResourceDescriptorV2->V1.PhysicalStart + ResourceLength;
 
-        if (PcdGet64 (PcdFdBaseAddress) == NextHob.ResourceDescriptor->PhysicalStart) {
+        if (PcdGet64 (PcdFdBaseAddress) == NextHob.ResourceDescriptorV2->V1.PhysicalStart) {
           if (SystemMemoryTop != FdTop) {
             // Create the System Memory HOB for the firmware
             BuildResourceDescriptorV2 (
@@ -161,8 +161,8 @@ MemoryPeim (
               );
 
             // Top of the FD is system memory available for UEFI
-            NextHob.ResourceDescriptor->PhysicalStart  += PcdGet32 (PcdFdSize);
-            NextHob.ResourceDescriptor->ResourceLength -= PcdGet32 (PcdFdSize);
+            NextHob.ResourceDescriptorV2->V1.PhysicalStart  += PcdGet32 (PcdFdSize);
+            NextHob.ResourceDescriptorV2->V1.ResourceLength -= PcdGet32 (PcdFdSize);
           }
         } else {
           // Create the System Memory HOB for the firmware
@@ -176,17 +176,17 @@ MemoryPeim (
             );
 
           // Update the HOB
-          NextHob.ResourceDescriptor->ResourceLength = PcdGet64 (PcdFdBaseAddress) - NextHob.ResourceDescriptor->PhysicalStart;
+          NextHob.ResourceDescriptorV2->V1.ResourceLength = PcdGet64 (PcdFdBaseAddress) - NextHob.ResourceDescriptorV2->V1.PhysicalStart;
 
           // If there is some memory available on the top of the FD then create a HOB
-          if (FdTop < NextHob.ResourceDescriptor->PhysicalStart + ResourceLength) {
+          if (FdTop < NextHob.ResourceDescriptorV2->V1.PhysicalStart + ResourceLength) {
             // Create the System Memory HOB for the remaining region (top of the FD)
             BuildResourceDescriptorV2 (
               EFI_RESOURCE_SYSTEM_MEMORY,
               ResourceAttributes,
               FdTop,
               ResourceTop - FdTop,
-              EFI_MEMORY_WB,
+              NextHob.ResourceDescriptorV2->V1.ResourceAttribute,
               NULL
               );
           }

--- a/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.c
+++ b/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.c
@@ -104,7 +104,7 @@ MemoryPeim (
   while ((NextHob.Raw = GetNextHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR2, NextHob.Raw)) != NULL) {
     if ((NextHob.ResourceDescriptorV2->V1.ResourceType == EFI_RESOURCE_SYSTEM_MEMORY) &&
         (SystemMemoryBase >= NextHob.ResourceDescriptorV2->V1.PhysicalStart) &&
-        (NextHob.ResourceDescriptorV2->V1.PhysicalStart + NextHob.ResourceDescriptorV2->V1.ResourceLength <= SystemMemoryTop))
+        (NextHob.ResourceDescriptorV2->V1.PhysicalStart + NextHob.ResourceDescriptorV2->V1.ResourceLength > SystemMemoryBase))
     {
       Found = TRUE;
       break;


### PR DESCRIPTION
## Description

This PR has two commits:

Update Resc Desc V2 HOB
--
MemoryInitPeiLib attempts to search for a Resc Desc V2 HOB that describes system memory and if needed split it up and create a resc desc HOB v2 for the FD region that is not overlapping.

Currently, the change to produce a resc desc HOB v2 for system memory if not found does not correctly update it to split the HOB and will create an overlapping FD HOB.

The patina readiness tool catches this. This commit fixes this by searching through resc desc HOB v2s to find the system memory HOB v2 that covers system memory to fix up.

This should be squashed with b8960d8a908c98b566cb5204cc9a6eb8b3d1b11a and fb5e75cbf1c471de9a14233044c5e31ee3028a38 on rebase.

Loosen HOB Check
--
Currently, MemoryInitPeiLib checks if a resc desc HOB partially or wholly covers the system memory range defined by PcdSystemMemoryBase and PcdSystemMemorySize. If a HOB is not found, then the lib produces the system memory resc desc HOB.

However, it does not take into account that platforms have a small range defined in the PCDs and at runtime query the system memory range and produce a larger HOB. The current logic will not discover the larger HOB and will produce a HOB that conflicts with this one. Patina will mark this as an error; edk2 will silently choose one, but it may choose the smaller one.

This commit fixes this behavior by not producing a HOB in this library if one already exists that contains PcdSystemMemoryBase.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on a virtual platform where Patina is being integrated.

## Integration Instructions

N/A.
