### PR TITLE
[TPM] Revert TPM over FFA revision changes

### DIFF
--- a/SecurityPkg/Tcg/Tcg2AcpiFfa/Tcg2AcpiFfa.c
+++ b/SecurityPkg/Tcg/Tcg2AcpiFfa/Tcg2AcpiFfa.c
@@ -69,21 +69,21 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #pragma pack(1)
 
 typedef struct {
-  EFI_ACPI_DESCRIPTION_HEADER                               Header;
+  EFI_ACPI_DESCRIPTION_HEADER    Header;
   // Flags field is replaced in version 4 and above
   //    BIT0~15:  PlatformClass      This field is only valid for version 4 and above
   //    BIT16~31: Reserved
-  UINT32                                                    Flags;
-  UINT64                                                    AddressOfControlArea;
-  UINT32                                                    StartMethod;
-  EFI_TPM2_ACPI_START_METHOD_SPECIFIC_PARAMETERS_ARM_FFA    FfaParameters;
-  UINT32                                                    Laml; // Optional
-  UINT64                                                    Lasa; // Optional
-} EFI_TPM2_ACPI_TABLE_V5;
+  UINT32                         Flags;
+  UINT64                         AddressOfControlArea;
+  UINT32                         StartMethod;
+  UINT8                          PlatformSpecificParameters[12]; // size up to 12
+  UINT32                         Laml;                           // Optional
+  UINT64                         Lasa;                           // Optional
+} EFI_TPM2_ACPI_TABLE_V4;
 
 #pragma pack()
 
-EFI_TPM2_ACPI_TABLE_V5  mTpm2AcpiTemplate = {
+EFI_TPM2_ACPI_TABLE_V4  mTpm2AcpiTemplate = {
   {
     EFI_ACPI_5_0_TRUSTED_COMPUTING_PLATFORM_2_TABLE_SIGNATURE,
     sizeof (mTpm2AcpiTemplate),
@@ -384,17 +384,17 @@ PublishTpm2 (
   PartitionId = PcdGet16 (PcdTpmServiceFfaPartitionId);
   ASSERT (PartitionId != 0);
   if (InterfaceType == Tpm2PtpInterfaceCrb) {
-    mTpm2AcpiTemplate.StartMethod              = EFI_TPM2_ACPI_TABLE_START_METHOD_COMMAND_RESPONSE_BUFFER_INTERFACE_WITH_FFA;
-    mTpm2AcpiTemplate.AddressOfControlArea     = PcdGet64 (PcdTpmBaseAddress) + 0x40;
-    mTpm2AcpiTemplate.FfaParameters.Flags      = 0x00;           // Notifications Not Supported
-    mTpm2AcpiTemplate.FfaParameters.Attributes = (EFI_TPM2_ACPI_TABLE_ARM_FFA_PARAMETER_ATTR_CRB_REGION_SIZE_4KB << EFI_TPM2_ACPI_TABLE_ARM_FFA_PARAMETER_ATTR_CRB_REGION_SIZE_SHIFT) |
-                                                 (EFI_TPM2_ACPI_TABLE_ARM_FFA_PARAMETER_ATTR_MEM_TYPE_NOT_CACHABLE << EFI_TPM2_ACPI_TABLE_ARM_FFA_PARAMETER_ATTR_MEM_TYPE_SHIFT);
-    mTpm2AcpiTemplate.FfaParameters.PartitionId = PartitionId;   // Partition ID
-    ControlArea                                 = (EFI_TPM2_ACPI_CONTROL_AREA *)(UINTN)mTpm2AcpiTemplate.AddressOfControlArea;
-    ControlArea->CommandSize                    = 0xF80;
-    ControlArea->ResponseSize                   = 0xF80;
-    ControlArea->Command                        = PcdGet64 (PcdTpmBaseAddress) + 0x80;
-    ControlArea->Response                       = PcdGet64 (PcdTpmBaseAddress) + 0x80;
+    mTpm2AcpiTemplate.StartMethod                   = EFI_TPM2_ACPI_TABLE_START_METHOD_COMMAND_RESPONSE_BUFFER_INTERFACE_WITH_FFA;
+    mTpm2AcpiTemplate.AddressOfControlArea          = PcdGet64 (PcdTpmBaseAddress) + 0x40;
+    mTpm2AcpiTemplate.PlatformSpecificParameters[0] = 0x00;                           // Notifications Not Supported
+    mTpm2AcpiTemplate.PlatformSpecificParameters[1] = 0x00;                           // CRB 4KiB size, Not Cacheable
+    mTpm2AcpiTemplate.PlatformSpecificParameters[2] = (PartitionId >> 8) & MAX_UINT8; // HI Byte of Partition ID
+    mTpm2AcpiTemplate.PlatformSpecificParameters[3] = (PartitionId) & MAX_UINT8;      // LO Byte of Partition ID
+    ControlArea                                     = (EFI_TPM2_ACPI_CONTROL_AREA *)(UINTN)mTpm2AcpiTemplate.AddressOfControlArea;
+    ControlArea->CommandSize                        = 0xF80;
+    ControlArea->ResponseSize                       = 0xF80;
+    ControlArea->Command                            = PcdGet64 (PcdTpmBaseAddress) + 0x80;
+    ControlArea->Response                           = PcdGet64 (PcdTpmBaseAddress) + 0x80;
   } else {
     DEBUG ((DEBUG_ERROR, "TPM2 InterfaceType get error! %d\n", InterfaceType));
     return EFI_UNSUPPORTED;

--- a/SecurityPkg/Tcg/Tcg2AcpiFfa/Tcg2AcpiFfa.c
+++ b/SecurityPkg/Tcg/Tcg2AcpiFfa/Tcg2AcpiFfa.c
@@ -362,18 +362,16 @@ PublishTpm2 (
   mTpm2AcpiTemplate.Header.Revision = PcdGet8 (PcdTpm2AcpiTableRev);
   DEBUG ((DEBUG_INFO, "Tpm2 ACPI table revision is %d\n", mTpm2AcpiTemplate.Header.Revision));
 
-  if (mTpm2AcpiTemplate.Header.Revision < EFI_TPM2_ACPI_TABLE_REVISION_5) {
-    DEBUG ((DEBUG_ERROR, "%a The minimum revision supported for TPM over FFA table is 5, not %d.\n", __func__, mTpm2AcpiTemplate.Header.Revision));
-    ASSERT (FALSE);
-    return EFI_UNSUPPORTED;
+  if (mTpm2AcpiTemplate.Header.Revision >= EFI_TPM2_ACPI_TABLE_REVISION_4) {
+    mTpm2AcpiTemplate.Flags = (mTpm2AcpiTemplate.Flags & 0xFFFF0000) | PcdGet8 (PcdTpmPlatformClass);
+    DEBUG ((DEBUG_INFO, "Tpm2 ACPI table PlatformClass is %d\n", (mTpm2AcpiTemplate.Flags & 0x0000FFFF)));
   }
-
-  mTpm2AcpiTemplate.Flags = (mTpm2AcpiTemplate.Flags & 0xFFFF0000) | PcdGet8 (PcdTpmPlatformClass);
-  DEBUG ((DEBUG_INFO, "Tpm2 ACPI table PlatformClass is %d\n", (mTpm2AcpiTemplate.Flags & 0x0000FFFF)));
 
   mTpm2AcpiTemplate.Laml = PcdGet32 (PcdTpm2AcpiTableLaml);
   mTpm2AcpiTemplate.Lasa = PcdGet64 (PcdTpm2AcpiTableLasa);
-  if ((mTpm2AcpiTemplate.Laml == 0) || (mTpm2AcpiTemplate.Lasa == 0)) {
+  if ((mTpm2AcpiTemplate.Header.Revision < EFI_TPM2_ACPI_TABLE_REVISION_4) ||
+      (mTpm2AcpiTemplate.Laml == 0) || (mTpm2AcpiTemplate.Lasa == 0))
+  {
     //
     // If version is smaller than 4 or Laml/Lasa is not valid, rollback to original Length.
     //


### PR DESCRIPTION
## Description

Some OS versions used in special environments are not ready for this change. Thus we need to revert the _breaking_ change.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This change is being tested.

## Integration Instructions

Change the `PcdTpm2AcpiTableRev` back to 4.
