### PR TITLE
MdeModulePkg: Print unknown error code instead of asserting

### DIFF
--- a/MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThruHci.c
+++ b/MdeModulePkg/Bus/Ufs/UfsPassThruDxe/UfsPassThruHci.c
@@ -181,7 +181,7 @@ DumpUicCmdExecResult (
         DEBUG ((DEBUG_VERBOSE, "UIC configuration command fails - DME_FAILURE\n"));
         break;
       default:
-        ASSERT (FALSE);
+        DEBUG ((DEBUG_VERBOSE, "UIC configuration command fails - UNKNOWN_ERROR (0x%02x)\n", Result));
         break;
     }
   } else {
@@ -192,7 +192,7 @@ DumpUicCmdExecResult (
         DEBUG ((DEBUG_VERBOSE, "UIC control command fails - FAILURE\n"));
         break;
       default:
-        ASSERT (FALSE);
+        DEBUG ((DEBUG_VERBOSE, "UIC control command fails - UNKNOWN_ERROR (0x%02x)\n", Result));
         break;
     }
   }
@@ -241,7 +241,7 @@ DumpQueryResponseResult (
       DEBUG ((DEBUG_VERBOSE, "Query Response with General Failure\n"));
       break;
     default:
-      ASSERT (FALSE);
+      DEBUG ((DEBUG_VERBOSE, "Query Response with Unknown Error (0x%02x)\n", Result));
       break;
   }
 }


### PR DESCRIPTION
## Description

DumpUicCmdExecResult is called to dump the result of UIC commands after a failure. Depending on the nature of the failure, not all information may have been properly initialized. This is already handled in callers with existing retry logic, but the assert in the dump command can cause a crash in debug builds for due to hardware race conditions on first attempt.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Testing on internal hardware

## Integration Instructions

N/A
