### PR TITLE
MdeModulePkg: DxeIplPeim Move Decompress to MsCorePkg/Core/GuidedSectionExtractPeim

### DIFF
--- a/MdeModulePkg/Core/DxeIplPeim/DxeIpl.h
+++ b/MdeModulePkg/Core/DxeIplPeim/DxeIpl.h
@@ -15,9 +15,13 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Ppi/EndOfPeiPhase.h>
 #include <Ppi/MemoryDiscovered.h>
 #include <Ppi/ReadOnlyVariable2.h>
-#include <Ppi/Decompress.h>
+// MU_CHANGE [BEGIN] - Move Decompress to MsCorePkg/Core/GuidedSectionExtractPeim
+// #include <Ppi/Decompress.h>
+// MU_CHANGE [END] - Move Decompress to MsCorePkg/Core/GuidedSectionExtractPeim
 #include <Ppi/FirmwareVolumeInfo.h>
-#include <Ppi/GuidedSectionExtraction.h>
+// MU_CHANGE [BEGIN] - Move Decompress to MsCorePkg/Core/GuidedSectionExtractPeim
+// #include <Ppi/GuidedSectionExtraction.h>
+// MU_CHANGE [END] - Move Decompress to MsCorePkg/Core/GuidedSectionExtractPeim
 #include <Ppi/LoadFile.h>
 #include <Ppi/S3Resume2.h>
 #include <Ppi/RecoveryModule.h>
@@ -34,8 +38,10 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/HobLib.h>
 #include <Library/PeiServicesLib.h>
 #include <Library/ReportStatusCodeLib.h>
-#include <Library/UefiDecompressLib.h>
-#include <Library/ExtractGuidedSectionLib.h>
+// MU_CHANGE [BEGIN] - Move Decompress to MsCorePkg/Core/GuidedSectionExtractPeim
+// #include <Library/UefiDecompressLib.h>
+// #include <Library/ExtractGuidedSectionLib.h>
+// MU_CHANGE [END] - Move Decompress to MsCorePkg/Core/GuidedSectionExtractPeim
 #include <Library/BaseMemoryLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/PcdLib.h>
@@ -135,6 +141,9 @@ UpdateStackHob (
   IN UINT64                Length
   );
 
+// MU_CHANGE [BEGIN] - Move Decompress to MsCorePkg/Core/GuidedSectionExtractPeim
+#if 0
+
 /**
   The ExtractSection() function processes the input section and
   returns a pointer to the section contents. If the section being
@@ -227,5 +236,8 @@ Decompress (
   OUT       VOID                     **OutputBuffer,
   OUT       UINTN                    *OutputSize
   );
+
+#endif
+// MU_CHANGE [END] - Move Decompress to MsCorePkg/Core/GuidedSectionExtractPeim
 
 #endif

--- a/MdeModulePkg/Core/DxeIplPeim/DxeIpl.inf
+++ b/MdeModulePkg/Core/DxeIplPeim/DxeIpl.inf
@@ -56,8 +56,8 @@
   PcdLib
   MemoryAllocationLib
   BaseMemoryLib
-  ExtractGuidedSectionLib
-  UefiDecompressLib
+#  ExtractGuidedSectionLib ## MU_CHANGE - Move Decompress to MsCorePkg/Core/GuidedSectionExtractPeim
+#  UefiDecompressLib ## MU_CHANGE - Move Decompress to MsCorePkg/Core/GuidedSectionExtractPeim
   ReportStatusCodeLib
   PeiServicesLib
   HobLib
@@ -108,6 +108,7 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdUse5LevelPageTable                  ## SOMETIMES_CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdGhcbBase                            ## CONSUMES
   gEfiMdeModulePkgTokenSpaceGuid.PcdGhcbSize                            ## CONSUMES
+  # gEfiMdeModulePkgTokenSpaceGuid.PcdDxeNxMemoryProtectionPolicy         ## CONSUMES ## MU_CHANGE
 
 [Pcd.IA32,Pcd.X64,Pcd.AARCH64]
   # gEfiMdeModulePkgTokenSpaceGuid.PcdDxeNxMemoryProtectionPolicy ## SOMETIMES_CONSUMES

--- a/MdeModulePkg/Core/DxeIplPeim/DxeLoad.c
+++ b/MdeModulePkg/Core/DxeIplPeim/DxeLoad.c
@@ -24,6 +24,8 @@ CONST EFI_PEI_PPI_DESCRIPTOR  mDxeIplPpiList = {
   (VOID *)&mDxeIplPpi
 };
 
+// MU_CHANGE [BEGIN] - Move Decompress to MsCorePkg/Core/GuidedSectionExtractPeim
+#if 0
 CONST EFI_PEI_GUIDED_SECTION_EXTRACTION_PPI  mCustomGuidedSectionExtractionPpi = {
   CustomGuidedSectionExtract
 };
@@ -37,6 +39,8 @@ CONST EFI_PEI_PPI_DESCRIPTOR  mDecompressPpiList = {
   &gEfiPeiDecompressPpiGuid,
   (VOID *)&mDecompressPpi
 };
+#endif
+// MU_CHANGE [END] - Move Decompress to MsCorePkg/Core/GuidedSectionExtractPeim
 
 CONST EFI_PEI_PPI_DESCRIPTOR  gEndOfPeiSignalPpi = {
   (EFI_PEI_PPI_DESCRIPTOR_PPI | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST),
@@ -147,7 +151,10 @@ InstallIplPermanentMemoryPpis (
   IN VOID                       *Ppi
   )
 {
-  EFI_STATUS              Status;
+  EFI_STATUS  Status;
+
+  // MU_CHANGE [BEGIN] - Move Decompress to MsCorePkg/Core/GuidedSectionExtractPeim
+ #if 0
   EFI_GUID                *ExtractHandlerGuidTable;
   UINTN                   ExtractHandlerNumber;
   EFI_PEI_PPI_DESCRIPTOR  *GuidPpi;
@@ -181,7 +188,9 @@ InstallIplPermanentMemoryPpis (
   //
   Status = PeiServicesInstallPpi (&mDecompressPpiList);
   ASSERT_EFI_ERROR (Status);
-
+ #endif
+  Status = EFI_SUCCESS;
+  // MU_CHANGE [END] - Move Decompress to MsCorePkg/Core/GuidedSectionExtractPeim
   return Status;
 }
 
@@ -522,6 +531,9 @@ DxeIplFindDxeCore (
   return NULL;
 }
 
+// MU_CHANGE [BEGIN] - Move Decompress to MsCorePkg/Core/GuidedSectionExtractPeim
+#if 0
+
 /**
   The ExtractSection() function processes the input section and
   returns a pointer to the section contents. If the section being
@@ -809,6 +821,9 @@ Decompress (
 
   return EFI_SUCCESS;
 }
+
+#endif
+// MU_CHANGE [END] - Move Decompress to MsCorePkg/Core/GuidedSectionExtractPeim
 
 /**
    Updates the Stack HOB passed to DXE phase.


### PR DESCRIPTION
## Description

  There are scenarios where PEIMs contained in compressed FVs are needed to complete
  the PEI stage (such as DxeIpl being in a compressed FV). GuidedSectionExtractPeim
  makes decompression available after memory is discovered instead of needing to
  wait for dxeipl to be given control. The functionality being remove here is entirely
  in GuidedSectionExtractPeimDisables, and requires platforms to include the PEIM
  out of hte MsCorePkg when they require decompression of Fvs.
  
  This change was split off the commit:
  https://github.com/microsoft/mu_basecore/commit/7a38833

- [X] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Physical platform encountered where multiple installations of Extract Guided section
PPIs triggered errors. 

## Integration Instructions
If a break is encountered, verify that the MsCorePkg's GuidedSectionExtractPeim is included
in the platforms DSC/FDF.