### PR TITLE
MdePkg: BasePeCoffLib: Record security data directory

### DIFF
--- a/MdePkg/Include/Library/PeCoffLib.h
+++ b/MdePkg/Include/Library/PeCoffLib.h
@@ -204,6 +204,11 @@ typedef struct {
   /// Private storage for implementation specific data.
   ///
   UINT64                      Context;
+  ///
+  /// Set by PeCoffLoaderGetImageInfo() to a copy of the image's EFI_IMAGE_DIRECTORY_ENTRY_SECURITY data directory entry.
+  /// If the image does not contain a security data directory entry, this field is set to zero.
+  ///
+  EFI_IMAGE_DATA_DIRECTORY    SecurityDataDirectory;
 } PE_COFF_LOADER_IMAGE_CONTEXT;
 
 /**

--- a/MdePkg/Library/BasePeCoffLib/BasePeCoff.c
+++ b/MdePkg/Library/BasePeCoffLib/BasePeCoff.c
@@ -76,6 +76,14 @@ PeCoffLoaderGetPeHeader (
   EFI_IMAGE_SECTION_HEADER  SectionHeader;
 
   //
+  // Zero the security data directory. It is populated below only if the image
+  // has a non-empty EFI_IMAGE_DIRECTORY_ENTRY_SECURITY entry that passes
+  // bounds checking.
+  //
+  ImageContext->SecurityDataDirectory.VirtualAddress = 0;
+  ImageContext->SecurityDataDirectory.Size           = 0;
+
+  //
   // Read the DOS image header to check for its existence
   //
   Size     = sizeof (EFI_IMAGE_DOS_HEADER);
@@ -303,6 +311,12 @@ PeCoffLoaderGetPeHeader (
 
             return Status;
           }
+
+          //
+          // The security data directory exists and is within the image bounds.Record a copy of it
+          // in the image context so callers can locate the certificate data without re-parsing the headers.
+          //
+          ImageContext->SecurityDataDirectory = Hdr.Pe32->OptionalHeader.DataDirectory[EFI_IMAGE_DIRECTORY_ENTRY_SECURITY];
         }
       }
 
@@ -425,6 +439,12 @@ PeCoffLoaderGetPeHeader (
 
             return Status;
           }
+
+          //
+          // The security data directory exists and is within the image bounds.Record a copy of it
+          // in the image context so callers can locate the certificate data without re-parsing the headers.
+          //
+          ImageContext->SecurityDataDirectory = Hdr.Pe32Plus->OptionalHeader.DataDirectory[EFI_IMAGE_DIRECTORY_ENTRY_SECURITY];
         }
       }
 


### PR DESCRIPTION
**NOTE**: This is a draft PR so that the team can review it before I put it up to EDK II. This is to support The Dxe Image Validation changes that are being made.

## Description

Add a new field, SecurityDataDirectory, to PE_COFF_LOADER_IMAGE_CONTEXT that records the security data directory of the image. This occurs when PeCoffLoaderGetImageInfo is called.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
