### PR TITLE
SecurityPkg: Skip PCR4 measurement for FV applications

### DIFF
--- a/SecurityPkg/Library/DxeTpm2MeasureBootLib/DxeTpm2MeasureBootLib.c
+++ b/SecurityPkg/Library/DxeTpm2MeasureBootLib/DxeTpm2MeasureBootLib.c
@@ -757,12 +757,10 @@ DxeTpm2MeasureBootHandler (
       return EFI_SUCCESS;
     }
 
+    // MU_CHANGE [BEGIN]
     //
     // The PE image from unmeasured Firmware volume need be measured
-    // The PE image from measured Firmware volume will be measured according to policy below.
-    //   If it is driver, do not measure
-    //   If it is application, still measure.
-    //
+    // MU_CHANGE [END]
     ApplicationRequired = TRUE;
 
     if ((mTcg2CacheMeasuredHandle != Handle) && (mTcg2MeasuredHobData != NULL)) {
@@ -857,8 +855,10 @@ DxeTpm2MeasureBootHandler (
   // Measure only application if Application flag is set
   // Measure drivers and applications if Application flag is not set
   //
-  if ((!ApplicationRequired) ||
-      (ApplicationRequired && (ImageContext.ImageType == EFI_IMAGE_SUBSYSTEM_EFI_APPLICATION)))
+  // MU_CHANGE
+  //if ((!ApplicationRequired) ||
+  //    (ApplicationRequired && (ImageContext.ImageType == EFI_IMAGE_SUBSYSTEM_EFI_APPLICATION)))
+  if (!ApplicationRequired)
   {
     //
     // Print the image path to be measured.
@@ -888,6 +888,28 @@ DxeTpm2MeasureBootHandler (
                DevicePathNode
                );
   }
+
+  // MU_CHANGE [END]
+  DEBUG_CODE_BEGIN ();
+  //
+  // Due to "TCG_SPEC_CHANGE: PCR4_SKIP_FV_APP" applications launched from measured firmware will be skipped
+  //
+
+  if (ApplicationRequired && (ImageContext.ImageType == EFI_IMAGE_SUBSYSTEM_EFI_APPLICATION)) {
+      CHAR16  *ToText;
+      ToText = ConvertDevicePathToText (
+                DevicePathNode,
+                FALSE,
+                TRUE
+                );
+      if (ToText != NULL) {
+        DEBUG ((DEBUG_INFO, "TCG_SPEC_CHANGE: PCR4_SKIP_FV_APP -- Skipping: %s.\n", ToText));
+        FreePool (ToText);
+    }
+  }
+
+  DEBUG_CODE_END ();
+  // MU_CHANGE [END]
 
   //
   // Done, free the allocated resource.


### PR DESCRIPTION
## Description

Update DxeTpm2MeasureBootLib to stop measuring EFI applications loaded from measured firmware volumes.

TCG PC Client Platform Firmware Profile Specification 1.06 r52 defines PCR[4] as Boot Manager Code and Boot Attempts. In 3.3.4.5, the required EV_EFI_BOOT_SERVICES_APPLICATION event is for the UEFI application code described by the Boot#### variable during a boot attempt.

Applications launched from measured firmware volumes are part of platform firmware execution, not a Boot#### boot-option handoff to boot manager code. The same spec separately treats platform firmware as part of the firmware trust chain measured outside the PCR[4] boot-attempt path, so skipping PCR[4] here is consistent with the spec's PCR role split.

- [x] Impacts functionality?
- [ ] Impacts security?
- [x] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Tested Q35 boot, dumping tcg log.

## Integration Instructions
This is a breaking change in that it be reflected in the PCR[4] measurements.
If an OS is bound to PCR[4], efi applications launched from Fvs will no longer show up in the log, and may trigger bitlocker recovery. 