### PR TITLE
[CWE-190] Security fix: Add integer overflow check for MessageLength

### DIFF
--- a/StandaloneMmPkg/Drivers/MmCommunicationDxe/GoogleTest/MmCommunicationDxeGoogleTest.cpp
+++ b/StandaloneMmPkg/Drivers/MmCommunicationDxe/GoogleTest/MmCommunicationDxeGoogleTest.cpp
@@ -1,0 +1,209 @@
+/** @file
+  GoogleTest for MmCommunicationDxe -- CVE repro for CWE-190 integer overflow
+  in the V1 legacy path of ProcessCommunicationBuffer.
+
+  Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/GoogleTestLib.h>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Library/BaseLib.h>
+  #include <Library/BaseMemoryLib.h>
+  #include <Protocol/MmControl.h>
+  #include <Protocol/SmmControl2.h>
+  #include <Protocol/MmCommunication.h>
+  #include <Pi/PiMultiPhase.h>
+  #include <Guid/MmCommBuffer.h>
+
+  //
+  // Declare the function under test (defined in MmCommunicationDxe.c)
+  //
+  EFI_STATUS
+  EFIAPI
+  ProcessCommunicationBuffer (
+    IN OUT VOID   *CommBuffer,
+    IN OUT UINTN  *CommSize OPTIONAL
+    );
+
+  //
+  // Globals defined in MmCommunicationDxe.c that we need to set up
+  //
+  extern MM_COMM_BUFFER             mMmCommonBuffer;
+  extern EFI_SMM_CONTROL2_PROTOCOL  *mSmmControl2;
+}
+
+////////////////////////////////////////////////////////////////////////
+// Symbol Definitions
+// These functions are not directly under test - but required to compile
+////////////////////////////////////////////////////////////////////////
+
+//
+// Mock Trigger function for SmmControl2 protocol
+//
+static EFI_STATUS EFIAPI
+MockTrigger (
+  IN CONST EFI_MM_CONTROL_PROTOCOL  *This,
+  IN OUT UINT8                      *CommandPort       OPTIONAL,
+  IN OUT UINT8                      *DataPort          OPTIONAL,
+  IN BOOLEAN                        Periodic           OPTIONAL,
+  IN UINTN                          ActivationInterval OPTIONAL
+  )
+{
+  return EFI_SUCCESS;
+}
+
+//
+// Mock Deactivate (Clear) function
+//
+static EFI_STATUS EFIAPI
+MockClear (
+  IN CONST EFI_MM_CONTROL_PROTOCOL  *This,
+  IN BOOLEAN                        Periodic OPTIONAL
+  )
+{
+  return EFI_SUCCESS;
+}
+
+////////////////////////////////////////////////////////////////////////
+// Defines
+////////////////////////////////////////////////////////////////////////
+
+#define COMM_BUFFER_PAGES  4  // 16 KiB common buffer
+#define COMM_BUFFER_SIZE   EFI_PAGES_TO_SIZE (COMM_BUFFER_PAGES)
+
+////////////////////////////////////////////////////////////////////////
+// MmCommunicationOverflowTest Tests
+////////////////////////////////////////////////////////////////////////
+
+class MmCommunicationOverflowTest : public ::testing::Test {
+public:
+  UINT8 mCommonBuffer[COMM_BUFFER_SIZE];
+  MM_COMM_BUFFER_STATUS mCommonBufferStatus;
+  EFI_MM_CONTROL_PROTOCOL mMockSmmControl2;
+  UINT8 mCommBuffer[COMM_BUFFER_SIZE];
+
+protected:
+  virtual void
+  SetUp (
+    )
+  {
+    ZeroMem (mCommonBuffer, sizeof (mCommonBuffer));
+    ZeroMem (&mCommonBufferStatus, sizeof (mCommonBufferStatus));
+    ZeroMem (mCommBuffer, sizeof (mCommBuffer));
+
+    // Set up the global MM common buffer struct
+    mMmCommonBuffer.PhysicalStart = (EFI_PHYSICAL_ADDRESS)(UINTN)mCommonBuffer;
+    mMmCommonBuffer.NumberOfPages = COMM_BUFFER_PAGES;
+    mMmCommonBuffer.Status        = (EFI_PHYSICAL_ADDRESS)(UINTN)&mCommonBufferStatus;
+
+    // Set up the mock SmmControl2 protocol
+    mMockSmmControl2.Trigger              = MockTrigger;
+    mMockSmmControl2.Clear                = MockClear;
+    mMockSmmControl2.MinimumTriggerPeriod = 0;
+    mSmmControl2                          = &mMockSmmControl2;
+  }
+
+  virtual void
+  TearDown (
+    )
+  {
+    // Clean up any resources or variables
+  }
+};
+
+// Test Description:
+// Normal V1 path works with small MessageLength
+TEST_F (MmCommunicationOverflowTest, V1NormalMessageLengthSucceeds) {
+  EFI_MM_COMMUNICATE_HEADER  *Header = (EFI_MM_COMMUNICATE_HEADER *)mCommBuffer;
+
+  ZeroMem (&Header->HeaderGuid, sizeof (EFI_GUID));
+  Header->MessageLength = 64;
+
+  UINTN  CommSize = OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, Data) + 64;
+
+  EFI_STATUS  Status = ProcessCommunicationBuffer (mCommBuffer, &CommSize);
+
+  // BufferSize = 24 + 64 = 88, well within 16KiB
+  ASSERT_EQ (Status, EFI_SUCCESS);
+}
+
+// Test Description:
+// V1 path - CWE-190 integer overflow wraps BufferSize to 0.
+// MessageLength = MAX_UINT64 - OFFSET_OF(...) + 1 causes addition to wrap to 0.
+TEST_F (MmCommunicationOverflowTest, V1MessageLengthOverflowWrapsToZero) {
+  EFI_MM_COMMUNICATE_HEADER  *Header = (EFI_MM_COMMUNICATE_HEADER *)mCommBuffer;
+
+  ZeroMem (&Header->HeaderGuid, sizeof (EFI_GUID));
+
+  //
+  // Craft MessageLength so that OFFSET_OF(Data) + MessageLength = 0 (wraps)
+  // OFFSET_OF(EFI_MM_COMMUNICATE_HEADER, Data) = 0x18 (24)
+  // MAX_UINT64 - 0x18 + 1 = 0xFFFFFFFFFFFFFFE8
+  //
+  Header->MessageLength = MAX_UINT64 - OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, Data) + 1;
+
+  EFI_STATUS  Status = ProcessCommunicationBuffer (mCommBuffer, NULL);
+
+  // Without fix: BufferSize wraps to 0, passes bounds check, returns EFI_SUCCESS
+  ASSERT_EQ (Status, EFI_INVALID_PARAMETER);
+}
+
+// Test Description:
+// V1 path - Integer overflow wraps BufferSize to a small nonzero value (0x08)
+TEST_F (MmCommunicationOverflowTest, V1MessageLengthOverflowWrapsToSmallValue) {
+  EFI_MM_COMMUNICATE_HEADER  *Header = (EFI_MM_COMMUNICATE_HEADER *)mCommBuffer;
+
+  ZeroMem (&Header->HeaderGuid, sizeof (EFI_GUID));
+
+  //
+  // MessageLength = MAX_UINT64 - 0x18 + 1 + 8 = MAX_UINT64 - 0x0F
+  // Result: OFFSET_OF(Data) + MessageLength = 0x18 + (MAX_UINT64 - 0x0F) = 0x08 (wraps)
+  //
+  Header->MessageLength = MAX_UINT64 - OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, Data) + 1 + 8;
+
+  EFI_STATUS  Status = ProcessCommunicationBuffer (mCommBuffer, NULL);
+
+  // Without fix: BufferSize = 8, passes bounds check, returns EFI_SUCCESS
+  ASSERT_EQ (Status, EFI_INVALID_PARAMETER);
+}
+
+// Test Description:
+// V1 path - Large MessageLength without overflow is rejected by bounds check
+TEST_F (MmCommunicationOverflowTest, V1LargeMessageLengthWithoutOverflowIsRejected) {
+  EFI_MM_COMMUNICATE_HEADER  *Header = (EFI_MM_COMMUNICATE_HEADER *)mCommBuffer;
+
+  ZeroMem (&Header->HeaderGuid, sizeof (EFI_GUID));
+
+  //
+  // Set MessageLength larger than common buffer but not large enough to overflow.
+  // BufferSize = 0x18 + 0x10000 = 0x10018, which exceeds 16KiB (0x4000).
+  // The MU_CHANGE bounds check should catch this.
+  //
+  Header->MessageLength = 0x10000;
+
+  EFI_STATUS  Status = ProcessCommunicationBuffer (mCommBuffer, NULL);
+
+  // The existing MU_CHANGE correctly rejects this (no overflow, just too large)
+  ASSERT_EQ (Status, EFI_INVALID_PARAMETER);
+}
+
+// Test Description:
+// NULL CommBuffer is rejected
+TEST_F (MmCommunicationOverflowTest, NullCommBufferReturnsInvalidParameter) {
+  EFI_STATUS  Status = ProcessCommunicationBuffer (NULL, NULL);
+
+  ASSERT_EQ (Status, EFI_INVALID_PARAMETER);
+}
+
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  testing::InitGoogleTest (&argc, argv);
+  return RUN_ALL_TESTS ();
+}

--- a/StandaloneMmPkg/Drivers/MmCommunicationDxe/GoogleTest/MmCommunicationDxeGoogleTest.inf
+++ b/StandaloneMmPkg/Drivers/MmCommunicationDxe/GoogleTest/MmCommunicationDxeGoogleTest.inf
@@ -34,7 +34,7 @@
   UefiBootServicesTableLib
   UefiLib
   UefiRuntimeLib
-
+  SafeIntLib
 [Protocols]
   gEfiMmCommunication3ProtocolGuid
   gEfiMmCommunication2ProtocolGuid

--- a/StandaloneMmPkg/Drivers/MmCommunicationDxe/GoogleTest/MmCommunicationDxeGoogleTest.inf
+++ b/StandaloneMmPkg/Drivers/MmCommunicationDxe/GoogleTest/MmCommunicationDxeGoogleTest.inf
@@ -1,0 +1,51 @@
+## @file
+# GoogleTest for MmCommunicationDxe -- CVE repro for CWE-190 integer overflow.
+#
+# Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION         = 0x0001001A
+  BASE_NAME           = MmCommunicationDxeGoogleTest
+  FILE_GUID           = 5bf153cc-013c-4c61-95b7-cd86b263bd9f
+  VERSION_STRING      = 1.0
+  MODULE_TYPE         = HOST_APPLICATION
+
+[Sources]
+  MmCommunicationDxeGoogleTest.cpp
+  ../MmCommunicationDxe.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  UefiCpuPkg/UefiCpuPkg.dec
+  StandaloneMmPkg/StandaloneMmPkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  HobLib
+  MemoryAllocationLib
+  ReportStatusCodeLib
+  UefiBootServicesTableLib
+  UefiLib
+  UefiRuntimeLib
+
+[Protocols]
+  gEfiMmCommunication3ProtocolGuid
+  gEfiMmCommunication2ProtocolGuid
+  gEfiMmCommunicationProtocolGuid
+  gEfiSmmControl2ProtocolGuid
+  gEfiSmmAccess2ProtocolGuid
+
+[Guids]
+  gMmCommBufferHobGuid
+  gEfiEventVirtualAddressChangeGuid
+  gEfiMmCommunicateHeaderV3Guid
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHsc

--- a/StandaloneMmPkg/Drivers/MmCommunicationDxe/MmCommunicationDxe.c
+++ b/StandaloneMmPkg/Drivers/MmCommunicationDxe/MmCommunicationDxe.c
@@ -102,20 +102,23 @@ ProcessCommunicationBuffer (
   CommunicateHeader = (EFI_MM_COMMUNICATE_HEADER *)CommBuffer;
   if (CompareGuid (&CommunicateHeader->HeaderGuid, &gEfiMmCommunicateHeaderV3Guid)) {
     CommunicateHeaderV3 = (EFI_MM_COMMUNICATE_HEADER_V3 *)CommBuffer;
-    if (CommunicateHeaderV3->BufferSize < sizeof (EFI_MM_COMMUNICATE_HEADER_V3) + CommunicateHeaderV3->MessageSize) {
+    // MU_CHANGE [BEGIN]: CWE-190 overflow check for V3 header size computation
+    Status = SafeUintnAdd (sizeof (EFI_MM_COMMUNICATE_HEADER_V3), CommunicateHeaderV3->MessageSize, &BufferSize);
+    if (EFI_ERROR (Status) || (CommunicateHeaderV3->BufferSize < BufferSize)) {
       return EFI_INVALID_PARAMETER;
     }
+
+    // MU_CHANGE [END]: CWE-190 overflow check for V3 header
 
     BufferSize = ((EFI_MM_COMMUNICATE_HEADER_V3 *)CommBuffer)->BufferSize;
   } else {
-    //
-    // Validate MessageLength to prevent integer overflow in BufferSize computation
-    //
-    if (CommunicateHeader->MessageLength > (MAX_UINTN - OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, Data))) {
+    // MU_CHANGE [BEGIN]: CWE-190 overflow check before computing BufferSize
+    Status = SafeUintnAdd (OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, Data), (UINTN)CommunicateHeader->MessageLength, &BufferSize);
+    if (EFI_ERROR (Status)) {
       return EFI_INVALID_PARAMETER;
     }
 
-    BufferSize = OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, Data) + CommunicateHeader->MessageLength;
+    // MU_CHANGE [END]: CWE-190 overflow check
   }
 
   // MU_CHANGE [BEGIN]: CommSize validation

--- a/StandaloneMmPkg/Drivers/MmCommunicationDxe/MmCommunicationDxe.c
+++ b/StandaloneMmPkg/Drivers/MmCommunicationDxe/MmCommunicationDxe.c
@@ -108,6 +108,12 @@ ProcessCommunicationBuffer (
 
     BufferSize = ((EFI_MM_COMMUNICATE_HEADER_V3 *)CommBuffer)->BufferSize;
   } else {
+    //
+    // Validate MessageLength to prevent integer overflow in BufferSize computation
+    //
+    if (CommunicateHeader->MessageLength > (MAX_UINTN - OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, Data))) {
+      return EFI_INVALID_PARAMETER;
+    }
     BufferSize = OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, Data) + CommunicateHeader->MessageLength;
   }
 

--- a/StandaloneMmPkg/Drivers/MmCommunicationDxe/MmCommunicationDxe.c
+++ b/StandaloneMmPkg/Drivers/MmCommunicationDxe/MmCommunicationDxe.c
@@ -114,6 +114,7 @@ ProcessCommunicationBuffer (
     if (CommunicateHeader->MessageLength > (MAX_UINTN - OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, Data))) {
       return EFI_INVALID_PARAMETER;
     }
+
     BufferSize = OFFSET_OF (EFI_MM_COMMUNICATE_HEADER, Data) + CommunicateHeader->MessageLength;
   }
 

--- a/StandaloneMmPkg/Drivers/MmCommunicationDxe/MmCommunicationDxe.h
+++ b/StandaloneMmPkg/Drivers/MmCommunicationDxe/MmCommunicationDxe.h
@@ -20,6 +20,7 @@
 #include <Library/MemoryAllocationLib.h>
 #include <Library/UefiRuntimeLib.h>
 #include <Library/ReportStatusCodeLib.h>
+#include <Library/SafeIntLib.h>
 
 #include <Protocol/SmmControl2.h>
 #include <Protocol/MmCommunication3.h>

--- a/StandaloneMmPkg/Drivers/MmCommunicationDxe/MmCommunicationDxe.inf
+++ b/StandaloneMmPkg/Drivers/MmCommunicationDxe/MmCommunicationDxe.inf
@@ -38,7 +38,7 @@
   UefiLib
   UefiRuntimeLib
   ReportStatusCodeLib
-
+  SafeIntLib
 [Guids]
   gMmCommBufferHobGuid
   gEfiEventVirtualAddressChangeGuid

--- a/StandaloneMmPkg/StandaloneMmPkg.ci.yaml
+++ b/StandaloneMmPkg/StandaloneMmPkg.ci.yaml
@@ -28,7 +28,7 @@
 
     ## options defined .pytool/Plugin/HostUnitTestCompilerPlugin
     "HostUnitTestCompilerPlugin": {
-        "DscPath": "" # Don't support this test
+        "DscPath": "Test/StandaloneMmPkgHostTest.dsc"
     },
 
     ## options defined .pytool/Plugin/CharEncodingCheck
@@ -64,7 +64,7 @@
     ## options defined .pytool/Plugin/HostUnitTestDscCompleteCheck
     "HostUnitTestDscCompleteCheck": {
         "IgnoreInf": [""],
-        "DscPath": "" # Don't support this test
+        "DscPath": "Test/StandaloneMmPkgHostTest.dsc"
     },
 
     ## options defined .pytool/Plugin/GuidCheck

--- a/StandaloneMmPkg/Test/StandaloneMmPkgHostTest.dsc
+++ b/StandaloneMmPkg/Test/StandaloneMmPkgHostTest.dsc
@@ -1,0 +1,40 @@
+## @file
+# StandaloneMmPkgHostTest DSC file used to build host-based unit tests.
+#
+# Copyright (c) 2024, Intel Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+[Defines]
+  PLATFORM_NAME           = StandaloneMmPkgHostTest
+  PLATFORM_GUID           = A3D4B87C-5E2F-4A19-8C6D-1F7E09B23D56
+  PLATFORM_VERSION        = 0.1
+  DSC_SPECIFICATION       = 0x00010005
+  OUTPUT_DIRECTORY        = Build/StandaloneMmPkg/HostTest
+  SUPPORTED_ARCHITECTURES = IA32|X64|AARCH64
+  BUILD_TARGETS           = NOOPT
+  SKUID_IDENTIFIER        = DEFAULT
+
+!include UnitTestFrameworkPkg/UnitTestFrameworkPkgHost.dsc.inc
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[Components]
+  #
+  # Build HOST_APPLICATION that tests StandaloneMmPkg
+  #
+  StandaloneMmPkg/Drivers/MmCommunicationDxe/GoogleTest/MmCommunicationDxeGoogleTest.inf
+  StandaloneMmPkg/Test/Mock/Library/GoogleTest/MockStandaloneMmMemLib/MockStandaloneMmMemLib.inf
+  
+[LibraryClasses]
+  DevicePathLib|MdePkg/Library/UefiDevicePathLib/UefiDevicePathLib.inf
+  DxeServicesTableLib|MdePkg/Library/DxeServicesTableLib/DxeServicesTableLib.inf
+  HobLib|MdePkg/Library/DxeHobLib/DxeHobLib.inf
+  ReportStatusCodeLib|MdePkg/Library/BaseReportStatusCodeLibNull/BaseReportStatusCodeLibNull.inf
+  UefiDriverEntryPoint|MdePkg/Library/UefiDriverEntryPoint/UefiDriverEntryPoint.inf
+  UefiLib|MdePkg/Library/UefiLib/UefiLib.inf
+  UefiRuntimeLib|MdePkg/Library/UefiRuntimeLib/UefiRuntimeLib.inf
+  UefiRuntimeServicesTableLib|MdePkg/Library/UefiRuntimeServicesTableLib/UefiRuntimeServicesTableLib.inf
+  DebugPrintErrorLevelLib|MdePkg/Library/BaseDebugPrintErrorLevelLib/BaseDebugPrintErrorLevelLib.inf


### PR DESCRIPTION
## Description

**CWE: CWE-190 (Integer Overflow)**
**`ProcessCommunicationBuffer()`** in `StandaloneMmPkg/Drivers/MmCommunicationDxe/MmCommunicationDxe.c `computes BufferSize by adding a fixed offset (24 bytes) to an attacker-controlled MessageLength (UINT64): `BufferSize = OFFSET_OF(EFI_MM_COMMUNICATE_HEADER, Data) + CommunicateHeader->MessageLength;`

When `MessageLength >= 0xFFFFFFFFFFFFFFE8`, the addition wraps to a small value (0–23 bytes) after UINTN truncation.

The subsequent bounds check `BufferSize > EFI_PAGES_TO_SIZE`(mMmCommonBuffer.NumberOfPages) evaluates FALSE on the wrapped value, bypassing size validation and allowing CopyMem to proceed with a corrupted size into the fixed MM communication buffer.

Fix: Added an overflow check before the addition — rejects with EFI_INVALID_PARAMETER `if MessageLength > MAX_UINTN - OFFSET_OF(EFI_MM_COMMUNICATE_HEADER, Data).`


- [ ] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Created GoogleTest host-based unit tests with **5** test cases:


- Valid small MessageLength  → EFI_SUCCESS - PASSED
- MessageLength at exact buffer boundary → EFI_SUCCESS - PASSED
- MessageLength exceeding buffer without overflow → EFI_INVALID_PARAMETER - PASSED
- MessageLength = 0xFFFFFFFFFFFFFFE8 (wraps to 0) → **Before fix:** EFI_SUCCESS - FAILED | **After fix:** EFI_INVALID_PARAMETER  - PASSED
- MessageLength = 0xFFFFFFFFFFFFFFFF (wraps to 23) → **Before fix:** EFI_SUCCESS - FAILED | **After fix:** EFI_INVALID_PARAMETER - PASSED


**Test results:**
Build cmd used: _stuart_ci_build -c MU_BASECORE/.pytool/CISettings.py -p StandaloneMmPkg -t NOOPT_
Before fix: 3/5 PASSED, 2/5 FAILED (overflow inputs bypass bounds check)
After fix: 5/5 PASSED

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
