### PR TITLE
ArmPkg/SmmuDxe: Set cacheability attributes in the Stage-2 page table leaf-level entries

### DIFF
--- a/ArmPkg/Drivers/SmmuDxe/IoMmu.c
+++ b/ArmPkg/Drivers/SmmuDxe/IoMmu.c
@@ -391,7 +391,7 @@ UpdateMapping (
     if (Valid) {
       Entry = (PhysicalAddress & ~PAGE_TABLE_BLOCK_OFFSET); // Assign PA
       // validate entry and set leaf level flags
-      Entry |= Flags | PAGE_TABLE_ACCESS_FLAG | PAGE_TABLE_DESCRIPTOR | PAGE_TABLE_ENTRY_VALID_BIT;
+      Entry |= Flags | PAGE_TABLE_S2_MEMATTR_NORMAL_WB | PAGE_TABLE_S2_SH_INNER_SHAREABLE | PAGE_TABLE_ACCESS_FLAG | PAGE_TABLE_DESCRIPTOR | PAGE_TABLE_ENTRY_VALID_BIT;
 
       // Break-before-make does not apply here because we are only switching between invalid/valid, no other Entry bits are changing.
       // If the entry is already valid, it must have the same PA and flags to be considered a match; otherwise it's an error because we don't expect multiple mappings for the same VA.

--- a/ArmPkg/Drivers/SmmuDxe/IoMmu.h
+++ b/ArmPkg/Drivers/SmmuDxe/IoMmu.h
@@ -22,6 +22,8 @@
 #define PAGE_TABLE_ACCESS_FLAG      (0x1 << 10)
 #define PAGE_TABLE_DESCRIPTOR       (0x1 << 1)
 #define PAGE_TABLE_READ_WRITE_FROM_IOMMU_ACCESS(IoMmuAccess)  (IoMmuAccess << 6)
+#define PAGE_TABLE_S2_MEMATTR_NORMAL_WB   (0xF << 2)
+#define PAGE_TABLE_S2_SH_INNER_SHAREABLE  (0x3 << 8)
 
 // Forward declaration; full definition lives in SmmuV3.h.
 typedef struct _SMMU_INFO SMMU_INFO;


### PR DESCRIPTION
## Description

ArmPkg/SmmuDxe: Set cacheability attributes in the Stage-2 page table leaf-level entries

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested on physical Arm platform and ArmVirtPkg.

Tested with BlockIoPerfTest and noted the performance gain from adding the cacheability attributes.

Tested high throughput scenario of windows hibernate/resume.

## Integration Instructions

N/A