### PR TITLE
[REBASE & FF] Revert Mu Commits in Favor of edk2 Commits

### DIFF
--- a/.pytool/Plugin/SpellCheck/cspell.base.yaml
+++ b/.pytool/Plugin/SpellCheck/cspell.base.yaml
@@ -28,6 +28,7 @@
         "muchange"
     ],
     "words": [
+        "AAPCS",
         "ACPICA",
         "ACPINVS",
         "armltd",

--- a/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.c
+++ b/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.c
@@ -5,6 +5,9 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
+
+#include <PiDxe.h>
+
 #include <Library/ArmLib.h>
 #include <Library/ArmFfaLib.h>
 #include <Library/ArmSmcLib.h>
@@ -23,6 +26,8 @@
 #include <IndustryStandard/ArmStdSmc.h>
 #include <IndustryStandard/ArmFfaSvc.h>
 #include <IndustryStandard/MmCommunicate.h>
+
+#define COMM_BUFFER_ATTRS  (EFI_MEMORY_WB | EFI_MEMORY_XP | EFI_MEMORY_RUNTIME)
 
 //
 // Partition ID if FF-A support is enabled
@@ -695,8 +700,9 @@ MmCommunication2Initialize (
   IN EFI_SYSTEM_TABLE  *SystemTable
   )
 {
-  EFI_STATUS  Status;
-  UINTN       Index;
+  EFI_STATUS                       Status;
+  UINTN                            Index;
+  EFI_GCD_MEMORY_SPACE_DESCRIPTOR  GcdDescriptor;
 
   // Initialize to make mm communication
   Status = InitializeCommunication ();
@@ -713,67 +719,68 @@ MmCommunication2Initialize (
 
   ASSERT (mNsCommBuffMemRegion.Length != 0);
 
-  Status = gDS->AddMemorySpace (
-                  EfiGcdMemoryTypeReserved,
+  Status = gDS->GetMemorySpaceDescriptor (
                   mNsCommBuffMemRegion.PhysicalBase,
-                  mNsCommBuffMemRegion.Length,
-                  EFI_MEMORY_WB |
-                  EFI_MEMORY_XP |
-                  EFI_MEMORY_RUNTIME
+                  &GcdDescriptor
                   );
-  if (EFI_ERROR (Status) && (Status != EFI_ACCESS_DENIED)) {
-    DEBUG ((
-      DEBUG_ERROR,
-      "MmCommunicateInitialize: "
-      "Failed to add MM-NS Buffer Memory Space - %r\n",
-      Status
-      ));
-    goto ReturnErrorStatus;
-  } else if (Status == EFI_ACCESS_DENIED) {
-    Status = gDS->FreeMemorySpace (
-                    mNsCommBuffMemRegion.PhysicalBase,
-                    mNsCommBuffMemRegion.Length
-                    );
-    if (EFI_ERROR (Status)) {
-      DEBUG ((
-        DEBUG_ERROR,
-        "MmCommunicateInitialize: "
-        "Failed to free existing MM-NS Buffer Memory Space - %r\n",
-        Status
-        ));
-      goto ReturnErrorStatus;
-    }
 
-    Status = gDS->RemoveMemorySpace (
-                    mNsCommBuffMemRegion.PhysicalBase,
-                    mNsCommBuffMemRegion.Length
-                    );
-    if (EFI_ERROR (Status)) {
-      DEBUG ((
-        DEBUG_ERROR,
-        "MmCommunicateInitialize: "
-        "Failed to remove existing MM-NS Buffer Memory Space - %r\n",
-        Status
-        ));
-      goto ReturnErrorStatus;
-    }
-
-    // Try to add the memory space again
+  if (EFI_ERROR (Status) || (GcdDescriptor.GcdMemoryType == EfiGcdMemoryTypeNonExistent)) {
+    // if this doesn't exist, add it ourselves
     Status = gDS->AddMemorySpace (
                     EfiGcdMemoryTypeReserved,
                     mNsCommBuffMemRegion.PhysicalBase,
                     mNsCommBuffMemRegion.Length,
-                    EFI_MEMORY_WB |
-                    EFI_MEMORY_XP |
-                    EFI_MEMORY_RUNTIME
+                    COMM_BUFFER_ATTRS
                     );
     if (EFI_ERROR (Status)) {
       DEBUG ((
         DEBUG_ERROR,
-        "MmCommunicateInitialize: "
-        "Failed to add MM-NS Buffer Memory Space (second attempt) - %r\n",
+        "%a: "
+        "Failed to add MM-NS Buffer Memory Space - %r\n",
+        __func__,
         Status
         ));
+      goto ReturnErrorStatus;
+    }
+  } else if (!((GcdDescriptor.BaseAddress <= mNsCommBuffMemRegion.PhysicalBase) &&
+               ((GcdDescriptor.BaseAddress + GcdDescriptor.Length) >=
+                (mNsCommBuffMemRegion.PhysicalBase + mNsCommBuffMemRegion.Length))))
+  {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Existing GCD memory space does not completely cover MM-NS Buffer Memory Space\n",
+      __func__
+      ));
+    ASSERT (FALSE);
+    Status = EFI_ABORTED;
+    goto ReturnErrorStatus;
+  } else if (GcdDescriptor.GcdMemoryType != EfiGcdMemoryTypeReserved) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: Existing GCD memory space is not EfiGcdMemoryTypeReserved for the MM-NS Buffer Memory Space\n",
+      __func__
+      ));
+    ASSERT (FALSE);
+    Status = EFI_ABORTED;
+    goto ReturnErrorStatus;
+  } else if ((GcdDescriptor.Capabilities & (COMM_BUFFER_ATTRS)) !=
+             (COMM_BUFFER_ATTRS))
+  {
+    Status = gDS->SetMemorySpaceCapabilities (
+                    mNsCommBuffMemRegion.PhysicalBase,
+                    mNsCommBuffMemRegion.Length,
+                    COMM_BUFFER_ATTRS
+                    );
+
+    if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a: "
+        "Failed to set MM-NS Buffer Memory capabilities with Status %r\n",
+        __func__,
+        Status
+        ));
+      ASSERT_EFI_ERROR (Status);
       goto ReturnErrorStatus;
     }
   }
@@ -781,15 +788,18 @@ MmCommunication2Initialize (
   Status = gDS->SetMemorySpaceAttributes (
                   mNsCommBuffMemRegion.PhysicalBase,
                   mNsCommBuffMemRegion.Length,
-                  EFI_MEMORY_WB | EFI_MEMORY_XP | EFI_MEMORY_RUNTIME
+                  COMM_BUFFER_ATTRS
                   );
   if (EFI_ERROR (Status)) {
     DEBUG ((
       DEBUG_ERROR,
-      "MmCommunicateInitialize: "
-      "Failed to set MM-NS Buffer Memory attributes\n"
+      "%a: "
+      "Failed to set MM-NS Buffer Memory attributes with Status %r\n",
+      __func__,
+      Status
       ));
-    goto CleanAddedMemorySpace;
+    ASSERT_EFI_ERROR (Status);
+    goto ReturnErrorStatus;
   }
 
   // Install the communication protocol
@@ -804,10 +814,11 @@ MmCommunication2Initialize (
   if (EFI_ERROR (Status)) {
     DEBUG ((
       DEBUG_ERROR,
-      "MmCommunicationInitialize: "
-      "Failed to install MM communication protocol\n"
+      "%a: "
+      "Failed to install MM communication protocol\n",
+      __func__
       ));
-    goto CleanAddedMemorySpace;
+    goto ReturnErrorStatus;
   }
 
   // Register notification callback when virtual address is associated
@@ -857,12 +868,6 @@ UninstallProtocol:
          mMmCommunicateHandle,
          &gEfiMmCommunication2ProtocolGuid,
          &mMmCommunication2
-         );
-
-CleanAddedMemorySpace:
-  gDS->RemoveMemorySpace (
-         mNsCommBuffMemRegion.PhysicalBase,
-         mNsCommBuffMemRegion.Length
          );
 
 ReturnErrorStatus:

--- a/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.c
+++ b/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.c
@@ -5,9 +5,6 @@
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
 **/
-
-#include <PiDxe.h>
-
 #include <Library/ArmLib.h>
 #include <Library/ArmFfaLib.h>
 #include <Library/ArmSmcLib.h>
@@ -26,8 +23,6 @@
 #include <IndustryStandard/ArmStdSmc.h>
 #include <IndustryStandard/ArmFfaSvc.h>
 #include <IndustryStandard/MmCommunicate.h>
-
-#define COMM_BUFFER_ATTRS (EFI_MEMORY_WB | EFI_MEMORY_XP | EFI_MEMORY_RUNTIME)
 
 //
 // Partition ID if FF-A support is enabled
@@ -702,7 +697,6 @@ MmCommunication2Initialize (
 {
   EFI_STATUS  Status;
   UINTN       Index;
-  EFI_GCD_MEMORY_SPACE_DESCRIPTOR  GcdDescriptor;
 
   // Initialize to make mm communication
   Status = InitializeCommunication ();
@@ -719,75 +713,83 @@ MmCommunication2Initialize (
 
   ASSERT (mNsCommBuffMemRegion.Length != 0);
 
-  Status = gDS->GetMemorySpaceDescriptor (
+  Status = gDS->AddMemorySpace (
+                  EfiGcdMemoryTypeReserved,
                   mNsCommBuffMemRegion.PhysicalBase,
-                  &GcdDescriptor
+                  mNsCommBuffMemRegion.Length,
+                  EFI_MEMORY_WB |
+                  EFI_MEMORY_XP |
+                  EFI_MEMORY_RUNTIME
                   );
-
-  if (EFI_ERROR (Status) || (GcdDescriptor.GcdMemoryType == EfiGcdMemoryTypeNonExistent)) {
-    // if this doesn't exist, add it ourselves
-    Status = gDS->AddMemorySpace (
-                    EfiGcdMemoryTypeReserved,
+  if (EFI_ERROR (Status) && (Status != EFI_ACCESS_DENIED)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "MmCommunicateInitialize: "
+      "Failed to add MM-NS Buffer Memory Space - %r\n",
+      Status
+      ));
+    goto ReturnErrorStatus;
+  } else if (Status == EFI_ACCESS_DENIED) {
+    Status = gDS->FreeMemorySpace (
                     mNsCommBuffMemRegion.PhysicalBase,
-                    mNsCommBuffMemRegion.Length,
-                    COMM_BUFFER_ATTRS
+                    mNsCommBuffMemRegion.Length
                     );
-     if (EFI_ERROR (Status)) {
+    if (EFI_ERROR (Status)) {
       DEBUG ((
         DEBUG_ERROR,
-        "%a: "
-        "Failed to add MM-NS Buffer Memory Space - %r\n",
-        __func__,
+        "MmCommunicateInitialize: "
+        "Failed to free existing MM-NS Buffer Memory Space - %r\n",
         Status
         ));
       goto ReturnErrorStatus;
     }
-  } else if (!(GcdDescriptor.BaseAddress <= mNsCommBuffMemRegion.PhysicalBase &&
-               (GcdDescriptor.BaseAddress + GcdDescriptor.Length) >=
-               (mNsCommBuffMemRegion.PhysicalBase + mNsCommBuffMemRegion.Length)))
-  {
-    DEBUG ((
-      DEBUG_ERROR,
-      "%a: Existing GCD memory space does not completely cover MM-NS Buffer Memory Space\n",
-      __func__
-      ));
-    ASSERT (FALSE);
-    goto ReturnErrorStatus;
-  } else if (GcdDescriptor.GcdMemoryType != EfiGcdMemoryTypeReserved) {
-    DEBUG ((
-      DEBUG_ERROR,
-      "%a: Existing GCD memory space is not EfiGcdMemoryTypeReserved for the MM-NS Buffer Memory Space\n",
-      __func__
-      ));
-    ASSERT_EFI_ERROR (Status);
-    goto ReturnErrorStatus;
-  }
-  else if ((GcdDescriptor.Capabilities & (COMM_BUFFER_ATTRS)) !=
-             (COMM_BUFFER_ATTRS))
-  {
-    // set the capabilities if we need to. If we fail, still try setting the attributes
-    // the worst case is it will error there.
-    Status = gDS->SetMemorySpaceCapabilities (
+
+    Status = gDS->RemoveMemorySpace (
+                    mNsCommBuffMemRegion.PhysicalBase,
+                    mNsCommBuffMemRegion.Length
+                    );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "MmCommunicateInitialize: "
+        "Failed to remove existing MM-NS Buffer Memory Space - %r\n",
+        Status
+        ));
+      goto ReturnErrorStatus;
+    }
+
+    // Try to add the memory space again
+    Status = gDS->AddMemorySpace (
+                    EfiGcdMemoryTypeReserved,
                     mNsCommBuffMemRegion.PhysicalBase,
                     mNsCommBuffMemRegion.Length,
-                    COMM_BUFFER_ATTRS
+                    EFI_MEMORY_WB |
+                    EFI_MEMORY_XP |
+                    EFI_MEMORY_RUNTIME
                     );
-    ASSERT_EFI_ERROR (Status);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "MmCommunicateInitialize: "
+        "Failed to add MM-NS Buffer Memory Space (second attempt) - %r\n",
+        Status
+        ));
+      goto ReturnErrorStatus;
+    }
   }
 
   Status = gDS->SetMemorySpaceAttributes (
                   mNsCommBuffMemRegion.PhysicalBase,
                   mNsCommBuffMemRegion.Length,
-                  COMM_BUFFER_ATTRS
+                  EFI_MEMORY_WB | EFI_MEMORY_XP | EFI_MEMORY_RUNTIME
                   );
   if (EFI_ERROR (Status)) {
     DEBUG ((
       DEBUG_ERROR,
-      "%a: "
-      "Failed to set MM-NS Buffer Memory attributes\n",
-      __func__
+      "MmCommunicateInitialize: "
+      "Failed to set MM-NS Buffer Memory attributes\n"
       ));
-    goto ReturnErrorStatus;
+    goto CleanAddedMemorySpace;
   }
 
   // Install the communication protocol
@@ -802,11 +804,10 @@ MmCommunication2Initialize (
   if (EFI_ERROR (Status)) {
     DEBUG ((
       DEBUG_ERROR,
-      "%a: "
-      "Failed to install MM communication protocol\n",
-      __func__
+      "MmCommunicationInitialize: "
+      "Failed to install MM communication protocol\n"
       ));
-    goto ReturnErrorStatus;
+    goto CleanAddedMemorySpace;
   }
 
   // Register notification callback when virtual address is associated
@@ -856,6 +857,12 @@ UninstallProtocol:
          mMmCommunicateHandle,
          &gEfiMmCommunication2ProtocolGuid,
          &mMmCommunication2
+         );
+
+CleanAddedMemorySpace:
+  gDS->RemoveMemorySpace (
+         mNsCommBuffMemRegion.PhysicalBase,
+         mNsCommBuffMemRegion.Length
          );
 
 ReturnErrorStatus:

--- a/MdePkg/Include/Base.h
+++ b/MdePkg/Include/Base.h
@@ -580,14 +580,27 @@ struct _LIST_ENTRY {
 
 #if defined (_M_ARM64)
 //
-// MSFT ARM variable argument list support.
+// MSVC AARCH64 and CLANGPDB AARCH64 hit this path. By default, they use the MS ABI for VA_LIST and
+// friends. However, this is against the AAPCS64 ABI and cause interop issues with GCC and CLANGDWARF.
+// These definitions coerce MSVC/CLANGPDB to use the AAPCS64 ABI.
 //
 
-typedef char *VA_LIST;
+typedef struct {
+  char    *Stack; // next stack param
+  char    *GrTop; // end of GP arg reg save area
+  char    *VrTop; // end of FP/SIMD arg reg save area
+  int     GrOffs; // offset from  GrTop to next GP register arg
+  int     VrOffs; // offset from  VrTop to next FP/SIMD register arg
+} VA_LIST;
 
-#define VA_START(Marker, Parameter)  __va_start (&Marker, &Parameter, _INT_SIZE_OF (Parameter), __alignof(Parameter), &Parameter)
-#define VA_ARG(Marker, TYPE)         (*(TYPE *) ((Marker += _INT_SIZE_OF (TYPE) + ((-(INTN)Marker) & (sizeof(TYPE) - 1))) - _INT_SIZE_OF (TYPE)))
-#define VA_END(Marker)               (Marker = (VA_LIST) 0)
+#define VA_START(Marker, Parameter)  (Marker).GrTop = (Marker).VrTop = NULL, \
+                                     (Marker).GrOffs = (Marker).VrOffs = 0,  \
+                                     __va_start (&(Marker).Stack, &Parameter, _INT_SIZE_OF (Parameter), __alignof (Parameter), &Parameter)
+#define VA_STACK_ARG(Marker, TYPE)   (((Marker).Stack += _INT_SIZE_OF (TYPE) + ((-(INTN)(Marker).Stack) & (sizeof(TYPE) - 1))) - _INT_SIZE_OF (TYPE))
+#define VA_ARG(Marker, TYPE)         (*(TYPE *) (((Marker).GrOffs += _INT_SIZE_OF (TYPE)) <= 0 \
+                                     ? &(Marker).GrTop[(Marker).GrOffs - _INT_SIZE_OF (TYPE)] \
+                                     : VA_STACK_ARG(Marker, TYPE)))
+#define VA_END(Marker)               ((Marker).Stack = NULL)
 #define VA_COPY(Dest, Start)         ((void)((Dest) = (Start)))
 
 #elif defined (__GNUC__) || defined (__clang__)


### PR DESCRIPTION
## Description

This reverts the Mu version of the MmCommunicationDxe Comm Buffer Init fix and cherry-picks the edk2 version as well as cherry-picking the VA_LIST ABI change.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A.

## Integration Instructions

N/A.