### PR TITLE
[dev/PQC] Add Image Secure Boot Verification Result Table

### DIFF
--- a/SecurityPkg/Include/Guid/ImageSecureBootVerificationResultTable.h
+++ b/SecurityPkg/Include/Guid/ImageSecureBootVerificationResultTable.h
@@ -1,0 +1,183 @@
+/** @file
+  Image Secure Boot Verification Result Table (IVRT) layout and structure definitions.
+
+  This configuration table records the outcome of DXE Secure Boot image
+  verification for every image that runs the full verification path, both
+  approved and rejected. This table fully describes the image and it's
+  evaluated signature(s) so that a consumer can determine the reason for
+  approval or rejection.
+
+  The table is a three-tier, self-describing structure:
+
+    EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE
+      +-- EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT
+      |     ImageStatus
+      |     ImageDigestAlgorithm
+      |     Name[]
+      |     DevicePath
+      |     +-- EFI_SIGNATURE_VERIFICATION_RESULT (per evaluated WIN_CERTIFICATE)
+      |          +-- Signature Index
+      |          +-- Verification Status
+      |          +-- ThumbprintAlgorithm
+      |          +-- Thumbprint[]
+      |     +-- EFI_SIGNATURE_VERIFICATION_RESULT
+      |     +-- ...
+      +-- EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT
+      +-- ...
+
+    Each entry (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT) describes one image that was
+    evaluated. Each entry will always contain the approval status of the image
+    and the device path. The name will be present if available, or NULL. If the
+    image status is a digest-based approval or rejection, the ImageDigestAlgorithm
+    field will contain the matching algorithm. Finally, each entry will contain
+    zero or more EFI_SIGNATURE_VERIFICATION_RESULT records. Each one represents
+    the evaluation of a single WIN_CERTIFICATE in the image's certificate table.
+    Note that the number of entries is not indicitive of the number of
+    signatures in the image due to how the image is processed.
+
+    Each EFI_SIGNATURE_VERIFICATION_RESULT record describes the outcome of evaluating
+    a single WIN_CERTIFICATE. The Signature Index matches the index of the WIN_CERTIFICATE
+    in the image's certificate table while the Status field describes the outcome of the
+    evaluation. The thumbprint is the TBS-cert hash of the certificate that drove the
+    approval or rejection decision from either the DB or DBX. If no certificate in the
+    signer's chain matched a DB entry, the thumbprint is not present and the
+    ThumbprintAlgorithm is the zero GUID.
+
+  Copyright (C) Microsoft Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_H_
+#define EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_H_
+
+#include <Uefi.h>
+
+///
+/// GUID that identifies the Image Secure Boot Verification Result Table (IVRT)
+/// when it is installed as a UEFI configuration table (gST->ConfigurationTable).
+///
+#define EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_GUID \
+  { 0x5ee66bd4, 0x895d, 0x421d, { 0x80, 0x05, 0x3a, 0x0c, 0x6b, 0x55, 0x18, 0xa1 } }
+
+extern EFI_GUID  gEfiImageSecureBootVerificationResultTableGuid;
+
+///
+/// Table signature ('IVRT') and current layout version.
+///
+#define EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_SIGNATURE  SIGNATURE_32 ('I', 'V', 'R', 'T')
+#define EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_VERSION    0x00010000
+
+// ***************************************************************************
+// Per-image status
+// ***************************************************************************
+
+#define EFI_IMAGE_VERIFICATION_STATUS_AUTHORIZED_BY_DIGEST     0x00000001 // Image digest is in db and not revoked by dbx.
+#define EFI_IMAGE_VERIFICATION_STATUS_AUTHORIZED_BY_AUTHORITY  0x00000002 // A signature chained to an unrevoked authority in the db.
+
+//
+// Rejections (bit 31 set).
+//
+#define EFI_IMAGE_VERIFICATION_STATUS_REJECTED_MALFORMED     0x80000001 // The image PE/COFF headers could not be parsed.
+#define EFI_IMAGE_VERIFICATION_STATUS_REJECTED_BY_DIGEST     0x80000002 // The image digest is in the dbx.
+#define EFI_IMAGE_VERIFICATION_STATUS_REJECTED_NO_AUTHORITY  0x80000003 // No signature chained to an unrevoked db authority.
+
+// ***************************************************************************
+// Per-signature status
+// ***************************************************************************
+
+///
+/// Outcome for a single evaluated WIN_CERTIFICATE.
+///
+/// A signer's chain is the set of certificates from the signer to the root CA.
+/// A certificate found in db is treated as the trust anchor for that chain; only
+/// certificates in the chain between the signer and that anchor are checked
+/// against dbx to decide whether the signature is authorized or revoked.
+///
+///                 | Full X.509 certificate           | Precomputed TBS-cert hash
+///   --------------+----------------------------------+------------------------------
+///     db (allow)  | CERTIFICATE_AUTHORITY            | TBS_HASH_AUTHORITY
+///    dbx (revoke) | AUTHORITY_REVOKED_BY_CERTIFICATE | AUTHORITY_REVOKED_BY_TBS_HASH
+///
+
+#define EFI_SIGNATURE_VERIFICATION_CERTIFICATE_AUTHORITY  0x00000001 // A certificate in the signer's chain was found in the db and was not revoked by the dbx.
+#define EFI_SIGNATURE_VERIFICATION_TBS_HASH_AUTHORITY     0x00000002 // A db TBS-cert hash derived from a certificate in the signer's chain was found in the db and was not revoked by the dbx.
+
+//
+// Rejections (bit 31 set).
+//
+#define EFI_SIGNATURE_VERIFICATION_MALFORMED                         0x80000000 // Payload unparseable or hash unsupported.
+#define EFI_SIGNATURE_VERIFICATION_AUTHORITY_REVOKED_BY_CERTIFICATE  0x80000001 // db authority existed, but a cert between the signer and that authority was in the dbx.
+#define EFI_SIGNATURE_VERIFICATION_AUTHORITY_REVOKED_BY_TBS_HASH     0x80000002 // db authority existed, but a TBS-cert hash derived from a cert between the signer and that authority was in the dbx.
+#define EFI_SIGNATURE_VERIFICATION_REJECTED_NO_AUTHORITY             0x80000003 // No db authority in the signer's chain.
+
+// ***************************************************************************
+// Structures
+// ***************************************************************************
+
+///
+/// Result for one evaluated WIN_CERTIFICATE within an image.
+///
+/// When the status code is one of the following, the contents of `Thumbprint` is as follows:
+///   - CERTIFICATE_AUTHORITY: TBS hash of the certificate in the signer's chain that matched a db entry.
+///   - TBS_HASH_AUTHORITY: TBS hash found in the db that was derived from a certificate in the signer's chain.
+///   - AUTHORITY_REVOKED_BY_CERTIFICATE: TBS hash of the certificate in the signer's chain between the signer and the authority that was found in the dbx.
+///   - AUTHORITY_REVOKED_BY_TBS_HASH: TBS hash found in the dbx that was derived from a certificate in the signer's chain between the signer and the authority that was found in the db.
+///   - REJECTED_NO_AUTHORITY: No certificate or TBS hash derived from a certificate in the signer's chain was found in the db, so no thumbprint is present.
+///   - MALFORMED: none; algorithm is the zero GUID.
+///
+typedef struct {
+  UINT32      Length;                // Total size of this record, including the trailing thumbprint.
+  UINT32      SignatureIndex;        // 0-based ordinal of this WIN_CERTIFICATE within the image.
+  UINT32      Status;                // EFI_SIGNATURE_VERIFICATION_* outcome for this WIN_CERTIFICATE.
+  EFI_GUID    ThumbprintAlgorithm;   // Digest algorithm of the trailing thumbprint (zero GUID if none).
+  // UINT8    Thumbprint[];          // TBS-cert hash of the decisive certificate (see notes above).
+} EFI_SIGNATURE_VERIFICATION_RESULT;
+
+///
+/// Overall result for one image.
+///
+/// ImageStatus reflects if the image was approved or rejected, and the generic
+/// reason for that decision (See EFI_IMAGE_VERIFICATION_STATUS_*).
+///
+/// If the image was approved or rejected by a digest match, ImageDigestAlgorithm
+/// contains the algorithm used to compute the image's hash that matched either
+/// the DB or DBX. Otherwise, ImageDigestAlgorithm is the zero GUID.
+///
+/// The payload that trails the fixed header is, in order:
+///   1. Name          - NameLength bytes. A NUL-terminated CHAR16 string, or absent
+///                      (NameLength == 0) when no user-friendly name was available.
+///   2. DevicePath    - DevicePathLength bytes. The self-terminating device path of
+///                      the image. Always present (DevicePathLength != 0).
+///   3. Signatures[]  - NumberOfSignatures self-sized EFI_SIGNATURE_VERIFICATION_RESULT
+///                      records, one per evaluated WIN_CERTIFICATE.
+///
+/// The Signatures[] array begins at
+/// (UINT8 *)Record + sizeof (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT) + NameLength + DevicePathLength.
+///
+typedef struct {
+  UINT32      Length;                // Total size of this record, including Name, DevicePath, Signatures[].
+  UINT32      ImageStatus;           // EFI_IMAGE_VERIFICATION_STATUS_*.
+  UINT32      NumberOfSignatures;    // Count of trailing EFI_SIGNATURE_VERIFICATION_RESULT records.
+  UINT32      NameLength;            // Size of the trailing Name in bytes (including NUL), or 0 if absent.
+  UINT32      DevicePathLength;      // Size of the trailing DevicePath in bytes (including end-of-path node).
+  EFI_GUID    ImageDigestAlgorithm;  // Matching algorithm for *_IMAGE_DIGEST outcomes; zero GUID otherwise.
+  // CHAR16                             Name[];        // NameLength bytes.
+  // EFI_DEVICE_PATH_PROTOCOL           DevicePath;    // DevicePathLength bytes.
+  // EFI_SIGNATURE_VERIFICATION_RESULT  Signatures[];  // NumberOfSignatures self-sized records.
+} EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT;
+
+///
+/// The configuration table.
+///
+/// A fixed header followed by a variable number of EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT
+/// records (one per evaluated image).
+///
+typedef struct {
+  UINT32    Signature;               // EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_SIGNATURE ('IVRT').
+  UINT32    Version;                 // EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_VERSION.
+  UINT32    Length;                  // Total table size in bytes, including all image records.
+  UINT32    NumberOfImages;          // Count of EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT records that follow.
+  // EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT  Images[];  // NumberOfImages records, each self-sized.
+} EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE;
+
+#endif // EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_H_

--- a/SecurityPkg/Include/Library/ImageSecureBootVerificationResultTableLib.h
+++ b/SecurityPkg/Include/Library/ImageSecureBootVerificationResultTableLib.h
@@ -92,12 +92,12 @@ ImageVerificationResultCreateImage (
 EFI_STATUS
 EFIAPI
 ImageVerificationResultAppendSignature (
-  IN OUT VOID           **Image,
-  IN     UINT32         SignatureIndex,
-  IN     UINT32         Status,
+  IN OUT VOID            **Image,
+  IN     UINT32          SignatureIndex,
+  IN     UINT32          Status,
   IN     CONST EFI_GUID  *ThumbprintAlgorithm OPTIONAL,
   IN     CONST VOID      *Thumbprint OPTIONAL,
-  IN     UINTN          ThumbprintSize
+  IN     UINTN           ThumbprintSize
   );
 
 /**

--- a/SecurityPkg/Include/Library/ImageSecureBootVerificationResultTableLib.h
+++ b/SecurityPkg/Include/Library/ImageSecureBootVerificationResultTableLib.h
@@ -1,0 +1,195 @@
+/** @file
+  Build and iterate the Image Secure Boot Verification Result Table (IVRT).
+
+  This library provides functionality for building an Image Secure Boot Verification
+  Result Table (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE) and iterating over
+  the contents of an existing table. The table is defined in
+  <Guid/ImageSecureBootVerificationResultTable.h>.
+
+  == Builder ==
+
+    VOID  *Image;
+
+    ImageVerificationResultCreateImage (Name, DevicePath, DevicePathSize, &Image);
+    ImageVerificationResultAppendSignature (&Image, ...);   // once per evaluated signature
+
+    // OldTable is an existing table, or NULL to create the table. Sizes live in
+    // the table headers, so none are passed (the new size is NewTable->Length).
+    ImageVerificationResultAppendImage (
+      OldTable, Image, ImageStatus, DigestAlgorithm, &NewTable);
+
+    FreePool (Image);
+    FreePool (OldTable);
+
+  == Iterator ==
+
+    ImageVerificationResultIteratorInit (&Iter, Table);
+    while ((Image = ImageVerificationResultIteratorNextImage (&Iter)) != NULL) {
+      // ... consume Image ...
+      while ((Sig = ImageVerificationResultIteratorNextSignature (&Iter)) != NULL) {
+        // ... consume Sig (a signature of Image) ...
+      }
+    }
+
+  Copyright (C) Microsoft Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_LIB_H_
+#define IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_LIB_H_
+
+#include <Uefi.h>
+#include <Guid/ImageSecureBootVerificationResultTable.h>
+
+/**
+  Allocate an image record from its identity (name and device path).
+
+  Returns a self-describing EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT allocation
+  with zero signatures; the overall status is supplied later, to
+  ImageVerificationResultAppendImage().
+
+  Caller is responsible for freeing Image with FreePool().
+
+  @param[in]   Name            Optional NUL-terminated CHAR16 image name; NULL for none.
+  @param[in]   DevicePath      The image's device path bytes. Required.
+  @param[in]   DevicePathSize  Size of DevicePath in bytes, including its end-of-path node.
+  @param[out]  Image           On success, the newly allocated image record. Free with FreePool().
+
+  @retval EFI_SUCCESS            The image record was allocated.
+  @retval EFI_INVALID_PARAMETER  Image or DevicePath is NULL, or DevicePathSize is 0.
+  @retval EFI_BAD_BUFFER_SIZE    The resulting record would exceed a UINT32 size field.
+  @retval EFI_OUT_OF_RESOURCES   The record could not be allocated.
+**/
+EFI_STATUS
+EFIAPI
+ImageVerificationResultCreateImage (
+  IN  CONST CHAR16  *Name OPTIONAL,
+  IN  CONST VOID    *DevicePath,
+  IN  UINTN         DevicePathSize,
+  OUT VOID          **Image
+  );
+
+/**
+  Grow an image record by one evaluated signature.
+
+  Reallocates *Image a signature larger and appends the signature at its tail. On
+  failure *Image is left unchanged (and still valid). Signatures are appended in
+  evaluation order.
+
+  @param[in,out]  Image                The image record to extend (from CreateImage). Updated in place.
+  @param[in]      SignatureIndex       0-based ordinal of the WIN_CERTIFICATE within the image.
+  @param[in]      Status               EFI_SIGNATURE_VERIFICATION_* outcome for the signature.
+  @param[in]      ThumbprintAlgorithm  Optional digest algorithm of Thumbprint; NULL => zero GUID.
+  @param[in]      Thumbprint           Optional decisive-cert TBS-cert hash; NULL => none.
+  @param[in]      ThumbprintSize       Bytes of Thumbprint; must be 0 iff Thumbprint is NULL.
+
+  @retval EFI_SUCCESS            The signature was appended.
+  @retval EFI_INVALID_PARAMETER  Image or *Image is NULL, or the Thumbprint / ThumbprintSize /
+                                 ThumbprintAlgorithm arguments are inconsistent.
+  @retval EFI_BAD_BUFFER_SIZE    The resulting record would exceed a UINT32 size field.
+  @retval EFI_OUT_OF_RESOURCES   The record could not be grown.
+**/
+EFI_STATUS
+EFIAPI
+ImageVerificationResultAppendSignature (
+  IN OUT VOID           **Image,
+  IN     UINT32         SignatureIndex,
+  IN     UINT32         Status,
+  IN     CONST EFI_GUID  *ThumbprintAlgorithm OPTIONAL,
+  IN     CONST VOID      *Thumbprint OPTIONAL,
+  IN     UINTN          ThumbprintSize
+  );
+
+/**
+  Append an image record to a copy of an existing table or creates a new table if OldTable is NULL.
+
+  Caller is responsible for freeing NewTable with FreePool().
+
+  @param[in]   OldTable             Optional currently installed table to extend; NULL for a fresh table.
+  @param[in]   Image                The image record to append (from CreateImage / AppendSignature).
+  @param[in]   ImageStatus          EFI_IMAGE_VERIFICATION_STATUS_* outcome for the image.
+  @param[in]   ImageDigestAlgorithm Optional matching digest algorithm; NULL => zero GUID.
+  @param[out]  NewTable             On success, the newly allocated table. Free with FreePool().
+
+  @retval EFI_SUCCESS            The image was appended and NewTable was produced.
+  @retval EFI_INVALID_PARAMETER  Image or NewTable is NULL, or OldTable is non-NULL but not a
+                                 valid table.
+  @retval EFI_BAD_BUFFER_SIZE    The resulting table would exceed the UINT32 Length / image count.
+  @retval EFI_OUT_OF_RESOURCES   The new table could not be allocated.
+**/
+EFI_STATUS
+EFIAPI
+ImageVerificationResultAppendImage (
+  IN  CONST VOID                                       *OldTable OPTIONAL,
+  IN  CONST VOID                                       *Image,
+  IN  UINT32                                           ImageStatus,
+  IN  CONST EFI_GUID                                   *ImageDigestAlgorithm OPTIONAL,
+  OUT EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE  **NewTable
+  );
+
+///
+/// Two-level forward-only iterator over an IVRT.
+///
+/// Fields are owned by the library implementation; callers should treat them as
+/// opaque and only manipulate them through the iterator routines below.
+///
+typedef struct {
+  CONST UINT8    *NextImageRecord;        // Next image record to return.
+  UINTN          ImagesRemaining;         // Valid images left in the top-level range.
+  CONST UINT8    *NextSignatureRecord;    // Next signature record of the current image.
+  UINTN          SignaturesRemaining;     // Signatures left in the current image.
+} IMAGE_VERIFICATION_RESULT_ITERATOR;
+
+/**
+  Initialize an iterator over an IVRT and validate its structure.
+
+  The table is validated here, so that the different iteration routines can be
+  infallible over the valid prefix. During initialization, the structure is
+  walked, and if any record fails to parse, the iteration range is truncated to
+  the last valid record. The TRUE / FALSE return indicates whether the entire
+  table was valid or not.
+
+  @param[out]  Iterator   Iterator state to initialize.
+  @param[in]   Table      The table buffer to walk, or NULL for an empty iterator.
+
+  @retval TRUE   The iterator covers every image and signature in the table.
+  @retval FALSE  The range was truncated (a malformed record was dropped) or the inputs were
+                 unusable (bad signature/version, or an inconsistent length). The exposed
+                 iterator is still safe to use and covers the valid prefix.
+**/
+BOOLEAN
+EFIAPI
+ImageVerificationResultIteratorInit (
+  OUT IMAGE_VERIFICATION_RESULT_ITERATOR  *Iterator,
+  IN  CONST VOID                          *Table
+  );
+
+/**
+  Return the next image result and reset the inner signature cursor to it.
+
+  @param[in,out]  Iterator  An initialized iterator.
+
+  @retval non-NULL  Pointer to the next EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT.
+  @retval NULL      Iteration over the images is complete.
+**/
+CONST EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *
+EFIAPI
+ImageVerificationResultIteratorNextImage (
+  IN OUT IMAGE_VERIFICATION_RESULT_ITERATOR  *Iterator
+  );
+
+/**
+  Return the next signature result for the current image.
+
+  @param[in,out]  Iterator  An initialized iterator.
+
+  @retval non-NULL  Pointer to the next EFI_SIGNATURE_VERIFICATION_RESULT of the current image.
+  @retval NULL      The current image has no more signatures (or no image is selected).
+**/
+CONST EFI_SIGNATURE_VERIFICATION_RESULT *
+EFIAPI
+ImageVerificationResultIteratorNextSignature (
+  IN OUT IMAGE_VERIFICATION_RESULT_ITERATOR  *Iterator
+  );
+
+#endif // IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_LIB_H_

--- a/SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/GoogleTest/BuilderGoogleTest.cpp
+++ b/SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/GoogleTest/BuilderGoogleTest.cpp
@@ -230,6 +230,7 @@ TEST (AppendImageTest, NullOldTable_ProducesSingleImageTable) {
   const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT  *Rec =
     (const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)((const UINT8 *)Table +
                                                         sizeof (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE));
+
   EXPECT_EQ (Rec->ImageStatus, (UINT32)EFI_IMAGE_VERIFICATION_STATUS_AUTHORIZED_BY_DIGEST);
   EXPECT_EQ (Rec->NameLength, (UINT32)StrSize (kName));
   EXPECT_EQ (0, memcmp (&Rec->ImageDigestAlgorithm, &kSha256, sizeof (EFI_GUID)));
@@ -307,9 +308,9 @@ TEST (WriteRoundTripTest, TwoImagesWithSignatures) {
   EXPECT_EQ (Table->NumberOfImages, 2u);
 
   // Walk it back and confirm the structure round-trips cleanly.
-  IMAGE_VERIFICATION_RESULT_ITERATOR                       Iter;
-  const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT         *Rec;
-  const EFI_SIGNATURE_VERIFICATION_RESULT                 *Sig;
+  IMAGE_VERIFICATION_RESULT_ITERATOR               Iter;
+  const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT  *Rec;
+  const EFI_SIGNATURE_VERIFICATION_RESULT          *Sig;
 
   EXPECT_TRUE (ImageVerificationResultIteratorInit (&Iter, Table));
 

--- a/SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/GoogleTest/BuilderGoogleTest.cpp
+++ b/SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/GoogleTest/BuilderGoogleTest.cpp
@@ -1,0 +1,358 @@
+/** @file
+  Unit tests for the ImageSecureBootVerificationResultTableLib write side:
+  ImageVerificationResultCreateImage / AppendSignature / AppendImage.
+
+  Copyright (C) Microsoft Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/GoogleTestLib.h>
+
+#include <vector>
+#include <cstring>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Library/BaseLib.h>
+  #include <Library/BaseMemoryLib.h>
+  #include <Library/MemoryAllocationLib.h>
+  #include <Library/ImageSecureBootVerificationResultTableLib.h>
+}
+
+//
+// GoogleTest entry point for the whole suite (both source files link into one
+// host application).
+//
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  testing::InitGoogleTest (&argc, argv);
+  return RUN_ALL_TESTS ();
+}
+
+// ---------------------------------------------------------------------------
+// Shared test data.
+// ---------------------------------------------------------------------------
+
+// A minimal "End Entire" device path node (type 0x7F, subtype 0xFF, length 4).
+static const UINT8  kDevicePath[] = { 0x7F, 0xFF, 0x04, 0x00 };
+
+// CHAR16 image name built from ints (host CHAR16 is 2 bytes; never use L"...").
+static const CHAR16  kName[] = { 'I', 'm', 'g', 0 };
+
+static const EFI_GUID  kSha256 = {
+  0x51aa59de, 0xfdf2, 0x4ea3, { 0xbc, 0x63, 0x87, 0x5f, 0xb7, 0x84, 0x2e, 0xe9 }
+};
+
+static const UINT8  kThumbprint[] = {
+  0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+  0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
+};
+
+// Read an image record's fixed header (a plain pool allocation is 8-aligned).
+static const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *
+AsImage (
+  const VOID  *Image
+  )
+{
+  return (const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)Image;
+}
+
+// ---------------------------------------------------------------------------
+// CreateImage
+// ---------------------------------------------------------------------------
+
+TEST (CreateImageTest, NullImageOut_ReturnsInvalidParameter) {
+  EXPECT_EQ (
+    ImageVerificationResultCreateImage (NULL, kDevicePath, sizeof (kDevicePath), NULL),
+    EFI_INVALID_PARAMETER
+    );
+}
+
+TEST (CreateImageTest, NullDevicePath_ReturnsInvalidParameter) {
+  VOID  *Image = NULL;
+
+  EXPECT_EQ (ImageVerificationResultCreateImage (NULL, NULL, 4, &Image), EFI_INVALID_PARAMETER);
+}
+
+TEST (CreateImageTest, ZeroDevicePathSize_ReturnsInvalidParameter) {
+  VOID  *Image = NULL;
+
+  EXPECT_EQ (ImageVerificationResultCreateImage (NULL, kDevicePath, 0, &Image), EFI_INVALID_PARAMETER);
+}
+
+TEST (CreateImageTest, DevicePathSizeOverflow_ReturnsBadBufferSize) {
+  VOID  *Image = NULL;
+
+  EXPECT_EQ (
+    ImageVerificationResultCreateImage (NULL, kDevicePath, (UINTN)MAX_UINT32, &Image),
+    EFI_BAD_BUFFER_SIZE
+    );
+}
+
+TEST (CreateImageTest, PopulatesHeader) {
+  VOID  *Image = NULL;
+
+  ASSERT_EQ (
+    ImageVerificationResultCreateImage (kName, kDevicePath, sizeof (kDevicePath), &Image),
+    EFI_SUCCESS
+    );
+
+  // Name and device path are recorded up front; status is stamped later.
+  EXPECT_EQ (AsImage (Image)->NumberOfSignatures, 0u);
+  EXPECT_EQ (AsImage (Image)->NameLength, (UINT32)StrSize (kName));
+  EXPECT_EQ (AsImage (Image)->DevicePathLength, (UINT32)sizeof (kDevicePath));
+  EXPECT_EQ (AsImage (Image)->ImageStatus, 0u);
+  EXPECT_EQ (
+    AsImage (Image)->Length,
+    (UINT32)(sizeof (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT) + StrSize (kName) + sizeof (kDevicePath))
+    );
+
+  FreePool (Image);
+}
+
+// ---------------------------------------------------------------------------
+// AppendSignature
+// ---------------------------------------------------------------------------
+
+TEST (AppendSignatureTest, NullImage_ReturnsInvalidParameter) {
+  VOID  *Image = NULL;
+
+  EXPECT_EQ (
+    ImageVerificationResultAppendSignature (NULL, 0, EFI_SIGNATURE_VERIFICATION_CERTIFICATE_AUTHORITY, NULL, NULL, 0),
+    EFI_INVALID_PARAMETER
+    );
+  EXPECT_EQ (
+    ImageVerificationResultAppendSignature (&Image, 0, EFI_SIGNATURE_VERIFICATION_CERTIFICATE_AUTHORITY, NULL, NULL, 0),
+    EFI_INVALID_PARAMETER
+    );
+}
+
+TEST (AppendSignatureTest, ThumbprintWithoutSize_ReturnsInvalidParameter) {
+  VOID  *Image = NULL;
+
+  ASSERT_EQ (ImageVerificationResultCreateImage (NULL, kDevicePath, sizeof (kDevicePath), &Image), EFI_SUCCESS);
+  EXPECT_EQ (
+    ImageVerificationResultAppendSignature (&Image, 0, EFI_SIGNATURE_VERIFICATION_CERTIFICATE_AUTHORITY, &kSha256, kThumbprint, 0),
+    EFI_INVALID_PARAMETER
+    );
+  FreePool (Image);
+}
+
+TEST (AppendSignatureTest, SizeWithoutThumbprint_ReturnsInvalidParameter) {
+  VOID  *Image = NULL;
+
+  ASSERT_EQ (ImageVerificationResultCreateImage (NULL, kDevicePath, sizeof (kDevicePath), &Image), EFI_SUCCESS);
+  EXPECT_EQ (
+    ImageVerificationResultAppendSignature (&Image, 0, EFI_SIGNATURE_VERIFICATION_CERTIFICATE_AUTHORITY, NULL, NULL, sizeof (kThumbprint)),
+    EFI_INVALID_PARAMETER
+    );
+  FreePool (Image);
+}
+
+TEST (AppendSignatureTest, ExtendsImage) {
+  VOID  *Image = NULL;
+
+  ASSERT_EQ (ImageVerificationResultCreateImage (NULL, kDevicePath, sizeof (kDevicePath), &Image), EFI_SUCCESS);
+
+  UINT32  LengthBefore = AsImage (Image)->Length;
+
+  ASSERT_EQ (
+    ImageVerificationResultAppendSignature (&Image, 3, EFI_SIGNATURE_VERIFICATION_TBS_HASH_AUTHORITY, &kSha256, kThumbprint, sizeof (kThumbprint)),
+    EFI_SUCCESS
+    );
+
+  // The image grew by exactly one signature record and counts it.
+  EXPECT_EQ (
+    AsImage (Image)->Length,
+    (UINT32)(LengthBefore + sizeof (EFI_SIGNATURE_VERIFICATION_RESULT) + sizeof (kThumbprint))
+    );
+  EXPECT_EQ (AsImage (Image)->NumberOfSignatures, 1u);
+
+  FreePool (Image);
+}
+
+// ---------------------------------------------------------------------------
+// AppendImage
+// ---------------------------------------------------------------------------
+
+TEST (AppendImageTest, NullImage_ReturnsInvalidParameter) {
+  EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE  *Table;
+
+  EXPECT_EQ (
+    ImageVerificationResultAppendImage (NULL, NULL, EFI_IMAGE_VERIFICATION_STATUS_AUTHORIZED_BY_AUTHORITY, NULL, &Table),
+    EFI_INVALID_PARAMETER
+    );
+}
+
+TEST (AppendImageTest, NullNewTable_ReturnsInvalidParameter) {
+  VOID  *Image = NULL;
+
+  ASSERT_EQ (ImageVerificationResultCreateImage (NULL, kDevicePath, sizeof (kDevicePath), &Image), EFI_SUCCESS);
+  EXPECT_EQ (
+    ImageVerificationResultAppendImage (NULL, Image, EFI_IMAGE_VERIFICATION_STATUS_AUTHORIZED_BY_AUTHORITY, NULL, NULL),
+    EFI_INVALID_PARAMETER
+    );
+  FreePool (Image);
+}
+
+TEST (AppendImageTest, BadOldTable_ReturnsInvalidParameter) {
+  VOID                                             *Image = NULL;
+  EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE  *Table;
+  UINT8                                            Junk[sizeof (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE)] = { 0 };
+
+  ASSERT_EQ (ImageVerificationResultCreateImage (NULL, kDevicePath, sizeof (kDevicePath), &Image), EFI_SUCCESS);
+  EXPECT_EQ (
+    ImageVerificationResultAppendImage (Junk, Image, EFI_IMAGE_VERIFICATION_STATUS_AUTHORIZED_BY_AUTHORITY, NULL, &Table),
+    EFI_INVALID_PARAMETER
+    );
+  FreePool (Image);
+}
+
+TEST (AppendImageTest, NullOldTable_ProducesSingleImageTable) {
+  VOID                                             *Image = NULL;
+  EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE  *Table;
+
+  ASSERT_EQ (ImageVerificationResultCreateImage (kName, kDevicePath, sizeof (kDevicePath), &Image), EFI_SUCCESS);
+  ASSERT_EQ (
+    ImageVerificationResultAppendImage (NULL, Image, EFI_IMAGE_VERIFICATION_STATUS_AUTHORIZED_BY_DIGEST, &kSha256, &Table),
+    EFI_SUCCESS
+    );
+
+  EXPECT_EQ (Table->Signature, (UINT32)EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_SIGNATURE);
+  EXPECT_EQ (Table->Version, (UINT32)EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_VERSION);
+  EXPECT_EQ (Table->NumberOfImages, 1u);
+
+  // Status/digest are stamped into the table copy; the source image is unchanged.
+  const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT  *Rec =
+    (const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)((const UINT8 *)Table +
+                                                        sizeof (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE));
+  EXPECT_EQ (Rec->ImageStatus, (UINT32)EFI_IMAGE_VERIFICATION_STATUS_AUTHORIZED_BY_DIGEST);
+  EXPECT_EQ (Rec->NameLength, (UINT32)StrSize (kName));
+  EXPECT_EQ (0, memcmp (&Rec->ImageDigestAlgorithm, &kSha256, sizeof (EFI_GUID)));
+  EXPECT_EQ (AsImage (Image)->ImageStatus, 0u);
+
+  FreePool (Image);
+  FreePool (Table);
+}
+
+TEST (AppendImageTest, AppendsToExistingTable) {
+  VOID                                             *Image0 = NULL;
+  VOID                                             *Image1 = NULL;
+  EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE  *Table0;
+  EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE  *Table1;
+
+  ASSERT_EQ (ImageVerificationResultCreateImage (NULL, kDevicePath, sizeof (kDevicePath), &Image0), EFI_SUCCESS);
+  ASSERT_EQ (
+    ImageVerificationResultAppendImage (NULL, Image0, EFI_IMAGE_VERIFICATION_STATUS_AUTHORIZED_BY_AUTHORITY, NULL, &Table0),
+    EFI_SUCCESS
+    );
+
+  ASSERT_EQ (ImageVerificationResultCreateImage (NULL, kDevicePath, sizeof (kDevicePath), &Image1), EFI_SUCCESS);
+  ASSERT_EQ (
+    ImageVerificationResultAppendImage (Table0, Image1, EFI_IMAGE_VERIFICATION_STATUS_REJECTED_NO_AUTHORITY, NULL, &Table1),
+    EFI_SUCCESS
+    );
+
+  // The old table is untouched; the new one has both images and is larger.
+  EXPECT_EQ (Table0->NumberOfImages, 1u);
+  EXPECT_EQ (Table1->NumberOfImages, 2u);
+  EXPECT_GT (Table1->Length, Table0->Length);
+
+  FreePool (Image0);
+  FreePool (Image1);
+  FreePool (Table0);
+  FreePool (Table1);
+}
+
+// ---------------------------------------------------------------------------
+// Build / iterate round trip.
+// ---------------------------------------------------------------------------
+
+TEST (WriteRoundTripTest, TwoImagesWithSignatures) {
+  VOID                                             *Image0 = NULL;
+  VOID                                             *Image1 = NULL;
+  EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE  *Table0;
+  EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE  *Table;
+
+  // Image 0: named, digest-approved, two signatures.
+  ASSERT_EQ (ImageVerificationResultCreateImage (kName, kDevicePath, sizeof (kDevicePath), &Image0), EFI_SUCCESS);
+  ASSERT_EQ (
+    ImageVerificationResultAppendSignature (&Image0, 0, EFI_SIGNATURE_VERIFICATION_REJECTED_NO_AUTHORITY, NULL, NULL, 0),
+    EFI_SUCCESS
+    );
+  ASSERT_EQ (
+    ImageVerificationResultAppendSignature (&Image0, 1, EFI_SIGNATURE_VERIFICATION_TBS_HASH_AUTHORITY, &kSha256, kThumbprint, sizeof (kThumbprint)),
+    EFI_SUCCESS
+    );
+  ASSERT_EQ (
+    ImageVerificationResultAppendImage (NULL, Image0, EFI_IMAGE_VERIFICATION_STATUS_AUTHORIZED_BY_DIGEST, &kSha256, &Table0),
+    EFI_SUCCESS
+    );
+
+  // Image 1: no name, rejected, one signature.
+  ASSERT_EQ (ImageVerificationResultCreateImage (NULL, kDevicePath, sizeof (kDevicePath), &Image1), EFI_SUCCESS);
+  ASSERT_EQ (
+    ImageVerificationResultAppendSignature (&Image1, 0, EFI_SIGNATURE_VERIFICATION_AUTHORITY_REVOKED_BY_CERTIFICATE, &kSha256, kThumbprint, sizeof (kThumbprint)),
+    EFI_SUCCESS
+    );
+  ASSERT_EQ (
+    ImageVerificationResultAppendImage (Table0, Image1, EFI_IMAGE_VERIFICATION_STATUS_REJECTED_NO_AUTHORITY, NULL, &Table),
+    EFI_SUCCESS
+    );
+
+  EXPECT_EQ (Table->NumberOfImages, 2u);
+
+  // Walk it back and confirm the structure round-trips cleanly.
+  IMAGE_VERIFICATION_RESULT_ITERATOR                       Iter;
+  const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT         *Rec;
+  const EFI_SIGNATURE_VERIFICATION_RESULT                 *Sig;
+
+  EXPECT_TRUE (ImageVerificationResultIteratorInit (&Iter, Table));
+
+  // Image 0.
+  Rec = ImageVerificationResultIteratorNextImage (&Iter);
+  ASSERT_NE (Rec, (const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)NULL);
+  EXPECT_EQ (Rec->ImageStatus, (UINT32)EFI_IMAGE_VERIFICATION_STATUS_AUTHORIZED_BY_DIGEST);
+  EXPECT_EQ (Rec->NumberOfSignatures, 2u);
+  EXPECT_EQ (Rec->NameLength, (UINT32)StrSize (kName));
+  EXPECT_EQ (Rec->DevicePathLength, (UINT32)sizeof (kDevicePath));
+  EXPECT_EQ (0, memcmp (&Rec->ImageDigestAlgorithm, &kSha256, sizeof (EFI_GUID)));
+
+  Sig = ImageVerificationResultIteratorNextSignature (&Iter);
+  ASSERT_NE (Sig, (const EFI_SIGNATURE_VERIFICATION_RESULT *)NULL);
+  EXPECT_EQ (Sig->SignatureIndex, 0u);
+  EXPECT_EQ (Sig->Status, (UINT32)EFI_SIGNATURE_VERIFICATION_REJECTED_NO_AUTHORITY);
+  EXPECT_EQ (Sig->Length, (UINT32)sizeof (EFI_SIGNATURE_VERIFICATION_RESULT));
+
+  Sig = ImageVerificationResultIteratorNextSignature (&Iter);
+  ASSERT_NE (Sig, (const EFI_SIGNATURE_VERIFICATION_RESULT *)NULL);
+  EXPECT_EQ (Sig->SignatureIndex, 1u);
+  EXPECT_EQ (Sig->Status, (UINT32)EFI_SIGNATURE_VERIFICATION_TBS_HASH_AUTHORITY);
+  EXPECT_EQ (Sig->Length, (UINT32)(sizeof (EFI_SIGNATURE_VERIFICATION_RESULT) + sizeof (kThumbprint)));
+  EXPECT_EQ (0, memcmp ((const UINT8 *)Sig + sizeof (EFI_SIGNATURE_VERIFICATION_RESULT), kThumbprint, sizeof (kThumbprint)));
+
+  EXPECT_EQ (ImageVerificationResultIteratorNextSignature (&Iter), (const EFI_SIGNATURE_VERIFICATION_RESULT *)NULL);
+
+  // Image 1.
+  Rec = ImageVerificationResultIteratorNextImage (&Iter);
+  ASSERT_NE (Rec, (const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)NULL);
+  EXPECT_EQ (Rec->ImageStatus, (UINT32)EFI_IMAGE_VERIFICATION_STATUS_REJECTED_NO_AUTHORITY);
+  EXPECT_EQ (Rec->NumberOfSignatures, 1u);
+  EXPECT_EQ (Rec->NameLength, 0u);
+
+  Sig = ImageVerificationResultIteratorNextSignature (&Iter);
+  ASSERT_NE (Sig, (const EFI_SIGNATURE_VERIFICATION_RESULT *)NULL);
+  EXPECT_EQ (Sig->SignatureIndex, 0u);
+  EXPECT_EQ (Sig->Status, (UINT32)EFI_SIGNATURE_VERIFICATION_AUTHORITY_REVOKED_BY_CERTIFICATE);
+
+  EXPECT_EQ (ImageVerificationResultIteratorNextImage (&Iter), (const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)NULL);
+
+  FreePool (Image0);
+  FreePool (Image1);
+  FreePool (Table0);
+  FreePool (Table);
+}

--- a/SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/GoogleTest/ImageSecureBootVerificationResultTableLibGoogleTest.inf
+++ b/SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/GoogleTest/ImageSecureBootVerificationResultTableLibGoogleTest.inf
@@ -1,0 +1,36 @@
+## @file
+# Unit test suite for ImageSecureBootVerificationResultTableLib using Google Test.
+#
+# Copyright (C) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = ImageSecureBootVerificationResultTableLibGoogleTest
+  FILE_GUID                      = 7C2D9E4F-1A6B-4C8E-B3D5-9F2A6C7E1B04
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  BuilderGoogleTest.cpp
+  IteratorGoogleTest.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  SecurityPkg/SecurityPkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  MemoryAllocationLib
+  ImageSecureBootVerificationResultTableLib

--- a/SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/GoogleTest/IteratorGoogleTest.cpp
+++ b/SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/GoogleTest/IteratorGoogleTest.cpp
@@ -1,0 +1,355 @@
+/** @file
+  Unit tests for the ImageSecureBootVerificationResultTableLib iterator:
+  ImageVerificationResultIteratorInit / NextImage / NextSignature.
+
+  Copyright (C) Microsoft Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/GoogleTestLib.h>
+
+#include <vector>
+#include <cstring>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Library/BaseLib.h>
+  #include <Library/BaseMemoryLib.h>
+  #include <Library/MemoryAllocationLib.h>
+  #include <Library/ImageSecureBootVerificationResultTableLib.h>
+}
+
+// ---------------------------------------------------------------------------
+// Shared test data and helpers.
+// ---------------------------------------------------------------------------
+
+static const UINT8  kDevicePath[] = { 0x7F, 0xFF, 0x04, 0x00 };
+
+static const EFI_GUID  kSha256 = {
+  0x51aa59de, 0xfdf2, 0x4ea3, { 0xbc, 0x63, 0x87, 0x5f, 0xb7, 0x84, 0x2e, 0xe9 }
+};
+
+// Byte offsets of the table header fields.
+static const size_t  kTableHeaderSize = sizeof (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE);
+
+// Test-local descriptor for a signature to append. The library appends
+// signatures one at a time, so the helpers below iterate this array and call
+// AppendSignature.
+typedef struct {
+  UINT32          SignatureIndex;
+  UINT32          Status;
+  const EFI_GUID  *ThumbprintAlgorithm;
+  const void      *Thumbprint;
+  UINTN           ThumbprintSize;
+} TEST_SIGNATURE_INFO;
+
+static void
+SetU32 (
+  std::vector<UINT8>  &Buffer,
+  size_t              Offset,
+  UINT32              Value
+  )
+{
+  Buffer[Offset + 0] = (UINT8)(Value);
+  Buffer[Offset + 1] = (UINT8)(Value >> 8);
+  Buffer[Offset + 2] = (UINT8)(Value >> 16);
+  Buffer[Offset + 3] = (UINT8)(Value >> 24);
+}
+
+// Build a valid empty table (header only, zero images) by hand, so tests can
+// mutate the bytes freely.
+static std::vector<UINT8>
+MakeEmptyTable (
+  void
+  )
+{
+  std::vector<UINT8>  Table (kTableHeaderSize, 0);
+
+  SetU32 (Table, OFFSET_OF (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE, Signature), EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_SIGNATURE);
+  SetU32 (Table, OFFSET_OF (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE, Version), EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_VERSION);
+  SetU32 (Table, OFFSET_OF (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE, Length), (UINT32)kTableHeaderSize);
+  SetU32 (Table, OFFSET_OF (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE, NumberOfImages), 0);
+  return Table;
+}
+
+// Append one image (with the shared device path and the given signatures) onto
+// an existing table (Old empty => a fresh table) via the real API, returning the
+// resulting table as an owned byte vector.
+static std::vector<UINT8>
+AppendImageToTable (
+  const std::vector<UINT8>   &Old,
+  UINT32                     ImageStatus,
+  const TEST_SIGNATURE_INFO  *Signatures,
+  UINTN                      SignatureCount
+  )
+{
+  VOID                                             *Image    = NULL;
+  EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE  *NewTable = NULL;
+  std::vector<UINT8>                               Bytes;
+  const VOID                                       *OldPtr = Old.empty () ? NULL : (const VOID *)Old.data ();
+
+  if (EFI_ERROR (ImageVerificationResultCreateImage (NULL, kDevicePath, sizeof (kDevicePath), &Image))) {
+    return Bytes;
+  }
+
+  for (UINTN Index = 0; Index < SignatureCount; Index++) {
+    ImageVerificationResultAppendSignature (
+      &Image,
+      Signatures[Index].SignatureIndex,
+      Signatures[Index].Status,
+      Signatures[Index].ThumbprintAlgorithm,
+      Signatures[Index].Thumbprint,
+      Signatures[Index].ThumbprintSize
+      );
+  }
+
+  if (!EFI_ERROR (
+         ImageVerificationResultAppendImage (OldPtr, Image, ImageStatus, NULL, &NewTable)
+         ))
+  {
+    Bytes.assign ((UINT8 *)NewTable, (UINT8 *)NewTable + NewTable->Length);
+    FreePool (NewTable);
+  }
+
+  FreePool (Image);
+  return Bytes;
+}
+
+// Build a table with one image (no name, 4-byte device path) carrying
+// SignatureCount signatures (indices 0..N-1, no thumbprints).
+static std::vector<UINT8>
+BuildSingleImageTable (
+  UINT32  SignatureCount
+  )
+{
+  std::vector<TEST_SIGNATURE_INFO>  Signatures (SignatureCount);
+
+  for (UINT32 Index = 0; Index < SignatureCount; Index++) {
+    ZeroMem (&Signatures[Index], sizeof (TEST_SIGNATURE_INFO));
+    Signatures[Index].SignatureIndex = Index;
+    Signatures[Index].Status         = EFI_SIGNATURE_VERIFICATION_CERTIFICATE_AUTHORITY;
+  }
+
+  return AppendImageToTable (
+           std::vector<UINT8> (),
+           EFI_IMAGE_VERIFICATION_STATUS_AUTHORIZED_BY_AUTHORITY,
+           (SignatureCount == 0) ? NULL : Signatures.data (),
+           SignatureCount
+           );
+}
+
+// ---------------------------------------------------------------------------
+// Init: unusable / empty inputs.
+// ---------------------------------------------------------------------------
+
+TEST (IteratorInitTest, NullIterator_ReturnsFalse) {
+  UINT8  Dummy[kTableHeaderSize] = { 0 };
+
+  EXPECT_FALSE (ImageVerificationResultIteratorInit (NULL, Dummy));
+}
+
+TEST (IteratorInitTest, NullTable_IsCleanEmpty) {
+  IMAGE_VERIFICATION_RESULT_ITERATOR  Iter;
+
+  EXPECT_TRUE (ImageVerificationResultIteratorInit (&Iter, NULL));
+  EXPECT_EQ (ImageVerificationResultIteratorNextImage (&Iter), (const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)NULL);
+  EXPECT_EQ (ImageVerificationResultIteratorNextSignature (&Iter), (const EFI_SIGNATURE_VERIFICATION_RESULT *)NULL);
+}
+
+TEST (IteratorInitTest, BadSignature_ReturnsFalse) {
+  IMAGE_VERIFICATION_RESULT_ITERATOR  Iter;
+  std::vector<UINT8>                  Table = BuildSingleImageTable (0);
+
+  SetU32 (Table, 0, 0x11223344);
+  EXPECT_FALSE (ImageVerificationResultIteratorInit (&Iter, Table.data ()));
+}
+
+TEST (IteratorInitTest, BadVersion_ReturnsFalse) {
+  IMAGE_VERIFICATION_RESULT_ITERATOR  Iter;
+  std::vector<UINT8>                  Table = BuildSingleImageTable (0);
+
+  SetU32 (Table, OFFSET_OF (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE, Version), 0xDEAD);
+  EXPECT_FALSE (ImageVerificationResultIteratorInit (&Iter, Table.data ()));
+}
+
+TEST (IteratorInitTest, LengthBelowHeader_ReturnsFalse) {
+  IMAGE_VERIFICATION_RESULT_ITERATOR  Iter;
+  std::vector<UINT8>                  Table = BuildSingleImageTable (0);
+
+  SetU32 (Table, OFFSET_OF (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE, Length), 4);
+  EXPECT_FALSE (ImageVerificationResultIteratorInit (&Iter, Table.data ()));
+}
+
+// ---------------------------------------------------------------------------
+// Init: well-formed tables.
+// ---------------------------------------------------------------------------
+
+TEST (IteratorInitTest, EmptyTable_IsClean) {
+  IMAGE_VERIFICATION_RESULT_ITERATOR  Iter;
+  std::vector<UINT8>                  Table = MakeEmptyTable ();
+
+  EXPECT_TRUE (ImageVerificationResultIteratorInit (&Iter, Table.data ()));
+  EXPECT_EQ (ImageVerificationResultIteratorNextImage (&Iter), (const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)NULL);
+}
+
+TEST (IteratorTest, SingleImageNoSignatures) {
+  IMAGE_VERIFICATION_RESULT_ITERATOR              Iter;
+  std::vector<UINT8>                              Table = BuildSingleImageTable (0);
+  const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *Image;
+
+  EXPECT_TRUE (ImageVerificationResultIteratorInit (&Iter, Table.data ()));
+
+  Image = ImageVerificationResultIteratorNextImage (&Iter);
+  ASSERT_NE (Image, (const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)NULL);
+  EXPECT_EQ (Image->NumberOfSignatures, 0u);
+  EXPECT_EQ (Image->DevicePathLength, (UINT32)sizeof (kDevicePath));
+  EXPECT_EQ (ImageVerificationResultIteratorNextSignature (&Iter), (const EFI_SIGNATURE_VERIFICATION_RESULT *)NULL);
+  EXPECT_EQ (ImageVerificationResultIteratorNextImage (&Iter), (const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)NULL);
+}
+
+TEST (IteratorTest, SingleImageWalksAllSignatures) {
+  IMAGE_VERIFICATION_RESULT_ITERATOR              Iter;
+  std::vector<UINT8>                              Table = BuildSingleImageTable (3);
+  const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *Image;
+  const EFI_SIGNATURE_VERIFICATION_RESULT         *Sig;
+
+  EXPECT_TRUE (ImageVerificationResultIteratorInit (&Iter, Table.data ()));
+
+  Image = ImageVerificationResultIteratorNextImage (&Iter);
+  ASSERT_NE (Image, (const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)NULL);
+  EXPECT_EQ (Image->NumberOfSignatures, 3u);
+
+  for (UINT32 Index = 0; Index < 3; Index++) {
+    Sig = ImageVerificationResultIteratorNextSignature (&Iter);
+    ASSERT_NE (Sig, (const EFI_SIGNATURE_VERIFICATION_RESULT *)NULL);
+    EXPECT_EQ (Sig->SignatureIndex, Index);
+  }
+
+  EXPECT_EQ (ImageVerificationResultIteratorNextSignature (&Iter), (const EFI_SIGNATURE_VERIFICATION_RESULT *)NULL);
+}
+
+TEST (IteratorTest, NextSignatureBeforeNextImage_ReturnsNull) {
+  IMAGE_VERIFICATION_RESULT_ITERATOR  Iter;
+  std::vector<UINT8>                  Table = BuildSingleImageTable (2);
+
+  EXPECT_TRUE (ImageVerificationResultIteratorInit (&Iter, Table.data ()));
+  // No image selected yet, so the inner cursor yields nothing.
+  EXPECT_EQ (ImageVerificationResultIteratorNextSignature (&Iter), (const EFI_SIGNATURE_VERIFICATION_RESULT *)NULL);
+}
+
+TEST (IteratorTest, NextImageResetsInnerCursor) {
+  IMAGE_VERIFICATION_RESULT_ITERATOR              Iter;
+  const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *Image;
+  const EFI_SIGNATURE_VERIFICATION_RESULT         *Sig;
+  TEST_SIGNATURE_INFO                             Sigs0[2];
+  TEST_SIGNATURE_INFO                             Sigs1[2];
+
+  ZeroMem (Sigs0, sizeof (Sigs0));
+  Sigs0[0].SignatureIndex = 0;
+  Sigs0[0].Status         = EFI_SIGNATURE_VERIFICATION_CERTIFICATE_AUTHORITY;
+  Sigs0[1].SignatureIndex = 1;
+  Sigs0[1].Status         = EFI_SIGNATURE_VERIFICATION_TBS_HASH_AUTHORITY;
+
+  ZeroMem (Sigs1, sizeof (Sigs1));
+  Sigs1[0].SignatureIndex = 0;
+  Sigs1[0].Status         = EFI_SIGNATURE_VERIFICATION_AUTHORITY_REVOKED_BY_CERTIFICATE;
+  Sigs1[1].SignatureIndex = 1;
+  Sigs1[1].Status         = EFI_SIGNATURE_VERIFICATION_AUTHORITY_REVOKED_BY_TBS_HASH;
+
+  // Image 0 with two signatures, then image 1 with two distinct-status signatures.
+  std::vector<UINT8>  Table = AppendImageToTable (std::vector<UINT8> (), EFI_IMAGE_VERIFICATION_STATUS_AUTHORIZED_BY_AUTHORITY, Sigs0, 2);
+  Table = AppendImageToTable (Table, EFI_IMAGE_VERIFICATION_STATUS_REJECTED_NO_AUTHORITY, Sigs1, 2);
+
+  EXPECT_TRUE (ImageVerificationResultIteratorInit (&Iter, Table.data ()));
+
+  // Select image 0 and consume only its first signature.
+  Image = ImageVerificationResultIteratorNextImage (&Iter);
+  ASSERT_NE (Image, (const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)NULL);
+  Sig = ImageVerificationResultIteratorNextSignature (&Iter);
+  ASSERT_NE (Sig, (const EFI_SIGNATURE_VERIFICATION_RESULT *)NULL);
+  EXPECT_EQ (Sig->Status, (UINT32)EFI_SIGNATURE_VERIFICATION_CERTIFICATE_AUTHORITY);
+
+  // Advancing to image 1 must reset the inner cursor to image 1's signatures,
+  // NOT continue with image 0's unconsumed second signature.
+  Image = ImageVerificationResultIteratorNextImage (&Iter);
+  ASSERT_NE (Image, (const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)NULL);
+  EXPECT_EQ (Image->ImageStatus, (UINT32)EFI_IMAGE_VERIFICATION_STATUS_REJECTED_NO_AUTHORITY);
+
+  Sig = ImageVerificationResultIteratorNextSignature (&Iter);
+  ASSERT_NE (Sig, (const EFI_SIGNATURE_VERIFICATION_RESULT *)NULL);
+  EXPECT_EQ (Sig->Status, (UINT32)EFI_SIGNATURE_VERIFICATION_AUTHORITY_REVOKED_BY_CERTIFICATE);
+  EXPECT_EQ (Sig->SignatureIndex, 0u);
+}
+
+// ---------------------------------------------------------------------------
+// Init: truncation clamps to the valid prefix.
+// ---------------------------------------------------------------------------
+
+TEST (IteratorTruncationTest, TrailingPartialImage_IteratesValidPrefix) {
+  IMAGE_VERIFICATION_RESULT_ITERATOR              Iter;
+  const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *Image;
+
+  // Two well-formed images (no signatures).
+  std::vector<UINT8>  Table = AppendImageToTable (std::vector<UINT8> (), EFI_IMAGE_VERIFICATION_STATUS_AUTHORIZED_BY_AUTHORITY, NULL, 0);
+  Table = AppendImageToTable (Table, EFI_IMAGE_VERIFICATION_STATUS_AUTHORIZED_BY_AUTHORITY, NULL, 0);
+  size_t              ValidSize = Table.size ();
+
+  // Append 4 junk bytes and claim them as a third (partial) image record.
+  Table.resize (ValidSize + 4, 0);
+  SetU32 (Table, OFFSET_OF (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE, Length), (UINT32)(ValidSize + 4));
+  SetU32 (Table, OFFSET_OF (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE, NumberOfImages), 3);
+
+  // Truncated (FALSE), but the two well-formed images still iterate.
+  EXPECT_FALSE (ImageVerificationResultIteratorInit (&Iter, Table.data ()));
+
+  Image = ImageVerificationResultIteratorNextImage (&Iter);
+  EXPECT_NE (Image, (const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)NULL);
+  Image = ImageVerificationResultIteratorNextImage (&Iter);
+  EXPECT_NE (Image, (const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)NULL);
+  Image = ImageVerificationResultIteratorNextImage (&Iter);
+  EXPECT_EQ (Image, (const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)NULL);
+}
+
+TEST (IteratorTruncationTest, ImageCountMismatch_ReturnsFalse) {
+  IMAGE_VERIFICATION_RESULT_ITERATOR  Iter;
+  std::vector<UINT8>                  Table = BuildSingleImageTable (0);
+
+  // Region still tiles into one image, but the header over-claims the count.
+  SetU32 (Table, OFFSET_OF (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE, NumberOfImages), 5);
+  EXPECT_FALSE (ImageVerificationResultIteratorInit (&Iter, Table.data ()));
+
+  // The one real image is still exposed.
+  EXPECT_NE (ImageVerificationResultIteratorNextImage (&Iter), (const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)NULL);
+  EXPECT_EQ (ImageVerificationResultIteratorNextImage (&Iter), (const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)NULL);
+}
+
+TEST (IteratorTruncationTest, SignatureCountMismatch_DropsImage) {
+  IMAGE_VERIFICATION_RESULT_ITERATOR  Iter;
+  std::vector<UINT8>                  Table = BuildSingleImageTable (1);
+  size_t                              ImageOffset = kTableHeaderSize;
+
+  // The image physically carries one signature; claim two.
+  SetU32 (
+    Table,
+    ImageOffset + OFFSET_OF (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT, NumberOfSignatures),
+    2
+    );
+
+  // The malformed image is dropped, leaving an empty (but truncated) prefix.
+  EXPECT_FALSE (ImageVerificationResultIteratorInit (&Iter, Table.data ()));
+  EXPECT_EQ (ImageVerificationResultIteratorNextImage (&Iter), (const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)NULL);
+}
+
+TEST (IteratorTruncationTest, ShortSignatureLength_DropsImage) {
+  IMAGE_VERIFICATION_RESULT_ITERATOR  Iter;
+  std::vector<UINT8>                  Table = BuildSingleImageTable (1);
+  size_t                              ImageOffset = kTableHeaderSize;
+  size_t                              SigOffset;
+
+  // Signatures begin after the image header + (0-byte) name + device path.
+  SigOffset = ImageOffset + sizeof (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT) + sizeof (kDevicePath);
+  SetU32 (Table, SigOffset + OFFSET_OF (EFI_SIGNATURE_VERIFICATION_RESULT, Length), 4);
+
+  EXPECT_FALSE (ImageVerificationResultIteratorInit (&Iter, Table.data ()));
+  EXPECT_EQ (ImageVerificationResultIteratorNextImage (&Iter), (const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)NULL);
+}

--- a/SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/GoogleTest/IteratorGoogleTest.cpp
+++ b/SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/GoogleTest/IteratorGoogleTest.cpp
@@ -36,11 +36,11 @@ static const size_t  kTableHeaderSize = sizeof (EFI_IMAGE_SECURE_BOOT_VERIFICATI
 // signatures one at a time, so the helpers below iterate this array and call
 // AppendSignature.
 typedef struct {
-  UINT32          SignatureIndex;
-  UINT32          Status;
-  const EFI_GUID  *ThumbprintAlgorithm;
-  const void      *Thumbprint;
-  UINTN           ThumbprintSize;
+  UINT32            SignatureIndex;
+  UINT32            Status;
+  const EFI_GUID    *ThumbprintAlgorithm;
+  const void        *Thumbprint;
+  UINTN             ThumbprintSize;
 } TEST_SIGNATURE_INFO;
 
 static void
@@ -193,9 +193,9 @@ TEST (IteratorInitTest, EmptyTable_IsClean) {
 }
 
 TEST (IteratorTest, SingleImageNoSignatures) {
-  IMAGE_VERIFICATION_RESULT_ITERATOR              Iter;
-  std::vector<UINT8>                              Table = BuildSingleImageTable (0);
-  const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *Image;
+  IMAGE_VERIFICATION_RESULT_ITERATOR               Iter;
+  std::vector<UINT8>                               Table = BuildSingleImageTable (0);
+  const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT  *Image;
 
   EXPECT_TRUE (ImageVerificationResultIteratorInit (&Iter, Table.data ()));
 
@@ -208,10 +208,10 @@ TEST (IteratorTest, SingleImageNoSignatures) {
 }
 
 TEST (IteratorTest, SingleImageWalksAllSignatures) {
-  IMAGE_VERIFICATION_RESULT_ITERATOR              Iter;
-  std::vector<UINT8>                              Table = BuildSingleImageTable (3);
-  const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *Image;
-  const EFI_SIGNATURE_VERIFICATION_RESULT         *Sig;
+  IMAGE_VERIFICATION_RESULT_ITERATOR               Iter;
+  std::vector<UINT8>                               Table = BuildSingleImageTable (3);
+  const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT  *Image;
+  const EFI_SIGNATURE_VERIFICATION_RESULT          *Sig;
 
   EXPECT_TRUE (ImageVerificationResultIteratorInit (&Iter, Table.data ()));
 
@@ -238,11 +238,11 @@ TEST (IteratorTest, NextSignatureBeforeNextImage_ReturnsNull) {
 }
 
 TEST (IteratorTest, NextImageResetsInnerCursor) {
-  IMAGE_VERIFICATION_RESULT_ITERATOR              Iter;
-  const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *Image;
-  const EFI_SIGNATURE_VERIFICATION_RESULT         *Sig;
-  TEST_SIGNATURE_INFO                             Sigs0[2];
-  TEST_SIGNATURE_INFO                             Sigs1[2];
+  IMAGE_VERIFICATION_RESULT_ITERATOR               Iter;
+  const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT  *Image;
+  const EFI_SIGNATURE_VERIFICATION_RESULT          *Sig;
+  TEST_SIGNATURE_INFO                              Sigs0[2];
+  TEST_SIGNATURE_INFO                              Sigs1[2];
 
   ZeroMem (Sigs0, sizeof (Sigs0));
   Sigs0[0].SignatureIndex = 0;
@@ -258,6 +258,7 @@ TEST (IteratorTest, NextImageResetsInnerCursor) {
 
   // Image 0 with two signatures, then image 1 with two distinct-status signatures.
   std::vector<UINT8>  Table = AppendImageToTable (std::vector<UINT8> (), EFI_IMAGE_VERIFICATION_STATUS_AUTHORIZED_BY_AUTHORITY, Sigs0, 2);
+
   Table = AppendImageToTable (Table, EFI_IMAGE_VERIFICATION_STATUS_REJECTED_NO_AUTHORITY, Sigs1, 2);
 
   EXPECT_TRUE (ImageVerificationResultIteratorInit (&Iter, Table.data ()));
@@ -286,13 +287,14 @@ TEST (IteratorTest, NextImageResetsInnerCursor) {
 // ---------------------------------------------------------------------------
 
 TEST (IteratorTruncationTest, TrailingPartialImage_IteratesValidPrefix) {
-  IMAGE_VERIFICATION_RESULT_ITERATOR              Iter;
-  const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *Image;
+  IMAGE_VERIFICATION_RESULT_ITERATOR               Iter;
+  const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT  *Image;
 
   // Two well-formed images (no signatures).
   std::vector<UINT8>  Table = AppendImageToTable (std::vector<UINT8> (), EFI_IMAGE_VERIFICATION_STATUS_AUTHORIZED_BY_AUTHORITY, NULL, 0);
+
   Table = AppendImageToTable (Table, EFI_IMAGE_VERIFICATION_STATUS_AUTHORIZED_BY_AUTHORITY, NULL, 0);
-  size_t              ValidSize = Table.size ();
+  size_t  ValidSize = Table.size ();
 
   // Append 4 junk bytes and claim them as a third (partial) image record.
   Table.resize (ValidSize + 4, 0);
@@ -325,7 +327,7 @@ TEST (IteratorTruncationTest, ImageCountMismatch_ReturnsFalse) {
 
 TEST (IteratorTruncationTest, SignatureCountMismatch_DropsImage) {
   IMAGE_VERIFICATION_RESULT_ITERATOR  Iter;
-  std::vector<UINT8>                  Table = BuildSingleImageTable (1);
+  std::vector<UINT8>                  Table       = BuildSingleImageTable (1);
   size_t                              ImageOffset = kTableHeaderSize;
 
   // The image physically carries one signature; claim two.
@@ -342,7 +344,7 @@ TEST (IteratorTruncationTest, SignatureCountMismatch_DropsImage) {
 
 TEST (IteratorTruncationTest, ShortSignatureLength_DropsImage) {
   IMAGE_VERIFICATION_RESULT_ITERATOR  Iter;
-  std::vector<UINT8>                  Table = BuildSingleImageTable (1);
+  std::vector<UINT8>                  Table       = BuildSingleImageTable (1);
   size_t                              ImageOffset = kTableHeaderSize;
   size_t                              SigOffset;
 

--- a/SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/ImageSecureBootVerificationResultTableLib.c
+++ b/SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/ImageSecureBootVerificationResultTableLib.c
@@ -212,12 +212,12 @@ ImageVerificationResultCreateImage (
 EFI_STATUS
 EFIAPI
 ImageVerificationResultAppendSignature (
-  IN OUT VOID           **Image,
-  IN     UINT32         SignatureIndex,
-  IN     UINT32         Status,
+  IN OUT VOID            **Image,
+  IN     UINT32          SignatureIndex,
+  IN     UINT32          Status,
   IN     CONST EFI_GUID  *ThumbprintAlgorithm OPTIONAL,
   IN     CONST VOID      *Thumbprint OPTIONAL,
-  IN     UINTN          ThumbprintSize
+  IN     UINTN           ThumbprintSize
   )
 {
   EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT  *Record;
@@ -569,8 +569,8 @@ ImageVerificationResultIteratorInit (
       break;
     }
 
-    Cursor    += RecordLength;
-    Remaining -= RecordLength;
+    Cursor     += RecordLength;
+    Remaining  -= RecordLength;
     ImageCount += 1;
   }
 
@@ -621,7 +621,7 @@ ImageVerificationResultIteratorNextImage (
   Iterator->NextSignatureRecord = Record + IVRT_IMAGE_HEADER_SIZE + NameLength + DevicePathLength;
   Iterator->SignaturesRemaining = NumberOfSignatures;
 
-  Iterator->NextImageRecord = Record + RecordLength;
+  Iterator->NextImageRecord  = Record + RecordLength;
   Iterator->ImagesRemaining -= 1;
 
   return (CONST EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)Record;
@@ -651,7 +651,7 @@ ImageVerificationResultIteratorNextSignature (
   Record       = Iterator->NextSignatureRecord;
   RecordLength = ReadUnaligned32 ((CONST UINT32 *)(Record + OFFSET_OF (EFI_SIGNATURE_VERIFICATION_RESULT, Length)));
 
-  Iterator->NextSignatureRecord = Record + RecordLength;
+  Iterator->NextSignatureRecord  = Record + RecordLength;
   Iterator->SignaturesRemaining -= 1;
 
   return (CONST EFI_SIGNATURE_VERIFICATION_RESULT *)Record;

--- a/SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/ImageSecureBootVerificationResultTableLib.c
+++ b/SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/ImageSecureBootVerificationResultTableLib.c
@@ -1,0 +1,658 @@
+/** @file
+  Build and iterate the Image Secure Boot Verification Result Table (IVRT).
+
+  This library provides functionality for building an Image Secure Boot Verification
+  Result Table (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE) and iterating over
+  the contents of an existing table. The table is defined in
+  <Guid/ImageSecureBootVerificationResultTable.h>.
+
+  == Builder ==
+
+    VOID  *Image;
+
+    ImageVerificationResultCreateImage (Name, DevicePath, DevicePathSize, &Image);
+    ImageVerificationResultAppendSignature (&Image, ...);   // once per evaluated signature
+
+    // OldTable is an existing table, or NULL to create the table. Sizes live in
+    // the table headers, so none are passed (the new size is NewTable->Length).
+    ImageVerificationResultAppendImage (
+      OldTable, Image, ImageStatus, DigestAlgorithm, &NewTable);
+
+    FreePool (Image);
+    FreePool (OldTable);
+
+  == Iterator ==
+
+    ImageVerificationResultIteratorInit (&Iter, Table);
+    while ((Image = ImageVerificationResultIteratorNextImage (&Iter)) != NULL) {
+      // ... consume Image ...
+      while ((Sig = ImageVerificationResultIteratorNextSignature (&Iter)) != NULL) {
+        // ... consume Sig (a signature of Image) ...
+      }
+    }
+
+  Records land at unaligned offsets inside the packed table, so every access to a
+  record's scalar fields goes through the unaligned Read/Write helpers, and blob
+  fields are moved with CopyMem.
+
+  Copyright (C) Microsoft Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Uefi.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/DebugLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/ImageSecureBootVerificationResultTableLib.h>
+
+//
+// Cached record header sizes. Every record is walked by its self-describing
+// Length, so these fixed prefixes bound where the variable payloads begin.
+//
+#define IVRT_TABLE_HEADER_SIZE  (sizeof (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE))
+#define IVRT_IMAGE_HEADER_SIZE  (sizeof (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT))
+#define IVRT_SIG_HEADER_SIZE    (sizeof (EFI_SIGNATURE_VERIFICATION_RESULT))
+
+// ***************************************************************************
+// Shared helpers
+// ***************************************************************************
+
+/**
+  Add two UINTN values, reporting UINT32 overflow.
+
+  The table and every record size field is a UINT32, so growth arithmetic is
+  validated against MAX_UINT32 using the addition form to avoid wraparound.
+
+  @param[in]   Augend  First value.
+  @param[in]   Addend  Second value.
+  @param[out]  Sum     On success, Augend + Addend.
+
+  @retval TRUE   The sum fits in a UINT32 and was written to Sum.
+  @retval FALSE  The sum would exceed MAX_UINT32; Sum is untouched.
+**/
+STATIC
+BOOLEAN
+SafeAddU32 (
+  IN  UINTN   Augend,
+  IN  UINTN   Addend,
+  OUT UINT32  *Sum
+  )
+{
+  if ((Augend > MAX_UINT32) || (Addend > MAX_UINT32 - Augend)) {
+    return FALSE;
+  }
+
+  *Sum = (UINT32)(Augend + Addend);
+  return TRUE;
+}
+
+/**
+  Store an EFI_GUID into a (possibly unaligned) record field, defaulting to the
+  zero GUID when no source GUID was supplied.
+
+  @param[out]  Destination  Field to populate.
+  @param[in]   Source       Optional GUID to copy; NULL stores the zero GUID.
+**/
+STATIC
+VOID
+SetOptionalGuid (
+  OUT VOID            *Destination,
+  IN  CONST EFI_GUID  *Source OPTIONAL
+  )
+{
+  if (Source != NULL) {
+    CopyMem (Destination, Source, sizeof (EFI_GUID));
+  } else {
+    ZeroMem (Destination, sizeof (EFI_GUID));
+  }
+}
+
+// ***************************************************************************
+// Builder (write side)
+// ***************************************************************************
+
+/**
+  Allocate an image record from its identity (name and device path).
+
+  Returns a self-describing EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT allocation
+  with zero signatures; the overall status is supplied later, to
+  ImageVerificationResultAppendImage().
+
+  Caller is responsible for freeing Image with FreePool().
+
+  @param[in]   Name            Optional NUL-terminated CHAR16 image name; NULL for none.
+  @param[in]   DevicePath      The image's device path bytes. Required.
+  @param[in]   DevicePathSize  Size of DevicePath in bytes, including its end-of-path node.
+  @param[out]  Image           On success, the newly allocated image record. Free with FreePool().
+
+  @retval EFI_SUCCESS            The image record was allocated.
+  @retval EFI_INVALID_PARAMETER  Image or DevicePath is NULL, or DevicePathSize is 0.
+  @retval EFI_BAD_BUFFER_SIZE    The resulting record would exceed a UINT32 size field.
+  @retval EFI_OUT_OF_RESOURCES   The record could not be allocated.
+**/
+EFI_STATUS
+EFIAPI
+ImageVerificationResultCreateImage (
+  IN  CONST CHAR16  *Name OPTIONAL,
+  IN  CONST VOID    *DevicePath,
+  IN  UINTN         DevicePathSize,
+  OUT VOID          **Image
+  )
+{
+  EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT  *Record;
+  UINTN                                      NameSize;
+  UINT32                                     RecordSize;
+  UINT8                                      *Cursor;
+
+  if ((Image == NULL) || (DevicePath == NULL) || (DevicePathSize == 0)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  NameSize = (Name != NULL) ? StrSize (Name) : 0;
+
+  //
+  // RecordSize = header + Name + DevicePath, guarded to fit the UINT32 Length.
+  //
+  if (!SafeAddU32 (IVRT_IMAGE_HEADER_SIZE, NameSize, &RecordSize) ||
+      !SafeAddU32 (RecordSize, DevicePathSize, &RecordSize))
+  {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Record = AllocatePool (RecordSize);
+  if (Record == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  //
+  // The record is allocated exactly (Length == allocation size). It is 8-aligned,
+  // so the fixed header is written through the struct directly; ImageStatus and
+  // ImageDigestAlgorithm stay zero until AppendImage stamps them.
+  //
+  Record->Length             = RecordSize;
+  Record->ImageStatus        = 0;
+  Record->NumberOfSignatures = 0;
+  Record->NameLength         = (UINT32)NameSize;
+  Record->DevicePathLength   = (UINT32)DevicePathSize;
+  ZeroMem (&Record->ImageDigestAlgorithm, sizeof (EFI_GUID));
+
+  Cursor = (UINT8 *)Record + IVRT_IMAGE_HEADER_SIZE;
+  if (NameSize != 0) {
+    CopyMem (Cursor, Name, NameSize);
+    Cursor += NameSize;
+  }
+
+  CopyMem (Cursor, DevicePath, DevicePathSize);
+
+  *Image = Record;
+  return EFI_SUCCESS;
+}
+
+/**
+  Grow an image record by one evaluated signature.
+
+  Reallocates *Image a signature larger and appends the signature at its tail. On
+  failure *Image is left unchanged (and still valid). Signatures are appended in
+  evaluation order.
+
+  @param[in,out]  Image                The image record to extend (from CreateImage). Updated in place.
+  @param[in]      SignatureIndex       0-based ordinal of the WIN_CERTIFICATE within the image.
+  @param[in]      Status               EFI_SIGNATURE_VERIFICATION_* outcome for the signature.
+  @param[in]      ThumbprintAlgorithm  Optional digest algorithm of Thumbprint; NULL => zero GUID.
+  @param[in]      Thumbprint           Optional decisive-cert TBS-cert hash; NULL => none.
+  @param[in]      ThumbprintSize       Bytes of Thumbprint; must be 0 iff Thumbprint is NULL.
+
+  @retval EFI_SUCCESS            The signature was appended.
+  @retval EFI_INVALID_PARAMETER  Image or *Image is NULL, or the Thumbprint / ThumbprintSize /
+                                 ThumbprintAlgorithm arguments are inconsistent.
+  @retval EFI_BAD_BUFFER_SIZE    The resulting record would exceed a UINT32 size field.
+  @retval EFI_OUT_OF_RESOURCES   The record could not be grown.
+**/
+EFI_STATUS
+EFIAPI
+ImageVerificationResultAppendSignature (
+  IN OUT VOID           **Image,
+  IN     UINT32         SignatureIndex,
+  IN     UINT32         Status,
+  IN     CONST EFI_GUID  *ThumbprintAlgorithm OPTIONAL,
+  IN     CONST VOID      *Thumbprint OPTIONAL,
+  IN     UINTN          ThumbprintSize
+  )
+{
+  EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT  *Record;
+  UINT32                                     OldLength;
+  UINT32                                     SigRecordSize;
+  UINT32                                     NewLength;
+  UINT8                                      *NewRecord;
+  UINT8                                      *Signature;
+
+  if ((Image == NULL) || (*Image == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // Thumbprint and its size must agree: a present blob has a non-zero size, an
+  // absent blob has a zero size.
+  //
+  if ((Thumbprint == NULL) != (ThumbprintSize == 0)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // The record is allocated exactly, so its Length is also its current size.
+  // SigRecordSize = signature header + thumbprint; the grown Length must fit its
+  // UINT32 field.
+  //
+  Record    = (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)*Image;
+  OldLength = Record->Length;
+
+  if (!SafeAddU32 (IVRT_SIG_HEADER_SIZE, ThumbprintSize, &SigRecordSize) ||
+      !SafeAddU32 (OldLength, SigRecordSize, &NewLength))
+  {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  //
+  // Reallocate exactly one signature larger. On failure ReallocatePool leaves the
+  // old allocation intact, so *Image stays valid.
+  //
+  NewRecord = ReallocatePool (OldLength, NewLength, *Image);
+  if (NewRecord == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  *Image = NewRecord;
+  Record = (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)NewRecord;
+
+  //
+  // The signature lands at the (unaligned) tail, so its scalar fields go through
+  // the unaligned writers.
+  //
+  Signature = NewRecord + OldLength;
+
+  WriteUnaligned32 ((UINT32 *)(Signature + OFFSET_OF (EFI_SIGNATURE_VERIFICATION_RESULT, Length)), SigRecordSize);
+  WriteUnaligned32 ((UINT32 *)(Signature + OFFSET_OF (EFI_SIGNATURE_VERIFICATION_RESULT, SignatureIndex)), SignatureIndex);
+  WriteUnaligned32 ((UINT32 *)(Signature + OFFSET_OF (EFI_SIGNATURE_VERIFICATION_RESULT, Status)), Status);
+  SetOptionalGuid (Signature + OFFSET_OF (EFI_SIGNATURE_VERIFICATION_RESULT, ThumbprintAlgorithm), ThumbprintAlgorithm);
+
+  if (ThumbprintSize != 0) {
+    CopyMem (Signature + IVRT_SIG_HEADER_SIZE, Thumbprint, ThumbprintSize);
+  }
+
+  Record->Length              = NewLength;
+  Record->NumberOfSignatures += 1;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Append an image record to a copy of an existing table or creates a new table if OldTable is NULL.
+
+  Caller is responsible for freeing NewTable with FreePool().
+
+  @param[in]   OldTable             Optional currently installed table to extend; NULL for a fresh table.
+  @param[in]   Image                The image record to append (from CreateImage / AppendSignature).
+  @param[in]   ImageStatus          EFI_IMAGE_VERIFICATION_STATUS_* outcome for the image.
+  @param[in]   ImageDigestAlgorithm Optional matching digest algorithm; NULL => zero GUID.
+  @param[out]  NewTable             On success, the newly allocated table. Free with FreePool().
+
+  @retval EFI_SUCCESS            The image was appended and NewTable was produced.
+  @retval EFI_INVALID_PARAMETER  Image or NewTable is NULL, or OldTable is non-NULL but not a
+                                 valid table.
+  @retval EFI_BAD_BUFFER_SIZE    The resulting table would exceed the UINT32 Length / image count.
+  @retval EFI_OUT_OF_RESOURCES   The new table could not be allocated.
+**/
+EFI_STATUS
+EFIAPI
+ImageVerificationResultAppendImage (
+  IN  CONST VOID                                       *OldTable OPTIONAL,
+  IN  CONST VOID                                       *Image,
+  IN  UINT32                                           ImageStatus,
+  IN  CONST EFI_GUID                                   *ImageDigestAlgorithm OPTIONAL,
+  OUT EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE  **NewTable
+  )
+{
+  CONST EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE  *Old;
+  EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE        *Result;
+  UINT32                                                 ImageLength;
+  UINT32                                                 OldLength;
+  UINT32                                                 OldImages;
+  UINT32                                                 NewLength;
+  UINT32                                                 NewImages;
+  UINT8                                                  *ImageRecord;
+
+  if ((Image == NULL) || (NewTable == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // Establish the base table: an empty header when there is no old table, or the
+  // validated old table otherwise. The old table is trusted (previously produced
+  // by this library), so its self-describing Length bounds the copy.
+  //
+  if (OldTable == NULL) {
+    Old       = NULL;
+    OldLength = (UINT32)IVRT_TABLE_HEADER_SIZE;
+    OldImages = 0;
+  } else {
+    Old = (CONST EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE *)OldTable;
+    if ((Old->Signature != EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_SIGNATURE) ||
+        (Old->Version != EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_VERSION) ||
+        (Old->Length < IVRT_TABLE_HEADER_SIZE))
+    {
+      return EFI_INVALID_PARAMETER;
+    }
+
+    OldLength = Old->Length;
+    OldImages = Old->NumberOfImages;
+  }
+
+  ImageLength = ((CONST EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)Image)->Length;
+
+  if (!SafeAddU32 (OldLength, ImageLength, &NewLength) ||
+      !SafeAddU32 (OldImages, 1, &NewImages))
+  {
+    return EFI_BAD_BUFFER_SIZE;
+  }
+
+  Result = AllocatePool (NewLength);
+  if (Result == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  //
+  // Copy the base (old images, or a fresh header), append the image record, then
+  // stamp the now-known status and digest algorithm at its (unaligned) offset.
+  //
+  if (Old != NULL) {
+    CopyMem (Result, Old, OldLength);
+  } else {
+    Result->Signature = EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_SIGNATURE;
+    Result->Version   = EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_VERSION;
+  }
+
+  ImageRecord = (UINT8 *)Result + OldLength;
+  CopyMem (ImageRecord, Image, ImageLength);
+  WriteUnaligned32 ((UINT32 *)(ImageRecord + OFFSET_OF (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT, ImageStatus)), ImageStatus);
+  SetOptionalGuid (ImageRecord + OFFSET_OF (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT, ImageDigestAlgorithm), ImageDigestAlgorithm);
+
+  Result->Length         = NewLength;
+  Result->NumberOfImages = NewImages;
+
+  *NewTable = Result;
+
+  return EFI_SUCCESS;
+}
+
+// ***************************************************************************
+// Iterator (read side)
+// ***************************************************************************
+
+/**
+  Validate the signature records that trail one image record.
+
+  Confirms the region [RegionSize] holds exactly ExpectedCount self-sized
+  EFI_SIGNATURE_VERIFICATION_RESULT records that tile the region with no leftover
+  bytes.
+
+  @param[in]  Region       Start of the signature region.
+  @param[in]  RegionSize   Size of the signature region in bytes.
+  @param[in]  ExpectedCount  NumberOfSignatures declared by the owning image.
+
+  @retval TRUE   The region contains exactly ExpectedCount well-formed records.
+  @retval FALSE  The region is malformed or the record count disagrees.
+**/
+STATIC
+BOOLEAN
+ValidateSignatureRegion (
+  IN CONST UINT8  *Region,
+  IN UINTN        RegionSize,
+  IN UINT32       ExpectedCount
+  )
+{
+  UINTN   Remaining;
+  UINT32  Count;
+  UINT32  RecordLength;
+
+  Remaining = RegionSize;
+  Count     = 0;
+
+  while (Remaining > 0) {
+    if (Remaining < IVRT_SIG_HEADER_SIZE) {
+      return FALSE;
+    }
+
+    RecordLength = ReadUnaligned32 ((CONST UINT32 *)(Region + OFFSET_OF (EFI_SIGNATURE_VERIFICATION_RESULT, Length)));
+    if ((RecordLength < IVRT_SIG_HEADER_SIZE) || (RecordLength > Remaining)) {
+      return FALSE;
+    }
+
+    if (Count == MAX_UINT32) {
+      return FALSE;
+    }
+
+    Region    += RecordLength;
+    Remaining -= RecordLength;
+    Count     += 1;
+  }
+
+  return (BOOLEAN)(Count == ExpectedCount);
+}
+
+/**
+  Validate a single image record and report its total size.
+
+  Checks that the fixed header fits, that Name + DevicePath + signatures fit
+  within the record's declared Length, and that the trailing signature records
+  are well-formed and match the declared NumberOfSignatures.
+
+  @param[in]   Record        Start of the candidate image record.
+  @param[in]   Remaining     Bytes available from Record to the end of the images region.
+  @param[out]  RecordLength  On success, the record's total size in bytes.
+
+  @retval TRUE   The record is well-formed; RecordLength was written.
+  @retval FALSE  The record is malformed.
+**/
+STATIC
+BOOLEAN
+ValidateImageRecord (
+  IN  CONST UINT8  *Record,
+  IN  UINTN        Remaining,
+  OUT UINT32       *RecordLength
+  )
+{
+  UINT32  Length;
+  UINT32  NumberOfSignatures;
+  UINT32  NameLength;
+  UINT32  DevicePathLength;
+  UINTN   PayloadOffset;
+
+  if (Remaining < IVRT_IMAGE_HEADER_SIZE) {
+    return FALSE;
+  }
+
+  Length             = ReadUnaligned32 ((CONST UINT32 *)(Record + OFFSET_OF (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT, Length)));
+  NumberOfSignatures = ReadUnaligned32 ((CONST UINT32 *)(Record + OFFSET_OF (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT, NumberOfSignatures)));
+  NameLength         = ReadUnaligned32 ((CONST UINT32 *)(Record + OFFSET_OF (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT, NameLength)));
+  DevicePathLength   = ReadUnaligned32 ((CONST UINT32 *)(Record + OFFSET_OF (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT, DevicePathLength)));
+
+  if ((Length < IVRT_IMAGE_HEADER_SIZE) || (Length > Remaining)) {
+    return FALSE;
+  }
+
+  //
+  // header + Name + DevicePath must fit within Length (computed in UINTN, which
+  // cannot overflow here because each addend is a UINT32).
+  //
+  PayloadOffset = IVRT_IMAGE_HEADER_SIZE + (UINTN)NameLength + (UINTN)DevicePathLength;
+  if (PayloadOffset > Length) {
+    return FALSE;
+  }
+
+  if (!ValidateSignatureRegion (Record + PayloadOffset, Length - PayloadOffset, NumberOfSignatures)) {
+    return FALSE;
+  }
+
+  *RecordLength = Length;
+  return TRUE;
+}
+
+/**
+  Initialize an iterator over an IVRT and validate its structure.
+
+  The table is validated here, so that the different iteration routines can be
+  infallible over the valid prefix. During initialization, the structure is
+  walked, and if any record fails to parse, the iteration range is truncated to
+  the last valid record. The TRUE / FALSE return indicates whether the entire
+  table was valid or not.
+
+  @param[out]  Iterator   Iterator state to initialize.
+  @param[in]   Table      The table buffer to walk, or NULL for an empty iterator.
+
+  @retval TRUE   The iterator covers every image and signature in the table.
+  @retval FALSE  The range was truncated (a malformed record was dropped) or the inputs were
+                 unusable (bad signature/version, or an inconsistent length). The exposed
+                 iterator is still safe to use and covers the valid prefix.
+**/
+BOOLEAN
+EFIAPI
+ImageVerificationResultIteratorInit (
+  OUT IMAGE_VERIFICATION_RESULT_ITERATOR  *Iterator,
+  IN  CONST VOID                          *Table
+  )
+{
+  CONST EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE  *Header;
+  CONST UINT8                                            *Cursor;
+  UINTN                                                  Remaining;
+  UINTN                                                  ImageCount;
+  UINT32                                                 RecordLength;
+
+  if (Iterator == NULL) {
+    return FALSE;
+  }
+
+  ZeroMem (Iterator, sizeof (*Iterator));
+
+  //
+  // An absent table is an empty (not truncated) iteration.
+  //
+  if (Table == NULL) {
+    return TRUE;
+  }
+
+  Header = (CONST EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE *)Table;
+
+  //
+  // The table is self-describing: Header->Length bounds the walk (as any
+  // configuration-table consumer must trust, since the table carries no external
+  // size). Reject a foreign or mis-versioned buffer, or a Length too small to
+  // hold the header.
+  //
+  if ((Header->Signature != EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_SIGNATURE) ||
+      (Header->Version != EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_VERSION) ||
+      (Header->Length < IVRT_TABLE_HEADER_SIZE))
+  {
+    return FALSE;
+  }
+
+  Cursor     = (CONST UINT8 *)Table + IVRT_TABLE_HEADER_SIZE;
+  Remaining  = Header->Length - IVRT_TABLE_HEADER_SIZE;
+  ImageCount = 0;
+
+  //
+  // Walk the image records, stopping at the first one that fails to parse. The
+  // valid prefix is everything that tiled cleanly before it.
+  //
+  while (Remaining > 0) {
+    if (!ValidateImageRecord (Cursor, Remaining, &RecordLength)) {
+      break;
+    }
+
+    Cursor    += RecordLength;
+    Remaining -= RecordLength;
+    ImageCount += 1;
+  }
+
+  Iterator->NextImageRecord = (CONST UINT8 *)Table + IVRT_TABLE_HEADER_SIZE;
+  Iterator->ImagesRemaining = ImageCount;
+
+  //
+  // Clean only when the whole images region tiled AND the tiled count matches
+  // the declared image count.
+  //
+  return (BOOLEAN)((Remaining == 0) && (ImageCount == Header->NumberOfImages));
+}
+
+/**
+  Return the next image result and reset the inner signature cursor to it.
+
+  @param[in,out]  Iterator  An initialized iterator.
+
+  @retval non-NULL  Pointer to the next EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT.
+  @retval NULL      Iteration over the images is complete.
+**/
+CONST EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *
+EFIAPI
+ImageVerificationResultIteratorNextImage (
+  IN OUT IMAGE_VERIFICATION_RESULT_ITERATOR  *Iterator
+  )
+{
+  CONST UINT8  *Record;
+  UINT32       RecordLength;
+  UINT32       NameLength;
+  UINT32       DevicePathLength;
+  UINT32       NumberOfSignatures;
+
+  if ((Iterator == NULL) || (Iterator->ImagesRemaining == 0)) {
+    return NULL;
+  }
+
+  Record             = Iterator->NextImageRecord;
+  RecordLength       = ReadUnaligned32 ((CONST UINT32 *)(Record + OFFSET_OF (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT, Length)));
+  NumberOfSignatures = ReadUnaligned32 ((CONST UINT32 *)(Record + OFFSET_OF (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT, NumberOfSignatures)));
+  NameLength         = ReadUnaligned32 ((CONST UINT32 *)(Record + OFFSET_OF (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT, NameLength)));
+  DevicePathLength   = ReadUnaligned32 ((CONST UINT32 *)(Record + OFFSET_OF (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT, DevicePathLength)));
+
+  //
+  // Reset the inner cursor to this image's signature region. Init already proved
+  // the offsets and record count are in-bounds, so this arithmetic is safe.
+  //
+  Iterator->NextSignatureRecord = Record + IVRT_IMAGE_HEADER_SIZE + NameLength + DevicePathLength;
+  Iterator->SignaturesRemaining = NumberOfSignatures;
+
+  Iterator->NextImageRecord = Record + RecordLength;
+  Iterator->ImagesRemaining -= 1;
+
+  return (CONST EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)Record;
+}
+
+/**
+  Return the next signature result for the current image.
+
+  @param[in,out]  Iterator  An initialized iterator.
+
+  @retval non-NULL  Pointer to the next EFI_SIGNATURE_VERIFICATION_RESULT of the current image.
+  @retval NULL      The current image has no more signatures (or no image is selected).
+**/
+CONST EFI_SIGNATURE_VERIFICATION_RESULT *
+EFIAPI
+ImageVerificationResultIteratorNextSignature (
+  IN OUT IMAGE_VERIFICATION_RESULT_ITERATOR  *Iterator
+  )
+{
+  CONST UINT8  *Record;
+  UINT32       RecordLength;
+
+  if ((Iterator == NULL) || (Iterator->SignaturesRemaining == 0)) {
+    return NULL;
+  }
+
+  Record       = Iterator->NextSignatureRecord;
+  RecordLength = ReadUnaligned32 ((CONST UINT32 *)(Record + OFFSET_OF (EFI_SIGNATURE_VERIFICATION_RESULT, Length)));
+
+  Iterator->NextSignatureRecord = Record + RecordLength;
+  Iterator->SignaturesRemaining -= 1;
+
+  return (CONST EFI_SIGNATURE_VERIFICATION_RESULT *)Record;
+}

--- a/SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/ImageSecureBootVerificationResultTableLib.inf
+++ b/SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/ImageSecureBootVerificationResultTableLib.inf
@@ -1,0 +1,40 @@
+## @file
+#  Build and iterate the Image Secure Boot Verification Result Table (IVRT).
+#
+#  Provides a streaming builder for producing the
+#  EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE and a two-level forward-only
+#  iterator for walking it. The table is an in-memory, dynamically sized
+#  configuration table describing the outcome of DXE Secure Boot image
+#  verification.
+#
+# Copyright (C) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = ImageSecureBootVerificationResultTableLib
+  FILE_GUID                      = 4B9F2E7A-8C3D-4E1F-9A6B-2D5C7E8F1A03
+  MODULE_TYPE                    = BASE
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = ImageSecureBootVerificationResultTableLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64 AARCH64
+#
+
+[Sources]
+  ImageSecureBootVerificationResultTableLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  SecurityPkg/SecurityPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  MemoryAllocationLib

--- a/SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/README.md
+++ b/SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/README.md
@@ -1,0 +1,78 @@
+# ImageSecureBootVerificationResultTableLib
+
+Image Secure Boot Verification Result Table (IVRT) table defintion to fully describe images
+evaluated by the secure boot image verification process. This table contains an entry for every
+image evaluated by secure boot. This library contains the full definition of this table and
+provides methods to both generate and parse this dynamically sized table.
+
+This structure has two nested dynamically sized entries. The first level of this structure is a
+dynamically sized list of `EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT` entries, which describe
+the verification status of each image evaluated. If a particular image contains signatures, then
+an additional nested dynamically sized lized of `EFI_SIGNATURE_VERIFICATION_RESULT` entries exists
+for that given entry. See the table layout below.
+
+## Table layout
+
+```text
+EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE
+  Signature ('IVRT') | Version | Length | NumberOfImages
+  +-- EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT
+  |     Length | ImageStatus | NumberOfSignatures | NameLength |
+  |     DevicePathLength | ImageDigestAlgorithm
+  |     Name[]        (NameLength bytes, optional)
+  |     DevicePath    (DevicePathLength bytes)
+  |     +-- EFI_SIGNATURE_VERIFICATION_RESULT
+  |     |     Length | SignatureIndex | Status | ThumbprintAlgorithm | Thumbprint[]
+  |     +-- ...
+  +-- ...
+```
+
+## Table Builder
+
+`CreateImage` allocates an image record (name + device path up front), `AppendSignature` reallocates
+it a signature larger for each evaluated signature, and `AppendImage` updates the now-known status and
+returns a new, exactly-sized table (old + image). The image record and the old table are pool
+allocations the caller frees with `FreePool`.
+
+```c
+VOID                                             *Image;
+EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE  *NewTable;
+
+// Allocate the image record, then record each evaluated signature.
+ImageVerificationResultCreateImage (Name, DevicePath, DevicePathSize, &Image);
+ImageVerificationResultAppendSignature (&Image, 0, SigStatus, ThumbAlgo, Thumb, ThumbSize);
+
+// Append to the currently installed table (OldTable, or NULL for the first image).
+// The now-known image status is supplied here.
+ImageVerificationResultAppendImage (OldTable, Image, ImageStatus, DigestAlgo, &NewTable);
+
+// ... install NewTable in place of OldTable, then free the old table and the image ...
+FreePool (OldTable);
+FreePool (Image);
+```
+
+## Table Iteration
+
+The table iterator is used to walk both tiers of the table (each individual image verification
+result and individual signature verification results per image verification). `NextImage` walks
+the image list and resets the inner cursor to the new image while `NextSignature` walks the
+current image's signatures:
+
+```c
+IMAGE_VERIFICATION_RESULT_ITERATOR               Iter;
+const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT  *Image;
+const EFI_SIGNATURE_VERIFICATION_RESULT          *Sig;
+
+if (!ImageVerificationResultIteratorInit (&Iter, Table)) {
+  DEBUG ((DEBUG_WARN, "IVRT truncated; iterating the valid prefix only\n"));
+}
+
+while ((Image = ImageVerificationResultIteratorNextImage (&Iter)) != NULL) {
+  while ((Sig = ImageVerificationResultIteratorNextSignature (&Iter)) != NULL) {
+    // ... a signature of the current Image ...
+  }
+}
+```
+
+Note that a malformed table can still be walked up to the portion that is malformed. This may
+result in an iterator of length zero.

--- a/SecurityPkg/SecurityPkg.dec
+++ b/SecurityPkg/SecurityPkg.dec
@@ -149,6 +149,10 @@
   #
   PeilessSecMeasureLib|Include/Library/PeilessSecMeasureLib.h
 
+  ##  @libraryclass  Builds and iterates the Image Secure Boot Verification Result Table (IVRT).
+  #
+  ImageSecureBootVerificationResultTableLib|Include/Library/ImageSecureBootVerificationResultTableLib.h
+
 [Guids]
   ## Security package token space guid.
   # Include/Guid/SecurityPkgTokenSpace.h
@@ -177,6 +181,10 @@
   ## GUID used to "certdb"/"certdbv" variable to store the signer's certificates for common variables with EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS attribute.
   #  Include/Guid/AuthenticatedVariableFormat.h
   gEfiCertDbGuid                     = { 0xd9bee56e, 0x75dc, 0x49d9, { 0xb4, 0xd7, 0xb5, 0x34, 0x21, 0xf, 0x63, 0x7a } }
+
+  ## GUID that identifies the Image Secure Boot Verification Result Table (IVRT) configuration table.
+  #  Include/Guid/ImageSecureBootVerificationResultTable.h
+  gEfiImageSecureBootVerificationResultTableGuid = { 0x5ee66bd4, 0x895d, 0x421d, { 0x80, 0x05, 0x3a, 0x0c, 0x6b, 0x55, 0x18, 0xa1 } }
 
   ## Hob GUID used to pass a TCG_PCR_EVENT from a TPM PEIM to a TPM DXE Driver.
   #  Include/Guid/TcgEventHob.h

--- a/SecurityPkg/SecurityPkg.dsc
+++ b/SecurityPkg/SecurityPkg.dsc
@@ -207,6 +207,7 @@
 [Components]
   SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.inf
   SecurityPkg/Library/DxeImageAuthenticationStatusLib/DxeImageAuthenticationStatusLib.inf
+  SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/ImageSecureBootVerificationResultTableLib.inf
 
   #
   # TPM

--- a/SecurityPkg/Test/SecurityPkgHostTest.dsc
+++ b/SecurityPkg/Test/SecurityPkgHostTest.dsc
@@ -65,6 +65,11 @@
 # MU_CHANGE - Problems with Consuming OpensslLibFull and UnitTestHostBaseCryptLib from CryptoPkg
 
 
+  SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/GoogleTest/ImageSecureBootVerificationResultTableLibGoogleTest.inf {
+    <LibraryClasses>
+      ImageSecureBootVerificationResultTableLib|SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/ImageSecureBootVerificationResultTableLib.inf
+  }
+
 [PcdsPatchableInModule]
   gEfiSecurityPkgTokenSpaceGuid.PcdOptionRomImageVerificationPolicy|0x04
   gEfiSecurityPkgTokenSpaceGuid.PcdRemovableMediaImageVerificationPolicy|0x04


### PR DESCRIPTION
## Description

Adds the Image Secure Boot Verification Result Table definition and a helper library class for creating and parsing the table.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

CI

## Integration Instructions

N/A
