### PR TITLE
[Cherry-Pick] UefiCpuPkg MmUnblockMemoryLib: Also allow MMIO to be unblocked

### DIFF
--- a/UefiCpuPkg/Library/MmUnblockMemoryLib/MmUnblockMemoryLib.c
+++ b/UefiCpuPkg/Library/MmUnblockMemoryLib/MmUnblockMemoryLib.c
@@ -22,11 +22,11 @@
 
 /**
   This function checks if the input buffer range [UnblockBase, UnblockEnd] is unblockable.
-  The input range should be covered by the EfiRuntimeServicesData, EfiACPIMemoryNVS or
-  EfiReservedMemoryType memory allocation HOB.
+  The input range should be covered by the EfiRuntimeServicesData, EfiACPIMemoryNVS,
+  EfiReservedMemoryType or EfiMemoryMappedIO memory allocation HOB.
 
   @param[in]  HobStart                The starting HOB pointer to search from.
-  @param[in]  UnblockAddress          Base address of the range to unblock.
+  @param[in]  UnblockBase             Base address of the range to unblock.
   @param[in]  UnblockEnd              End address of the range to unblock.
 
   @retval RETURN_SUCCESS              The range is unblockable.
@@ -50,11 +50,12 @@ MmUnblockMemoryLibIsUnblockableRegion (
               MemoryAllocationHob->AllocDescriptor.MemoryLength;
     if ((UnblockBase < HobEnd) && (UnblockEnd > HobBase)) {
       //
-      // The overlapped memory allocation HOB type must be one of the three specific types.
+      // The overlapped memory allocation HOB type must be one of the four specific types.
       //
       if ((MemoryAllocationHob->AllocDescriptor.MemoryType != EfiRuntimeServicesData) &&
           (MemoryAllocationHob->AllocDescriptor.MemoryType != EfiACPIMemoryNVS) &&
-          (MemoryAllocationHob->AllocDescriptor.MemoryType != EfiReservedMemoryType))
+          (MemoryAllocationHob->AllocDescriptor.MemoryType != EfiReservedMemoryType) &&
+          (MemoryAllocationHob->AllocDescriptor.MemoryType != EfiMemoryMappedIO))
       {
         DEBUG ((DEBUG_ERROR, "Error: range [0x%lx, 0x%lx] to unblock contains invalid type memory\n", UnblockBase, UnblockEnd));
         return RETURN_INVALID_PARAMETER;


### PR DESCRIPTION
## Description

UefiCpuPkg MmUnblockMemoryLib: Also allow MMIO to be unblocked
This patch updates MmUnblockMemoryLib to also allow MMIO to be unblocked to be accessed from inside MM.

(cherry picked from commit a9d85a19b0e93432ed8af2002eb0278ce4f07a13)


- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
