### PR TITLE
BaseTools/UefiVarPatcher: Patch all ROMs in OUTPUT_ROM for all build variants

### DIFF
--- a/BaseTools/Plugin/UefiVarPatcher/UefiVarPatcher.py
+++ b/BaseTools/Plugin/UefiVarPatcher/UefiVarPatcher.py
@@ -107,27 +107,27 @@ class UefiVarPatcher(IUefiBuildPlugin):
                 + int(builder.env.GetValue("FLASH_REGION_NVSTORAGE_OFFSET"), 16)
             )
 
-        # Load the variable store from the file.
-        var_store = VarStore.VariableStore(
-            out_rom,
-            store_base=var_store_rom_offset,
-            store_size=int(builder.env.GetValue("FLASH_REGION_NVSTORAGE_SIZE"), 16),
-        )
+            # Load the variable store from the file.
+            var_store = VarStore.VariableStore(
+                out_rom,
+                store_base=var_store_rom_offset,
+                store_size=int(builder.env.GetValue("FLASH_REGION_NVSTORAGE_SIZE"), 16),
+            )
 
-        # Print information about the current variables.
-        for var in var_store.variables:
-            if var.State == VF.VAR_ADDED:
-                print(f"Var Found: '{var.VendorGuid}:{var.Name}'")
+            # Print information about the current variables.
+            for var in var_store.variables:
+                if var.State == VF.VAR_ADDED:
+                    print(f"Var Found: '{var.VendorGuid}:{var.Name}'")
 
-        # Attempt to load the set script file.
-        set_vars = load_variable_xml(built_in_vars_xml_path)
+            # Attempt to load the set script file.
+            set_vars = load_variable_xml(built_in_vars_xml_path)
 
-        # Attempt to patch existing variables in the var store.
-        create_vars = patch_variables(set_vars, var_store)
+            # Attempt to patch existing variables in the var store.
+            create_vars = patch_variables(set_vars, var_store)
 
-        # If we had variables we were unable to update, let's create them now.
-        create_variables(create_vars, var_store)
+            # If we had variables we were unable to update, let's create them now.
+            create_variables(create_vars, var_store)
 
-        var_store.flush_to_file()
+            var_store.flush_to_file()
 
         return 0


### PR DESCRIPTION
## Description

`UefiVarPatcher.do_post_build` accepts a semicolon-delimited list of ROM images
in `OUTPUT_ROM` and is expected to inject the platform's built-in variables
(`BuiltInVars.xml`) into the NV variable store of **each** ROM.

However, only the per-ROM existence check and varstore-offset calculation were
inside the `for out_rom in out_roms:` loop. The code that actually loads the
variable store, patches/creates the variables, and flushes it back to disk was
dedented **outside** the loop. With current code, if I have 3 different build variants A/B/C, the var ROM will only be patched into the C.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Tested with real hardware, now all builds will have the var ROM.