### PR TITLE
ArmPkg: MmCommunicationDxe: Fix Comm Buffer Init

### DIFF
--- a/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.c
+++ b/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.c
@@ -5,6 +5,9 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
+
+#include <PiDxe.h>
+
 #include <Library/ArmLib.h>
 #include <Library/ArmFfaLib.h>
 #include <Library/ArmSmcLib.h>
@@ -23,6 +26,8 @@
 #include <IndustryStandard/ArmStdSmc.h>
 #include <IndustryStandard/ArmFfaSvc.h>
 #include <IndustryStandard/MmCommunicate.h>
+
+#define COMM_BUFFER_ATTRS (EFI_MEMORY_WB | EFI_MEMORY_XP | EFI_MEMORY_RUNTIME)
 
 //
 // Partition ID if FF-A support is enabled
@@ -697,6 +702,7 @@ MmCommunication2Initialize (
 {
   EFI_STATUS  Status;
   UINTN       Index;
+  EFI_GCD_MEMORY_SPACE_DESCRIPTOR  GcdDescriptor;
 
   // Initialize to make mm communication
   Status = InitializeCommunication ();
@@ -713,83 +719,75 @@ MmCommunication2Initialize (
 
   ASSERT (mNsCommBuffMemRegion.Length != 0);
 
-  Status = gDS->AddMemorySpace (
-                  EfiGcdMemoryTypeReserved,
+  Status = gDS->GetMemorySpaceDescriptor (
                   mNsCommBuffMemRegion.PhysicalBase,
-                  mNsCommBuffMemRegion.Length,
-                  EFI_MEMORY_WB |
-                  EFI_MEMORY_XP |
-                  EFI_MEMORY_RUNTIME
+                  &GcdDescriptor
                   );
-  if (EFI_ERROR (Status) && (Status != EFI_ACCESS_DENIED)) {
-    DEBUG ((
-      DEBUG_ERROR,
-      "MmCommunicateInitialize: "
-      "Failed to add MM-NS Buffer Memory Space - %r\n",
-      Status
-      ));
-    goto ReturnErrorStatus;
-  } else if (Status == EFI_ACCESS_DENIED) {
-    Status = gDS->FreeMemorySpace (
-                    mNsCommBuffMemRegion.PhysicalBase,
-                    mNsCommBuffMemRegion.Length
-                    );
-    if (EFI_ERROR (Status)) {
-      DEBUG ((
-        DEBUG_ERROR,
-        "MmCommunicateInitialize: "
-        "Failed to free existing MM-NS Buffer Memory Space - %r\n",
-        Status
-        ));
-      goto ReturnErrorStatus;
-    }
 
-    Status = gDS->RemoveMemorySpace (
-                    mNsCommBuffMemRegion.PhysicalBase,
-                    mNsCommBuffMemRegion.Length
-                    );
-    if (EFI_ERROR (Status)) {
-      DEBUG ((
-        DEBUG_ERROR,
-        "MmCommunicateInitialize: "
-        "Failed to remove existing MM-NS Buffer Memory Space - %r\n",
-        Status
-        ));
-      goto ReturnErrorStatus;
-    }
-
-    // Try to add the memory space again
+  if (EFI_ERROR (Status) || (GcdDescriptor.GcdMemoryType == EfiGcdMemoryTypeNonExistent)) {
+    // if this doesn't exist, add it ourselves
     Status = gDS->AddMemorySpace (
                     EfiGcdMemoryTypeReserved,
                     mNsCommBuffMemRegion.PhysicalBase,
                     mNsCommBuffMemRegion.Length,
-                    EFI_MEMORY_WB |
-                    EFI_MEMORY_XP |
-                    EFI_MEMORY_RUNTIME
+                    COMM_BUFFER_ATTRS
                     );
-    if (EFI_ERROR (Status)) {
+     if (EFI_ERROR (Status)) {
       DEBUG ((
         DEBUG_ERROR,
-        "MmCommunicateInitialize: "
-        "Failed to add MM-NS Buffer Memory Space (second attempt) - %r\n",
+        "%a: "
+        "Failed to add MM-NS Buffer Memory Space - %r\n",
+        __func__,
         Status
         ));
       goto ReturnErrorStatus;
     }
+  } else if (!(GcdDescriptor.BaseAddress <= mNsCommBuffMemRegion.PhysicalBase &&
+               (GcdDescriptor.BaseAddress + GcdDescriptor.Length) >=
+               (mNsCommBuffMemRegion.PhysicalBase + mNsCommBuffMemRegion.Length)))
+  {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Existing GCD memory space does not completely cover MM-NS Buffer Memory Space\n",
+      __func__
+      ));
+    ASSERT (FALSE);
+    goto ReturnErrorStatus;
+  } else if (GcdDescriptor.GcdMemoryType != EfiGcdMemoryTypeReserved) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Existing GCD memory space is not EfiGcdMemoryTypeReserved for the MM-NS Buffer Memory Space\n",
+      __func__
+      ));
+    ASSERT_EFI_ERROR (Status);
+    goto ReturnErrorStatus;
+  }
+  else if ((GcdDescriptor.Capabilities & (COMM_BUFFER_ATTRS)) !=
+             (COMM_BUFFER_ATTRS))
+  {
+    // set the capabilities if we need to. If we fail, still try setting the attributes
+    // the worst case is it will error there.
+    Status = gDS->SetMemorySpaceCapabilities (
+                    mNsCommBuffMemRegion.PhysicalBase,
+                    mNsCommBuffMemRegion.Length,
+                    COMM_BUFFER_ATTRS
+                    );
+    ASSERT_EFI_ERROR (Status);
   }
 
   Status = gDS->SetMemorySpaceAttributes (
                   mNsCommBuffMemRegion.PhysicalBase,
                   mNsCommBuffMemRegion.Length,
-                  EFI_MEMORY_WB | EFI_MEMORY_XP | EFI_MEMORY_RUNTIME
+                  COMM_BUFFER_ATTRS
                   );
   if (EFI_ERROR (Status)) {
     DEBUG ((
       DEBUG_ERROR,
-      "MmCommunicateInitialize: "
-      "Failed to set MM-NS Buffer Memory attributes\n"
+      "%a: "
+      "Failed to set MM-NS Buffer Memory attributes\n",
+      __func__
       ));
-    goto CleanAddedMemorySpace;
+    goto ReturnErrorStatus;
   }
 
   // Install the communication protocol
@@ -804,10 +802,11 @@ MmCommunication2Initialize (
   if (EFI_ERROR (Status)) {
     DEBUG ((
       DEBUG_ERROR,
-      "MmCommunicationInitialize: "
-      "Failed to install MM communication protocol\n"
+      "%a: "
+      "Failed to install MM communication protocol\n",
+      __func__
       ));
-    goto CleanAddedMemorySpace;
+    goto ReturnErrorStatus;
   }
 
   // Register notification callback when virtual address is associated
@@ -857,12 +856,6 @@ UninstallProtocol:
          mMmCommunicateHandle,
          &gEfiMmCommunication2ProtocolGuid,
          &mMmCommunication2
-         );
-
-CleanAddedMemorySpace:
-  gDS->RemoveMemorySpace (
-         mNsCommBuffMemRegion.PhysicalBase,
-         mNsCommBuffMemRegion.Length
          );
 
 ReturnErrorStatus:


### PR DESCRIPTION
## Description

Currently, MmCommunicationDxe expects the MM comm buffer to either be not added by the platform or added and allocated by the platform. However, not all platforms follow this pattern.

This commit makes the handling more generic by checking to see if a GCD descriptor exists that covers this range. If it does, the capabilities are updated as needed. If only a partial desc exists for this range, the driver will fail as that is a platform misconfiguration.

If the descriptor does not exist, the driver will add the buffer.

Then, for all successful cases, the attributes are updated on the buffer to what the driver expects them to be.

This will be taken to edk2 in parallel.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on an aarch64 platform that was producing the HOB but not having it allocated. This fixed it.

## Integration Instructions

Platforms must either not produce a resource descriptor HOB for the MM Communicate Buffer or must produce a HOB fully covering the region.