### PR TITLE
ArmPkg: Handle FFA_BUSY response for MM communication

### DIFF
--- a/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.c
+++ b/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.c
@@ -29,6 +29,11 @@
 
 #define COMM_BUFFER_ATTRS  (EFI_MEMORY_WB | EFI_MEMORY_XP | EFI_MEMORY_RUNTIME)
 
+// This an absurdly high number. The timer cannot be used reliably at runtime so having some upper bound is necessary.
+// This number is chosen with back-of-the-envelope calculations where the rough time to get a BUSY response it around
+// 10 microseconds, so 500,000 retries is roughly 5 seconds.
+#define MAX_BUSY_RETRIES  500000 // MU_CHANGE: Add busy response handling
+
 //
 // Partition ID if FF-A support is enabled
 //
@@ -65,16 +70,33 @@ SendFfaMmCommunicate (
 {
   EFI_STATUS       Status;
   DIRECT_MSG_ARGS  CommunicateArgs;
+  // MU_CHANGE START: Handle busy response
+  UINT64  Retries = 0;
 
-  ZeroMem (&CommunicateArgs, sizeof (DIRECT_MSG_ARGS));
+  while (TRUE) {
+    ZeroMem (&CommunicateArgs, sizeof (DIRECT_MSG_ARGS));
+    CommunicateArgs.Arg0 = (UINTN)mNsCommBuffMemRegion.PhysicalBase;
 
-  CommunicateArgs.Arg0 = (UINTN)mNsCommBuffMemRegion.PhysicalBase;
+    Status = ArmFfaLibMsgSendDirectReq (
+               mStMmPartId,
+               0,
+               &CommunicateArgs
+               );
 
-  Status = ArmFfaLibMsgSendDirectReq (
-             mStMmPartId,
-             0,
-             &CommunicateArgs
-             );
+    if (Status == EFI_NO_RESPONSE) {
+      // Only try for so long before just failing.
+      if (Retries >= MAX_BUSY_RETRIES) {
+        return EFI_TIMEOUT;
+      }
+
+      Retries++;
+      continue;
+    }
+
+    break;
+  }
+
+  // MU_CHANGE END: Handle busy response
 
   while (Status == EFI_INTERRUPT_PENDING) {
     // We are assuming vCPU0 of the StMM SP since it is UP.


### PR DESCRIPTION
## Description

MM communicate is used at runtime, and the secure partition it is communicating with may provide services access through other means then the UEFI runtime services. As such, the MM communication library must not assume that the partition will be in the waiting state. Instead, it must handle the case where the partition is busy and retry the communication to some limit.

### Observed issue

This specifically resolves a bugcheck observed booting to Windows on multiple platforms where the variable services are access through the runtime services at the same time that the TPM PPI is invoking StMM to access the PPI variables. This causes a busy response in the runtime services, which are not currently handled. The inverse is already handled as the ACPI FFH opregion handling for FF-A already accounts for busy responses.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- [x] Boot to OS on ArmVirt
- [x] Boot to OS on physical platform

## Integration Instructions

N/A
