### PR TITLE
[2511] MdeModulePkg/Variable: Remove Mu RT cache buffer allocation changes [Rebase & FF]

### DIFF
--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -913,20 +913,6 @@
   # @Prompt Enable the UEFI variable runtime cache.
   gEfiMdeModulePkgTokenSpaceGuid.PcdEnableVariableRuntimeCache|TRUE|BOOLEAN|0x00010039
 
-  # MU_CHANGE [BEGIN] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
-  ## Indicates whether to allocate variable runtime cache buffers in PEI or DXE phase.<BR><BR>
-  #  When TRUE, buffers are allocated as EfiBootServicesData in PEI and migrated to
-  #  EfiRuntimeServicesData in DXE to prevent runtime memory fragmentation.<BR>
-  #  When FALSE, buffers are allocated directly as EfiRuntimeServicesData in PEI
-  #  (original behavior).<BR><BR>
-  #  This should only be set to TRUE on platforms that can unblock MM memory in DXE such as those
-  #  with the Project Mu MM Supervisor.<BR><BR>
-  #   TRUE  - Allocate in PEI as boot services data and migrate to runtime in DXE.<BR>
-  #   FALSE - Allocate in PEI directly as runtime services data (default).<BR>
-  # @Prompt Migrate variable runtime cache buffer allocation from PEI to DXE.
-  gEfiMdeModulePkgTokenSpaceGuid.PcdMigrateVariableRuntimeCacheBufferAllocation|FALSE|BOOLEAN|0x0001009d
-  # MU_CHANGE [END] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
-
   ## Indicates if the statistics about variable usage will be collected. This information is
   #  stored as a vendor configuration table into the EFI system table.
   #  Set this PCD to TRUE to use VariableInfo application in MdeModulePkg\Application directory to get

--- a/MdeModulePkg/Universal/Variable/Pei/Variable.c
+++ b/MdeModulePkg/Universal/Variable/Pei/Variable.c
@@ -1456,35 +1456,27 @@ BuildVariableRuntimeCacheInfoHob (
 {
   VARIABLE_RUNTIME_CACHE_INFO  TempHobBuffer;
   VARIABLE_RUNTIME_CACHE_INFO  *VariableRuntimeCacheInfo;
-  // MU_CHANGE [BEGIN] - Comment out unused variable when moving allocation to DXE
-  // EFI_STATUS                   Status;
-  // MU_CHANGE [END]
-  VOID     *Buffer;
-  UINTN    BufferSize;
-  BOOLEAN  NvAuthFlag;
-  UINTN    Pages;
+  EFI_STATUS                   Status;
+  VOID                         *Buffer;
+  UINTN                        BufferSize;
+  BOOLEAN                      NvAuthFlag;
+  UINTN                        Pages;
 
   ZeroMem (&TempHobBuffer, sizeof (VARIABLE_RUNTIME_CACHE_INFO));
 
   //
-  // MU_CHANGE [BEGIN] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
-  // AllocatePages for CACHE_INFO_FLAG buffer (will be relocated to runtime by DXE).
+  // AllocateRuntimePages for CACHE_INFO_FLAG and unblock it.
   //
   Pages  = EFI_SIZE_TO_PAGES (sizeof (CACHE_INFO_FLAG));
-  Buffer = AllocatePages (Pages);
+  Buffer = AllocateRuntimePages (Pages);
   ASSERT (Buffer != NULL);
-  //
-  // MU_CHANGE - Commented out runtime allocation and memory unblock (moved to DXE)
-  // Buffer = AllocateRuntimePages (Pages);
-  // Status = MmUnblockMemoryRequest (
-  //            (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
-  //            Pages
-  //            );
-  // if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-  //   return Status;
-  // }
-  //
-  // MU_CHANGE [END]
+  Status = MmUnblockMemoryRequest (
+             (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
+             Pages
+             );
+  if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+    return Status;
+  }
 
   TempHobBuffer.CacheInfoFlagBuffer = (UINTN)Buffer;
   DEBUG ((
@@ -1495,31 +1487,24 @@ BuildVariableRuntimeCacheInfoHob (
     ));
 
   //
-  // MU_CHANGE [BEGIN] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
-  // AllocatePages for VolatileCache buffer (will be relocated to runtime by DXE).
+  // AllocateRuntimePages for VolatileCache and unblock it.
   //
   BufferSize = PcdGet32 (PcdVariableStoreSize);
   if (BufferSize > 0) {
     Pages  = EFI_SIZE_TO_PAGES (BufferSize);
-    Buffer = AllocatePages (Pages);
+    Buffer = AllocateRuntimePages (Pages);
     ASSERT (Buffer != NULL);
-    //
-    // MU_CHANGE - Commented out runtime allocation and memory unblock (moved to DXE)
-    // Buffer = AllocateRuntimePages (Pages);
-    // Status = MmUnblockMemoryRequest (
-    //            (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
-    //            Pages
-    //            );
-    // if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-    //   return Status;
-    // }
-    //
+    Status = MmUnblockMemoryRequest (
+               (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
+               Pages
+               );
+    if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+      return Status;
+    }
 
     TempHobBuffer.RuntimeVolatileCacheBuffer = (UINTN)Buffer;
     TempHobBuffer.RuntimeVolatileCachePages  = Pages;
   }
-
-  // MU_CHANGE [END]
 
   DEBUG ((
     DEBUG_INFO,
@@ -1529,31 +1514,24 @@ BuildVariableRuntimeCacheInfoHob (
     ));
 
   //
-  // MU_CHANGE [BEGIN] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
-  // AllocatePages for NVCache buffer (will be relocated to runtime by DXE).
+  // AllocateRuntimePages for NVCache and unblock it.
   //
   BufferSize = CalculateNvVariableCacheSize (&NvAuthFlag);
   if (BufferSize > 0) {
     Pages  = EFI_SIZE_TO_PAGES (BufferSize);
-    Buffer = AllocatePages (Pages);
+    Buffer = AllocateRuntimePages (Pages);
     ASSERT (Buffer != NULL);
-    //
-    // MU_CHANGE - Commented out runtime allocation and memory unblock (moved to DXE)
-    // Buffer = AllocateRuntimePages (Pages);
-    // Status = MmUnblockMemoryRequest (
-    //            (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
-    //            Pages
-    //            );
-    // if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-    //   return Status;
-    // }
-    //
+    Status = MmUnblockMemoryRequest (
+               (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
+               Pages
+               );
+    if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+      return Status;
+    }
 
     TempHobBuffer.RuntimeNvCacheBuffer = (UINTN)Buffer;
     TempHobBuffer.RuntimeNvCachePages  = Pages;
   }
-
-  // MU_CHANGE [END]
 
   DEBUG ((
     DEBUG_INFO,
@@ -1563,31 +1541,24 @@ BuildVariableRuntimeCacheInfoHob (
     ));
 
   //
-  // MU_CHANGE [BEGIN] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
-  // AllocatePages for HobCache buffer (will be relocated to runtime by DXE).
+  // AllocateRuntimePages for HobCache and unblock it.
   //
   BufferSize = CalculateHobVariableCacheSize (NvAuthFlag);
   if (BufferSize > 0) {
     Pages  = EFI_SIZE_TO_PAGES (BufferSize);
-    Buffer = AllocatePages (Pages);
+    Buffer = AllocateRuntimePages (Pages);
     ASSERT (Buffer != NULL);
-    //
-    // MU_CHANGE - Commented out runtime allocation and memory unblock (moved to DXE)
-    // Buffer = AllocateRuntimePages (Pages);
-    // Status = MmUnblockMemoryRequest (
-    //            (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
-    //            Pages
-    //            );
-    // if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-    //   return Status;
-    // }
-    //
+    Status = MmUnblockMemoryRequest (
+               (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
+               Pages
+               );
+    if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+      return Status;
+    }
 
     TempHobBuffer.RuntimeHobCacheBuffer = (UINTN)Buffer;
     TempHobBuffer.RuntimeHobCachePages  = Pages;
   }
-
-  // MU_CHANGE [END]
 
   DEBUG ((
     DEBUG_INFO,

--- a/MdeModulePkg/Universal/Variable/Pei/Variable.c
+++ b/MdeModulePkg/Universal/Variable/Pei/Variable.c
@@ -1456,38 +1456,34 @@ BuildVariableRuntimeCacheInfoHob (
 {
   VARIABLE_RUNTIME_CACHE_INFO  TempHobBuffer;
   VARIABLE_RUNTIME_CACHE_INFO  *VariableRuntimeCacheInfo;
-  EFI_STATUS                   Status;
-  VOID                         *Buffer;
-  UINTN                        BufferSize;
-  BOOLEAN                      NvAuthFlag;
-  UINTN                        Pages;
+  // MU_CHANGE [BEGIN] - Comment out unused variable when moving allocation to DXE
+  // EFI_STATUS                   Status;
+  // MU_CHANGE [END]
+  VOID     *Buffer;
+  UINTN    BufferSize;
+  BOOLEAN  NvAuthFlag;
+  UINTN    Pages;
 
   ZeroMem (&TempHobBuffer, sizeof (VARIABLE_RUNTIME_CACHE_INFO));
 
+  //
   // MU_CHANGE [BEGIN] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
-  Pages = EFI_SIZE_TO_PAGES (sizeof (CACHE_INFO_FLAG));
-
-  if (PcdGetBool (PcdMigrateVariableRuntimeCacheBufferAllocation)) {
-    //
-    // AllocatePages for CACHE_INFO_FLAG buffer (will be relocated to runtime by DXE).
-    //
-    Buffer = AllocatePages (Pages);
-    ASSERT (Buffer != NULL);
-  } else {
-    //
-    // AllocateRuntimePages for CACHE_INFO_FLAG and unblock it.
-    //
-    Buffer = AllocateRuntimePages (Pages);
-    ASSERT (Buffer != NULL);
-    Status = MmUnblockMemoryRequest (
-               (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
-               Pages
-               );
-    if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-      return Status;
-    }
-  }
-
+  // AllocatePages for CACHE_INFO_FLAG buffer (will be relocated to runtime by DXE).
+  //
+  Pages  = EFI_SIZE_TO_PAGES (sizeof (CACHE_INFO_FLAG));
+  Buffer = AllocatePages (Pages);
+  ASSERT (Buffer != NULL);
+  //
+  // MU_CHANGE - Commented out runtime allocation and memory unblock (moved to DXE)
+  // Buffer = AllocateRuntimePages (Pages);
+  // Status = MmUnblockMemoryRequest (
+  //            (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
+  //            Pages
+  //            );
+  // if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+  //   return Status;
+  // }
+  //
   // MU_CHANGE [END]
 
   TempHobBuffer.CacheInfoFlagBuffer = (UINTN)Buffer;
@@ -1498,30 +1494,26 @@ BuildVariableRuntimeCacheInfoHob (
     Pages
     ));
 
+  //
   // MU_CHANGE [BEGIN] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
+  // AllocatePages for VolatileCache buffer (will be relocated to runtime by DXE).
+  //
   BufferSize = PcdGet32 (PcdVariableStoreSize);
   if (BufferSize > 0) {
-    Pages = EFI_SIZE_TO_PAGES (BufferSize);
-    if (PcdGetBool (PcdMigrateVariableRuntimeCacheBufferAllocation)) {
-      //
-      // AllocatePages for VolatileCache buffer (will be relocated to runtime by DXE).
-      //
-      Buffer = AllocatePages (Pages);
-      ASSERT (Buffer != NULL);
-    } else {
-      //
-      // AllocateRuntimePages for VolatileCache and unblock it.
-      //
-      Buffer = AllocateRuntimePages (Pages);
-      ASSERT (Buffer != NULL);
-      Status = MmUnblockMemoryRequest (
-                 (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
-                 Pages
-                 );
-      if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-        return Status;
-      }
-    }
+    Pages  = EFI_SIZE_TO_PAGES (BufferSize);
+    Buffer = AllocatePages (Pages);
+    ASSERT (Buffer != NULL);
+    //
+    // MU_CHANGE - Commented out runtime allocation and memory unblock (moved to DXE)
+    // Buffer = AllocateRuntimePages (Pages);
+    // Status = MmUnblockMemoryRequest (
+    //            (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
+    //            Pages
+    //            );
+    // if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+    //   return Status;
+    // }
+    //
 
     TempHobBuffer.RuntimeVolatileCacheBuffer = (UINTN)Buffer;
     TempHobBuffer.RuntimeVolatileCachePages  = Pages;
@@ -1536,30 +1528,26 @@ BuildVariableRuntimeCacheInfoHob (
     TempHobBuffer.RuntimeVolatileCachePages
     ));
 
+  //
   // MU_CHANGE [BEGIN] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
+  // AllocatePages for NVCache buffer (will be relocated to runtime by DXE).
+  //
   BufferSize = CalculateNvVariableCacheSize (&NvAuthFlag);
   if (BufferSize > 0) {
-    Pages = EFI_SIZE_TO_PAGES (BufferSize);
-    if (PcdGetBool (PcdMigrateVariableRuntimeCacheBufferAllocation)) {
-      //
-      // AllocatePages for NVCache buffer (will be relocated to runtime by DXE).
-      //
-      Buffer = AllocatePages (Pages);
-      ASSERT (Buffer != NULL);
-    } else {
-      //
-      // AllocateRuntimePages for NVCache and unblock it.
-      //
-      Buffer = AllocateRuntimePages (Pages);
-      ASSERT (Buffer != NULL);
-      Status = MmUnblockMemoryRequest (
-                 (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
-                 Pages
-                 );
-      if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-        return Status;
-      }
-    }
+    Pages  = EFI_SIZE_TO_PAGES (BufferSize);
+    Buffer = AllocatePages (Pages);
+    ASSERT (Buffer != NULL);
+    //
+    // MU_CHANGE - Commented out runtime allocation and memory unblock (moved to DXE)
+    // Buffer = AllocateRuntimePages (Pages);
+    // Status = MmUnblockMemoryRequest (
+    //            (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
+    //            Pages
+    //            );
+    // if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+    //   return Status;
+    // }
+    //
 
     TempHobBuffer.RuntimeNvCacheBuffer = (UINTN)Buffer;
     TempHobBuffer.RuntimeNvCachePages  = Pages;
@@ -1574,30 +1562,26 @@ BuildVariableRuntimeCacheInfoHob (
     TempHobBuffer.RuntimeNvCachePages
     ));
 
+  //
   // MU_CHANGE [BEGIN] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
+  // AllocatePages for HobCache buffer (will be relocated to runtime by DXE).
+  //
   BufferSize = CalculateHobVariableCacheSize (NvAuthFlag);
   if (BufferSize > 0) {
-    Pages = EFI_SIZE_TO_PAGES (BufferSize);
-    if (PcdGetBool (PcdMigrateVariableRuntimeCacheBufferAllocation)) {
-      //
-      // AllocatePages for HobCache buffer (will be relocated to runtime by DXE).
-      //
-      Buffer = AllocatePages (Pages);
-      ASSERT (Buffer != NULL);
-    } else {
-      //
-      // AllocateRuntimePages for HobCache and unblock it.
-      //
-      Buffer = AllocateRuntimePages (Pages);
-      ASSERT (Buffer != NULL);
-      Status = MmUnblockMemoryRequest (
-                 (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
-                 Pages
-                 );
-      if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-        return Status;
-      }
-    }
+    Pages  = EFI_SIZE_TO_PAGES (BufferSize);
+    Buffer = AllocatePages (Pages);
+    ASSERT (Buffer != NULL);
+    //
+    // MU_CHANGE - Commented out runtime allocation and memory unblock (moved to DXE)
+    // Buffer = AllocateRuntimePages (Pages);
+    // Status = MmUnblockMemoryRequest (
+    //            (EFI_PHYSICAL_ADDRESS)(UINTN)Buffer,
+    //            Pages
+    //            );
+    // if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+    //   return Status;
+    // }
+    //
 
     TempHobBuffer.RuntimeHobCacheBuffer = (UINTN)Buffer;
     TempHobBuffer.RuntimeHobCachePages  = Pages;

--- a/MdeModulePkg/Universal/Variable/Pei/Variable.h
+++ b/MdeModulePkg/Universal/Variable/Pei/Variable.h
@@ -22,9 +22,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/PeiServicesLib.h>
 #include <Library/SafeIntLib.h>
 #include <Library/VariableFlashInfoLib.h>
-// MU_CHANGE [BEGIN] - Comment out unused include when moving allocation to DXE
-// #include <Library/MmUnblockMemoryLib.h>
-// MU_CHANGE [END]
+#include <Library/MmUnblockMemoryLib.h>
 #include <Library/MemoryAllocationLib.h>
 
 #include <Guid/VariableFormat.h>

--- a/MdeModulePkg/Universal/Variable/Pei/Variable.h
+++ b/MdeModulePkg/Universal/Variable/Pei/Variable.h
@@ -22,7 +22,9 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/PeiServicesLib.h>
 #include <Library/SafeIntLib.h>
 #include <Library/VariableFlashInfoLib.h>
-#include <Library/MmUnblockMemoryLib.h>
+// MU_CHANGE [BEGIN] - Comment out unused include when moving allocation to DXE
+// #include <Library/MmUnblockMemoryLib.h>
+// MU_CHANGE [END]
 #include <Library/MemoryAllocationLib.h>
 
 #include <Guid/VariableFormat.h>

--- a/MdeModulePkg/Universal/Variable/Pei/VariablePei.inf
+++ b/MdeModulePkg/Universal/Variable/Pei/VariablePei.inf
@@ -41,9 +41,7 @@
   PeiServicesLib
   SafeIntLib
   VariableFlashInfoLib
-  # MU_CHANGE [BEGIN] - Comment out unused library when moving allocation to DXE
-  # MmUnblockMemoryLib
-  # MU_CHANGE [END]
+  MmUnblockMemoryLib
   MemoryAllocationLib
 
 [Guids]

--- a/MdeModulePkg/Universal/Variable/Pei/VariablePei.inf
+++ b/MdeModulePkg/Universal/Variable/Pei/VariablePei.inf
@@ -41,7 +41,9 @@
   PeiServicesLib
   SafeIntLib
   VariableFlashInfoLib
-  MmUnblockMemoryLib
+  # MU_CHANGE [BEGIN] - Comment out unused library when moving allocation to DXE
+  # MmUnblockMemoryLib
+  # MU_CHANGE [END]
   MemoryAllocationLib
 
 [Guids]
@@ -68,7 +70,6 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdEmuVariableNvModeEnable         ## SOMETIMES_CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdVariableStoreSize               ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdEnableVariableRuntimeCache      ## CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdMigrateVariableRuntimeCacheBufferAllocation  ## CONSUMES  # MU_CHANGE
 
 [Depex]
   gEdkiiFaultTolerantWriteGuid

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
@@ -1703,172 +1703,168 @@ InitVariableCache (
       );
 
     CopyMem (&mVariableRtCacheInfo, VariableRuntimeCacheInfo, sizeof (VARIABLE_RUNTIME_CACHE_INFO));
+    //
+    // MU_CHANGE - Commented out old header initialization (moved to individual buffer relocations)
+    // InitVariableStoreHeader ((VOID *)(UINTN)mVariableRtCacheInfo.RuntimeHobCacheBuffer, AllocatedHobCacheSize);
+    // InitVariableStoreHeader ((VOID *)(UINTN)mVariableRtCacheInfo.RuntimeNvCacheBuffer, AllocatedNvCacheSize);
+    // InitVariableStoreHeader ((VOID *)(UINTN)mVariableRtCacheInfo.RuntimeVolatileCacheBuffer, AllocatedVolatileCacheSize);
+    //
 
-    // MU_CHANGE [BEGIN] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
-    if (PcdGetBool (PcdMigrateVariableRuntimeCacheBufferAllocation)) {
-      //
-      // Relocate runtime cache buffers from boot services to runtime services
-      // This prevents runtime memory fragmentation by consolidating allocations in DXE
-      //
-      // Relocate CacheInfoFlag buffer from boot services to runtime services
-      //
-      if (mVariableRtCacheInfo.CacheInfoFlagBuffer != 0) {
-        Pages  = EFI_SIZE_TO_PAGES (sizeof (CACHE_INFO_FLAG));
-        Status = gBS->AllocatePages (
-                        AllocateAnyPages,
-                        EfiRuntimeServicesData,
-                        Pages,
-                        &TempCacheInfoBuffer
-                        );
-        if (EFI_ERROR (Status)) {
-          DEBUG ((DEBUG_WARN, "Failed to allocate runtime CacheInfoFlag buffer: %r\n", Status));
-          AllRtBufferAllocationsSucceeded = FALSE;
-        } else {
-          Status = MmUnblockMemoryRequest (TempCacheInfoBuffer, Pages);
-          if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-            DEBUG ((DEBUG_WARN, "Failed to unblock CacheInfoFlag buffer: %r\n", Status));
-            gBS->FreePages (TempCacheInfoBuffer, Pages);
-            TempCacheInfoBuffer             = 0;
-            AllRtBufferAllocationsSucceeded = FALSE;
-          }
-        }
-      }
-
-      if (AllRtBufferAllocationsSucceeded && (mVariableRtCacheInfo.RuntimeHobCacheBuffer != 0) && (AllocatedHobCacheSize > 0)) {
-        Pages  = EFI_SIZE_TO_PAGES (AllocatedHobCacheSize);
-        Status = gBS->AllocatePages (
-                        AllocateAnyPages,
-                        EfiRuntimeServicesData,
-                        Pages,
-                        &TempHobCacheBuffer
-                        );
-        if (EFI_ERROR (Status)) {
-          DEBUG ((DEBUG_WARN, "Failed to allocate runtime HOB cache buffer: %r\n", Status));
-          AllRtBufferAllocationsSucceeded = FALSE;
-        } else {
-          Status = MmUnblockMemoryRequest (TempHobCacheBuffer, Pages);
-          if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-            DEBUG ((DEBUG_WARN, "Failed to unblock HOB cache buffer: %r\n", Status));
-            gBS->FreePages (TempHobCacheBuffer, Pages);
-            TempHobCacheBuffer              = 0;
-            AllRtBufferAllocationsSucceeded = FALSE;
-          }
-        }
-      }
-
-      if (AllRtBufferAllocationsSucceeded && (mVariableRtCacheInfo.RuntimeNvCacheBuffer != 0) && (AllocatedNvCacheSize > 0)) {
-        Pages  = EFI_SIZE_TO_PAGES (AllocatedNvCacheSize);
-        Status = gBS->AllocatePages (
-                        AllocateAnyPages,
-                        EfiRuntimeServicesData,
-                        Pages,
-                        &TempNvCacheBuffer
-                        );
-        if (EFI_ERROR (Status)) {
-          DEBUG ((DEBUG_WARN, "Failed to allocate runtime NV cache buffer: %r\n", Status));
-          AllRtBufferAllocationsSucceeded = FALSE;
-        } else {
-          Status = MmUnblockMemoryRequest (TempNvCacheBuffer, Pages);
-          if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-            DEBUG ((DEBUG_WARN, "Failed to unblock NV cache buffer: %r\n", Status));
-            gBS->FreePages (TempNvCacheBuffer, Pages);
-            TempNvCacheBuffer               = 0;
-            AllRtBufferAllocationsSucceeded = FALSE;
-          }
-        }
-      }
-
-      if (AllRtBufferAllocationsSucceeded && (mVariableRtCacheInfo.RuntimeVolatileCacheBuffer != 0) && (AllocatedVolatileCacheSize > 0)) {
-        Pages  = EFI_SIZE_TO_PAGES (AllocatedVolatileCacheSize);
-        Status = gBS->AllocatePages (
-                        AllocateAnyPages,
-                        EfiRuntimeServicesData,
-                        Pages,
-                        &TempVolatileCacheBuffer
-                        );
-        if (EFI_ERROR (Status)) {
-          DEBUG ((DEBUG_WARN, "Failed to allocate runtime volatile cache buffer: %r\n", Status));
-          AllRtBufferAllocationsSucceeded = FALSE;
-        } else {
-          Status = MmUnblockMemoryRequest (TempVolatileCacheBuffer, Pages);
-          if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-            DEBUG ((DEBUG_WARN, "Failed to unblock volatile cache buffer: %r\n", Status));
-            gBS->FreePages (TempVolatileCacheBuffer, Pages);
-            TempVolatileCacheBuffer         = 0;
-            AllRtBufferAllocationsSucceeded = FALSE;
-          }
-        }
-      }
-
-      if (AllRtBufferAllocationsSucceeded) {
-        if (TempCacheInfoBuffer != 0) {
-          RuntimeBuffer = (VOID *)(UINTN)TempCacheInfoBuffer;
-          CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.CacheInfoFlagBuffer, sizeof (CACHE_INFO_FLAG));
-          mVariableRtCacheInfo.CacheInfoFlagBuffer = TempCacheInfoBuffer;
-        }
-
-        if (TempHobCacheBuffer != 0) {
-          RuntimeBuffer = (VOID *)(UINTN)TempHobCacheBuffer;
-          CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeHobCacheBuffer, AllocatedHobCacheSize);
-          mVariableRtCacheInfo.RuntimeHobCacheBuffer = TempHobCacheBuffer;
-          InitVariableStoreHeader (RuntimeBuffer, AllocatedHobCacheSize);
-        }
-
-        if (TempNvCacheBuffer != 0) {
-          RuntimeBuffer = (VOID *)(UINTN)TempNvCacheBuffer;
-          CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeNvCacheBuffer, AllocatedNvCacheSize);
-          mVariableRtCacheInfo.RuntimeNvCacheBuffer = TempNvCacheBuffer;
-          InitVariableStoreHeader (RuntimeBuffer, AllocatedNvCacheSize);
-        }
-
-        if (TempVolatileCacheBuffer != 0) {
-          RuntimeBuffer = (VOID *)(UINTN)TempVolatileCacheBuffer;
-          CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeVolatileCacheBuffer, AllocatedVolatileCacheSize);
-          mVariableRtCacheInfo.RuntimeVolatileCacheBuffer = TempVolatileCacheBuffer;
-          InitVariableStoreHeader (RuntimeBuffer, AllocatedVolatileCacheSize);
-        }
-
-        DEBUG ((DEBUG_INFO, "Runtime variable cache buffers successfully relocated\n"));
+    //
+    // MU_CHANGE [BEGIN] - Relocate runtime cache buffers from boot services to runtime services
+    // This prevents runtime memory fragmentation by consolidating allocations in DXE
+    //
+    // Relocate CacheInfoFlag buffer from boot services to runtime services
+    //
+    if (mVariableRtCacheInfo.CacheInfoFlagBuffer != 0) {
+      Pages  = EFI_SIZE_TO_PAGES (sizeof (CACHE_INFO_FLAG));
+      Status = gBS->AllocatePages (
+                      AllocateAnyPages,
+                      EfiRuntimeServicesData,
+                      Pages,
+                      &TempCacheInfoBuffer
+                      );
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_WARN, "Failed to allocate runtime CacheInfoFlag buffer: %r\n", Status));
+        AllRtBufferAllocationsSucceeded = FALSE;
       } else {
-        //
-        // One or more allocations failed - clean up any successful allocations
-        // and disable runtime caching entirely
-        //
-        if (TempCacheInfoBuffer != 0) {
-          gBS->FreePages (TempCacheInfoBuffer, EFI_SIZE_TO_PAGES (sizeof (CACHE_INFO_FLAG)));
+        Status = MmUnblockMemoryRequest (TempCacheInfoBuffer, Pages);
+        if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_WARN, "Failed to unblock CacheInfoFlag buffer: %r\n", Status));
+          gBS->FreePages (TempCacheInfoBuffer, Pages);
+          TempCacheInfoBuffer             = 0;
+          AllRtBufferAllocationsSucceeded = FALSE;
         }
-
-        if (TempHobCacheBuffer != 0) {
-          gBS->FreePages (TempHobCacheBuffer, EFI_SIZE_TO_PAGES (AllocatedHobCacheSize));
-        }
-
-        if (TempNvCacheBuffer != 0) {
-          gBS->FreePages (TempNvCacheBuffer, EFI_SIZE_TO_PAGES (AllocatedNvCacheSize));
-        }
-
-        if (TempVolatileCacheBuffer != 0) {
-          gBS->FreePages (TempVolatileCacheBuffer, EFI_SIZE_TO_PAGES (AllocatedVolatileCacheSize));
-        }
-
-        //
-        // Null all runtime cache pointers to prevent access to boot services memory
-        //
-        InvalidateAllRuntimeCaches ();
-
-        DEBUG ((DEBUG_WARN, "Runtime variable cache disabled due to allocation failure.\n"));
-
-        // Don't return failure - the variable service can function without the runtime cache
       }
-    } else {
-      //
-      // Original behavior: Use buffers allocated in PEI directly (already runtime memory)
-      //
-      InitVariableStoreHeader ((VOID *)(UINTN)mVariableRtCacheInfo.RuntimeHobCacheBuffer, AllocatedHobCacheSize);
-      InitVariableStoreHeader ((VOID *)(UINTN)mVariableRtCacheInfo.RuntimeNvCacheBuffer, AllocatedNvCacheSize);
-      InitVariableStoreHeader ((VOID *)(UINTN)mVariableRtCacheInfo.RuntimeVolatileCacheBuffer, AllocatedVolatileCacheSize);
     }
 
-    // MU_CHANGE [END] - Allocate RT cache buffer in DXE instead of PEI to prevent fragmentation
+    if (AllRtBufferAllocationsSucceeded && (mVariableRtCacheInfo.RuntimeHobCacheBuffer != 0) && (AllocatedHobCacheSize > 0)) {
+      Pages  = EFI_SIZE_TO_PAGES (AllocatedHobCacheSize);
+      Status = gBS->AllocatePages (
+                      AllocateAnyPages,
+                      EfiRuntimeServicesData,
+                      Pages,
+                      &TempHobCacheBuffer
+                      );
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_WARN, "Failed to allocate runtime HOB cache buffer: %r\n", Status));
+        AllRtBufferAllocationsSucceeded = FALSE;
+      } else {
+        Status = MmUnblockMemoryRequest (TempHobCacheBuffer, Pages);
+        if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_WARN, "Failed to unblock HOB cache buffer: %r\n", Status));
+          gBS->FreePages (TempHobCacheBuffer, Pages);
+          TempHobCacheBuffer              = 0;
+          AllRtBufferAllocationsSucceeded = FALSE;
+        }
+      }
+    }
+
+    if (AllRtBufferAllocationsSucceeded && (mVariableRtCacheInfo.RuntimeNvCacheBuffer != 0) && (AllocatedNvCacheSize > 0)) {
+      Pages  = EFI_SIZE_TO_PAGES (AllocatedNvCacheSize);
+      Status = gBS->AllocatePages (
+                      AllocateAnyPages,
+                      EfiRuntimeServicesData,
+                      Pages,
+                      &TempNvCacheBuffer
+                      );
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_WARN, "Failed to allocate runtime NV cache buffer: %r\n", Status));
+        AllRtBufferAllocationsSucceeded = FALSE;
+      } else {
+        Status = MmUnblockMemoryRequest (TempNvCacheBuffer, Pages);
+        if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_WARN, "Failed to unblock NV cache buffer: %r\n", Status));
+          gBS->FreePages (TempNvCacheBuffer, Pages);
+          TempNvCacheBuffer               = 0;
+          AllRtBufferAllocationsSucceeded = FALSE;
+        }
+      }
+    }
+
+    if (AllRtBufferAllocationsSucceeded && (mVariableRtCacheInfo.RuntimeVolatileCacheBuffer != 0) && (AllocatedVolatileCacheSize > 0)) {
+      Pages  = EFI_SIZE_TO_PAGES (AllocatedVolatileCacheSize);
+      Status = gBS->AllocatePages (
+                      AllocateAnyPages,
+                      EfiRuntimeServicesData,
+                      Pages,
+                      &TempVolatileCacheBuffer
+                      );
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_WARN, "Failed to allocate runtime volatile cache buffer: %r\n", Status));
+        AllRtBufferAllocationsSucceeded = FALSE;
+      } else {
+        Status = MmUnblockMemoryRequest (TempVolatileCacheBuffer, Pages);
+        if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+          DEBUG ((DEBUG_WARN, "Failed to unblock volatile cache buffer: %r\n", Status));
+          gBS->FreePages (TempVolatileCacheBuffer, Pages);
+          TempVolatileCacheBuffer         = 0;
+          AllRtBufferAllocationsSucceeded = FALSE;
+        }
+      }
+    }
+
+    if (AllRtBufferAllocationsSucceeded) {
+      if (TempCacheInfoBuffer != 0) {
+        RuntimeBuffer = (VOID *)(UINTN)TempCacheInfoBuffer;
+        CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.CacheInfoFlagBuffer, sizeof (CACHE_INFO_FLAG));
+        mVariableRtCacheInfo.CacheInfoFlagBuffer = TempCacheInfoBuffer;
+      }
+
+      if (TempHobCacheBuffer != 0) {
+        RuntimeBuffer = (VOID *)(UINTN)TempHobCacheBuffer;
+        CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeHobCacheBuffer, AllocatedHobCacheSize);
+        mVariableRtCacheInfo.RuntimeHobCacheBuffer = TempHobCacheBuffer;
+        InitVariableStoreHeader (RuntimeBuffer, AllocatedHobCacheSize);
+      }
+
+      if (TempNvCacheBuffer != 0) {
+        RuntimeBuffer = (VOID *)(UINTN)TempNvCacheBuffer;
+        CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeNvCacheBuffer, AllocatedNvCacheSize);
+        mVariableRtCacheInfo.RuntimeNvCacheBuffer = TempNvCacheBuffer;
+        InitVariableStoreHeader (RuntimeBuffer, AllocatedNvCacheSize);
+      }
+
+      if (TempVolatileCacheBuffer != 0) {
+        RuntimeBuffer = (VOID *)(UINTN)TempVolatileCacheBuffer;
+        CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeVolatileCacheBuffer, AllocatedVolatileCacheSize);
+        mVariableRtCacheInfo.RuntimeVolatileCacheBuffer = TempVolatileCacheBuffer;
+        InitVariableStoreHeader (RuntimeBuffer, AllocatedVolatileCacheSize);
+      }
+
+      DEBUG ((DEBUG_INFO, "Runtime variable cache buffers successfully relocated\n"));
+    } else {
+      //
+      // One or more allocations failed - clean up any successful allocations
+      // and disable runtime caching entirely
+      //
+      if (TempCacheInfoBuffer != 0) {
+        gBS->FreePages (TempCacheInfoBuffer, EFI_SIZE_TO_PAGES (sizeof (CACHE_INFO_FLAG)));
+      }
+
+      if (TempHobCacheBuffer != 0) {
+        gBS->FreePages (TempHobCacheBuffer, EFI_SIZE_TO_PAGES (AllocatedHobCacheSize));
+      }
+
+      if (TempNvCacheBuffer != 0) {
+        gBS->FreePages (TempNvCacheBuffer, EFI_SIZE_TO_PAGES (AllocatedNvCacheSize));
+      }
+
+      if (TempVolatileCacheBuffer != 0) {
+        gBS->FreePages (TempVolatileCacheBuffer, EFI_SIZE_TO_PAGES (AllocatedVolatileCacheSize));
+      }
+
+      //
+      // Null all runtime cache pointers to prevent access to boot services memory
+      //
+      InvalidateAllRuntimeCaches ();
+
+      DEBUG ((DEBUG_WARN, "Runtime variable cache disabled due to allocation failure.\n"));
+
+      // Don't return failure - the variable service can function without the runtime cache
+    }
+
+    // MU_CHANGE [END] - Relocate runtime cache buffers using all-or-nothing approach
   }
 
   return Status;

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
@@ -1625,27 +1625,6 @@ InitVariableStoreHeader (
   }
 }
 
-//
-// MU_CHANGE [BEGIN] - Add helper function for runtime cache cleanup
-//
-
-/**
-  Invalidates all runtime cache pointers to prevent access to boot services memory.
-
-**/
-VOID
-InvalidateAllRuntimeCaches (
-  VOID
-  )
-{
-  mVariableRtCacheInfo.CacheInfoFlagBuffer        = 0;
-  mVariableRtCacheInfo.RuntimeHobCacheBuffer      = 0;
-  mVariableRtCacheInfo.RuntimeNvCacheBuffer       = 0;
-  mVariableRtCacheInfo.RuntimeVolatileCacheBuffer = 0;
-}
-
-// MU_CHANGE [END] - Add helper function for runtime cache cleanup
-
 /**
   Initialize the runtime variable cache related content.
 
@@ -1669,15 +1648,9 @@ InitVariableCache (
   UINTN                        AllocatedVolatileCacheSize;
   VARIABLE_RUNTIME_CACHE_INFO  *VariableRuntimeCacheInfo;
   // MU_CHANGE [BEGIN] - Add variables for runtime buffer relocation from DXE
-  VOID   *RuntimeBuffer;
-  UINTN  Pages;
-
-  // Storage for temporary allocations - only commit to mVariableRtCacheInfo if ALL succeed
-  EFI_PHYSICAL_ADDRESS  TempCacheInfoBuffer             = 0;
-  EFI_PHYSICAL_ADDRESS  TempHobCacheBuffer              = 0;
-  EFI_PHYSICAL_ADDRESS  TempNvCacheBuffer               = 0;
-  EFI_PHYSICAL_ADDRESS  TempVolatileCacheBuffer         = 0;
-  BOOLEAN               AllRtBufferAllocationsSucceeded = TRUE;
+  VOID                  *RuntimeBuffer;
+  EFI_PHYSICAL_ADDRESS  RuntimeBufferPhysicalAddress;
+  UINTN                 Pages;
 
   // MU_CHANGE [END]
 
@@ -1722,149 +1695,104 @@ InitVariableCache (
                       AllocateAnyPages,
                       EfiRuntimeServicesData,
                       Pages,
-                      &TempCacheInfoBuffer
+                      &RuntimeBufferPhysicalAddress
                       );
-      if (EFI_ERROR (Status)) {
-        DEBUG ((DEBUG_WARN, "Failed to allocate runtime CacheInfoFlag buffer: %r\n", Status));
-        AllRtBufferAllocationsSucceeded = FALSE;
-      } else {
-        Status = MmUnblockMemoryRequest (TempCacheInfoBuffer, Pages);
+      if (!EFI_ERROR (Status)) {
+        RuntimeBuffer = (VOID *)(UINTN)RuntimeBufferPhysicalAddress;
+        CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.CacheInfoFlagBuffer, sizeof (CACHE_INFO_FLAG));
+        mVariableRtCacheInfo.CacheInfoFlagBuffer = (UINTN)RuntimeBuffer;
+
+        Status = MmUnblockMemoryRequest (RuntimeBufferPhysicalAddress, Pages);
         if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-          DEBUG ((DEBUG_WARN, "Failed to unblock CacheInfoFlag buffer: %r\n", Status));
-          gBS->FreePages (TempCacheInfoBuffer, Pages);
-          TempCacheInfoBuffer             = 0;
-          AllRtBufferAllocationsSucceeded = FALSE;
+          return Status;
         }
+      } else {
+        return Status;
       }
     }
 
-    if (AllRtBufferAllocationsSucceeded && (mVariableRtCacheInfo.RuntimeHobCacheBuffer != 0) && (AllocatedHobCacheSize > 0)) {
+    //
+    // Relocate RuntimeHobCache buffer from boot services to runtime services
+    //
+    if ((mVariableRtCacheInfo.RuntimeHobCacheBuffer != 0) && (AllocatedHobCacheSize > 0)) {
       Pages  = EFI_SIZE_TO_PAGES (AllocatedHobCacheSize);
       Status = gBS->AllocatePages (
                       AllocateAnyPages,
                       EfiRuntimeServicesData,
                       Pages,
-                      &TempHobCacheBuffer
+                      &RuntimeBufferPhysicalAddress
                       );
-      if (EFI_ERROR (Status)) {
-        DEBUG ((DEBUG_WARN, "Failed to allocate runtime HOB cache buffer: %r\n", Status));
-        AllRtBufferAllocationsSucceeded = FALSE;
-      } else {
-        Status = MmUnblockMemoryRequest (TempHobCacheBuffer, Pages);
+      if (!EFI_ERROR (Status)) {
+        RuntimeBuffer = (VOID *)(UINTN)RuntimeBufferPhysicalAddress;
+        CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeHobCacheBuffer, AllocatedHobCacheSize);
+        mVariableRtCacheInfo.RuntimeHobCacheBuffer = (UINTN)RuntimeBuffer;
+
+        Status = MmUnblockMemoryRequest (RuntimeBufferPhysicalAddress, Pages);
         if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-          DEBUG ((DEBUG_WARN, "Failed to unblock HOB cache buffer: %r\n", Status));
-          gBS->FreePages (TempHobCacheBuffer, Pages);
-          TempHobCacheBuffer              = 0;
-          AllRtBufferAllocationsSucceeded = FALSE;
+          return Status;
         }
+
+        InitVariableStoreHeader (RuntimeBuffer, AllocatedHobCacheSize);
+      } else {
+        return Status;
       }
     }
 
-    if (AllRtBufferAllocationsSucceeded && (mVariableRtCacheInfo.RuntimeNvCacheBuffer != 0) && (AllocatedNvCacheSize > 0)) {
+    //
+    // Relocate RuntimeNvCache buffer from boot services to runtime services
+    //
+    if ((mVariableRtCacheInfo.RuntimeNvCacheBuffer != 0) && (AllocatedNvCacheSize > 0)) {
       Pages  = EFI_SIZE_TO_PAGES (AllocatedNvCacheSize);
       Status = gBS->AllocatePages (
                       AllocateAnyPages,
                       EfiRuntimeServicesData,
                       Pages,
-                      &TempNvCacheBuffer
+                      &RuntimeBufferPhysicalAddress
                       );
-      if (EFI_ERROR (Status)) {
-        DEBUG ((DEBUG_WARN, "Failed to allocate runtime NV cache buffer: %r\n", Status));
-        AllRtBufferAllocationsSucceeded = FALSE;
-      } else {
-        Status = MmUnblockMemoryRequest (TempNvCacheBuffer, Pages);
+      if (!EFI_ERROR (Status)) {
+        RuntimeBuffer = (VOID *)(UINTN)RuntimeBufferPhysicalAddress;
+        CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeNvCacheBuffer, AllocatedNvCacheSize);
+        mVariableRtCacheInfo.RuntimeNvCacheBuffer = (UINTN)RuntimeBuffer;
+
+        Status = MmUnblockMemoryRequest (RuntimeBufferPhysicalAddress, Pages);
         if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-          DEBUG ((DEBUG_WARN, "Failed to unblock NV cache buffer: %r\n", Status));
-          gBS->FreePages (TempNvCacheBuffer, Pages);
-          TempNvCacheBuffer               = 0;
-          AllRtBufferAllocationsSucceeded = FALSE;
+          return Status;
         }
+
+        InitVariableStoreHeader (RuntimeBuffer, AllocatedNvCacheSize);
+      } else {
+        return Status;
       }
     }
 
-    if (AllRtBufferAllocationsSucceeded && (mVariableRtCacheInfo.RuntimeVolatileCacheBuffer != 0) && (AllocatedVolatileCacheSize > 0)) {
+    //
+    // Relocate RuntimeVolatileCache buffer from boot services to runtime services
+    //
+    if ((mVariableRtCacheInfo.RuntimeVolatileCacheBuffer != 0) && (AllocatedVolatileCacheSize > 0)) {
       Pages  = EFI_SIZE_TO_PAGES (AllocatedVolatileCacheSize);
       Status = gBS->AllocatePages (
                       AllocateAnyPages,
                       EfiRuntimeServicesData,
                       Pages,
-                      &TempVolatileCacheBuffer
+                      &RuntimeBufferPhysicalAddress
                       );
-      if (EFI_ERROR (Status)) {
-        DEBUG ((DEBUG_WARN, "Failed to allocate runtime volatile cache buffer: %r\n", Status));
-        AllRtBufferAllocationsSucceeded = FALSE;
-      } else {
-        Status = MmUnblockMemoryRequest (TempVolatileCacheBuffer, Pages);
-        if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-          DEBUG ((DEBUG_WARN, "Failed to unblock volatile cache buffer: %r\n", Status));
-          gBS->FreePages (TempVolatileCacheBuffer, Pages);
-          TempVolatileCacheBuffer         = 0;
-          AllRtBufferAllocationsSucceeded = FALSE;
-        }
-      }
-    }
-
-    if (AllRtBufferAllocationsSucceeded) {
-      if (TempCacheInfoBuffer != 0) {
-        RuntimeBuffer = (VOID *)(UINTN)TempCacheInfoBuffer;
-        CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.CacheInfoFlagBuffer, sizeof (CACHE_INFO_FLAG));
-        mVariableRtCacheInfo.CacheInfoFlagBuffer = TempCacheInfoBuffer;
-      }
-
-      if (TempHobCacheBuffer != 0) {
-        RuntimeBuffer = (VOID *)(UINTN)TempHobCacheBuffer;
-        CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeHobCacheBuffer, AllocatedHobCacheSize);
-        mVariableRtCacheInfo.RuntimeHobCacheBuffer = TempHobCacheBuffer;
-        InitVariableStoreHeader (RuntimeBuffer, AllocatedHobCacheSize);
-      }
-
-      if (TempNvCacheBuffer != 0) {
-        RuntimeBuffer = (VOID *)(UINTN)TempNvCacheBuffer;
-        CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeNvCacheBuffer, AllocatedNvCacheSize);
-        mVariableRtCacheInfo.RuntimeNvCacheBuffer = TempNvCacheBuffer;
-        InitVariableStoreHeader (RuntimeBuffer, AllocatedNvCacheSize);
-      }
-
-      if (TempVolatileCacheBuffer != 0) {
-        RuntimeBuffer = (VOID *)(UINTN)TempVolatileCacheBuffer;
+      if (!EFI_ERROR (Status)) {
+        RuntimeBuffer = (VOID *)(UINTN)RuntimeBufferPhysicalAddress;
         CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeVolatileCacheBuffer, AllocatedVolatileCacheSize);
-        mVariableRtCacheInfo.RuntimeVolatileCacheBuffer = TempVolatileCacheBuffer;
+        mVariableRtCacheInfo.RuntimeVolatileCacheBuffer = (UINTN)RuntimeBuffer;
+
+        Status = MmUnblockMemoryRequest (RuntimeBufferPhysicalAddress, Pages);
+        if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
+          return Status;
+        }
+
         InitVariableStoreHeader (RuntimeBuffer, AllocatedVolatileCacheSize);
+      } else {
+        return Status;
       }
-
-      DEBUG ((DEBUG_INFO, "Runtime variable cache buffers successfully relocated\n"));
-    } else {
-      //
-      // One or more allocations failed - clean up any successful allocations
-      // and disable runtime caching entirely
-      //
-      if (TempCacheInfoBuffer != 0) {
-        gBS->FreePages (TempCacheInfoBuffer, EFI_SIZE_TO_PAGES (sizeof (CACHE_INFO_FLAG)));
-      }
-
-      if (TempHobCacheBuffer != 0) {
-        gBS->FreePages (TempHobCacheBuffer, EFI_SIZE_TO_PAGES (AllocatedHobCacheSize));
-      }
-
-      if (TempNvCacheBuffer != 0) {
-        gBS->FreePages (TempNvCacheBuffer, EFI_SIZE_TO_PAGES (AllocatedNvCacheSize));
-      }
-
-      if (TempVolatileCacheBuffer != 0) {
-        gBS->FreePages (TempVolatileCacheBuffer, EFI_SIZE_TO_PAGES (AllocatedVolatileCacheSize));
-      }
-
-      //
-      // Null all runtime cache pointers to prevent access to boot services memory
-      //
-      InvalidateAllRuntimeCaches ();
-
-      DEBUG ((DEBUG_WARN, "Runtime variable cache disabled due to allocation failure.\n"));
-
-      // Don't return failure - the variable service can function without the runtime cache
     }
 
-    // MU_CHANGE [END] - Relocate runtime cache buffers using all-or-nothing approach
+    // MU_CHANGE [END] - Relocate runtime cache buffers from boot services to runtime services
   }
 
   return Status;

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
@@ -37,9 +37,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/UefiLib.h>
 #include <Library/BaseLib.h>
 #include <Library/HobLib.h>
-// MU_CHANGE [BEGIN] - Add include for memory unblock when moving allocation to DXE
-#include <Library/MmUnblockMemoryLib.h>
-// MU_CHANGE [END]
 
 #include <Guid/EventGroup.h>
 #include <Guid/SmmVariableCommon.h>
@@ -1647,12 +1644,6 @@ InitVariableCache (
   UINTN                        AllocatedNvCacheSize;
   UINTN                        AllocatedVolatileCacheSize;
   VARIABLE_RUNTIME_CACHE_INFO  *VariableRuntimeCacheInfo;
-  // MU_CHANGE [BEGIN] - Add variables for runtime buffer relocation from DXE
-  VOID                  *RuntimeBuffer;
-  EFI_PHYSICAL_ADDRESS  RuntimeBufferPhysicalAddress;
-  UINTN                 Pages;
-
-  // MU_CHANGE [END]
 
   //
   // Get needed runtime cache buffer size and check if auth variables are to be used from SMM
@@ -1676,123 +1667,9 @@ InitVariableCache (
       );
 
     CopyMem (&mVariableRtCacheInfo, VariableRuntimeCacheInfo, sizeof (VARIABLE_RUNTIME_CACHE_INFO));
-    //
-    // MU_CHANGE - Commented out old header initialization (moved to individual buffer relocations)
-    // InitVariableStoreHeader ((VOID *)(UINTN)mVariableRtCacheInfo.RuntimeHobCacheBuffer, AllocatedHobCacheSize);
-    // InitVariableStoreHeader ((VOID *)(UINTN)mVariableRtCacheInfo.RuntimeNvCacheBuffer, AllocatedNvCacheSize);
-    // InitVariableStoreHeader ((VOID *)(UINTN)mVariableRtCacheInfo.RuntimeVolatileCacheBuffer, AllocatedVolatileCacheSize);
-    //
-
-    //
-    // MU_CHANGE [BEGIN] - Relocate runtime cache buffers from boot services to runtime services
-    // This prevents runtime memory fragmentation by consolidating allocations in DXE
-    //
-    // Relocate CacheInfoFlag buffer from boot services to runtime services
-    //
-    if (mVariableRtCacheInfo.CacheInfoFlagBuffer != 0) {
-      Pages  = EFI_SIZE_TO_PAGES (sizeof (CACHE_INFO_FLAG));
-      Status = gBS->AllocatePages (
-                      AllocateAnyPages,
-                      EfiRuntimeServicesData,
-                      Pages,
-                      &RuntimeBufferPhysicalAddress
-                      );
-      if (!EFI_ERROR (Status)) {
-        RuntimeBuffer = (VOID *)(UINTN)RuntimeBufferPhysicalAddress;
-        CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.CacheInfoFlagBuffer, sizeof (CACHE_INFO_FLAG));
-        mVariableRtCacheInfo.CacheInfoFlagBuffer = (UINTN)RuntimeBuffer;
-
-        Status = MmUnblockMemoryRequest (RuntimeBufferPhysicalAddress, Pages);
-        if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-          return Status;
-        }
-      } else {
-        return Status;
-      }
-    }
-
-    //
-    // Relocate RuntimeHobCache buffer from boot services to runtime services
-    //
-    if ((mVariableRtCacheInfo.RuntimeHobCacheBuffer != 0) && (AllocatedHobCacheSize > 0)) {
-      Pages  = EFI_SIZE_TO_PAGES (AllocatedHobCacheSize);
-      Status = gBS->AllocatePages (
-                      AllocateAnyPages,
-                      EfiRuntimeServicesData,
-                      Pages,
-                      &RuntimeBufferPhysicalAddress
-                      );
-      if (!EFI_ERROR (Status)) {
-        RuntimeBuffer = (VOID *)(UINTN)RuntimeBufferPhysicalAddress;
-        CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeHobCacheBuffer, AllocatedHobCacheSize);
-        mVariableRtCacheInfo.RuntimeHobCacheBuffer = (UINTN)RuntimeBuffer;
-
-        Status = MmUnblockMemoryRequest (RuntimeBufferPhysicalAddress, Pages);
-        if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-          return Status;
-        }
-
-        InitVariableStoreHeader (RuntimeBuffer, AllocatedHobCacheSize);
-      } else {
-        return Status;
-      }
-    }
-
-    //
-    // Relocate RuntimeNvCache buffer from boot services to runtime services
-    //
-    if ((mVariableRtCacheInfo.RuntimeNvCacheBuffer != 0) && (AllocatedNvCacheSize > 0)) {
-      Pages  = EFI_SIZE_TO_PAGES (AllocatedNvCacheSize);
-      Status = gBS->AllocatePages (
-                      AllocateAnyPages,
-                      EfiRuntimeServicesData,
-                      Pages,
-                      &RuntimeBufferPhysicalAddress
-                      );
-      if (!EFI_ERROR (Status)) {
-        RuntimeBuffer = (VOID *)(UINTN)RuntimeBufferPhysicalAddress;
-        CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeNvCacheBuffer, AllocatedNvCacheSize);
-        mVariableRtCacheInfo.RuntimeNvCacheBuffer = (UINTN)RuntimeBuffer;
-
-        Status = MmUnblockMemoryRequest (RuntimeBufferPhysicalAddress, Pages);
-        if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-          return Status;
-        }
-
-        InitVariableStoreHeader (RuntimeBuffer, AllocatedNvCacheSize);
-      } else {
-        return Status;
-      }
-    }
-
-    //
-    // Relocate RuntimeVolatileCache buffer from boot services to runtime services
-    //
-    if ((mVariableRtCacheInfo.RuntimeVolatileCacheBuffer != 0) && (AllocatedVolatileCacheSize > 0)) {
-      Pages  = EFI_SIZE_TO_PAGES (AllocatedVolatileCacheSize);
-      Status = gBS->AllocatePages (
-                      AllocateAnyPages,
-                      EfiRuntimeServicesData,
-                      Pages,
-                      &RuntimeBufferPhysicalAddress
-                      );
-      if (!EFI_ERROR (Status)) {
-        RuntimeBuffer = (VOID *)(UINTN)RuntimeBufferPhysicalAddress;
-        CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.RuntimeVolatileCacheBuffer, AllocatedVolatileCacheSize);
-        mVariableRtCacheInfo.RuntimeVolatileCacheBuffer = (UINTN)RuntimeBuffer;
-
-        Status = MmUnblockMemoryRequest (RuntimeBufferPhysicalAddress, Pages);
-        if ((Status != EFI_UNSUPPORTED) && EFI_ERROR (Status)) {
-          return Status;
-        }
-
-        InitVariableStoreHeader (RuntimeBuffer, AllocatedVolatileCacheSize);
-      } else {
-        return Status;
-      }
-    }
-
-    // MU_CHANGE [END] - Relocate runtime cache buffers from boot services to runtime services
+    InitVariableStoreHeader ((VOID *)(UINTN)mVariableRtCacheInfo.RuntimeHobCacheBuffer, AllocatedHobCacheSize);
+    InitVariableStoreHeader ((VOID *)(UINTN)mVariableRtCacheInfo.RuntimeNvCacheBuffer, AllocatedNvCacheSize);
+    InitVariableStoreHeader ((VOID *)(UINTN)mVariableRtCacheInfo.RuntimeVolatileCacheBuffer, AllocatedVolatileCacheSize);
   }
 
   return Status;

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.c
@@ -1801,15 +1801,6 @@ InitVariableCache (
       }
 
       if (AllRtBufferAllocationsSucceeded) {
-        //
-        // Reset Status since MmUnblockMemoryRequest() may have returned
-        // EFI_UNSUPPORTED (which is tolerated but leaves Status set to
-        // an error value that would propagate to the caller).
-        //
-        if (Status == EFI_UNSUPPORTED) {
-          Status = EFI_SUCCESS;
-        }
-
         if (TempCacheInfoBuffer != 0) {
           RuntimeBuffer = (VOID *)(UINTN)TempCacheInfoBuffer;
           CopyMem (RuntimeBuffer, (VOID *)(UINTN)mVariableRtCacheInfo.CacheInfoFlagBuffer, sizeof (CACHE_INFO_FLAG));

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf
@@ -88,7 +88,6 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdAllowVariablePolicyEnforcementDisable     ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdTcgPfpMeasurementRevision                 ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdEnableSpdmDeviceAuthentication             ## PRODUCES AND CONSUMES
-  gEfiMdeModulePkgTokenSpaceGuid.PcdMigrateVariableRuntimeCacheBufferAllocation  ## CONSUMES  # MU_CHANGE
 
 [Guids]
   ## PRODUCES             ## GUID # Signature of Variable store header

--- a/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf
+++ b/MdeModulePkg/Universal/Variable/RuntimeDxe/VariableSmmRuntimeDxe.inf
@@ -64,9 +64,6 @@
   PcdLib
   HobLib
   DeviceStateLib # MU_CHANGE - Check device state before locking variable policy
-  # MU_CHANGE [BEGIN] - Add library for memory unblock when moving allocation to DXE
-  MmUnblockMemoryLib
-  # MU_CHANGE [END]
 
 [Protocols]
   gEfiVariableWriteArchProtocolGuid             ## PRODUCES


### PR DESCRIPTION
## Description

Project Mu had changes to move UEFI variable runtime cache allocation to DXE instead of PEI. The Project Mu MM model allows the runtime buffer allocations to be unblocked for MM access in DXE and allocating in DXE did not cause RT buffer fragmentation in the memory map to better accommodate hibernate resume.

With PEI memory buckets being added in https://github.com/microsoft/mu_basecore/pull/1759 to Project Mu beginning with the 2511 branch, the upstream flow to allocate the RT cache buffer in PEI can be restored

This PR reverts commits that added DXE runtime cache buffer allocation support individually, so it is clear exactly what is reverted and these changes can be skipped on future Mu release branches.

---

1. Revert "[CHERRY-PICK] MdeModulePkg/VariableSmmRuntimeDxe: Fix EFI_UNSUPPORTED leak (#1668)"
2. Revert "MdeModulePkg/Variable: Add PCD to control RT cache allocation (#1588)"
3. Revert "MdeModulePkg/VariableSmmRuntimeDxe: Disable var RT cache on alloc failure"
4. Revert "MdeModulePkg/Variable: Move RT cache buffer allocation to DXE"

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Boot on QEMU Q35 and a physical Intel platform with the change (and PEI memory buckets present)
- Compared resulting files with edk2 variable code taking into account other unrelated Mu changes

## Integration Instructions

- `gEfiMdeModulePkgTokenSpaceGuid.PcdMigrateVariableRuntimeCacheBufferAllocation` is removed from MdeModulePkg.dec so delete any references in that in platform code.
- It is recommended to ensure the PEI memory buckets PR referenced in this PR's description is included in the Mu Basecore code used by the platform so PEI memory buckets can be used to reduce runtime memory fragmentation.
