### PR TITLE
[CHERRY-PICK] Fix FFA_DIRECT_REQ2 into STMM partition receiving extra bytes

### DIFF
--- a/ArmPkg/Include/Library/ArmStandaloneMmCoreEntryPoint.h
+++ b/ArmPkg/Include/Library/ArmStandaloneMmCoreEntryPoint.h
@@ -136,13 +136,13 @@ typedef struct FfaMsgInfo {
  */
 typedef struct {
   /// Service guid
-  EFI_GUID           HeaderGuid;
+  EFI_GUID        HeaderGuid;
 
   /// Length of Message. In case of misc service, sizeof (EventSvcArgs)
-  UINTN              MessageLength;
+  UINTN           MessageLength;
 
   /// Delivered register values.
-  DIRECT_MSG_ARGS    DirectMsgArgs;
+  ARM_FFA_ARGS    FfaArgs;
 } MISC_MM_COMMUNICATE_BUFFER;
 
 typedef struct {

--- a/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/ArmStandaloneMmCoreEntryPoint.c
+++ b/ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/ArmStandaloneMmCoreEntryPoint.c
@@ -757,20 +757,20 @@ SetEventCompleteSvcArgs (
         EventCompleteSvcArgs->Arg0 = ARM_FID_FFA_MSG_SEND_DIRECT_RESP2;
 
         if (FfaMsgInfo->ServiceType == ServiceTypeMisc) {
-          EventCompleteSvcArgs->Arg4  = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg0;
-          EventCompleteSvcArgs->Arg5  = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg1;
-          EventCompleteSvcArgs->Arg6  = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg2;
-          EventCompleteSvcArgs->Arg7  = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg3;
-          EventCompleteSvcArgs->Arg8  = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg4;
-          EventCompleteSvcArgs->Arg9  = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg5;
-          EventCompleteSvcArgs->Arg10 = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg6;
-          EventCompleteSvcArgs->Arg11 = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg7;
-          EventCompleteSvcArgs->Arg12 = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg8;
-          EventCompleteSvcArgs->Arg13 = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg9;
-          EventCompleteSvcArgs->Arg14 = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg10;
-          EventCompleteSvcArgs->Arg15 = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg11;
-          EventCompleteSvcArgs->Arg16 = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg12;
-          EventCompleteSvcArgs->Arg17 = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg13;
+          EventCompleteSvcArgs->Arg4  = mMiscMmCommunicateBuffer->FfaArgs.Arg4;
+          EventCompleteSvcArgs->Arg5  = mMiscMmCommunicateBuffer->FfaArgs.Arg5;
+          EventCompleteSvcArgs->Arg6  = mMiscMmCommunicateBuffer->FfaArgs.Arg6;
+          EventCompleteSvcArgs->Arg7  = mMiscMmCommunicateBuffer->FfaArgs.Arg7;
+          EventCompleteSvcArgs->Arg8  = mMiscMmCommunicateBuffer->FfaArgs.Arg8;
+          EventCompleteSvcArgs->Arg9  = mMiscMmCommunicateBuffer->FfaArgs.Arg9;
+          EventCompleteSvcArgs->Arg10 = mMiscMmCommunicateBuffer->FfaArgs.Arg10;
+          EventCompleteSvcArgs->Arg11 = mMiscMmCommunicateBuffer->FfaArgs.Arg11;
+          EventCompleteSvcArgs->Arg12 = mMiscMmCommunicateBuffer->FfaArgs.Arg12;
+          EventCompleteSvcArgs->Arg13 = mMiscMmCommunicateBuffer->FfaArgs.Arg13;
+          EventCompleteSvcArgs->Arg14 = mMiscMmCommunicateBuffer->FfaArgs.Arg14;
+          EventCompleteSvcArgs->Arg15 = mMiscMmCommunicateBuffer->FfaArgs.Arg15;
+          EventCompleteSvcArgs->Arg16 = mMiscMmCommunicateBuffer->FfaArgs.Arg16;
+          EventCompleteSvcArgs->Arg17 = mMiscMmCommunicateBuffer->FfaArgs.Arg17;
         }
       }
 
@@ -808,21 +808,9 @@ InitializeMiscMmCommunicateBuffer (
 {
   ZeroMem (Buffer, sizeof (MISC_MM_COMMUNICATE_BUFFER));
 
-  Buffer->MessageLength       = sizeof (DIRECT_MSG_ARGS);
-  Buffer->DirectMsgArgs.Arg0  = EventSvcArgs->Arg4;
-  Buffer->DirectMsgArgs.Arg1  = EventSvcArgs->Arg5;
-  Buffer->DirectMsgArgs.Arg2  = EventSvcArgs->Arg6;
-  Buffer->DirectMsgArgs.Arg3  = EventSvcArgs->Arg7;
-  Buffer->DirectMsgArgs.Arg4  = EventSvcArgs->Arg8;
-  Buffer->DirectMsgArgs.Arg5  = EventSvcArgs->Arg9;
-  Buffer->DirectMsgArgs.Arg6  = EventSvcArgs->Arg10;
-  Buffer->DirectMsgArgs.Arg7  = EventSvcArgs->Arg11;
-  Buffer->DirectMsgArgs.Arg8  = EventSvcArgs->Arg12;
-  Buffer->DirectMsgArgs.Arg9  = EventSvcArgs->Arg13;
-  Buffer->DirectMsgArgs.Arg10 = EventSvcArgs->Arg14;
-  Buffer->DirectMsgArgs.Arg11 = EventSvcArgs->Arg15;
-  Buffer->DirectMsgArgs.Arg12 = EventSvcArgs->Arg16;
-  Buffer->DirectMsgArgs.Arg13 = EventSvcArgs->Arg17;
+  Buffer->MessageLength = sizeof (DIRECT_MSG_ARGS);
+
+  CopyMem (&Buffer->FfaArgs, EventSvcArgs, sizeof (ARM_FFA_ARGS));
 
   CopyGuid (&Buffer->HeaderGuid, ServiceGuid);
 }

--- a/SecurityPkg/Tcg/Tcg2StandaloneMmArm/Tcg2StandaloneMmArm.c
+++ b/SecurityPkg/Tcg/Tcg2StandaloneMmArm/Tcg2StandaloneMmArm.c
@@ -18,11 +18,14 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <PiMm.h>
 #include <IndustryStandard/TcgPhysicalPresence.h>
 #include <Guid/TpmNvsMm.h>
+#include <Library/ArmFfaLib.h>
 #include <Library/DebugLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/MmServicesTableLib.h>
 #include <Library/StandaloneMmMemLib.h>
 #include <Library/Tcg2PhysicalPresenceLib.h>
+
+STATIC_ASSERT (sizeof (TCG_NVS) <= (sizeof (ARM_FFA_ARGS) - OFFSET_OF (ARM_FFA_ARGS, Arg4)), "TCG_NVS size is larger than direct message buffer size");
 
 /**
   This function checks if the required instance is a supported TPM 2.0 instance.
@@ -97,7 +100,7 @@ PhysicalPresenceCallback (
     return EFI_INVALID_PARAMETER;
   }
 
-  if (*CommBufferSize < sizeof (TCG_NVS)) {
+  if (*CommBufferSize < sizeof (ARM_FFA_ARGS)) {
     return EFI_INVALID_PARAMETER;
   }
 
@@ -107,7 +110,7 @@ PhysicalPresenceCallback (
   }
 
   // Enough complaints, now get to work...
-  LocalTcgNvs = (TCG_NVS *)CommBuffer;
+  LocalTcgNvs = (TCG_NVS *)((UINT8 *)CommBuffer + OFFSET_OF (ARM_FFA_ARGS, Arg4));
 
   if (LocalTcgNvs->PhysicalPresence.Parameter == TCG_ACPI_FUNCTION_RETURN_REQUEST_RESPONSE_TO_OS) {
     LocalTcgNvs->PhysicalPresence.ReturnCode = Tcg2PhysicalPresenceLibReturnOperationResponseToOsFunction (


### PR DESCRIPTION
## Description

The previous change that introduces the header from FFA_DIRECT_REQ2 calls has a side effect of injecting 4 extra arguments into MM communication buffer, causing the handler parsing the data incorrectly.

This change strip off the extra 4 arguments from the core side before handing off to the receiver.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This was tested on QEMU Arm Virt and verified the TPM PPI is functional again.

## Integration Instructions

N/A