### PR TITLE
[Cherry-Pick] MdeModulePkg: StatusCodeHandler Stmm remove assert

### DIFF
--- a/MdeModulePkg/Universal/StatusCodeHandler/Smm/StatusCodeHandlerStandalone.c
+++ b/MdeModulePkg/Universal/StatusCodeHandler/Smm/StatusCodeHandlerStandalone.c
@@ -29,11 +29,12 @@ IsStatusCodeUsingSerialPort (
   MM_STATUS_CODE_USE_SERIAL  *StatusCodeUseSerialHob;
 
   Hob = GetFirstGuidHob (&gMmStatusCodeUseSerialHobGuid);
-  ASSERT (Hob != NULL);
+  if (Hob != NULL) {
+    StatusCodeUseSerialHob = (MM_STATUS_CODE_USE_SERIAL *)GET_GUID_HOB_DATA (Hob);
+    return StatusCodeUseSerialHob->StatusCodeUseSerial;
+  }
 
-  StatusCodeUseSerialHob = (MM_STATUS_CODE_USE_SERIAL *)GET_GUID_HOB_DATA (Hob);
-
-  return StatusCodeUseSerialHob->StatusCodeUseSerial;
+  return FALSE;
 }
 
 /**


### PR DESCRIPTION


## Description

In StandaloneMM mode, IsStatusCodeUsingSerialPort is expecting to find gMmStatusCodeUseSerialHobGuid, and will assert if it is not found.

Change the logic so that if the Guided Hob is not found, to let the function return FALSE and progress to proceed.

(cherry picked from commit 4743d8d9925654a3f4d150e3bc502a02979f3892)
- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Assert prior to change, no assert after the change.

## Integration Instructions
No integration necessary.