### PR TITLE
CryptoPkg: Correct MockBaseCryptLib interface

### DIFF
--- a/CryptoPkg/Test/Mock/Include/GoogleTest/Library/MockBaseCryptLib.h
+++ b/CryptoPkg/Test/Mock/Include/GoogleTest/Library/MockBaseCryptLib.h
@@ -869,7 +869,10 @@ struct MockBaseCryptLib {
      IN   CONST UINT8  *KeyPassword,
      IN   UINT8        *InData,
      IN   UINTN        InDataSize,
-     IN   UINT8        *SignCert,
+     // MU_CHANGE [TCBZ3925] - Pkcs7Sign is broken
+     IN   CONST UINT8  *SignCert,
+     // MU_CHANGE [TCBZ3925] - Pkcs7Sign is broken
+     IN   UINTN        SignCertSize,
      IN   UINT8        *OtherCerts      OPTIONAL,
      OUT  UINT8        **SignedData,
      OUT  UINTN        *SignedDataSize

--- a/CryptoPkg/Test/Mock/Library/GoogleTest/MockBaseCryptLib/MockBaseCryptLib.cpp
+++ b/CryptoPkg/Test/Mock/Library/GoogleTest/MockBaseCryptLib/MockBaseCryptLib.cpp
@@ -92,7 +92,9 @@ MOCK_FUNCTION_DEFINITION (MockBaseCryptLib, RsaOaepDecrypt, 6, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockBaseCryptLib, Pkcs7GetSigners, 6, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockBaseCryptLib, Pkcs7FreeSigners, 1, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockBaseCryptLib, Pkcs7GetCertificatesList, 6, EFIAPI);
-MOCK_FUNCTION_DEFINITION (MockBaseCryptLib, Pkcs7Sign, 9, EFIAPI);
+// MU_CHANGE [TCBZ3925] - Pkcs7Sign is broken
+MOCK_FUNCTION_DEFINITION (MockBaseCryptLib, Pkcs7Sign, 10, EFIAPI);
+// MU_CHANGE [TCBZ3925] - Pkcs7Sign is broken
 MOCK_FUNCTION_DEFINITION (MockBaseCryptLib, Pkcs7Verify, 6, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockBaseCryptLib, Pkcs7Encrypt, 7, EFIAPI);
 MOCK_FUNCTION_DEFINITION (MockBaseCryptLib, VerifyEKUsInPkcs7Signature, 5, EFIAPI);


### PR DESCRIPTION
## Description

MU_BASECORE has a override (TCBZ3925) in BaseCryptLib.h. So the mock library should align to the change in override.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Enable the current disabled Host Unit Test for CryptoPkg (https://github.com/PaddyDeng-v/mu_basecore/commit/c24c879178379c4ff1ebc722b877d15edd499571). Make sure MockBaseCryptLib is built and the CI build process passed.

## Integration Instructions

N/A