### PR TITLE
[CHERRY-PICK] MdeModulePkg/Core/Dxe/Gcd: make persistent override special-purpose

### DIFF
--- a/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
+++ b/MdeModulePkg/Core/Dxe/Gcd/Gcd.c
@@ -2762,14 +2762,14 @@ CoreInitializeGcdServices (
             GcdMemoryType = EfiGcdMemoryTypeReserved;
           }
 
-          if ((ResourceHob->ResourceAttribute & EFI_RESOURCE_ATTRIBUTE_PERSISTENT) == EFI_RESOURCE_ATTRIBUTE_PERSISTENT) {
-            GcdMemoryType = EfiGcdMemoryTypePersistent;
-          }
-
           // Mark special purpose memory as system memory, if it was system memory in the HOB
           // However, if this is also marked as persistent, let persistent take precedence
           if ((ResourceHob->ResourceAttribute & EFI_RESOURCE_ATTRIBUTE_SPECIAL_PURPOSE) == EFI_RESOURCE_ATTRIBUTE_SPECIAL_PURPOSE) {
             GcdMemoryType = EfiGcdMemoryTypeSystemMemory;
+          }
+
+          if ((ResourceHob->ResourceAttribute & EFI_RESOURCE_ATTRIBUTE_PERSISTENT) == EFI_RESOURCE_ATTRIBUTE_PERSISTENT) {
+            GcdMemoryType = EfiGcdMemoryTypePersistent;
           }
 
           break;


### PR DESCRIPTION
MdeModulePkg/Core/Dxe/Gcd: make persistent override special-purpose

Fix the GCD memory type selection logic in DXE GCD initialization so persistent memory correctly takes precedence over special-purpose memory when both attributes are present.

The existing code/comment said persistent should win, but the condition order allowed special-purpose to overwrite persistent. This change swaps the checks so behavior matches the intended precedence and comment.


(cherry picked from commit e03fb69e9aad9d8ee501c512c0f1a08d8aa1fa8b)

## Description

Fix the GCD memory type selection logic in DXE GCD initialization so persistent memory correctly takes precedence over special-purpose memory when both attributes are present.

The existing code/comment said persistent should win, but the condition order allowed special-purpose to overwrite persistent. This change swaps the checks so behavior matches the intended precedence and comment.

Signed-off-by: Sureshkumar Ponnusamy [sponnusamy@microsoft.com](mailto:sponnusamy@microsoft.com)

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Validated on target system with a Resource Descriptor HOB containing both EFI_RESOURCE_ATTRIBUTE_PERSISTENT and EFI_RESOURCE_ATTRIBUTE_SPECIAL_PURPOSE.

Confirmed resulting GCD memory type is EfiGcdMemoryTypePersistent

## Integration Instructions

N/A
