### PR TITLE
[CHERRY-PICK] MdePkg/Acpi65|66.h: Add Generic Port Affinity structure and flags for SRAT

### DIFF
--- a/MdePkg/Include/IndustryStandard/Acpi65.h
+++ b/MdePkg/Include/IndustryStandard/Acpi65.h
@@ -793,7 +793,7 @@ typedef struct {
 
 //
 // SRAT structure types.
-// All other values between 0x06 an 0xFF are reserved and
+// All other values between 0x07 and 0xFF are reserved and
 // will be ignored by OSPM.
 //
 #define EFI_ACPI_6_5_PROCESSOR_LOCAL_APIC_SAPIC_AFFINITY  0x00
@@ -802,6 +802,7 @@ typedef struct {
 #define EFI_ACPI_6_5_GICC_AFFINITY                        0x03
 #define EFI_ACPI_6_5_GIC_ITS_AFFINITY                     0x04
 #define EFI_ACPI_6_5_GENERIC_INITIATOR_AFFINITY           0x05
+#define EFI_ACPI_6_5_GENERIC_PORT_AFFINITY                0x06
 
 ///
 /// Processor Local APIC/SAPIC Affinity Structure Definition
@@ -942,6 +943,18 @@ typedef struct {
 ///
 #define EFI_ACPI_6_5_GENERIC_INITIATOR_AFFINITY_STRUCTURE_ENABLED                     BIT0
 #define EFI_ACPI_6_5_GENERIC_INITIATOR_AFFINITY_STRUCTURE_ARCHITECTURAL_TRANSACTIONS  BIT1
+
+///
+/// Generic Port Affinity Structure
+///
+typedef EFI_ACPI_6_5_GENERIC_INITIATOR_AFFINITY_STRUCTURE EFI_ACPI_6_5_GENERIC_PORT_AFFINITY_STRUCTURE;
+
+///
+/// Generic Port Affinity Structure Flags. All other bits are reserved
+/// and must be 0.
+///
+#define EFI_ACPI_6_5_GENERIC_PORT_AFFINITY_STRUCTURE_ENABLED                     BIT0
+#define EFI_ACPI_6_5_GENERIC_PORT_AFFINITY_STRUCTURE_ARCHITECTURAL_TRANSACTIONS  BIT1
 
 ///
 /// System Locality Distance Information Table (SLIT).

--- a/MdePkg/Include/IndustryStandard/Acpi66.h
+++ b/MdePkg/Include/IndustryStandard/Acpi66.h
@@ -1043,6 +1043,18 @@ typedef struct {
 #define EFI_ACPI_6_6_GENERIC_INITIATOR_AFFINITY_STRUCTURE_ARCHITECTURAL_TRANSACTIONS  BIT1
 
 ///
+/// Generic Port Affinity Structure
+///
+typedef EFI_ACPI_6_6_GENERIC_INITIATOR_AFFINITY_STRUCTURE EFI_ACPI_6_6_GENERIC_PORT_AFFINITY_STRUCTURE;
+
+///
+/// Generic Port Affinity Structure Flags. All other bits are reserved
+/// and must be 0.
+///
+#define EFI_ACPI_6_6_GENERIC_PORT_AFFINITY_STRUCTURE_ENABLED                     BIT0
+#define EFI_ACPI_6_6_GENERIC_PORT_AFFINITY_STRUCTURE_ARCHITECTURAL_TRANSACTIONS  BIT1
+
+///
 /// System Locality Distance Information Table (SLIT).
 /// The rest of the table is a matrix.
 ///


### PR DESCRIPTION
## Description

MdePkg/Acpi65|66.h: Add Generic Port Affinity structure and flags for SRAT

(cherry picked from commit 92e662f1aa8fb167088373d16cf79b3e599a2121)


- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
