### PR TITLE
[CHERRY-PICK] StandaloneMmPkg: StandaloneMmIplPei: Guard S3 hob with PcdAcpiS3Enable

### DIFF
--- a/StandaloneMmPkg/Drivers/StandaloneMmIplPei/MmFoundationHob.c
+++ b/StandaloneMmPkg/Drivers/StandaloneMmIplPei/MmFoundationHob.c
@@ -1026,9 +1026,12 @@ CreateMmFoundationHobList (
   //
   // Build ACPI variable HOB
   //
-  HobLength = GetRemainingHobSize (*FoundationHobSize, UsedSize);
-  MmIplCopyGuidHob (FoundationHobList + UsedSize, &HobLength, &gEfiAcpiVariableGuid, FALSE);
-  UsedSize += HobLength;
+  if (PcdGetBool (PcdAcpiS3Enable)) {
+    // Only check on this variable when S3 needs it.
+    HobLength = GetRemainingHobSize (*FoundationHobSize, UsedSize);
+    MmIplCopyGuidHob (FoundationHobList + UsedSize, &HobLength, &gEfiAcpiVariableGuid, FALSE);
+    UsedSize += HobLength;
+  }
 
   if (FeaturePcdGet (PcdCpuSmmProfileEnable)) {
     //


### PR DESCRIPTION
## Description

The current module checks the value of gEfiAcpiVariableGuid hobs and could assert if there is no such hob available.

However, these hobs are only available if a platform elects to support S3. Thus this change moves the hob copy logic behind a PCD check to prevent unnecessary asserts.

(cherry picked from commit 1fe2504afb6ed8a991d5cfe2e3cf1d39afb47b95)

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on QEMU Q35 and booted to Windows desktop.

## Integration Instructions

N/A