### PR TITLE
NvmExpressDxe: Add PcdNvmeGenericTimeout to configure timeout per platform

### DIFF
--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.h
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpress.h
@@ -152,10 +152,14 @@ extern EFI_DRIVER_SUPPORTED_EFI_VERSION_PROTOCOL  gNvmExpressDriverSupportedEfiV
 
 #define NVME_CONTROLLER_ID  0
 
+// MU_CHANGE [BEGIN] - Set generic timeout based on PcdNvmeGenericTimeout
+
 //
-// Time out value for Nvme transaction execution
+// Time out value for Nvme transaction execution (in seconds, from PcdNvmeGenericTimeout).
 //
-#define NVME_GENERIC_TIMEOUT  EFI_TIMER_PERIOD_SECONDS (5)
+#define NVME_GENERIC_TIMEOUT  EFI_TIMER_PERIOD_SECONDS (FixedPcdGet32 (PcdNvmeGenericTimeout))
+
+// MU_CHANGE [END] - Set generic timeout based on PcdNvmeGenericTimeout
 
 //
 // Nvme async transfer timer interval, set by experience.

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressDxe.inf
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/NvmExpressDxe.inf
@@ -85,6 +85,11 @@
   gEfiMdeModulePkgTokenSpaceGuid.PcdNvmeNamespaceFilterId         ## CONSUMES
   ## MU_CHANGE [END] - NVMe namespace filtering
 
+## MU_CHANGE [BEGIN] - Configurable NVMe generic command timeout
+[FixedPcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdNvmeGenericTimeout            ## CONSUMES
+## MU_CHANGE [END] - Configurable NVMe generic command timeout
+
 # [Event]
 # EVENT_TYPE_RELATIVE_TIMER ## SOMETIMES_CONSUMES
 #

--- a/MdeModulePkg/Bus/Pci/NvmExpressDxe/UnitTest/MediaSanitizeUnitTestHost.inf
+++ b/MdeModulePkg/Bus/Pci/NvmExpressDxe/UnitTest/MediaSanitizeUnitTestHost.inf
@@ -35,3 +35,9 @@
   UnitTestLib
   PrintLib
   MemoryAllocationLib
+  PcdLib  # MU_CHANGE - Configurable NVMe generic command timeout
+
+## MU_CHANGE [BEGIN] - Configurable NVMe generic command timeout
+[FixedPcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdNvmeGenericTimeout            ## CONSUMES
+## MU_CHANGE [END] - Configurable NVMe generic command timeout

--- a/MdeModulePkg/MdeModulePkg.dec
+++ b/MdeModulePkg/MdeModulePkg.dec
@@ -1416,6 +1416,12 @@
   # Size in pages. Current default is roughly 1.6GB.
   gEfiMdeModulePkgTokenSpaceGuid.PcdMaxMemoryTypeInfoPages            |0x60000|UINT32|0x40000150
   # MU_CHANGE TCBZ1086 [END]
+
+  # MU_CHANGE [BEGIN] - Configurable NVMe generic command timeout
+  ## Timeout, in seconds, used for generic NVMe transactions issued by NvmExpressDxe.
+  # @Prompt NVMe generic command timeout (seconds).
+  gEfiMdeModulePkgTokenSpaceGuid.PcdNvmeGenericTimeout|5|UINT32|0x40000154
+  # MU_CHANGE [END] - Configurable NVMe generic command timeout
   
 [PcdsFixedAtBuild, PcdsPatchableInModule]
   ## Dynamic type PCD can be registered callback function for Pcd setting action.


### PR DESCRIPTION
## Description

Changes the NvmExpressDxe driver to reference `PcdNvmeGenericTimeout` for generic timeouts, allowing platforms to define their own timeout value.

mu_msvm is dependent on this change. In Azure, some virtual machines' backing storage resolve to remote storage backends. Traditionally, we have seen that SCSI devices waiting on remote storage can take far longer than 5 seconds. Others have previously agreed that NVMe devices using the same backing remote storage can also suffer from this. 

mu_msvm previously had a fork of NvmExpressDxe that overrode this value to 120 seconds. Now, mu_msvm has agreed to use the upstream NvmExpressDxe driver, but this change is lacking, and thus we lack full parity with our old fork currently.

Using a PCD prevents other consumers of this driver from having to make their own override. Instead, MsvmPkg for mu_msvm, for example, could simply redefine `PcdNvmeGenericTimeout` to be 120 seconds in the MsvmPkgX64.dsc and MsvmPkgAARCH64.dsc

- [X] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested with CI validation

## Integration Instructions

N/A