### PR TITLE
.github: Switch Mu PR Validation workflow to main branch

### DIFF
--- a/.github/workflows/mu-pr-validation-post.yml
+++ b/.github/workflows/mu-pr-validation-post.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   post-results:
     name: Post Validation Results
-    uses: microsoft/mu_devops/.github/workflows/MuPrValidationPost.yml@add_mu_pr_val_workflow_e2e_val
+    uses: microsoft/mu_devops/.github/workflows/MuPrValidationPost.yml@main
     with:
       app-id: ${{ vars.MU_ACCESS_APP_ID }}
       conclusion: ${{ github.event.workflow_run.conclusion }}

--- a/.github/workflows/mu-pr-validation.yml
+++ b/.github/workflows/mu-pr-validation.yml
@@ -119,7 +119,7 @@ jobs:
     name: Run Mu QEMU Validation
     needs: [prepare]
     if: needs.prepare.result == 'success' && needs.prepare.outputs.skip != 'true'
-    uses: microsoft/mu_devops/.github/workflows/MuPrValidation.yml@add_mu_pr_val_workflow_e2e_val
+    uses: microsoft/mu_devops/.github/workflows/MuPrValidation.yml@main
     with:
       app-id: ${{ vars.MU_ACCESS_APP_ID }}
       caller-ref: ${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
## Description

These workflow files were previously using a dedicated branch for development of the Mu PR Validation workflow. It has been stable for a couple of months now, so we can switch back to using the main branch which has the latest changes.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Compare branch content (`main` <-> `add_mu_pr_val_workflow_e2e_val`)

## Integration Instructions

- N/A. Only affects GitHub repo workflow.