### PR TITLE
[SQUASH ON REBASE] ArmPlatformPkg: MemoryInitPeiLib: Fix V2 HOB Attribute

### DIFF
--- a/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.c
+++ b/ArmPlatformPkg/MemoryInitPei/MemoryInitPeiLib.c
@@ -186,7 +186,7 @@ MemoryPeim (
               ResourceAttributes,
               FdTop,
               ResourceTop - FdTop,
-              NextHob.ResourceDescriptorV2->V1.ResourceAttribute,
+              NextHob.ResourceDescriptorV2->Attributes,
               NULL
               );
           }


### PR DESCRIPTION
## Description

Commit 5e381f8de665bbc7ce520134049758274910a9bf updated the V2 resc desc HOB parsing in MemoryInitPeiLib, but if splitting the system memory HOB to accommodate the FD HOB, the attribute chosen for the leftover system memory HOB was the resource attributes, not the memory attributes.

This fixes this by preserving the memory attribute correctly.

This should be squashed with b8960d8a908c98b566cb5204cc9a6eb8b3d1b11a, 5e381f8de665bbc7ce520134049758274910a9bf, and
fb5e75cbf1c471de9a14233044c5e31ee3028a38 on rebase.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on a physical platform where the Patina readiness tool was failing because invalid attributes were set in a HOB field. After this change it passes.

## Integration Instructions

N/A.
