### PR TITLE
[REBASE & FF] [CHERRY-PICK] Revert Mu Change In Favor of edk2 Commits

### DIFF
--- a/EmbeddedPkg/Include/Library/PrePiLib.h
+++ b/EmbeddedPkg/Include/Library/PrePiLib.h
@@ -181,7 +181,8 @@ FfsGetVolumeInfo (
 /**
   Get Fv image from the FV type file, then add FV & FV2 Hob.
 
-  @param FileHandle      File handle of a Fv type file.
+  @param FvFileHandle        File handle of a Fv type file.
+  @param ParentVolumeHandle  Parent volume handle, for filling out FvName field in FV2 Hob
 
   @retval EFI_NOT_FOUND  FV image can't be found.
   @retval EFI_SUCCESS    Successfully to process it.
@@ -190,7 +191,8 @@ FfsGetVolumeInfo (
 EFI_STATUS
 EFIAPI
 FfsProcessFvFile (
-  IN  EFI_PEI_FILE_HANDLE  FvFileHandle
+  IN  EFI_PEI_FILE_HANDLE  FvFileHandle,
+  IN EFI_PEI_FV_HANDLE     ParentVolumeHandle
   );
 
 /**
@@ -210,22 +212,6 @@ FfsAnyFvFindFirstFile (
   IN  EFI_FV_FILETYPE      FileType,
   OUT EFI_PEI_FV_HANDLE    *VolumeHandle,
   OUT EFI_PEI_FILE_HANDLE  *FileHandle
-  );
-
-/**
-  Get Fv image from the FV type file, then add FV & FV2 Hob.
-
-  @param FileHandle  File handle of a Fv type file.
-
-
-  @retval EFI_NOT_FOUND  FV image can't be found.
-  @retval EFI_SUCCESS    Successfully to process it.
-
-**/
-EFI_STATUS
-EFIAPI
-FfsProcessFvFile (
-  IN  EFI_PEI_FILE_HANDLE  FvFileHandle
   );
 
 /**

--- a/EmbeddedPkg/Include/Library/PrePiLib.h
+++ b/EmbeddedPkg/Include/Library/PrePiLib.h
@@ -181,8 +181,7 @@ FfsGetVolumeInfo (
 /**
   Get Fv image from the FV type file, then add FV & FV2 Hob.
 
-  @param FvFileHandle        File handle of a Fv type file.
-  @param ParentVolumeHandle  Parent volume handle, for filling out FvName field in FV2 Hob
+  @param FileHandle      File handle of a Fv type file.
 
   @retval EFI_NOT_FOUND  FV image can't be found.
   @retval EFI_SUCCESS    Successfully to process it.
@@ -191,8 +190,7 @@ FfsGetVolumeInfo (
 EFI_STATUS
 EFIAPI
 FfsProcessFvFile (
-  IN  EFI_PEI_FILE_HANDLE  FvFileHandle,
-  IN EFI_PEI_FV_HANDLE     ParentVolumeHandle  // MU_CHANGE
+  IN  EFI_PEI_FILE_HANDLE  FvFileHandle
   );
 
 /**
@@ -212,6 +210,22 @@ FfsAnyFvFindFirstFile (
   IN  EFI_FV_FILETYPE      FileType,
   OUT EFI_PEI_FV_HANDLE    *VolumeHandle,
   OUT EFI_PEI_FILE_HANDLE  *FileHandle
+  );
+
+/**
+  Get Fv image from the FV type file, then add FV & FV2 Hob.
+
+  @param FileHandle  File handle of a Fv type file.
+
+
+  @retval EFI_NOT_FOUND  FV image can't be found.
+  @retval EFI_SUCCESS    Successfully to process it.
+
+**/
+EFI_STATUS
+EFIAPI
+FfsProcessFvFile (
+  IN  EFI_PEI_FILE_HANDLE  FvFileHandle
   );
 
 /**

--- a/EmbeddedPkg/Include/Library/PrePiLib.h
+++ b/EmbeddedPkg/Include/Library/PrePiLib.h
@@ -69,9 +69,11 @@ EFI_STATUS
 
   @param  SectionType           The value of the section type to find.
   @param  SectionCheckHook      A hook which can check if the section is the target one.
-  @param  FileHeader            A pointer to the file header that contains the set of sections to
+  @param  FileHandle            A pointer to the file header that contains the set of sections to
                                 be searched.
   @param  SectionData           A pointer to the discovered section, if successful.
+  @param  AuthenticationStatus  Pointer to the authentication status. This parameter is optional. If non-NULL and
+                                GUIDed extraction occurs, the authentication status will be updated.
 
   @retval EFI_SUCCESS           The section was found.
   @retval EFI_NOT_FOUND         The section was not found.
@@ -83,7 +85,8 @@ FfsFindSectionDataWithHook (
   IN EFI_SECTION_TYPE        SectionType,
   IN FFS_CHECK_SECTION_HOOK  SectionCheckHook,
   IN EFI_PEI_FILE_HANDLE     FileHandle,
-  OUT VOID                   **SectionData
+  OUT VOID                   **SectionData,
+  OUT UINT32                 *AuthenticationStatus OPTIONAL
   );
 
 /**

--- a/EmbeddedPkg/Library/PrePiLib/FwVol.c
+++ b/EmbeddedPkg/Library/PrePiLib/FwVol.c
@@ -877,7 +877,7 @@ FfsProcessFvFile (
   EFI_FV_INFO           FvImageInfo;
   UINT32                FvAlignment;
   VOID                  *FvBuffer;
-  EFI_PEI_HOB_POINTERS  HobFv2;
+  EFI_PEI_HOB_POINTERS  Hob;
 
   FvBuffer = NULL;
 
@@ -885,16 +885,22 @@ FfsProcessFvFile (
   // Check if this EFI_FV_FILETYPE_FIRMWARE_VOLUME_IMAGE file has already
   // been extracted.
   //
-  HobFv2.Raw = GetHobList ();
-  while ((HobFv2.Raw = GetNextHob (EFI_HOB_TYPE_FV2, HobFv2.Raw)) != NULL) {
-    if (CompareGuid (&(((EFI_FFS_FILE_HEADER *)FvFileHandle)->Name), &HobFv2.FirmwareVolume2->FileName)) {
-      //
-      // this FILE has been dispatched, it will not be dispatched again.
-      //
-      return EFI_SUCCESS;
+  for (Hob.Raw = GetHobList (); !END_OF_HOB_LIST (Hob); Hob.Raw = GET_NEXT_HOB (Hob)) {
+    if (GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_FV2) {
+      if (CompareGuid (&(((EFI_FFS_FILE_HEADER *)FvFileHandle)->Name), &Hob.FirmwareVolume2->FileName)) {
+        //
+        // this FILE has been dispatched, it will not be dispatched again.
+        //
+        return EFI_SUCCESS;
+      }
+    } else if ((GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_FV3) && Hob.FirmwareVolume3->ExtractedFv) {
+      if (CompareGuid (&(((EFI_FFS_FILE_HEADER *)FvFileHandle)->Name), &Hob.FirmwareVolume3->FileName)) {
+        //
+        // this FILE has been dispatched, it will not be dispatched again.
+        //
+        return EFI_SUCCESS;
+      }
     }
-
-    HobFv2.Raw = GET_NEXT_HOB (HobFv2);
   }
 
   //

--- a/EmbeddedPkg/Library/PrePiLib/FwVol.c
+++ b/EmbeddedPkg/Library/PrePiLib/FwVol.c
@@ -353,11 +353,13 @@ GetSectionNCompressionType (
   Go through the file to search SectionType section,
   when meeting an encapsuled section.
 
-  @param  SectionType       - Filter to find only section of this type.
-  @param  SectionCheckHook  - A hook which can check if the section is the target one.
-  @param  Section           - From where to search.
-  @param  SectionSize       - The file size to search.
-  @param  OutputBuffer      - Pointer to the section to search.
+  @param  SectionType           - Filter to find only section of this type.
+  @param  SectionCheckHook      - A hook which can check if the section is the target one.
+  @param  Section               - From where to search.
+  @param  SectionSize           - The file size to search.
+  @param  OutputBuffer          - Pointer to the section to search.
+  @param  AuthenticationStatus  - Pointer to the authentication status. This parameter is optional. If non-NULL and
+                                  GUIDed extraction occurs, the authentication status will be updated.
 
   @retval EFI_SUCCESS
 **/
@@ -367,7 +369,8 @@ FfsProcessSection (
   IN FFS_CHECK_SECTION_HOOK     SectionCheckHook,
   IN EFI_COMMON_SECTION_HEADER  *Section,
   IN UINTN                      SectionSize,
-  OUT VOID                      **OutputBuffer
+  OUT VOID                      **OutputBuffer,
+  OUT UINT32                    *AuthenticationStatus OPTIONAL
   )
 {
   EFI_STATUS  Status;
@@ -375,6 +378,7 @@ FfsProcessSection (
   UINTN       ParsedLength;
   UINT32      DstBufferSize;
   VOID        *DstBuffer;
+  UINT32      TempAuthStatus;
 
   ParsedLength = 0;
 
@@ -472,14 +476,16 @@ FfsProcessSection (
                    ScratchBuffer
                    );
       } else if (Section->Type == EFI_SECTION_GUID_DEFINED) {
-        UINT32  AuthenticationStatus;
-
         Status = ExtractGuidedSectionDecode (
                    Section,
                    &DstBuffer,
                    ScratchBuffer,
-                   &AuthenticationStatus
+                   &TempAuthStatus
                    );
+
+        if ((Status == EFI_SUCCESS) && (AuthenticationStatus != NULL)) {
+          *AuthenticationStatus = TempAuthStatus;
+        }
       }
 
       if (EFI_ERROR (Status)) {
@@ -495,7 +501,8 @@ FfsProcessSection (
                SectionCheckHook,
                DstBuffer,
                DstBufferSize,
-               OutputBuffer
+               OutputBuffer,
+               AuthenticationStatus
                );
     }
 
@@ -524,6 +531,8 @@ CheckNextSection:
   @param  FileHandle            A pointer to the file header that contains the set of sections to
                                 be searched.
   @param  SectionData           A pointer to the discovered section, if successful.
+  @param  AuthenticationStatus  Pointer to the authentication status. This parameter is optional. If non-NULL and
+                                GUIDed extraction occurs, the authentication status will be updated.
 
   @retval EFI_SUCCESS           The section was found.
   @retval EFI_NOT_FOUND         The section was not found.
@@ -535,7 +544,8 @@ FfsFindSectionDataWithHook (
   IN EFI_SECTION_TYPE        SectionType,
   IN FFS_CHECK_SECTION_HOOK  SectionCheckHook,
   IN EFI_PEI_FILE_HANDLE     FileHandle,
-  OUT VOID                   **SectionData
+  OUT VOID                   **SectionData,
+  OUT UINT32                 *AuthenticationStatus OPTIONAL
   )
 {
   EFI_FFS_FILE_HEADER        *FfsFileHeader;
@@ -558,7 +568,8 @@ FfsFindSectionDataWithHook (
            SectionCheckHook,
            Section,
            FileSize,
-           SectionData
+           SectionData,
+           AuthenticationStatus
            );
 }
 
@@ -582,7 +593,7 @@ FfsFindSectionData (
   OUT VOID                **SectionData
   )
 {
-  return FfsFindSectionDataWithHook (SectionType, NULL, FileHandle, SectionData);
+  return FfsFindSectionDataWithHook (SectionType, NULL, FileHandle, SectionData, NULL);
 }
 
 /**
@@ -881,8 +892,10 @@ FfsProcessFvFile (
   UINT32                FvAlignment;
   VOID                  *FvBuffer;
   EFI_PEI_HOB_POINTERS  Hob;
+  UINT32                AuthenticationStatus;
 
-  FvBuffer = NULL;
+  FvBuffer             = NULL;
+  AuthenticationStatus = 0;
 
   //
   // Check if this EFI_FV_FILETYPE_FIRMWARE_VOLUME_IMAGE file has already
@@ -909,7 +922,7 @@ FfsProcessFvFile (
   //
   // Find FvImage in FvFile
   //
-  Status = FfsFindSectionDataWithHook (EFI_SECTION_FIRMWARE_VOLUME_IMAGE, NULL, FvFileHandle, (VOID **)&FvImageHandle);
+  Status = FfsFindSectionDataWithHook (EFI_SECTION_FIRMWARE_VOLUME_IMAGE, NULL, FvFileHandle, (VOID **)&FvImageHandle, &AuthenticationStatus);
   if (EFI_ERROR (Status)) {
     return Status;
   }
@@ -959,6 +972,15 @@ FfsProcessFvFile (
   BuildFv2Hob (
     (EFI_PHYSICAL_ADDRESS)(UINTN)FvImageInfo.FvStart,
     FvImageInfo.FvSize,
+    &ParentVolumeInfo.FvName,
+    &(((EFI_FFS_FILE_HEADER *)FvFileHandle)->Name)
+    );
+
+  BuildFv3Hob (
+    (EFI_PHYSICAL_ADDRESS)(UINTN)FvImageInfo.FvStart,
+    FvImageInfo.FvSize,
+    AuthenticationStatus,
+    TRUE,
     &ParentVolumeInfo.FvName,
     &(((EFI_FFS_FILE_HEADER *)FvFileHandle)->Name)
     );

--- a/EmbeddedPkg/Library/PrePiLib/FwVol.c
+++ b/EmbeddedPkg/Library/PrePiLib/FwVol.c
@@ -800,6 +800,7 @@ FfsGetVolumeInfo (
     return EFI_INVALID_PARAMETER;
   }
 
+  ZeroMem (VolumeInfo, sizeof (*VolumeInfo));
   VolumeInfo->FvAttributes = FwVolHeader.Attributes;
   VolumeInfo->FvStart      = (VOID *)VolumeHandle;
   VolumeInfo->FvSize       = FwVolHeader.FvLength;
@@ -914,7 +915,6 @@ FfsProcessFvFile (
   //
   // Collect FvImage Info.
   //
-  ZeroMem (&FvImageInfo, sizeof (FvImageInfo));
   Status = FfsGetVolumeInfo (FvImageHandle, &FvImageInfo);
   ASSERT_EFI_ERROR (Status);
 

--- a/EmbeddedPkg/Library/PrePiLib/FwVol.c
+++ b/EmbeddedPkg/Library/PrePiLib/FwVol.c
@@ -859,8 +859,8 @@ FfsAnyFvFindFirstFile (
 /**
   Get Fv image from the FV type file, then add FV & FV2 Hob.
 
-  @param FvFileHandle        File handle of a Fv type file.
-  @param ParentVolumeHandle  Parent volume handle, for filling out FvName field in FV2 Hob
+  @param FileHandle  File handle of a Fv type file.
+
 
   @retval EFI_NOT_FOUND  FV image can't be found.
   @retval EFI_SUCCESS    Successfully to process it.
@@ -869,14 +869,12 @@ FfsAnyFvFindFirstFile (
 EFI_STATUS
 EFIAPI
 FfsProcessFvFile (
-  IN  EFI_PEI_FILE_HANDLE  FvFileHandle,
-  IN EFI_PEI_FV_HANDLE     ParentVolumeHandle  // MU_CHANGE
+  IN  EFI_PEI_FILE_HANDLE  FvFileHandle
   )
 {
   EFI_STATUS            Status;
   EFI_PEI_FV_HANDLE     FvImageHandle;
   EFI_FV_INFO           FvImageInfo;
-  EFI_FV_INFO           ParentVolumeInfo; // MU_CHANGE
   UINT32                FvAlignment;
   VOID                  *FvBuffer;
   EFI_PEI_HOB_POINTERS  HobFv2;
@@ -943,11 +941,6 @@ FfsProcessFvFile (
   //
   BuildFvHob ((EFI_PHYSICAL_ADDRESS)(UINTN)FvImageInfo.FvStart, FvImageInfo.FvSize);
 
-  // MU_CHANGE Start
-  Status = FfsGetVolumeInfo (ParentVolumeHandle, &ParentVolumeInfo);
-  ASSERT_EFI_ERROR (Status);
-  // MU_CHANGE End
-
   //
   // Makes the encapsulated volume show up in DXE phase to skip processing of
   // encapsulated file again.
@@ -955,7 +948,7 @@ FfsProcessFvFile (
   BuildFv2Hob (
     (EFI_PHYSICAL_ADDRESS)(UINTN)FvImageInfo.FvStart,
     FvImageInfo.FvSize,
-    &ParentVolumeInfo.FvName, // MU_CHANGE
+    &FvImageInfo.FvName,
     &(((EFI_FFS_FILE_HEADER *)FvFileHandle)->Name)
     );
 

--- a/EmbeddedPkg/Library/PrePiLib/FwVol.c
+++ b/EmbeddedPkg/Library/PrePiLib/FwVol.c
@@ -860,8 +860,8 @@ FfsAnyFvFindFirstFile (
 /**
   Get Fv image from the FV type file, then add FV & FV2 Hob.
 
-  @param FileHandle  File handle of a Fv type file.
-
+  @param FvFileHandle        File handle of a Fv type file.
+  @param ParentVolumeHandle  Parent volume handle, for filling out FvName field in FV2 Hob
 
   @retval EFI_NOT_FOUND  FV image can't be found.
   @retval EFI_SUCCESS    Successfully to process it.
@@ -870,12 +870,14 @@ FfsAnyFvFindFirstFile (
 EFI_STATUS
 EFIAPI
 FfsProcessFvFile (
-  IN  EFI_PEI_FILE_HANDLE  FvFileHandle
+  IN  EFI_PEI_FILE_HANDLE  FvFileHandle,
+  IN EFI_PEI_FV_HANDLE     ParentVolumeHandle
   )
 {
   EFI_STATUS            Status;
   EFI_PEI_FV_HANDLE     FvImageHandle;
   EFI_FV_INFO           FvImageInfo;
+  EFI_FV_INFO           ParentVolumeInfo;
   UINT32                FvAlignment;
   VOID                  *FvBuffer;
   EFI_PEI_HOB_POINTERS  Hob;
@@ -947,6 +949,9 @@ FfsProcessFvFile (
   //
   BuildFvHob ((EFI_PHYSICAL_ADDRESS)(UINTN)FvImageInfo.FvStart, FvImageInfo.FvSize);
 
+  Status = FfsGetVolumeInfo (ParentVolumeHandle, &ParentVolumeInfo);
+  ASSERT_EFI_ERROR (Status);
+
   //
   // Makes the encapsulated volume show up in DXE phase to skip processing of
   // encapsulated file again.
@@ -954,7 +959,7 @@ FfsProcessFvFile (
   BuildFv2Hob (
     (EFI_PHYSICAL_ADDRESS)(UINTN)FvImageInfo.FvStart,
     FvImageInfo.FvSize,
-    &FvImageInfo.FvName,
+    &ParentVolumeInfo.FvName,
     &(((EFI_FFS_FILE_HEADER *)FvFileHandle)->Name)
     );
 

--- a/EmbeddedPkg/Library/PrePiLib/PrePi.h
+++ b/EmbeddedPkg/Library/PrePiLib/PrePi.h
@@ -23,18 +23,8 @@
 #include <Library/MemoryAllocationLib.h>
 #include <Library/TimerLib.h>
 #include <Library/PerformanceLib.h>
+#include <Library/HobLib.h>
 
 #include <Guid/MemoryAllocationHob.h>
-
-#define GET_HOB_TYPE(Hob)     ((Hob).Header->HobType)
-#define GET_HOB_LENGTH(Hob)   ((Hob).Header->HobLength)
-#define GET_NEXT_HOB(Hob)     ((Hob).Raw + GET_HOB_LENGTH (Hob))
-#define END_OF_HOB_LIST(Hob)  (GET_HOB_TYPE (Hob) == EFI_HOB_TYPE_END_OF_HOB_LIST)
-
-//
-// Get the data and data size field of GUID
-//
-#define GET_GUID_HOB_DATA(GuidHob)       ((VOID *) (((UINT8 *) &((GuidHob)->Name)) + sizeof (EFI_GUID)))
-#define GET_GUID_HOB_DATA_SIZE(GuidHob)  (((GuidHob)->Header).HobLength - sizeof (EFI_HOB_GUID_TYPE))
 
 #endif

--- a/EmbeddedPkg/Library/PrePiLib/PrePiLib.c
+++ b/EmbeddedPkg/Library/PrePiLib/PrePiLib.c
@@ -231,7 +231,7 @@ DecompressFirstFv (
 
   Status = FfsAnyFvFindFirstFile (EFI_FV_FILETYPE_FIRMWARE_VOLUME_IMAGE, &VolumeHandle, &FileHandle);
   if (!EFI_ERROR (Status)) {
-    Status = FfsProcessFvFile (FileHandle);
+    Status = FfsProcessFvFile (FileHandle, VolumeHandle);
   }
 
   return Status;

--- a/EmbeddedPkg/Library/PrePiLib/PrePiLib.c
+++ b/EmbeddedPkg/Library/PrePiLib/PrePiLib.c
@@ -131,7 +131,7 @@ LoadDxeCoreFromFfsFile (
   VOID                  *Hob;
   EFI_FV_FILE_INFO      FvFileInfo;
 
-  Status = FfsFindSectionDataWithHook (EFI_SECTION_PE32, NULL, FileHandle, &PeCoffImage);
+  Status = FfsFindSectionDataWithHook (EFI_SECTION_PE32, NULL, FileHandle, &PeCoffImage, NULL);
   if (EFI_ERROR (Status)) {
     return Status;
   }

--- a/EmbeddedPkg/Library/PrePiLib/PrePiLib.c
+++ b/EmbeddedPkg/Library/PrePiLib/PrePiLib.c
@@ -231,7 +231,7 @@ DecompressFirstFv (
 
   Status = FfsAnyFvFindFirstFile (EFI_FV_FILETYPE_FIRMWARE_VOLUME_IMAGE, &VolumeHandle, &FileHandle);
   if (!EFI_ERROR (Status)) {
-    Status = FfsProcessFvFile (FileHandle, VolumeHandle); // MU_CHANGE
+    Status = FfsProcessFvFile (FileHandle);
   }
 
   return Status;


### PR DESCRIPTION
## Description

This reverts a MU_CHANGE and cherry-picks the relevant edk2 commits.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

See edk2 PR.

## Integration Instructions

Callers of FfsFindSectionDataWithHook() must update the call to add the AuthenticationStatus parameter. For existing use cases, this can always be NULL. If the authentication status is desired to be returned, then a UINT32 pointer may be passed here.