### PR TITLE
MdeModulePkg: Add IOMMU protocol NULL check

### DIFF
--- a/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceIo.c
+++ b/MdeModulePkg/Bus/Pci/NonDiscoverablePciDeviceDxe/NonDiscoverablePciDeviceIo.c
@@ -822,63 +822,67 @@ CoherentPciIoMap (
   // MU_CHANGE [BEGIN]
   *Mapping = MapInfo;
 
-  switch (Operation) {
-    case EfiPciIoOperationBusMasterRead:
-      IoMmuOperation = EdkiiIoMmuOperationBusMasterRead;
-      IoMmuAttribute = EDKII_IOMMU_ACCESS_READ;
-      break;
+  if (IoMmuIsPresent ()) {
+    switch (Operation) {
+      case EfiPciIoOperationBusMasterRead:
+        IoMmuOperation = EdkiiIoMmuOperationBusMasterRead;
+        IoMmuAttribute = EDKII_IOMMU_ACCESS_READ;
+        break;
 
-    case EfiPciIoOperationBusMasterWrite:
-      IoMmuOperation = EdkiiIoMmuOperationBusMasterWrite;
-      IoMmuAttribute = EDKII_IOMMU_ACCESS_WRITE;
-      break;
+      case EfiPciIoOperationBusMasterWrite:
+        IoMmuOperation = EdkiiIoMmuOperationBusMasterWrite;
+        IoMmuAttribute = EDKII_IOMMU_ACCESS_WRITE;
+        break;
 
-    case EfiPciIoOperationBusMasterCommonBuffer:
-      IoMmuOperation = EdkiiIoMmuOperationBusMasterCommonBuffer;
-      IoMmuAttribute = EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE;
-      break;
+      case EfiPciIoOperationBusMasterCommonBuffer:
+        IoMmuOperation = EdkiiIoMmuOperationBusMasterCommonBuffer;
+        IoMmuAttribute = EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE;
+        break;
 
-    default:
-      DEBUG ((DEBUG_ERROR, "%a - Invalid operation %d\n", __func__, Operation));
+      default:
+        DEBUG ((DEBUG_ERROR, "%a - Invalid operation %d\n", __func__, Operation));
+        ASSERT (FALSE);
+        return EFI_INVALID_PARAMETER;
+    }
+
+    if ((Dev->Attributes & EFI_PCI_IO_ATTRIBUTE_DUAL_ADDRESS_CYCLE) != 0) {
+      IoMmuOperation += EdkiiIoMmuOperationBusMasterRead64;
+    }
+
+    Status = IoMmuMap (
+               IoMmuOperation,
+               IoMmuHostAddress,
+               NumberOfBytes,
+               DeviceAddress,
+               &MapInfo->IoMmuContext
+               );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a - IoMmuMap failed.\n", __func__));
       ASSERT (FALSE);
-      return EFI_INVALID_PARAMETER;
-  }
+      goto FreeMapInfo;
+    }
 
-  if ((Dev->Attributes & EFI_PCI_IO_ATTRIBUTE_DUAL_ADDRESS_CYCLE) != 0) {
-    IoMmuOperation += EdkiiIoMmuOperationBusMasterRead64;
-  }
-
-  Status = IoMmuMap (
-             IoMmuOperation,
-             IoMmuHostAddress,
-             NumberOfBytes,
-             DeviceAddress,
-             &MapInfo->IoMmuContext
-             );
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a - IoMmuMap failed.\n", __func__));
-    ASSERT (FALSE);
-    goto FreeMapInfo;
-  }
-
-  Status = IoMmuSetAttribute (
-             NULL,
-             MapInfo->IoMmuContext,
-             IoMmuAttribute
-             );
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttribute failed.\n", __func__));
-    ASSERT (FALSE);
-    goto Unmap;
+    Status = IoMmuSetAttribute (
+               NULL,
+               MapInfo->IoMmuContext,
+               IoMmuAttribute
+               );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttribute failed.\n", __func__));
+      ASSERT (FALSE);
+      goto Unmap;
+    }
   }
 
   return EFI_SUCCESS;
 
 Unmap:
-  Status = IoMmuUnmap (MapInfo->IoMmuContext);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a - IoMmuUnmap failed.\n", __func__));
-    ASSERT (FALSE);
+  if (IoMmuIsPresent ()) {
+    Status = IoMmuUnmap (MapInfo->IoMmuContext);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a - IoMmuUnmap failed.\n", __func__));
+      ASSERT (FALSE);
+    }
   }
 
 FreeMapInfo:
@@ -916,18 +920,20 @@ CoherentPciIoUnmap (
 
   MapInfo = Mapping;
 
-  Status = IoMmuSetAttribute (NULL, MapInfo->IoMmuContext, 0);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttribute failed.\n", __func__));
-    ASSERT (FALSE);
-    return Status;
-  }
+  if (IoMmuIsPresent ()) {
+    Status = IoMmuSetAttribute (NULL, MapInfo->IoMmuContext, 0);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttribute failed.\n", __func__));
+      ASSERT (FALSE);
+      return Status;
+    }
 
-  Status = IoMmuUnmap (MapInfo->IoMmuContext);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a - IoMmuUnmap failed.\n", __func__));
-    ASSERT (FALSE);
-    return Status;
+    Status = IoMmuUnmap (MapInfo->IoMmuContext);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a - IoMmuUnmap failed.\n", __func__));
+      ASSERT (FALSE);
+      return Status;
+    }
   }
 
   // Only copy the data back and free for the bounce buffer case.
@@ -1516,63 +1522,67 @@ NonCoherentPciIoMap (
   *Mapping = MapInfo;
 
   // MU_CHANGE [BEGIN]
-  switch (Operation) {
-    case EfiPciIoOperationBusMasterRead:
-      IoMmuOperation = EdkiiIoMmuOperationBusMasterRead;
-      IoMmuAttribute = EDKII_IOMMU_ACCESS_READ;
-      break;
+  if (IoMmuIsPresent ()) {
+    switch (Operation) {
+      case EfiPciIoOperationBusMasterRead:
+        IoMmuOperation = EdkiiIoMmuOperationBusMasterRead;
+        IoMmuAttribute = EDKII_IOMMU_ACCESS_READ;
+        break;
 
-    case EfiPciIoOperationBusMasterWrite:
-      IoMmuOperation = EdkiiIoMmuOperationBusMasterWrite;
-      IoMmuAttribute = EDKII_IOMMU_ACCESS_WRITE;
-      break;
+      case EfiPciIoOperationBusMasterWrite:
+        IoMmuOperation = EdkiiIoMmuOperationBusMasterWrite;
+        IoMmuAttribute = EDKII_IOMMU_ACCESS_WRITE;
+        break;
 
-    case EfiPciIoOperationBusMasterCommonBuffer:
-      IoMmuOperation = EdkiiIoMmuOperationBusMasterCommonBuffer;
-      IoMmuAttribute = EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE;
-      break;
+      case EfiPciIoOperationBusMasterCommonBuffer:
+        IoMmuOperation = EdkiiIoMmuOperationBusMasterCommonBuffer;
+        IoMmuAttribute = EDKII_IOMMU_ACCESS_READ | EDKII_IOMMU_ACCESS_WRITE;
+        break;
 
-    default:
-      DEBUG ((DEBUG_ERROR, "%a - Invalid operation %d\n", __func__, Operation));
+      default:
+        DEBUG ((DEBUG_ERROR, "%a - Invalid operation %d\n", __func__, Operation));
+        ASSERT (FALSE);
+        return EFI_INVALID_PARAMETER;
+    }
+
+    if ((Dev->Attributes & EFI_PCI_IO_ATTRIBUTE_DUAL_ADDRESS_CYCLE) != 0) {
+      IoMmuOperation += EdkiiIoMmuOperationBusMasterRead64;
+    }
+
+    Status = IoMmuMap (
+               IoMmuOperation,
+               IoMmuHostAddress,
+               NumberOfBytes,
+               DeviceAddress,
+               &MapInfo->IoMmuContext
+               );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a - IoMmuMap failed.\n", __func__));
       ASSERT (FALSE);
-      return EFI_INVALID_PARAMETER;
-  }
+      goto FreeMapInfo;
+    }
 
-  if ((Dev->Attributes & EFI_PCI_IO_ATTRIBUTE_DUAL_ADDRESS_CYCLE) != 0) {
-    IoMmuOperation += EdkiiIoMmuOperationBusMasterRead64;
-  }
-
-  Status = IoMmuMap (
-             IoMmuOperation,
-             IoMmuHostAddress,
-             NumberOfBytes,
-             DeviceAddress,
-             &MapInfo->IoMmuContext
-             );
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a - IoMmuMap failed.\n", __func__));
-    ASSERT (FALSE);
-    goto FreeMapInfo;
-  }
-
-  Status = IoMmuSetAttribute (
-             NULL,
-             MapInfo->IoMmuContext,
-             IoMmuAttribute
-             );
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttribute failed.\n", __func__));
-    ASSERT (FALSE);
-    goto Unmap;
+    Status = IoMmuSetAttribute (
+               NULL,
+               MapInfo->IoMmuContext,
+               IoMmuAttribute
+               );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttribute failed.\n", __func__));
+      ASSERT (FALSE);
+      goto Unmap;
+    }
   }
 
   return EFI_SUCCESS;
 
 Unmap:
-  Status = IoMmuUnmap (MapInfo->IoMmuContext);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a - IoMmuUnmap failed.\n", __func__));
-    ASSERT (FALSE);
+  if (IoMmuIsPresent ()) {
+    Status = IoMmuUnmap (MapInfo->IoMmuContext);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a - IoMmuUnmap failed.\n", __func__));
+      ASSERT (FALSE);
+    }
   }
 
   // MU_CHANGE [END]
@@ -1610,18 +1620,20 @@ NonCoherentPciIoUnmap (
   MapInfo = Mapping;
 
   // MU_CHANGE [BEGIN]
-  Status = IoMmuSetAttribute (NULL, MapInfo->IoMmuContext, 0);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttribute failed.\n", __func__));
-    ASSERT (FALSE);
-    return Status;
-  }
+  if (IoMmuIsPresent ()) {
+    Status = IoMmuSetAttribute (NULL, MapInfo->IoMmuContext, 0);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttribute failed.\n", __func__));
+      ASSERT (FALSE);
+      return Status;
+    }
 
-  Status = IoMmuUnmap (MapInfo->IoMmuContext);
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a - IoMmuUnmap failed.\n", __func__));
-    ASSERT (FALSE);
-    return Status;
+    Status = IoMmuUnmap (MapInfo->IoMmuContext);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a - IoMmuUnmap failed.\n", __func__));
+      ASSERT (FALSE);
+      return Status;
+    }
   }
 
   // MU_CHANGE [END]

--- a/MdeModulePkg/Bus/Pci/PciBusDxe/PciIo.c
+++ b/MdeModulePkg/Bus/Pci/PciBusDxe/PciIo.c
@@ -1026,7 +1026,7 @@ PciIoMap (
   //     }
   // MU_CHANGE [END]
 
-  if (!EFI_ERROR (Status)) {
+  if (!EFI_ERROR (Status) && IoMmuIsPresent ()) {
     switch (Operation) {
       case EfiPciIoOperationBusMasterRead:
         IoMmuAttribute = EDKII_IOMMU_ACCESS_READ;
@@ -1100,15 +1100,17 @@ PciIoUnmap (
   // MU_CHANGE [END]
 
   // MU_CHANGE [BEGIN] - Use IoMmuLib
-  Status = IoMmuSetAttribute (
-             PciIoDevice->Handle,
-             Mapping,
-             0
-             );
-  if (EFI_ERROR (Status)) {
-    DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttribute failed.\n", __func__));
-    ASSERT (FALSE);
-    return Status;
+  if (IoMmuIsPresent ()) {
+    Status = IoMmuSetAttribute (
+               PciIoDevice->Handle,
+               Mapping,
+               0
+               );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a - IoMmuSetAttribute failed.\n", __func__));
+      ASSERT (FALSE);
+      return Status;
+    }
   }
 
   // MU_CHANGE [END]


### PR DESCRIPTION
Add IOMMU protocol null check before call IOMMU protocol functions. This avoids IOMMU protocol function pointers is NULL.

Sign-off-by: Hank Lin <hanklin@ami.com>

## Description

Add IoMmuIsPresent() checks before IOMMU API calls in PCI map/unmap paths.
This prevents invalid IOMMU calls and potential NULL function pointer issues when IOMMU is absent.
Behavior is unchanged on IOMMU-enabled platforms, while robustness is improved on non-IOMMU platforms.

This issue does not reproduce in upstream edk2.  
In mu_basecore, MU_CHANGE-altered flow no longer preserves the same IOMMU presence-check behavior, which can lead to IOMMU API calls when IOMMU is absent.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
- Built the impacted module/package and confirmed no build errors.
- Boot-tested on:
  - an IOMMU-enabled platform
  - an IOMMU-disabled/absent platform
- Exercised PCI map/unmap paths (DMA read/write/common buffer scenarios).
- Verified no regression in normal PCI I/O flow and no IOMMU API misuse when IOMMU is absent.


## Integration Instructions

N/A
