### PR TITLE
[REBASE&FF] SecurityPkg: Add Google Test MockSecureBootVariableLib

### DIFF
--- a/SecurityPkg/Test/Mock/Include/GoogleTest/Library/MockSecureBootVariableLib.h
+++ b/SecurityPkg/Test/Mock/Include/GoogleTest/Library/MockSecureBootVariableLib.h
@@ -1,0 +1,27 @@
+/** @file
+  Google Test mocks for SecureBootVariableLib
+
+  Copyright (C) Microsoft Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#pragma once
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+extern "C" {
+  #include <Uefi.h>
+  #include <UefiSecureBoot.h>
+  #include <Guid/ImageAuthentication.h>
+  #include <Library/SecureBootVariableLib.h>
+}
+
+struct MockSecureBootVariableLib {
+  MOCK_INTERFACE_DECLARATION (MockSecureBootVariableLib);
+
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    IsSecureBootEnabled,
+    ()
+    );
+};

--- a/SecurityPkg/Test/Mock/Library/GoogleTest/MockSecureBootVariableLib/MockSecureBootVariableLib.cpp
+++ b/SecurityPkg/Test/Mock/Library/GoogleTest/MockSecureBootVariableLib/MockSecureBootVariableLib.cpp
@@ -1,0 +1,11 @@
+/** @file
+  Google Test mocks for SecureBootVariableLib
+
+  Copyright (C) Microsoft Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+#include <GoogleTest/Library/MockSecureBootVariableLib.h>
+
+MOCK_INTERFACE_DEFINITION (MockSecureBootVariableLib);
+
+MOCK_FUNCTION_DEFINITION (MockSecureBootVariableLib, IsSecureBootEnabled, 0, EFIAPI);

--- a/SecurityPkg/Test/Mock/Library/GoogleTest/MockSecureBootVariableLib/MockSecureBootVariableLib.inf
+++ b/SecurityPkg/Test/Mock/Library/GoogleTest/MockSecureBootVariableLib/MockSecureBootVariableLib.inf
@@ -1,0 +1,34 @@
+## @file
+# Google Test mocks for SecureBootVariableLib
+#
+# Copyright (C) Microsoft Corporation. All rights reserved.<BR>
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MockSecureBootVariableLib
+  FILE_GUID                      = 4F5C2D34-2E9F-4F1E-9D6E-1F1F8C9D7C3A
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = SecureBootVariableLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  MockSecureBootVariableLib.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  SecurityPkg/SecurityPkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHsc

--- a/SecurityPkg/Test/SecurityPkgHostTest.dsc
+++ b/SecurityPkg/Test/SecurityPkgHostTest.dsc
@@ -28,6 +28,7 @@
   SecurityPkg/Test/Mock/Library/GoogleTest/MockPlatformPKProtectionLib/MockPlatformPKProtectionLib.inf
   SecurityPkg/Library/DxeTpm2MeasureBootLib/InternalUnitTest/DxeTpm2MeasureBootLibSanitizationTestHost.inf
   SecurityPkg/Library/DxeTpmMeasureBootLib/InternalUnitTest/DxeTpmMeasureBootLibSanitizationTestHost.inf
+  SecurityPkg/Test/Mock/Library/GoogleTest/MockSecureBootVariableLib/MockSecureBootVariableLib.inf
   #
   # Build SecurityPkg HOST_APPLICATION Tests
   #


### PR DESCRIPTION


## Description

Cherry-pick from edk2: https://github.com/tianocore/edk2/commit/3fec6254088b8585e35f660b4fe289b179a15349

Add Google Test Mock library header and implementation for SecureBootVariableLib to allow simple mocking for host based unit tests that utilize the Google Test framework.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
