### PR TITLE
[Rebase & FF] Fix Partition ID being used for FFA_RUN calls

### DIFF
--- a/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.c
+++ b/ArmPkg/Drivers/MmCommunicationDxe/MmCommunication.c
@@ -100,7 +100,8 @@ SendFfaMmCommunicate (
 
   while (Status == EFI_INTERRUPT_PENDING) {
     // We are assuming vCPU0 of the StMM SP since it is UP.
-    Status = ArmFfaLibRun (mStMmPartId, 0x00, NULL);
+    // MU_CHANGE: Use the source partition ID of the FFA header for the ffa_run call.
+    Status = ArmFfaLibRun (GET_SOURCE_PARTITION_ID (CommunicateArgs.Header.x1), 0x00, &CommunicateArgs);
   }
 
   return Status;

--- a/ArmPkg/Drivers/MmCommunicationPei/MmCommunicationPei.c
+++ b/ArmPkg/Drivers/MmCommunicationPei/MmCommunicationPei.c
@@ -235,7 +235,8 @@ SendFfaMmCommunicate (
 
   while (Status == EFI_INTERRUPT_PENDING) {
     // We are assuming vCPU0 of the StMM SP since it is UP.
-    Status = ArmFfaLibRun (mStMmPartId, 0x00, NULL);
+    // MU_CHANGE: Use the source partition ID of the FFA header for the ffa_run call.
+    Status = ArmFfaLibRun (GET_SOURCE_PARTITION_ID (CommunicateArgs.Header.x1), 0x00, &CommunicateArgs);
   }
 
   return Status;

--- a/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
+++ b/MdeModulePkg/Library/ArmFfaLib/ArmFfaCommon.c
@@ -741,12 +741,16 @@ ArmFfaLibRun (
   ArmCallFfa (&FfaArgs);
 
   Status = FfaArgsToEfiStatus (&FfaArgs);
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
+  // MU_CHANGE: Copy the FFA header to the direct message arguments
+  // if (EFI_ERROR (Status)) {
+  //   return Status;
+  // }
 
   if (DirectMsgArg != NULL) {
     ZeroMem (DirectMsgArg, sizeof (DIRECT_MSG_ARGS));
+
+    // MU_CHANGE: Copy the FFA header to the direct message arguments
+    CopyMem (&(DirectMsgArg->Header), &FfaArgs, sizeof (DirectMsgArg->Header));
 
     if (FfaArgs.Arg0 == ARM_FID_FFA_MSG_SEND_DIRECT_RESP) {
       DirectMsgArg->Arg0 = FfaArgs.Arg3;
@@ -782,6 +786,9 @@ ArmFfaLibRun (
   @param [in]      Flags            Message flags
   @param [in, out] ImpDefArgs       Implemented defined arguments and
                                     Implemented defined return values
+                                    // MU_CHANGE: Copy the FFA header to the direct message arguments
+                                    The header registers (x0-x2) will be initialized
+                                    with the values from DestPartId and Flags.
 
   @retval EFI_SUCCESS               Success
   @retval Others                    Error
@@ -823,6 +830,8 @@ ArmFfaLibMsgSendDirectReq (
 
   Status = FfaArgsToEfiStatus (&FfaArgs);
   if (EFI_ERROR (Status)) {
+    // MU_CHANGE: Copy the FFA header to the direct message arguments
+    CopyMem (ImpDefArgs, &FfaArgs, sizeof (DIRECT_MSG_ARGS));
     return Status;
   }
 
@@ -842,6 +851,9 @@ ArmFfaLibMsgSendDirectReq (
   @param [in]       ServiceGuid      Service guid
   @param [in, out]  ImpDefArgs       Implemented defined arguments and
                                      Implemented defined return values
+                                     // MU_CHANGE: Copy the FFA header to the direct message arguments
+                                     The header registers (x0-x3) will be
+                                     initialized with the values from DestPartId and ServiceGuid.
 
   @retval EFI_SUCCESS               Success
   @retval Others                    Error
@@ -907,6 +919,8 @@ ArmFfaLibMsgSendDirectReq2 (
 
   Status = FfaArgsToEfiStatus (&FfaArgs);
   if (EFI_ERROR (Status)) {
+    // MU_CHANGE: Copy the FFA header to the direct message arguments
+    CopyMem (ImpDefArgs, &FfaArgs, sizeof (DIRECT_MSG_ARGS));
     return Status;
   }
 

--- a/MdePkg/Include/Library/ArmFfaLib.h
+++ b/MdePkg/Include/Library/ArmFfaLib.h
@@ -54,6 +54,15 @@ typedef struct ArmFfaArgs {
  *  FFA_SEND_MSG_DIRECT_REQ2/FFA_SEND_MSG_DIRECT_RESP2 (i.e. v2)
  */
 typedef struct DirectMsgArgs {
+  // MU_CHANGE: Carry the FFA header as part of the direct message content
+  /// Header containing the arguments for the header registers (x0-x2 (v1) or x0-x3 (v2))
+  struct {
+    UINTN    x0;
+    UINTN    x1;
+    UINTN    x2;
+    UINTN    x3;
+  } Header;
+
   /// Implementation define argument 0, this will be set to/from x3(v1) or x4(v2)
   UINTN    Arg0;
 
@@ -96,6 +105,9 @@ typedef struct DirectMsgArgs {
   /// Implementation define argument 13, this will be set to/from x17(v2)
   UINTN    Arg13;
 } DIRECT_MSG_ARGS;
+
+// MU_CHANGE: Carry the FFA header as part of the direct message content
+STATIC_ASSERT (sizeof (DIRECT_MSG_ARGS) == sizeof (ARM_FFA_ARGS), "DIRECT_MSG_ARGS and ARM_FFA_ARGS must be the same size");
 
 /**
   Trigger FF-A ABI call according to PcdFfaLibConduitSmc.

--- a/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2ServiceFfaRaw.c
+++ b/SecurityPkg/Library/Tpm2DeviceLibFfa/Tpm2ServiceFfaRaw.c
@@ -154,7 +154,8 @@ Tpm2GetInterfaceVersion (
   Status = ArmFfaLibMsgSendDirectReq2 (FfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
   while (Status == EFI_INTERRUPT_PENDING) {
     // We are assuming vCPU0 of the TPM SP since it is UP.
-    Status = ArmFfaLibRun (FfaTpm2PartitionId, 0x00, &FfaDirectReq2Args);
+    // MU_CHANGE: Use the source partition ID of the FFA header for the ffa_run call.
+    Status = ArmFfaLibRun (GET_SOURCE_PARTITION_ID (FfaDirectReq2Args.Header.x1), 0x00, &FfaDirectReq2Args);
   }
 
   if (EFI_ERROR (Status)) {
@@ -203,7 +204,8 @@ Tpm2GetFeatureInfo (
   Status = ArmFfaLibMsgSendDirectReq2 (FfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
   while (Status == EFI_INTERRUPT_PENDING) {
     // We are assuming vCPU0 of the TPM SP since it is UP.
-    Status = ArmFfaLibRun (FfaTpm2PartitionId, 0x00, &FfaDirectReq2Args);
+    // MU_CHANGE: Use the source partition ID of the FFA header for the ffa_run call.
+    Status = ArmFfaLibRun (GET_SOURCE_PARTITION_ID (FfaDirectReq2Args.Header.x1), 0x00, &FfaDirectReq2Args);
   }
 
   if (EFI_ERROR (Status)) {
@@ -243,7 +245,8 @@ Tpm2ServiceStart (
   Status = ArmFfaLibMsgSendDirectReq2 (FfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
   while (Status == EFI_INTERRUPT_PENDING) {
     // We are assuming vCPU0 of the TPM SP since it is UP.
-    Status = ArmFfaLibRun (FfaTpm2PartitionId, 0x00, &FfaDirectReq2Args);
+    // MU_CHANGE: Use the source partition ID of the FFA header for the ffa_run call.
+    Status = ArmFfaLibRun (GET_SOURCE_PARTITION_ID (FfaDirectReq2Args.Header.x1), 0x00, &FfaDirectReq2Args);
   }
 
   if (EFI_ERROR (Status)) {
@@ -284,7 +287,8 @@ Tpm2RegisterNotification (
   Status = ArmFfaLibMsgSendDirectReq2 (FfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
   while (Status == EFI_INTERRUPT_PENDING) {
     // We are assuming vCPU0 of the TPM SP since it is UP.
-    Status = ArmFfaLibRun (FfaTpm2PartitionId, 0x00, &FfaDirectReq2Args);
+    // MU_CHANGE: Use the source partition ID of the FFA header for the ffa_run call.
+    Status = ArmFfaLibRun (GET_SOURCE_PARTITION_ID (FfaDirectReq2Args.Header.x1), 0x00, &FfaDirectReq2Args);
   }
 
   if (EFI_ERROR (Status)) {
@@ -317,7 +321,8 @@ Tpm2UnregisterNotification (
   Status = ArmFfaLibMsgSendDirectReq2 (FfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
   while (Status == EFI_INTERRUPT_PENDING) {
     // We are assuming vCPU0 of the TPM SP since it is UP.
-    Status = ArmFfaLibRun (FfaTpm2PartitionId, 0x00, &FfaDirectReq2Args);
+    // MU_CHANGE: Use the source partition ID of the FFA header for the ffa_run call.
+    Status = ArmFfaLibRun (GET_SOURCE_PARTITION_ID (FfaDirectReq2Args.Header.x1), 0x00, &FfaDirectReq2Args);
   }
 
   if (EFI_ERROR (Status)) {
@@ -350,7 +355,8 @@ Tpm2FinishNotified (
   Status = ArmFfaLibMsgSendDirectReq2 (FfaTpm2PartitionId, &gTpm2ServiceFfaGuid, &FfaDirectReq2Args);
   while (Status == EFI_INTERRUPT_PENDING) {
     // We are assuming vCPU0 of the TPM SP since it is UP.
-    Status = ArmFfaLibRun (FfaTpm2PartitionId, 0x00, &FfaDirectReq2Args);
+    // MU_CHANGE: Use the source partition ID of the FFA header for the ffa_run call.
+    Status = ArmFfaLibRun (GET_SOURCE_PARTITION_ID (FfaDirectReq2Args.Header.x1), 0x00, &FfaDirectReq2Args);
   }
 
   if (EFI_ERROR (Status)) {

--- a/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigFfaPeim.c
+++ b/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigFfaPeim.c
@@ -69,7 +69,8 @@ Tpm2FfaCheckInterfaceVersion (
   Status = ArmFfaLibMsgSendDirectReq2 (TpmPartId, &gTpm2ServiceFfaGuid, &TpmArgs);
   while (Status == EFI_INTERRUPT_PENDING) {
     // We are assuming vCPU0 of the TPM SP since it is UP.
-    Status = ArmFfaLibRun (TpmPartId, 0x00, &TpmArgs);
+    // MU_CHANGE: Use the source partition ID of the FFA header for the ffa_run call.
+    Status = ArmFfaLibRun (GET_SOURCE_PARTITION_ID (TpmArgs.Header.x1), 0x00, &TpmArgs);
   }
 
   if (EFI_ERROR (Status) || (TpmArgs.Arg0 != TPM2_FFA_SUCCESS_OK_RESULTS_RETURNED)) {


### PR DESCRIPTION
## Description

The current implementation of FFA run invocation always uses the original partition ID as the input for FFA_RUN. However, this is problematic when the partitions are chain loading the direct request 2 functions and the partitions are interruptible. In that case, the caller should FFA_RUN to the partition specified in w1.

Then the w1 information was eaten in the case of direct request calls, because we only exposed the payload to the callers.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This is tested on ARM virt and physical platform.

## Integration Instructions

N/A