### PR TITLE
[Squash On Rebase] MdeModulePkg: Unconditionally ApplyMemoryProtectionPolicy

### DIFF
--- a/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
+++ b/MdeModulePkg/Core/Dxe/Misc/MemoryProtection.c
@@ -1586,7 +1586,10 @@ ApplyMemoryProtectionPolicy (
   IN  UINT64                Length
   )
 {
-  UINT64  OldAttributes;
+  // MU_CHANGE - Start - Enforce that the Core returns memory with expected attributes
+  // UINT64  OldAttributes;
+  // MU_CHANGE - End - Enforce that the Core returns memory with expected attributes
+
   UINT64  NewAttributes;
 
   //
@@ -1645,16 +1648,21 @@ ApplyMemoryProtectionPolicy (
   //
   NewAttributes = GetPermissionAttributeForMemoryType (NewType);
 
-  if (OldType != EfiMaxMemoryType) {
-    OldAttributes = GetPermissionAttributeForMemoryType (OldType);
-    if (OldAttributes == NewAttributes) {
-      // policy is the same between OldType and NewType
-      return EFI_SUCCESS;
-    }
-  } else if (NewAttributes == 0) {
-    // newly added region of a type that does not require protection
-    return EFI_SUCCESS;
-  }
+  // MU_CHANGE - Start - Enforce that the Core returns memory with expected attributes
+  // Ensure that the memory has the expected attributes by skipping the Edk2 checks.
+  // Compat mode, Memory Attributes Protocol, Cpu Arch are all able to
+  // change memory attributes so ensure the memory range attributes match expectations.
+  // if (OldType != EfiMaxMemoryType) {
+  //  OldAttributes = GetPermissionAttributeForMemoryType (OldType);
+  //  if (OldAttributes == NewAttributes) {
+  //    // policy is the same between OldType and NewType
+  //    return EFI_SUCCESS;
+  //  }
+  // } else if (NewAttributes == 0) {
+  //  // newly added region of a type that does not require protection
+  //  return EFI_SUCCESS;
+  // }
+  // MU_CHANGE - End - Enforce that the Core returns memory with expected attribute
 
   return gCpu->SetMemoryAttributes (gCpu, Memory, Length, NewAttributes);
 }


### PR DESCRIPTION
## Description

When a non-NX_COMPAT EFI_APPLICATION (e.g. grubx64.efi) is loaded,
ActivateCompatibilityMode() sets mEnhancedMemoryProtectionActive = FALSE.
From then on, GetPermissionAttributeForMemoryType() returns 0 for every
memory type.

ApplyMemoryProtectionPolicy() would get OldAttributes and NewAttributes
based upon the memory type, not the actual memory settings, and if attributes 
matched, return early without a call to SetMemoryAttributes.  This could result
in the system providing memory with unintended attributes.

Skip the type-compare shortcut. Always call SetMemoryAttributes
when returning allocated memory.

Squash on Rebase with https://github.com/microsoft/mu_basecore/commit/b8374261aae751adae10f005b67bea2858d59358
(Implement Compatibility Mode for Enhanced Memory Protection)

- [X] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Physical platform booting grubx64.

## Integration Instructions
No integration necessary.