### PR TITLE
[CHERRY-PICK] Include British English Dictionary [Rebase & FF]

### DIFF
--- a/.pytool/Plugin/SpellCheck/cspell.base.yaml
+++ b/.pytool/Plugin/SpellCheck/cspell.base.yaml
@@ -6,9 +6,9 @@
 ##
 {
     "version": "0.1",
-    "language": "en",
+    "language": "en,en-GB",
     "dictionaries": [
-        "companies ",
+        "companies",
         "softwareTerms",
         "python",
         "cpp"

--- a/ArmPkg/Drivers/CpuDxe/AArch64/Mmu.c
+++ b/ArmPkg/Drivers/CpuDxe/AArch64/Mmu.c
@@ -167,7 +167,7 @@ GetFirstPageAttribute (
 
 /**
   This function recursively traverses the translation table heirarchy to
-  synchronize the GCD with the translation table.  # MU_CHANGE: Fix typo
+  synchronise the GCD with the translation table.
 
   @param[in]        TableAddress        The address of the table being processed.
   @param[in]        EntryCount          The number of entries in the current level of the table.


### PR DESCRIPTION
## Description

The last remaining change in a typo fix commit in `ArmPkg` just had the British spelling of "synchronize". That was addressed in edk2 by including the `en-GB` dictionary, in addition to the US English dictionary, also preventing similar words from being recognized as typos.

---

**[CHERRY-PICK] .pytool: Include the British English dictionary**

Prevent British English words from being flagged as spelling errors.

---

**Revert "ArmPkg: Fix recent typos" (due to edk2 cherry-pick)**

This reverts commit 8e2f868 as it is no longer needed after a
different approach was taken to more comprehensively prevent the
typo from being recognized in the first place by including the British
English dictionary introduced in edk2 commit 58e8828.

---

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Run SpellCheck plugin before and after the change

## Integration Instructions

- N/A