### PR TITLE
EmbeddedPkg/VirtualRealTimeClockLib: Fix RTC offset logic for negative TimeZone

### DIFF
--- a/EmbeddedPkg/Library/VirtualRealTimeClockLib/VirtualRealTimeClockLib.c
+++ b/EmbeddedPkg/Library/VirtualRealTimeClockLib/VirtualRealTimeClockLib.c
@@ -55,6 +55,7 @@ LibGetTime (
   UINT64      Remainder;
   UINTN       EpochSeconds;
   UINTN       Size;
+  INT64       AdjustedEpochSeconds;
 
   if (Time == NULL) {
     return EFI_INVALID_PARAMETER;
@@ -150,7 +151,13 @@ LibGetTime (
 
     // Adjust for the correct time zone
     if (Time->TimeZone != EFI_UNSPECIFIED_TIMEZONE) {
-      EpochSeconds += Time->TimeZone * SEC_PER_MIN;
+      AdjustedEpochSeconds  = (INT64)EpochSeconds;
+      AdjustedEpochSeconds += (INT64)Time->TimeZone * (INT64)SEC_PER_MIN;
+      if (AdjustedEpochSeconds < 0) {
+        AdjustedEpochSeconds = 0;
+      }
+
+      EpochSeconds = (UINTN)AdjustedEpochSeconds;
     }
   }
 
@@ -253,7 +260,7 @@ LibSetTime (
   // Adjust for the correct time zone, i.e. convert to UTC time zone
   if (Time->TimeZone != EFI_UNSPECIFIED_TIMEZONE) {
     AdjustedEpochSeconds  = (INT64)EpochSeconds;
-    AdjustedEpochSeconds -= (INT64)Time->TimeZone * SEC_PER_MIN;
+    AdjustedEpochSeconds -= (INT64)Time->TimeZone * (INT64)SEC_PER_MIN;
     if (AdjustedEpochSeconds < 0) {
       AdjustedEpochSeconds = 0;
     }

--- a/EmbeddedPkg/Library/VirtualRealTimeClockLib/VirtualRealTimeClockLib.c
+++ b/EmbeddedPkg/Library/VirtualRealTimeClockLib/VirtualRealTimeClockLib.c
@@ -242,6 +242,7 @@ LibSetTime (
   UINT64      Counter;
   UINT64      Remainder;
   UINTN       EpochSeconds;
+  INT64       AdjustedEpochSeconds;
 
   if (!IsTimeValid (Time)) {
     return EFI_INVALID_PARAMETER;
@@ -250,10 +251,14 @@ LibSetTime (
   EpochSeconds = EfiTimeToEpoch (Time);
 
   // Adjust for the correct time zone, i.e. convert to UTC time zone
-  if (  (Time->TimeZone != EFI_UNSPECIFIED_TIMEZONE)
-     && (EpochSeconds > Time->TimeZone * SEC_PER_MIN))
-  {
-    EpochSeconds -= Time->TimeZone * SEC_PER_MIN;
+  if (Time->TimeZone != EFI_UNSPECIFIED_TIMEZONE) {
+    AdjustedEpochSeconds  = (INT64)EpochSeconds;
+    AdjustedEpochSeconds -= (INT64)Time->TimeZone * SEC_PER_MIN;
+    if (AdjustedEpochSeconds < 0) {
+      AdjustedEpochSeconds = 0;
+    }
+
+    EpochSeconds = (UINTN)AdjustedEpochSeconds;
   }
 
   // Adjust for the correct period


### PR DESCRIPTION
## Description

[Problem]
A logic defect in VirtualRealTimeClockLib causes incorrect RTC calculation when Time->TimeZone is negative (e.g., -480 for UTC+8). The comparison EpochSeconds > (Time->TimeZone * SEC_PER_MIN) performs unsigned comparison due to C type promotion rules. This treats the negative offset as a very large unsigned integer, causing the code to skip necessary timezone compensation.
 
[Solution]
Updated the logic to ensure the timezone offset calculation and comparison handle signed values correctly. This allows the library to properly apply compensation for both positive and negative timezones.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
[Steps]
Set the system timezone to UTC+8 (which translates to a -480 offset in the UEFI variable).
Perform a shutdown or hibernate and cold boot.
Observe the RTC time in the UEFI shell and OS.

[Result]
The RTC correctly reflects the local time, and the signed/unsigned comparison issue is resolved.

## Integration Instructions
N/A
