### PR TITLE
[REBASE & FF] Revert EFI_SW_DXE_CORE_EC_IMAGE_LOAD_FAILURE

### DIFF
--- a/MdeModulePkg/Core/Dxe/Image/Image.c
+++ b/MdeModulePkg/Core/Dxe/Image/Image.c
@@ -1493,7 +1493,10 @@ CoreLoadImageCommon (
     }
   }
 
-  ProtectUefiImage (&Image->Info, Image->LoadedImageDevicePath);
+  Status = ProtectUefiImage (&Image->Info, Image->LoadedImageDevicePath);
+  if (EFI_ERROR (Status)) {
+    goto Done;
+  }
 
   //
   // Success.  Return the image handle

--- a/MdeModulePkg/Core/Dxe/Image/Image.c
+++ b/MdeModulePkg/Core/Dxe/Image/Image.c
@@ -275,20 +275,7 @@ CoreInitializeImageServices (
 
   InitializeListHead (&mAvailableEmulators);
 
-  // MU_CHANGE START Use Image Failure Status Code
-  Status = ProtectUefiImage (&Image->Info, Image->LoadedImageDevicePath);
-
-  // Omit EFI_NOT_READY as it just implies gCPU is not yet installed
-  Status = (Status == EFI_NOT_READY) ? EFI_SUCCESS : Status;
-
-  if (EFI_ERROR (Status)) {
-    REPORT_STATUS_CODE (
-      EFI_ERROR_CODE | EFI_ERROR_MAJOR,
-      (EFI_SOFTWARE_DXE_CORE | EFI_SW_DXE_CORE_EC_IMAGE_LOAD_FAILURE)
-      );
-  }
-
-  // MU_CHANGE END
+  ProtectUefiImage (&Image->Info, Image->LoadedImageDevicePath);
 
   return Status;
 }
@@ -1506,17 +1493,7 @@ CoreLoadImageCommon (
     }
   }
 
-  // MU_CHANGE START Use enhanced ProtectUefiImage
-  Status = ProtectUefiImage (&Image->Info, Image->LoadedImageDevicePath);
-
-  // Set to unload if ProtectUefiImage returned an error other than EFI_NOT_READY
-  // which implies the CPU Arch Protocol has not yet been installed
-  Status = (Status == EFI_NOT_READY) ? EFI_SUCCESS : Status;
-  if (EFI_ERROR (Status)) {
-    goto Done;
-  }
-
-  // MU_CHANGE END
+  ProtectUefiImage (&Image->Info, Image->LoadedImageDevicePath);
 
   //
   // Success.  Return the image handle

--- a/MdePkg/Include/Pi/PiStatusCode.h
+++ b/MdePkg/Include/Pi/PiStatusCode.h
@@ -1039,8 +1039,7 @@ typedef struct {
 /// Software Class DXE Foundation Subclass Error Code definitions.
 ///
 ///@{
-#define EFI_SW_DXE_CORE_EC_NO_ARCH             (EFI_SUBCLASS_SPECIFIC | 0x00000000)
-#define EFI_SW_DXE_CORE_EC_IMAGE_LOAD_FAILURE  (EFI_SUBCLASS_SPECIFIC | 0x00000001)    // MU_CHANGE
+#define EFI_SW_DXE_CORE_EC_NO_ARCH  (EFI_SUBCLASS_SPECIFIC | 0x00000000)
 ///@}
 
 ///


### PR DESCRIPTION
## Description

EFI_SW_DXE_CORE_EC_IMAGE_LOAD_FAILURE is an unused Mu only status code. Revert the commits adding it.

One of the commits had functionality that should have been part of 9eaaa57a24363b324611d58dd3f7c18d24b90781, so it is added as a squash on rebase commit. ProtectUefiImage does not actually return EFI_NOT_READY when the CPU Arch protocol is not installed, so that logic is dropped.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A.

## Integration Instructions

N/A.
