### PR TITLE
[CHERRY-PICK] BaseTools/GenFv: Preserve legacy rebase behavior when Xip is unused

### DIFF
--- a/BaseTools/Source/C/GenFv/GenFvInternalLib.c
+++ b/BaseTools/Source/C/GenFv/GenFvInternalLib.c
@@ -333,6 +333,7 @@ Returns:
       if (XipFlag != NULL && stricmp (XipFlag, ",XIP") == 0) {
         *XipFlag = '\0';
         FvInfo->XipFile[Number + Index] = TRUE;
+        FvInfo->XipFileCount++;
       } else {
         FvInfo->XipFile[Number + Index] = FALSE;
       }
@@ -3464,10 +3465,12 @@ Returns:
   }
 
   //
-  // If ForceRebase Flag specified to TRUE, only rebase files marked with XIP.
+  // If ForceRebase Flag specified to TRUE and at least one file has XIP flag,
+  // use selective rebase: only rebase files marked with XIP.
+  // If no files have XIP flag, preserve legacy behavior: rebase all files.
   //
   if (FvInfo->ForceRebase == 1) {
-    if (!FvInfo->XipFile[FileIndex]) {
+    if (FvInfo->XipFileCount > 0 && !FvInfo->XipFile[FileIndex]) {
       return EFI_SUCCESS;
     }
   }

--- a/BaseTools/Source/C/GenFv/GenFvInternalLib.h
+++ b/BaseTools/Source/C/GenFv/GenFvInternalLib.h
@@ -211,6 +211,7 @@ typedef struct {
   EFI_FV_BLOCK_MAP_ENTRY  FvBlocks[MAX_NUMBER_OF_FV_BLOCKS];
   CHAR8                   FvFiles[MAX_NUMBER_OF_FILES_IN_FV][MAX_LONG_FILE_PATH];
   BOOLEAN                 XipFile[MAX_NUMBER_OF_FILES_IN_FV];
+  UINT32                  XipFileCount;
   UINT32                  SizeofFvFiles[MAX_NUMBER_OF_FILES_IN_FV];
   BOOLEAN                 IsPiFvImage;
   INT8                    ForceRebase;

--- a/BaseTools/Tests/TestGenFvXip.py
+++ b/BaseTools/Tests/TestGenFvXip.py
@@ -9,13 +9,14 @@
 # FfsRebase() in GenFvInternalLib.c decides whether to rebase each PE/COFF
 # image in an FV based on three inputs: ForceRebase, BaseAddress, and XipFile[].
 #
-#   ForceRebase  BaseAddress  XipFile[]  Result
-#   -----------  -----------  ---------  ---------------------------------
-#   -1 (unset)   0            any        No rebase (early return)
-#   0  (FALSE)   any          any        No rebase (early return)
-#   1  (TRUE)    any          FALSE      No rebase (skip non-XIP file)
-#   1  (TRUE)    any          TRUE       Rebase (XIP file selected)
-#   -1 (unset)   != 0         any        Rebase ALL files (legacy path)
+#   ForceRebase  BaseAddress  XipFileCount  XipFile[]  Result
+#   -----------  -----------  ------------  ---------  ---------------------------------
+#   -1 (unset)   0            any           any        No rebase (early return)
+#   0  (FALSE)   any          any           any        No rebase (early return)
+#   1  (TRUE)    any          0             any        Rebase ALL files (legacy compat)
+#   1  (TRUE)    any          > 0           FALSE      No rebase (skip non-XIP file)
+#   1  (TRUE)    any          > 0           TRUE       Rebase (XIP file selected)
+#   -1 (unset)   != 0         any           any        Rebase ALL files (legacy path)
 #
 # Unit Tests (TestDetermineXipEnabled):
 #   11 parameterized subtests calling FfsInfStatement.DetermineXipEnabled()
@@ -35,7 +36,7 @@
 #   TC3: ForceRebase=FALSE, Base!=0       -> no rebase
 #   TC4: ForceRebase=TRUE,  all Xip=TRUE  -> rebase all
 #   TC5: ForceRebase=TRUE,  selective Xip -> rebase only Xip=TRUE
-#   TC6: ForceRebase=TRUE,  no Xip        -> no rebase
+#   TC6: ForceRebase=TRUE,  no Xip        -> rebase all (legacy compat)
 #   TC7: ForceRebase=TRUE,  mixed Xip     -> rebase Xip=TRUE only
 #   TC8: ForceRebase=TRUE,  Base=0, Xip   -> rebase (force overrides)
 #
@@ -802,9 +803,9 @@ INF  TestXipRebasePkg/TestDxeDriver/TestDxeDriver.inf
         ('TESTFV5', '0x00800000', 'TRUE',  'TRUE', 'TRUE', None,
          (True,  True,  False), 'TC5: ForceRebase=TRUE, selective Xip -> rebase Xip only'),
         # TC6: ForceRebase=TRUE, no files have Xip keyword.
-        # All files have XipFile==FALSE, so none are rebased.
+        # XipFileCount==0, so legacy behavior is preserved: rebase all files.
         ('TESTFV6', '0x00800000', 'TRUE',  None,   None,   None,
-         (False, False, False), 'TC6: ForceRebase=TRUE, no Xip -> no rebase'),
+         (True,  True,  True),  'TC6: ForceRebase=TRUE, no Xip -> rebase all (legacy compat)'),
         # TC7: ForceRebase=TRUE, PEIM1 has Xip=TRUE, PEIM2 has Xip=FALSE.
         # Mixed XIP within same module type via RuleOverride.
         # Only PEIM1 is rebased; PEIM2 and DXE are skipped.


### PR DESCRIPTION
## Description

**[CHERRY-PICK] BaseTools/GenFv: Preserve legacy rebase behavior when Xip is unused**

Add XipFileCount to FV_INFO to track how many files have the ,XIP
suffix. Update FfsRebase() to only apply selective XIP rebase when
XipFileCount > 0. When no files have the ,XIP suffix (XipFileCount
== 0), preserve the legacy ForceRebase=TRUE behavior of rebasing all
files. This maintains backward compatibility for existing platforms
that use FvForceRebase=TRUE without any Xip rules.

(cherry picked from commit 0347d3b7113ef215e0f19a38206703e86a4e5d1b)

---

**[CHERRY-PICK] BaseTools/Tests: Update TC6 for backward-compatible rebase behavior**

Update the test decision matrix and TC6 expected result to reflect
the backward-compatible ForceRebase logic: when ForceRebase=TRUE and
no files have the ,XIP suffix (XipFileCount==0), all files are
rebased using the legacy behavior rather than skipping all files.

(cherry picked from commit ae023dbe9952cef22a108bf247605030d0c60b50)

---

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested by original reporter that backwards compat was broken.

## Integration Instructions

N/A.
