### PR TITLE
[dev/PQC] MdePkg: PeCoffLib: Record Security Data Directory

### DIFF
--- a/MdePkg/Include/Library/PeCoffLib.h
+++ b/MdePkg/Include/Library/PeCoffLib.h
@@ -204,6 +204,16 @@ typedef struct {
   /// Private storage for implementation specific data.
   ///
   UINT64                      Context;
+  ///
+  /// Set by PeCoffLoaderGetImageInfo() to a copy of the image's
+  /// EFI_IMAGE_DIRECTORY_ENTRY_SECURITY data directory entry. The entry is
+  /// populated only after PeCoffLoaderGetImageInfo() has validated that the
+  /// security data directory is non-empty and lies within the image bounds.
+  /// If the image declares no security directory, this field is zeroed. This
+  /// field is always written by PeCoffLoaderGetImageInfo(), so callers do not
+  /// need to zero-initialize the image context to consume it.
+  ///
+  EFI_IMAGE_DATA_DIRECTORY    SecurityDataDirectory;
 } PE_COFF_LOADER_IMAGE_CONTEXT;
 
 /**

--- a/MdePkg/Library/BasePeCoffLib/BasePeCoff.c
+++ b/MdePkg/Library/BasePeCoffLib/BasePeCoff.c
@@ -76,6 +76,15 @@ PeCoffLoaderGetPeHeader (
   EFI_IMAGE_SECTION_HEADER  SectionHeader;
 
   //
+  // Zero the security data directory. It is populated below only if the image
+  // declares a non-empty EFI_IMAGE_DIRECTORY_ENTRY_SECURITY entry that passes
+  // bounds checking. Callers are not required to zero-initialize the image
+  // context, so this field must always be explicitly initialized here.
+  //
+  ImageContext->SecurityDataDirectory.VirtualAddress = 0;
+  ImageContext->SecurityDataDirectory.Size           = 0;
+
+  //
   // Read the DOS image header to check for its existence
   //
   Size     = sizeof (EFI_IMAGE_DOS_HEADER);
@@ -303,6 +312,13 @@ PeCoffLoaderGetPeHeader (
 
             return Status;
           }
+
+          //
+          // The security data directory has been validated to lie within the
+          // image bounds. Record a copy of it in the image context so callers
+          // can locate the certificate data without re-parsing the headers.
+          //
+          ImageContext->SecurityDataDirectory = Hdr.Pe32->OptionalHeader.DataDirectory[EFI_IMAGE_DIRECTORY_ENTRY_SECURITY];
         }
       }
 
@@ -425,6 +441,13 @@ PeCoffLoaderGetPeHeader (
 
             return Status;
           }
+
+          //
+          // The security data directory has been validated to lie within the
+          // image bounds. Record a copy of it in the image context so callers
+          // can locate the certificate data without re-parsing the headers.
+          //
+          ImageContext->SecurityDataDirectory = Hdr.Pe32Plus->OptionalHeader.DataDirectory[EFI_IMAGE_DIRECTORY_ENTRY_SECURITY];
         }
       }
 


### PR DESCRIPTION
## Description

Adds an additional field to PE_COFF_LOADER_IMAGE_CONTEXT that is a copy of the Security Data Directory, if it exists. This field gets set when PeCoffLoaderGetImageInfo is called, if the security data directory exists. It is zerod by default.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
