### PR TITLE
[CHERRY-PICK] MdePkg/AdapterInformation: Add CDAT adapter information type

### DIFF
--- a/MdePkg/Include/Protocol/AdapterInformation.h
+++ b/MdePkg/Include/Protocol/AdapterInformation.h
@@ -4,6 +4,7 @@
   or set device information for an adapter.
 
   Copyright (c) 2014 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (C) 2026 Advanced Micro Devices, Inc. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
   @par Revision Reference:
@@ -43,6 +44,11 @@
   { \
     0x8484472f, 0x71ec, 0x411a, { 0xb3, 0x9c, 0x62, 0xcd, 0x94, 0xd9, 0x91, 0x6e } \
   }
+
+#define EFI_ADAPTER_INFO_CDAT_TYPE_GUID \
+{ \
+    0x77af24d1, 0xb6f0, 0x42b9, { 0x83, 0xf5, 0x8f, 0xe6, 0xe8, 0x3e, 0xb6, 0xf0 } \
+}
 
 typedef struct _EFI_ADAPTER_INFORMATION_PROTOCOL EFI_ADAPTER_INFORMATION_PROTOCOL;
 
@@ -134,6 +140,20 @@ typedef struct {
   ///
   BOOLEAN    Ipv6Support;
 } EFI_ADAPTER_INFO_UNDI_IPV6_SUPPORT;
+
+///
+/// EFI_ADAPTER_INFO_CDAT_TYPE_TYPE
+///
+typedef struct {
+  ///
+  /// Returns the size of the CDAT in bytes.
+  ///
+  UINTN    CdatSize;
+  ///
+  /// Returns the CDAT data.
+  ///
+  UINT8    Cdat[];
+} EFI_ADAPTER_INFO_CDAT_TYPE_TYPE;
 
 /**
   Returns the current state information for the adapter.
@@ -251,5 +271,7 @@ extern EFI_GUID  gEfiAdapterInfoNetworkBootGuid;
 extern EFI_GUID  gEfiAdapterInfoSanMacAddressGuid;
 
 extern EFI_GUID  gEfiAdapterInfoUndiIpv6SupportGuid;
+
+extern EFI_GUID  gEfiAdapterInfoCdatTypeGuid;
 
 #endif

--- a/MdePkg/MdePkg.dec
+++ b/MdePkg/MdePkg.dec
@@ -9,7 +9,7 @@
 # (C) Copyright 2016 - 2021 Hewlett Packard Enterprise Development LP<BR>
 # Copyright (c) 2022, Loongson Technology Corporation Limited. All rights reserved.<BR>
 # Copyright (c) 2021 - 2022, Arm Limited. All rights reserved.<BR>
-# Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.<BR>
+# Copyright (C) 2023 - 2026 Advanced Micro Devices, Inc. All rights reserved.<BR>
 # Copyright (c) 2023, Ampere Computing LLC. All rights reserved.<BR>
 # Copyright (c) Microsoft Corporation.<BR>
 #
@@ -709,6 +709,7 @@
   gEfiAdapterInfoMediaStateGuid       = { 0xD7C74207, 0xA831, 0x4A26, {0xB1, 0xF5, 0xD1, 0x93, 0x06, 0x5C, 0xE8, 0xB6 }}
   gEfiAdapterInfoNetworkBootGuid      = { 0x1FBD2960, 0x4130, 0x41E5, {0x94, 0xAC, 0xD2, 0xCF, 0x03, 0x7F, 0xB3, 0x7C }}
   gEfiAdapterInfoSanMacAddressGuid    = { 0x114da5ef, 0x2cf1, 0x4e12, {0x9b, 0xbb, 0xc4, 0x70, 0xb5, 0x52, 0x5, 0xd9 }}
+  gEfiAdapterInfoCdatTypeGuid         = { 0x77af24d1, 0xb6f0, 0x42b9, {0x83, 0xf5, 0x8f, 0xe6, 0xe8, 0x3e, 0xb6, 0xf0 }}
 
   ## Include/Guid/CapsuleReport.h
   gEfiCapsuleReportGuid               = { 0x39b68c46, 0xf7fb, 0x441b, {0xb6, 0xec, 0x16, 0xb0, 0xf6, 0x98, 0x21, 0xf3 }}


### PR DESCRIPTION
## Description

Define EFI_ADAPTER_INFO_CDAT_TYPE_GUID and EFI_ADAPTER_INFO_CDAT_TYPE_TYPE
for exposing Coherent Device Attribute Table (CDAT) data via
EFI_ADAPTER_INFORMATION_PROTOCOL. Register gEfiAdapterInfoCdatTypeGuid in
MdePkg.dec.

Ref: UEFI spec 2.11 sec 11.12
https://uefi.org/specs/UEFI/2.11/11_Protocols_UEFI_Driver_Model.html#efi-adapter-information-protocol-information-types

Signed-off-by: Abdul Lateef Attar <AbdulLateef.Attar@amd.com>
(cherry picked from commit 0bc238d066842101c7f65b2a4b36d26faf7f5e0d)

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Verify Build validate

## Integration Instructions

N/A