### PR TITLE
[CHERRY-PICK] SecurityPkg: AuthVariableLib: Handle empty signature lists

### DIFF
--- a/SecurityPkg/Library/AuthVariableLib/AuthService.c
+++ b/SecurityPkg/Library/AuthVariableLib/AuthService.c
@@ -593,7 +593,7 @@ CheckSignatureListFormat (
       CertData   = (EFI_SIGNATURE_DATA *)((UINT8 *)SigList + sizeof (EFI_SIGNATURE_LIST) + SigList->SignatureHeaderSize);
       CertLen    = SigList->SignatureSize - sizeof (EFI_GUID);
       RsaContext = NULL;
-      if (!RsaGetPublicKeyFromX509 (CertData->SignatureData, CertLen, &RsaContext)) {
+      if ((CertLen > 0) && !RsaGetPublicKeyFromX509 (CertData->SignatureData, CertLen, &RsaContext)) {
         return EFI_INVALID_PARAMETER;
       }
 


### PR DESCRIPTION
## Description

The current implementation fails to set authenticated variables when the signature list is empty. This can legitimately occur for dbx when no signatures are revoked after a certificate rotation.

Update the logic to explicitly handle empty signature lists, avoiding an implicit dependency on the variable being absent from variable storage.

(cherry picked from commit b980aa07196a5534581b16563cd78cfc67a74074)

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on physical ARM64 platforms and booted to OS desktop and can set empty siglist variable from powershell.

## Integration Instructions

N/A