### PR TITLE
[2502][CHERRY-PICK] MdeModulePkg: CpuExceptionHandlerLib: Define X86_CPU_INTERRUPT_NUM

### DIFF
--- a/MdeModulePkg/Include/Library/CpuExceptionHandlerLib.h
+++ b/MdeModulePkg/Include/Library/CpuExceptionHandlerLib.h
@@ -13,6 +13,8 @@
 #include <Ppi/VectorHandoffInfo.h>
 #include <Protocol/Cpu.h>
 
+#define X86_CPU_INTERRUPT_NUM  256
+
 /**
   Initializes all CPU exceptions entries and provides the default exception handlers.
 


### PR DESCRIPTION
## Description

There are currently many definitions for the number of interrupts for X86 processors. Centralize this definition in CpuExceptionHandlerLib.

(cherry picked from edk2 commit 3ed9aceeb8e6b1175403b42ef3f97a2547e93c89)

---

This is already in release/202511. This definition is the main breaking change for some repos sharing code across release branches.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- CI and build modules using CpuExceptionHandlerLib that reference `X86_CPU_INTERRUPT_NUM`

## Integration Instructions

- N/A