### PR TITLE
[SQUASH ON REBASE] Rename TpmTestApp to TpmShellApp

### DIFF
--- a/SecurityPkg/Applications/TpmShellApp/TpmShellApp.c
+++ b/SecurityPkg/Applications/TpmShellApp/TpmShellApp.c
@@ -858,16 +858,16 @@ PrintUsage (
   VOID
   )
 {
-  Print (L"TpmTestApp - TPM 2.0 Physical Presence Test Utility\n");
+  Print (L"TpmShellApp - TPM 2.0 Physical Presence Test Utility\n");
   Print (L"\n");
   Print (L"Usage:\n");
-  Print (L"  TpmTestApp help             - Show usage\n");
-  Print (L"  TpmTestApp info             - Show PCR banks\n");
-  Print (L"  TpmTestApp setpcr <mask>    - Request PCR bank change (hex bitmask)\n");
-  Print (L"  TpmTestApp logall           - Enable all supported PCR banks\n");
-  Print (L"  TpmTestApp eventlog         - Dump the TCG2 event log\n");
-  Print (L"  TpmTestApp replay           - Replay event log and verify PCRs\n");
-  Print (L"  TpmTestApp lastresponse     - Show last SetActivePcrBanks result\n");
+  Print (L"  TpmShellApp help             - Show usage\n");
+  Print (L"  TpmShellApp info             - Show PCR banks\n");
+  Print (L"  TpmShellApp setpcr <mask>    - Request PCR bank change (hex bitmask)\n");
+  Print (L"  TpmShellApp logall           - Enable all supported PCR banks\n");
+  Print (L"  TpmShellApp eventlog         - Dump the TCG2 event log\n");
+  Print (L"  TpmShellApp replay           - Replay event log and verify PCRs\n");
+  Print (L"  TpmShellApp lastresponse     - Show last SetActivePcrBanks result\n");
   Print (L"\n");
   Print (L"PCR bank bitmask values:\n");
   Print (L"  0x00000001 = SHA1\n");
@@ -876,8 +876,8 @@ PrintUsage (
   Print (L"  0x00000008 = SHA512\n");
   Print (L"  0x00000010 = SM3_256\n");
   Print (L"\n");
-  Print (L"Example: TpmTestApp setpcr 0x2   (enable SHA256 only)\n");
-  Print (L"Example: TpmTestApp setpcr 0x6   (enable SHA256 + SHA384)\n");
+  Print (L"Example: TpmShellApp setpcr 0x2   (enable SHA256 only)\n");
+  Print (L"Example: TpmShellApp setpcr 0x6   (enable SHA256 + SHA384)\n");
 }
 
 /**
@@ -891,7 +891,7 @@ PrintUsage (
 **/
 EFI_STATUS
 EFIAPI
-TpmTestAppEntry (
+TpmShellAppEntry (
   IN EFI_HANDLE        ImageHandle,
   IN EFI_SYSTEM_TABLE  *SystemTable
   )
@@ -923,7 +923,7 @@ TpmTestAppEntry (
   Argc = ShellCommandLineGetCount (ParamPackage);
   if (Argc < 2) {
     Print (L"\n[Invalid Usage]\n");
-    Print (L"  Use 'TpmTestApp help' for usage.\n");
+    Print (L"  Use 'TpmShellApp help' for usage.\n");
     Status = EFI_INVALID_PARAMETER;
     goto Exit;
   }
@@ -951,7 +951,7 @@ TpmTestAppEntry (
     Print (L"\n[Set PCR Banks]\n\n");
     if (Argc < 3) {
       Print (L"setpcr requires a hex bitmask parameter.\n");
-      Print (L"  Example: TpmTestApp setpcr 0x2\n");
+      Print (L"  Example: TpmShellApp setpcr 0x2\n");
       Status = EFI_INVALID_PARAMETER;
       goto Exit;
     }
@@ -991,7 +991,7 @@ TpmTestAppEntry (
   } else {
     Print (L"\n[Invalid Input Command]\n\n");
     Print (L"  Unknown command '%s'\n", Command);
-    Print (L"  Use 'TpmTestApp help' for usage.\n");
+    Print (L"  Use 'TpmShellApp help' for usage.\n");
     Status = EFI_INVALID_PARAMETER;
   }
 

--- a/SecurityPkg/Applications/TpmShellApp/TpmShellApp.inf
+++ b/SecurityPkg/Applications/TpmShellApp/TpmShellApp.inf
@@ -1,6 +1,6 @@
 ## @file
 # MU_CHANGE
-# TpmTestApp.inf
+# TpmShellApp.inf
 #
 # UEFI shell application for testing TPM 2.0 Physical Presence Interface
 # operations, including querying and configuring PCR banks.
@@ -12,11 +12,11 @@
 
 [Defines]
   INF_VERSION                    = 0x00010006
-  BASE_NAME                      = TpmTestApp
+  BASE_NAME                      = TpmShellApp
   FILE_GUID                      = A3B2D4F1-7E6C-4A89-B5D0-3C1F8E2A9D07
   MODULE_TYPE                    = UEFI_APPLICATION
   VERSION_STRING                 = 1.0
-  ENTRY_POINT                    = TpmTestAppEntry
+  ENTRY_POINT                    = TpmShellAppEntry
 
 #
 # The following information is for reference only and not required by the build tools.
@@ -25,7 +25,7 @@
 #
 
 [Sources]
-  TpmTestApp.c
+  TpmShellApp.c
 
 [Packages]
   MdePkg/MdePkg.dec

--- a/SecurityPkg/Applications/TpmShellApp/TpmShellApp.md
+++ b/SecurityPkg/Applications/TpmShellApp/TpmShellApp.md
@@ -1,4 +1,4 @@
-# TpmTestApp
+# TpmShellApp
 
 A UEFI shell application for testing TPM 2.0 Physical Presence Interface operations,
 including querying and configuring PCR banks. The app communicates exclusively through the
@@ -15,7 +15,7 @@ presence libraries, or TPM hardware.
 
 ## Overview
 
-TpmTestApp is a `UEFI_APPLICATION` that validates TPM 2.0 PCR bank operations via the
+TpmShellApp is a `UEFI_APPLICATION` that validates TPM 2.0 PCR bank operations via the
 TCG2 Protocol. It is designed to test that a platform's Physical Presence Interface
 correctly handles PCR bank change requests, including verifying that unsupported operations
 are gracefully rejected.
@@ -27,13 +27,13 @@ console.
 ## Commands
 
 ```text
-TpmTestApp help             Show usage information
-TpmTestApp info             Show supported and active PCR banks
-TpmTestApp setpcr <mask>    Request a PCR bank configuration change
-TpmTestApp logall           Request enabling all supported PCR banks
-TpmTestApp eventlog         Dump the TCG2 event log
-TpmTestApp replay           Replay event log and verify PCRs
-TpmTestApp lastresponse     Show the result of the last SetActivePcrBanks call
+TpmShellApp help             Show usage information
+TpmShellApp info             Show supported and active PCR banks
+TpmShellApp setpcr <mask>    Request a PCR bank configuration change
+TpmShellApp logall           Request enabling all supported PCR banks
+TpmShellApp eventlog         Dump the TCG2 event log
+TpmShellApp replay           Replay event log and verify PCRs
+TpmShellApp lastresponse     Show the result of the last SetActivePcrBanks call
 ```
 
 ### `help`
@@ -80,9 +80,9 @@ Values can be combined: `0x06` = SHA256 + SHA384.
 The mask parameter accepts hex with or without a `0x` prefix.
 
 ```text
-TpmTestApp setpcr 0x2       Enable SHA256 only
-TpmTestApp setpcr 0x6       Enable SHA256 + SHA384
-TpmTestApp setpcr 2         Also valid (no prefix)
+TpmShellApp setpcr 0x2       Enable SHA256 only
+TpmShellApp setpcr 0x6       Enable SHA256 + SHA384
+TpmShellApp setpcr 2         Also valid (no prefix)
 ```
 
 > **Note**: `SetActivePcrBanks` submits a Physical Presence request. The actual bank
@@ -140,12 +140,12 @@ library for the result of the most recent `SetActivePcrBanks` operation. Display
 
 ### INF
 
-The app is defined in `SecurityPkg/Applications/TpmTestApp/TpmTestApp.inf`:
+The app is defined in `SecurityPkg/Applications/TpmShellApp/TpmShellApp.inf`:
 
 | Property | Value |
 | -------- | ----- |
 | `MODULE_TYPE` | `UEFI_APPLICATION` |
-| `ENTRY_POINT` | `TpmTestAppEntry` |
+| `ENTRY_POINT` | `TpmShellAppEntry` |
 | `FILE_GUID` | `A3B2D4F1-7E6C-4A89-B5D0-3C1F8E2A9D07` |
 
 Dependencies:
@@ -165,7 +165,7 @@ TCG2 Protocol.
 Add the INF to the platform DSC components section:
 
 ```ini
-SecurityPkg/Applications/TpmTestApp/TpmTestApp.inf
+SecurityPkg/Applications/TpmShellApp/TpmShellApp.inf
 ```
 
 The platform DSC must also map `IntrinsicLib` for the `UEFI_APPLICATION` module type.
@@ -186,12 +186,12 @@ not available.
 Add the INF to the appropriate firmware volume in the platform FDF:
 
 ```ini
-INF SecurityPkg/Applications/TpmTestApp/TpmTestApp.inf
+INF SecurityPkg/Applications/TpmShellApp/TpmShellApp.inf
 ```
 
 ## Protocol Dependency
 
-TpmTestApp uses only `EFI_TCG2_PROTOCOL` (`gEfiTcg2ProtocolGuid`). This protocol is
+TpmShellApp uses only `EFI_TCG2_PROTOCOL` (`gEfiTcg2ProtocolGuid`). This protocol is
 installed by `Tcg2Dxe.efi`, which requires TPM to be enabled in the platform
 configuration.
 

--- a/SecurityPkg/SecurityPkg.dsc
+++ b/SecurityPkg/SecurityPkg.dsc
@@ -247,7 +247,7 @@
   SecurityPkg/Library/PeiDxeTpmPlatformHierarchyLib/PeiDxeTpmPlatformHierarchyLib.inf
   SecurityPkg/Library/PeiDxeTpmPlatformHierarchyLibNull/PeiDxeTpmPlatformHierarchyLib.inf
 
-  SecurityPkg/Applications/TpmTestApp/TpmTestApp.inf  ## MU_CHANGE
+  SecurityPkg/Applications/TpmShellApp/TpmShellApp.inf  ## MU_CHANGE
 
   #
   # TCG Storage.


### PR DESCRIPTION
## Description

Renamed TpmTestApp to TpmShellApp. This removes the need for a TPM_TEST_APP_ENABLE gate due to the name being *TestApp. This was causing issues in CI where the TpmTestApp was being auto included as a unit test when it isn't set up as a unit test app.

Commit to squash into:
https://github.com/microsoft/mu_basecore/commit/8cbf7761deaba3a4e62eaf882416cfc1b4fcdb43 SecurityPkg: Introduce TpmTestApp

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Build both QEMU SBSA and Q35 with the TpmShellApp enabled (TPM_ENABLE/TPM2_ENABLE == TRUE). Verified TpmShellApp functionality.

## Integration Instructions

N/A
