### PR TITLE
[2502] NetworkPkg/DxeNetLib: Reduce SNP media detect timeout and retry attempts [Rebase & FF]

### DIFF
--- a/NetworkPkg/Include/Library/NetLib.h
+++ b/NetworkPkg/Include/Library/NetLib.h
@@ -109,7 +109,12 @@ typedef UINT16  TCP_PORTNO;
 //
 // Number of times to attempt to detect network media through SNP
 //
-#define DETECT_NET_MEDIA_RETRY_ATTEMPTS  2
+#define SNP_MEDIA_DETECT_RETRY_ATTEMPTS  0
+
+//
+// Amount of time to wait for network media to be detected through SNP, in 100ns units
+//
+#define SNP_MEDIA_DETECT_WAITING_TIME  EFI_TIMER_PERIOD_SECONDS(2)
 
 // MU_CHANGE [END] - Consider timeout for NetLibDetectMedia() calls in NetLibDetectMediaWaitTimeout()
 

--- a/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
+++ b/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
@@ -3021,13 +3021,14 @@ NetLibAipWaitForMediaState (
   connected state, connecting state and no media state respectively. When function detects
   the current state is EFI_NOT_READY, it will loop to wait for next time's check until state
   turns to be EFI_SUCCESS or EFI_NO_MEDIA. If Aip protocol is not supported, function will
-  call NetLibDetectMedia() and return state directly.
+  call NetLibDetectSnpMediaWithRetry() and wait for media to be present with a retry mechanism
+  and a minimal timeout.
 
   @param[in]   ServiceHandle    The handle where network service binding protocols are
                                 installed on.
   @param[in]   Timeout          The maximum number of 100ns units to wait when network
-                                is connecting. Zero value means detect once and return
-                                immediately.
+                                is connecting using AIP. Zero value means detect once and
+                                return immediately.
   @param[out]  MediaState       The pointer to the detected media state.
 
   @retval EFI_SUCCESS           Media detection success.
@@ -3075,7 +3076,7 @@ NetLibDetectMediaWaitTimeout (
                   );
   if (EFI_ERROR (Status)) {
     return NetLibNormalizeMediaReturnStatus (
-             NetLibDetectSnpMediaWithRetry (ServiceHandle, Timeout, DETECT_NET_MEDIA_RETRY_ATTEMPTS, MediaState),
+             NetLibDetectSnpMediaWithRetry (ServiceHandle, SNP_MEDIA_DETECT_WAITING_TIME, SNP_MEDIA_DETECT_RETRY_ATTEMPTS, MediaState),
              MediaState
              );
   }
@@ -3098,7 +3099,7 @@ NetLibDetectMediaWaitTimeout (
     }
 
     return NetLibNormalizeMediaReturnStatus (
-             NetLibDetectSnpMediaWithRetry (ServiceHandle, Timeout, DETECT_NET_MEDIA_RETRY_ATTEMPTS, MediaState),
+             NetLibDetectSnpMediaWithRetry (ServiceHandle, SNP_MEDIA_DETECT_WAITING_TIME, SNP_MEDIA_DETECT_RETRY_ATTEMPTS, MediaState),
              MediaState
              );
   }

--- a/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
+++ b/NetworkPkg/Library/DxeNetLib/DxeNetLib.c
@@ -2567,7 +2567,7 @@ NetLibSnpWaitForMediaPresent (
   }
 
   Timer         = NULL;
-  TimeRemaining = Timeout;
+  TimeRemaining = MIN (Timeout, MAX_INT64);
   Status        = gBS->CreateEvent (EVT_TIMER, TPL_CALLBACK, NULL, NULL, &Timer);
   if (EFI_ERROR (Status)) {
     return EFI_DEVICE_ERROR;
@@ -2951,7 +2951,7 @@ NetLibAipWaitForMediaState (
   EFI_STATUS                    Status;
   EFI_STATUS                    TimerStatus;
   EFI_EVENT                     Timer;
-  UINT64                        TimeRemaining;
+  INT64                         TimeRemaining;
   UINTN                         DataSize;
   EFI_ADAPTER_INFO_MEDIA_STATE  *MediaInfo;
 
@@ -2962,7 +2962,7 @@ NetLibAipWaitForMediaState (
   MediaInfo = NULL;
 
   Timer         = NULL;
-  TimeRemaining = Timeout;
+  TimeRemaining = MIN (Timeout, MAX_INT64);
   Status        = gBS->CreateEvent (EVT_TIMER, TPL_CALLBACK, NULL, NULL, &Timer);
   if (EFI_ERROR (Status)) {
     return EFI_DEVICE_ERROR;


### PR DESCRIPTION
## Description

Straight port of a 2511 PR to 2502.

https://github.com/microsoft/mu_basecore/pull/1715

---

Originally, `NetLibDetectMediaWaitTimeout()` only used a timeout when detecting media through AIP. When AIP is not available or fails, media detection falls back to SNP. Commit ef7bb4d made the SNP media detection process more robust with a timeout and retry mechanism. This improved detection reliability and overall stability on the network devices targeted by the change. However, it also applied conservative timeout and retry values that may cause longer wait times in some cases where AIP is not used and the SNP media state is already known to be "not present".

This change reduces SNP retry attempts to 0 and the waiting time to 2 seconds. This leaves the retry logic in place but avoids using it for now. The maximum connection time observed in this fallback case has been 1.5 seconds, so 2 seconds is chosen to provide a reasonable buffer while avoiding unnecessarily long waits.

---

A commit is also included to make timeout code in DxeNetLib consistent:

**NetworkPkg/DxeNetLib: Clamp timeouts to MAX_INT64**

The original implementation of tracking remaining time in the NetLibDetectMediaWaitTimeout() used a UINT64 to track the remaining time, which could wrap around depending on whether the subtracted time interval (MEDIA_STATE_DETECT_TIME_INTERVAL) was a factor of the timeout given.

This change makes the TimeRemaining variable a INT64 to prevent the wrap around and clamps the incoming timeout to MAX_INT64 to prevent overflow.

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

See the original 2511 PR: https://github.com/microsoft/mu_basecore/pull/1715

## Integration Instructions

See the original 2511 PR: https://github.com/microsoft/mu_basecore/pull/1715