### PR TITLE
[dev/PQC] SecurityPkg: Image Secure Boot Verification Result Table updates

### DIFF
--- a/SecurityPkg/Include/Guid/ImageSecureBootVerificationResultTable.h
+++ b/SecurityPkg/Include/Guid/ImageSecureBootVerificationResultTable.h
@@ -1,5 +1,5 @@
 /** @file
-  Image Secure Boot Verification Result Table (IVRT) layout and structure definitions.
+  Image Secure Boot Verification Result Table (SBRT) layout and structure definitions.
 
   This configuration table records the outcome of DXE Secure Boot image
   verification for every image that runs the full verification path, both
@@ -53,7 +53,7 @@
 #include <Uefi.h>
 
 ///
-/// GUID that identifies the Image Secure Boot Verification Result Table (IVRT)
+/// GUID that identifies the Image Secure Boot Verification Result Table (SBRT)
 /// when it is installed as a UEFI configuration table (gST->ConfigurationTable).
 ///
 #define EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_GUID \
@@ -62,9 +62,9 @@
 extern EFI_GUID  gEfiImageSecureBootVerificationResultTableGuid;
 
 ///
-/// Table signature ('IVRT') and current layout version.
+/// Table signature ('SBRT') and current layout version.
 ///
-#define EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_SIGNATURE  SIGNATURE_32 ('I', 'V', 'R', 'T')
+#define EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_SIGNATURE  SIGNATURE_32 ('S', 'B', 'R', 'T')
 #define EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_VERSION    0x00010000
 
 // ***************************************************************************
@@ -126,11 +126,14 @@ extern EFI_GUID  gEfiImageSecureBootVerificationResultTableGuid;
 ///   - MALFORMED: none; algorithm is the zero GUID.
 ///
 typedef struct {
-  UINT32      Length;                // Total size of this record, including the trailing thumbprint.
+  UINT32      Length;                // Total size of this record in bytes, including the trailing
+                                     // thumbprint and any padding; always a multiple of 8.
   UINT32      SignatureIndex;        // 0-based ordinal of this WIN_CERTIFICATE within the image.
   UINT32      Status;                // EFI_SIGNATURE_VERIFICATION_* outcome for this WIN_CERTIFICATE.
+  UINT32      ThumbprintSize;        // Size of the trailing thumbprint in bytes (0 if none).
   EFI_GUID    ThumbprintAlgorithm;   // Digest algorithm of the trailing thumbprint (zero GUID if none).
-  // UINT8    Thumbprint[];          // TBS-cert hash of the decisive certificate (see notes above).
+  // UINT8    Thumbprint[];          // ThumbprintSize bytes: TBS-cert hash of the decisive certificate.
+  // UINT8    Padding[];             // Zero padding to the next 8-byte boundary.
 } EFI_SIGNATURE_VERIFICATION_RESULT;
 
 ///
@@ -151,18 +154,21 @@ typedef struct {
 ///   3. Signatures[]  - NumberOfSignatures self-sized EFI_SIGNATURE_VERIFICATION_RESULT
 ///                      records, one per evaluated WIN_CERTIFICATE.
 ///
-/// The Signatures[] array begins at
+/// The Signatures[] array begins at the next 8-byte boundary at or after
 /// (UINT8 *)Record + sizeof (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT) + NameLength + DevicePathLength.
 ///
 typedef struct {
-  UINT32      Length;                // Total size of this record, including Name, DevicePath, Signatures[].
+  UINT32      Length;                // Total size of this record in bytes, including Name, DevicePath,
+                                     // padding, and Signatures[].
   UINT32      ImageStatus;           // EFI_IMAGE_VERIFICATION_STATUS_*.
   UINT32      NumberOfSignatures;    // Count of trailing EFI_SIGNATURE_VERIFICATION_RESULT records.
   UINT32      NameLength;            // Size of the trailing Name in bytes (including NUL), or 0 if absent.
   UINT32      DevicePathLength;      // Size of the trailing DevicePath in bytes (including end-of-path node).
+  UINT32      Reserved;              // Reserved; must be 0.
   EFI_GUID    ImageDigestAlgorithm;  // Matching algorithm for *_IMAGE_DIGEST outcomes; zero GUID otherwise.
   // CHAR16                             Name[];        // NameLength bytes.
   // EFI_DEVICE_PATH_PROTOCOL           DevicePath;    // DevicePathLength bytes.
+  // UINT8                              Padding[];     // Zero padding so Signatures[] starts 8-aligned.
   // EFI_SIGNATURE_VERIFICATION_RESULT  Signatures[];  // NumberOfSignatures self-sized records.
 } EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT;
 
@@ -170,10 +176,10 @@ typedef struct {
 /// The configuration table.
 ///
 /// A fixed header followed by a variable number of EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT
-/// records (one per evaluated image).
+/// records (one per evaluated image). Each image record is padded to an 8-byte oundary.
 ///
 typedef struct {
-  UINT32    Signature;               // EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_SIGNATURE ('IVRT').
+  UINT32    Signature;               // EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_SIGNATURE ('SBRT').
   UINT32    Version;                 // EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_VERSION.
   UINT32    Length;                  // Total table size in bytes, including all image records.
   UINT32    NumberOfImages;          // Count of EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT records that follow.

--- a/SecurityPkg/Include/Library/ImageSecureBootVerificationResultTableLib.h
+++ b/SecurityPkg/Include/Library/ImageSecureBootVerificationResultTableLib.h
@@ -1,5 +1,5 @@
 /** @file
-  Build and iterate the Image Secure Boot Verification Result Table (IVRT).
+  Build and iterate the Image Secure Boot Verification Result Table (SBRT).
 
   This library provides functionality for building an Image Secure Boot Verification
   Result Table (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE) and iterating over
@@ -44,9 +44,8 @@
 /**
   Allocate an image record from its identity (name and device path).
 
-  Returns a self-describing EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT allocation
-  with zero signatures; the overall status is supplied later, to
-  ImageVerificationResultAppendImage().
+  Returns a EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT allocation
+  with zero signatures; the overall status is set by the caller.
 
   Caller is responsible for freeing Image with FreePool().
 
@@ -77,7 +76,7 @@ ImageVerificationResultCreateImage (
   evaluation order.
 
   @param[in,out]  Image                The image record to extend (from CreateImage). Updated in place.
-  @param[in]      SignatureIndex       0-based ordinal of the WIN_CERTIFICATE within the image.
+  @param[in]      SignatureIndex       Index of the WIN_CERTIFICATE within the image.
   @param[in]      Status               EFI_SIGNATURE_VERIFICATION_* outcome for the signature.
   @param[in]      ThumbprintAlgorithm  Optional digest algorithm of Thumbprint; NULL => zero GUID.
   @param[in]      Thumbprint           Optional decisive-cert TBS-cert hash; NULL => none.
@@ -128,7 +127,7 @@ ImageVerificationResultAppendImage (
   );
 
 ///
-/// Two-level forward-only iterator over an IVRT.
+/// Two-level forward-only iterator over an SBRT.
 ///
 /// Fields are owned by the library implementation; callers should treat them as
 /// opaque and only manipulate them through the iterator routines below.
@@ -141,7 +140,7 @@ typedef struct {
 } IMAGE_VERIFICATION_RESULT_ITERATOR;
 
 /**
-  Initialize an iterator over an IVRT and validate its structure.
+  Initialize an iterator over an SBRT and validate its structure.
 
   The table is validated here, so that the different iteration routines can be
   infallible over the valid prefix. During initialization, the structure is

--- a/SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/GoogleTest/BuilderGoogleTest.cpp
+++ b/SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/GoogleTest/BuilderGoogleTest.cpp
@@ -108,7 +108,7 @@ TEST (CreateImageTest, PopulatesHeader) {
   EXPECT_EQ (AsImage (Image)->ImageStatus, 0u);
   EXPECT_EQ (
     AsImage (Image)->Length,
-    (UINT32)(sizeof (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT) + StrSize (kName) + sizeof (kDevicePath))
+    (UINT32)ALIGN_VALUE (sizeof (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT) + StrSize (kName) + sizeof (kDevicePath), 8)
     );
 
   FreePool (Image);
@@ -165,12 +165,40 @@ TEST (AppendSignatureTest, ExtendsImage) {
     EFI_SUCCESS
     );
 
-  // The image grew by exactly one signature record and counts it.
+  // The image grew by exactly one (8-byte aligned) signature record and counts it.
   EXPECT_EQ (
     AsImage (Image)->Length,
-    (UINT32)(LengthBefore + sizeof (EFI_SIGNATURE_VERIFICATION_RESULT) + sizeof (kThumbprint))
+    (UINT32)(LengthBefore + ALIGN_VALUE (sizeof (EFI_SIGNATURE_VERIFICATION_RESULT) + sizeof (kThumbprint), 8))
     );
   EXPECT_EQ (AsImage (Image)->NumberOfSignatures, 1u);
+
+  FreePool (Image);
+}
+
+TEST (AppendSignatureTest, PadsUnalignedThumbprint) {
+  VOID                *Image             = NULL;
+  static const UINT8  kOddThumbprint[20] = {
+    0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+    0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+    0x20, 0x21, 0x22, 0x23
+  };
+
+  ASSERT_EQ (ImageVerificationResultCreateImage (NULL, kDevicePath, sizeof (kDevicePath), &Image), EFI_SUCCESS);
+
+  UINT32  LengthBefore = AsImage (Image)->Length;
+
+  ASSERT_EQ (
+    ImageVerificationResultAppendSignature (&Image, 0, EFI_SIGNATURE_VERIFICATION_CERTIFICATE_AUTHORITY, &kSha256, kOddThumbprint, sizeof (kOddThumbprint)),
+    EFI_SUCCESS
+    );
+
+  const EFI_SIGNATURE_VERIFICATION_RESULT  *Sig =
+    (const EFI_SIGNATURE_VERIFICATION_RESULT *)((const UINT8 *)Image + LengthBefore);
+
+  EXPECT_EQ (Sig->Length, (UINT32)ALIGN_VALUE (sizeof (EFI_SIGNATURE_VERIFICATION_RESULT) + sizeof (kOddThumbprint), 8));
+  EXPECT_EQ ((Sig->Length & 7u), 0u);
+  EXPECT_EQ (Sig->ThumbprintSize, (UINT32)sizeof (kOddThumbprint));
+  EXPECT_EQ (0, memcmp ((const UINT8 *)Sig + sizeof (EFI_SIGNATURE_VERIFICATION_RESULT), kOddThumbprint, sizeof (kOddThumbprint)));
 
   FreePool (Image);
 }
@@ -328,12 +356,14 @@ TEST (WriteRoundTripTest, TwoImagesWithSignatures) {
   EXPECT_EQ (Sig->SignatureIndex, 0u);
   EXPECT_EQ (Sig->Status, (UINT32)EFI_SIGNATURE_VERIFICATION_REJECTED_NO_AUTHORITY);
   EXPECT_EQ (Sig->Length, (UINT32)sizeof (EFI_SIGNATURE_VERIFICATION_RESULT));
+  EXPECT_EQ (Sig->ThumbprintSize, 0u);
 
   Sig = ImageVerificationResultIteratorNextSignature (&Iter);
   ASSERT_NE (Sig, (const EFI_SIGNATURE_VERIFICATION_RESULT *)NULL);
   EXPECT_EQ (Sig->SignatureIndex, 1u);
   EXPECT_EQ (Sig->Status, (UINT32)EFI_SIGNATURE_VERIFICATION_TBS_HASH_AUTHORITY);
-  EXPECT_EQ (Sig->Length, (UINT32)(sizeof (EFI_SIGNATURE_VERIFICATION_RESULT) + sizeof (kThumbprint)));
+  EXPECT_EQ (Sig->Length, (UINT32)ALIGN_VALUE (sizeof (EFI_SIGNATURE_VERIFICATION_RESULT) + sizeof (kThumbprint), 8));
+  EXPECT_EQ (Sig->ThumbprintSize, (UINT32)sizeof (kThumbprint));
   EXPECT_EQ (0, memcmp ((const UINT8 *)Sig + sizeof (EFI_SIGNATURE_VERIFICATION_RESULT), kThumbprint, sizeof (kThumbprint)));
 
   EXPECT_EQ (ImageVerificationResultIteratorNextSignature (&Iter), (const EFI_SIGNATURE_VERIFICATION_RESULT *)NULL);

--- a/SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/GoogleTest/IteratorGoogleTest.cpp
+++ b/SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/GoogleTest/IteratorGoogleTest.cpp
@@ -348,8 +348,9 @@ TEST (IteratorTruncationTest, ShortSignatureLength_DropsImage) {
   size_t                              ImageOffset = kTableHeaderSize;
   size_t                              SigOffset;
 
-  // Signatures begin after the image header + (0-byte) name + device path.
-  SigOffset = ImageOffset + sizeof (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT) + sizeof (kDevicePath);
+  // Signatures begin at the next 8-byte boundary after the header + (0-byte)
+  // name + device path.
+  SigOffset = ImageOffset + ALIGN_VALUE (sizeof (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT) + sizeof (kDevicePath), 8);
   SetU32 (Table, SigOffset + OFFSET_OF (EFI_SIGNATURE_VERIFICATION_RESULT, Length), 4);
 
   EXPECT_FALSE (ImageVerificationResultIteratorInit (&Iter, Table.data ()));

--- a/SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/ImageSecureBootVerificationResultTableLib.c
+++ b/SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/ImageSecureBootVerificationResultTableLib.c
@@ -1,5 +1,5 @@
 /** @file
-  Build and iterate the Image Secure Boot Verification Result Table (IVRT).
+  Build and iterate the Image Secure Boot Verification Result Table (SBRT).
 
   This library provides functionality for building an Image Secure Boot Verification
   Result Table (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE) and iterating over
@@ -44,80 +44,52 @@
 #include <Library/BaseMemoryLib.h>
 #include <Library/DebugLib.h>
 #include <Library/MemoryAllocationLib.h>
+#include <Library/SafeIntLib.h>
 #include <Library/ImageSecureBootVerificationResultTableLib.h>
 
-//
-// Cached record header sizes. Every record is walked by its self-describing
-// Length, so these fixed prefixes bound where the variable payloads begin.
-//
-#define IVRT_TABLE_HEADER_SIZE  (sizeof (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE))
-#define IVRT_IMAGE_HEADER_SIZE  (sizeof (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT))
-#define IVRT_SIG_HEADER_SIZE    (sizeof (EFI_SIGNATURE_VERIFICATION_RESULT))
-
-// ***************************************************************************
-// Shared helpers
-// ***************************************************************************
+#define SBRT_TABLE_HEADER_SIZE  (sizeof (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE))
+#define SBRT_IMAGE_HEADER_SIZE  (sizeof (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT))
+#define SBRT_SIG_HEADER_SIZE    (sizeof (EFI_SIGNATURE_VERIFICATION_RESULT))
+#define SBRT_RECORD_ALIGNMENT  8U
 
 /**
-  Add two UINTN values, reporting UINT32 overflow.
+  Round an unpadded record size up to the table's 8-byte record alignment.
 
-  The table and every record size field is a UINT32, so growth arithmetic is
-  validated against MAX_UINT32 using the addition form to avoid wraparound.
+  Every record starts on an 8-byte boundary so consumers can read record fields
+  directly, so each record's stored Length is padded up to SBRT_RECORD_ALIGNMENT.
 
-  @param[in]   Augend  First value.
-  @param[in]   Addend  Second value.
-  @param[out]  Sum     On success, Augend + Addend.
+  @param[in]   Unpadded  The record's header + payload size in bytes.
+  @param[out]  Aligned   On success, Unpadded rounded up to SBRT_RECORD_ALIGNMENT.
 
-  @retval TRUE   The sum fits in a UINT32 and was written to Sum.
-  @retval FALSE  The sum would exceed MAX_UINT32; Sum is untouched.
+  @retval TRUE   The aligned size fits in a UINT32 and was written to Aligned.
+  @retval FALSE  The aligned size would exceed MAX_UINT32; Aligned is untouched.
 **/
 STATIC
 BOOLEAN
-SafeAddU32 (
-  IN  UINTN   Augend,
-  IN  UINTN   Addend,
-  OUT UINT32  *Sum
+AlignRecordSize (
+  IN  UINTN   Unpadded,
+  OUT UINT32  *Aligned
   )
 {
-  if ((Augend > MAX_UINT32) || (Addend > MAX_UINT32 - Augend)) {
+  UINTN  Pad;
+  UINTN  Padded;
+
+  Pad = (SBRT_RECORD_ALIGNMENT - (Unpadded & (SBRT_RECORD_ALIGNMENT - 1))) & (SBRT_RECORD_ALIGNMENT - 1);
+
+  if (EFI_ERROR (SafeUintnAdd (Unpadded, Pad, &Padded)) ||
+      EFI_ERROR (SafeUintnToUint32 (Padded, Aligned)))
+  {
     return FALSE;
   }
 
-  *Sum = (UINT32)(Augend + Addend);
   return TRUE;
 }
 
 /**
-  Store an EFI_GUID into a (possibly unaligned) record field, defaulting to the
-  zero GUID when no source GUID was supplied.
-
-  @param[out]  Destination  Field to populate.
-  @param[in]   Source       Optional GUID to copy; NULL stores the zero GUID.
-**/
-STATIC
-VOID
-SetOptionalGuid (
-  OUT VOID            *Destination,
-  IN  CONST EFI_GUID  *Source OPTIONAL
-  )
-{
-  if (Source != NULL) {
-    CopyMem (Destination, Source, sizeof (EFI_GUID));
-  } else {
-    ZeroMem (Destination, sizeof (EFI_GUID));
-  }
-}
-
-// ***************************************************************************
-// Builder (write side)
-// ***************************************************************************
-
-/**
   Allocate an image record from its identity (name and device path).
 
-  Returns a self-describing EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT allocation
-  with zero signatures; the overall status is supplied later, to
-  ImageVerificationResultAppendImage().
+  Returns a EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT allocation
+  with zero signatures; the overall status is set by the caller.
 
   Caller is responsible for freeing Image with FreePool().
 
@@ -142,6 +114,7 @@ ImageVerificationResultCreateImage (
 {
   EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT  *Record;
   UINTN                                      NameSize;
+  UINTN                                      RecordSizeN;
   UINT32                                     RecordSize;
   UINT8                                      *Cursor;
 
@@ -152,32 +125,29 @@ ImageVerificationResultCreateImage (
   NameSize = (Name != NULL) ? StrSize (Name) : 0;
 
   //
-  // RecordSize = header + Name + DevicePath, guarded to fit the UINT32 Length.
+  // RecordSize = ALIGN8 (header + Name + DevicePath), guarded to fit the UINT32
+  // Length.
   //
-  if (!SafeAddU32 (IVRT_IMAGE_HEADER_SIZE, NameSize, &RecordSize) ||
-      !SafeAddU32 (RecordSize, DevicePathSize, &RecordSize))
+  if (EFI_ERROR (SafeUintnAdd (SBRT_IMAGE_HEADER_SIZE, NameSize, &RecordSizeN)) ||
+      EFI_ERROR (SafeUintnAdd (RecordSizeN, DevicePathSize, &RecordSizeN)) ||
+      !AlignRecordSize (RecordSizeN, &RecordSize))
   {
     return EFI_BAD_BUFFER_SIZE;
   }
 
-  Record = AllocatePool (RecordSize);
+  //
+  // Zero-fill so the reserved field and every padding byte are deterministic.
+  //
+  Record = AllocateZeroPool (RecordSize);
   if (Record == NULL) {
     return EFI_OUT_OF_RESOURCES;
   }
 
-  //
-  // The record is allocated exactly (Length == allocation size). It is 8-aligned,
-  // so the fixed header is written through the struct directly; ImageStatus and
-  // ImageDigestAlgorithm stay zero until AppendImage stamps them.
-  //
-  Record->Length             = RecordSize;
-  Record->ImageStatus        = 0;
-  Record->NumberOfSignatures = 0;
-  Record->NameLength         = (UINT32)NameSize;
-  Record->DevicePathLength   = (UINT32)DevicePathSize;
-  ZeroMem (&Record->ImageDigestAlgorithm, sizeof (EFI_GUID));
+  Record->Length           = RecordSize;
+  Record->NameLength       = (UINT32)NameSize;
+  Record->DevicePathLength = (UINT32)DevicePathSize;
 
-  Cursor = (UINT8 *)Record + IVRT_IMAGE_HEADER_SIZE;
+  Cursor = (UINT8 *)Record + SBRT_IMAGE_HEADER_SIZE;
   if (NameSize != 0) {
     CopyMem (Cursor, Name, NameSize);
     Cursor += NameSize;
@@ -197,7 +167,7 @@ ImageVerificationResultCreateImage (
   evaluation order.
 
   @param[in,out]  Image                The image record to extend (from CreateImage). Updated in place.
-  @param[in]      SignatureIndex       0-based ordinal of the WIN_CERTIFICATE within the image.
+  @param[in]      SignatureIndex       Index of the WIN_CERTIFICATE within the image.
   @param[in]      Status               EFI_SIGNATURE_VERIFICATION_* outcome for the signature.
   @param[in]      ThumbprintAlgorithm  Optional digest algorithm of Thumbprint; NULL => zero GUID.
   @param[in]      Thumbprint           Optional decisive-cert TBS-cert hash; NULL => none.
@@ -221,42 +191,37 @@ ImageVerificationResultAppendSignature (
   )
 {
   EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT  *Record;
+  EFI_SIGNATURE_VERIFICATION_RESULT          *Signature;
+  UINTN                                      SigRecordSizeN;
   UINT32                                     OldLength;
   UINT32                                     SigRecordSize;
   UINT32                                     NewLength;
   UINT8                                      *NewRecord;
-  UINT8                                      *Signature;
 
   if ((Image == NULL) || (*Image == NULL)) {
     return EFI_INVALID_PARAMETER;
   }
 
   //
-  // Thumbprint and its size must agree: a present blob has a non-zero size, an
-  // absent blob has a zero size.
+  // If Thumbprint is null, ThumbprintSize must be 0; if Thumbprint is non-null,
+  // ThumbprintSize must be non-zero.
   //
   if ((Thumbprint == NULL) != (ThumbprintSize == 0)) {
     return EFI_INVALID_PARAMETER;
   }
 
-  //
-  // The record is allocated exactly, so its Length is also its current size.
-  // SigRecordSize = signature header + thumbprint; the grown Length must fit its
-  // UINT32 field.
-  //
   Record    = (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)*Image;
   OldLength = Record->Length;
 
-  if (!SafeAddU32 (IVRT_SIG_HEADER_SIZE, ThumbprintSize, &SigRecordSize) ||
-      !SafeAddU32 (OldLength, SigRecordSize, &NewLength))
+  //
+  // SigRecordSize = ALIGN8 (header + Thumbprint).
+  if (EFI_ERROR (SafeUintnAdd (SBRT_SIG_HEADER_SIZE, ThumbprintSize, &SigRecordSizeN)) ||
+      !AlignRecordSize (SigRecordSizeN, &SigRecordSize) ||
+      EFI_ERROR (SafeUint32Add (OldLength, SigRecordSize, &NewLength)))
   {
     return EFI_BAD_BUFFER_SIZE;
   }
 
-  //
-  // Reallocate exactly one signature larger. On failure ReallocatePool leaves the
-  // old allocation intact, so *Image stays valid.
-  //
   NewRecord = ReallocatePool (OldLength, NewLength, *Image);
   if (NewRecord == NULL) {
     return EFI_OUT_OF_RESOURCES;
@@ -266,18 +231,20 @@ ImageVerificationResultAppendSignature (
   Record = (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)NewRecord;
 
   //
-  // The signature lands at the (unaligned) tail, so its scalar fields go through
-  // the unaligned writers.
-  //
-  Signature = NewRecord + OldLength;
+  // ReallocatePool leaves the grown tail uninitialized; zero the new record.
+  Signature = (EFI_SIGNATURE_VERIFICATION_RESULT *)(NewRecord + OldLength);
+  ZeroMem (Signature, SigRecordSize);
 
-  WriteUnaligned32 ((UINT32 *)(Signature + OFFSET_OF (EFI_SIGNATURE_VERIFICATION_RESULT, Length)), SigRecordSize);
-  WriteUnaligned32 ((UINT32 *)(Signature + OFFSET_OF (EFI_SIGNATURE_VERIFICATION_RESULT, SignatureIndex)), SignatureIndex);
-  WriteUnaligned32 ((UINT32 *)(Signature + OFFSET_OF (EFI_SIGNATURE_VERIFICATION_RESULT, Status)), Status);
-  SetOptionalGuid (Signature + OFFSET_OF (EFI_SIGNATURE_VERIFICATION_RESULT, ThumbprintAlgorithm), ThumbprintAlgorithm);
+  Signature->Length         = SigRecordSize;
+  Signature->SignatureIndex = SignatureIndex;
+  Signature->Status         = Status;
+  Signature->ThumbprintSize = (UINT32)ThumbprintSize;
+  if (ThumbprintAlgorithm != NULL) {
+    CopyGuid (&Signature->ThumbprintAlgorithm, ThumbprintAlgorithm);
+  }
 
   if (ThumbprintSize != 0) {
-    CopyMem (Signature + IVRT_SIG_HEADER_SIZE, Thumbprint, ThumbprintSize);
+    CopyMem ((UINT8 *)Signature + SBRT_SIG_HEADER_SIZE, Thumbprint, ThumbprintSize);
   }
 
   Record->Length              = NewLength;
@@ -315,31 +282,28 @@ ImageVerificationResultAppendImage (
 {
   CONST EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE  *Old;
   EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE        *Result;
+  EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT              *NewImage;
   UINT32                                                 ImageLength;
   UINT32                                                 OldLength;
   UINT32                                                 OldImages;
   UINT32                                                 NewLength;
   UINT32                                                 NewImages;
-  UINT8                                                  *ImageRecord;
 
   if ((Image == NULL) || (NewTable == NULL)) {
     return EFI_INVALID_PARAMETER;
   }
 
   //
-  // Establish the base table: an empty header when there is no old table, or the
-  // validated old table otherwise. The old table is trusted (previously produced
-  // by this library), so its self-describing Length bounds the copy.
-  //
+  // Reuse the old table's header if present, otherwise start a new table.
   if (OldTable == NULL) {
     Old       = NULL;
-    OldLength = (UINT32)IVRT_TABLE_HEADER_SIZE;
+    OldLength = (UINT32)SBRT_TABLE_HEADER_SIZE;
     OldImages = 0;
   } else {
     Old = (CONST EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE *)OldTable;
     if ((Old->Signature != EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_SIGNATURE) ||
         (Old->Version != EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_VERSION) ||
-        (Old->Length < IVRT_TABLE_HEADER_SIZE))
+        (Old->Length < SBRT_TABLE_HEADER_SIZE))
     {
       return EFI_INVALID_PARAMETER;
     }
@@ -350,8 +314,8 @@ ImageVerificationResultAppendImage (
 
   ImageLength = ((CONST EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)Image)->Length;
 
-  if (!SafeAddU32 (OldLength, ImageLength, &NewLength) ||
-      !SafeAddU32 (OldImages, 1, &NewImages))
+  if (EFI_ERROR (SafeUint32Add (OldLength, ImageLength, &NewLength)) ||
+      EFI_ERROR (SafeUint32Add (OldImages, 1, &NewImages)))
   {
     return EFI_BAD_BUFFER_SIZE;
   }
@@ -361,10 +325,6 @@ ImageVerificationResultAppendImage (
     return EFI_OUT_OF_RESOURCES;
   }
 
-  //
-  // Copy the base (old images, or a fresh header), append the image record, then
-  // stamp the now-known status and digest algorithm at its (unaligned) offset.
-  //
   if (Old != NULL) {
     CopyMem (Result, Old, OldLength);
   } else {
@@ -372,10 +332,12 @@ ImageVerificationResultAppendImage (
     Result->Version   = EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_VERSION;
   }
 
-  ImageRecord = (UINT8 *)Result + OldLength;
-  CopyMem (ImageRecord, Image, ImageLength);
-  WriteUnaligned32 ((UINT32 *)(ImageRecord + OFFSET_OF (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT, ImageStatus)), ImageStatus);
-  SetOptionalGuid (ImageRecord + OFFSET_OF (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT, ImageDigestAlgorithm), ImageDigestAlgorithm);
+  NewImage = (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)((UINT8 *)Result + OldLength);
+  CopyMem (NewImage, Image, ImageLength);
+  NewImage->ImageStatus = ImageStatus;
+  if (ImageDigestAlgorithm != NULL) {
+    CopyGuid (&NewImage->ImageDigestAlgorithm, ImageDigestAlgorithm);
+  }
 
   Result->Length         = NewLength;
   Result->NumberOfImages = NewImages;
@@ -385,16 +347,8 @@ ImageVerificationResultAppendImage (
   return EFI_SUCCESS;
 }
 
-// ***************************************************************************
-// Iterator (read side)
-// ***************************************************************************
-
 /**
   Validate the signature records that trail one image record.
-
-  Confirms the region [RegionSize] holds exactly ExpectedCount self-sized
-  EFI_SIGNATURE_VERIFICATION_RESULT records that tile the region with no leftover
-  bytes.
 
   @param[in]  Region       Start of the signature region.
   @param[in]  RegionSize   Size of the signature region in bytes.
@@ -411,20 +365,27 @@ ValidateSignatureRegion (
   IN UINT32       ExpectedCount
   )
 {
-  UINTN   Remaining;
-  UINT32  Count;
-  UINT32  RecordLength;
+  CONST EFI_SIGNATURE_VERIFICATION_RESULT  *Signature;
+  UINTN                                    Remaining;
+  UINT32                                   Count;
+  UINT32                                   RecordLength;
 
   Remaining = RegionSize;
   Count     = 0;
 
   while (Remaining > 0) {
-    if (Remaining < IVRT_SIG_HEADER_SIZE) {
+    if (Remaining < SBRT_SIG_HEADER_SIZE) {
       return FALSE;
     }
 
-    RecordLength = ReadUnaligned32 ((CONST UINT32 *)(Region + OFFSET_OF (EFI_SIGNATURE_VERIFICATION_RESULT, Length)));
-    if ((RecordLength < IVRT_SIG_HEADER_SIZE) || (RecordLength > Remaining)) {
+    Signature    = (CONST EFI_SIGNATURE_VERIFICATION_RESULT *)Region;
+    RecordLength = Signature->Length;
+
+    if ((RecordLength < SBRT_SIG_HEADER_SIZE) ||
+        (RecordLength > Remaining) ||
+        ((RecordLength & (SBRT_RECORD_ALIGNMENT - 1)) != 0) ||
+        (Signature->ThumbprintSize > RecordLength - SBRT_SIG_HEADER_SIZE))
+    {
       return FALSE;
     }
 
@@ -443,10 +404,6 @@ ValidateSignatureRegion (
 /**
   Validate a single image record and report its total size.
 
-  Checks that the fixed header fits, that Name + DevicePath + signatures fit
-  within the record's declared Length, and that the trailing signature records
-  are well-formed and match the declared NumberOfSignatures.
-
   @param[in]   Record        Start of the candidate image record.
   @param[in]   Remaining     Bytes available from Record to the end of the images region.
   @param[out]  RecordLength  On success, the record's total size in bytes.
@@ -462,35 +419,39 @@ ValidateImageRecord (
   OUT UINT32       *RecordLength
   )
 {
-  UINT32  Length;
-  UINT32  NumberOfSignatures;
-  UINT32  NameLength;
-  UINT32  DevicePathLength;
-  UINTN   PayloadOffset;
+  CONST EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT  *Image;
+  UINT32                                           Length;
+  UINT32                                           NameLength;
+  UINT32                                           DevicePathLength;
+  UINTN                                            PayloadOffset;
 
-  if (Remaining < IVRT_IMAGE_HEADER_SIZE) {
+  if (Remaining < SBRT_IMAGE_HEADER_SIZE) {
     return FALSE;
   }
 
-  Length             = ReadUnaligned32 ((CONST UINT32 *)(Record + OFFSET_OF (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT, Length)));
-  NumberOfSignatures = ReadUnaligned32 ((CONST UINT32 *)(Record + OFFSET_OF (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT, NumberOfSignatures)));
-  NameLength         = ReadUnaligned32 ((CONST UINT32 *)(Record + OFFSET_OF (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT, NameLength)));
-  DevicePathLength   = ReadUnaligned32 ((CONST UINT32 *)(Record + OFFSET_OF (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT, DevicePathLength)));
+  Image            = (CONST EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)Record;
+  Length           = Image->Length;
+  NameLength       = Image->NameLength;
+  DevicePathLength = Image->DevicePathLength;
 
-  if ((Length < IVRT_IMAGE_HEADER_SIZE) || (Length > Remaining)) {
+  if ((Length < SBRT_IMAGE_HEADER_SIZE) ||
+      (Length > Remaining) ||
+      ((Length & (SBRT_RECORD_ALIGNMENT - 1)) != 0) ||
+      (NameLength > Length - SBRT_IMAGE_HEADER_SIZE) ||
+      (DevicePathLength > Length - SBRT_IMAGE_HEADER_SIZE - NameLength))
+  {
     return FALSE;
   }
 
   //
-  // header + Name + DevicePath must fit within Length (computed in UINTN, which
-  // cannot overflow here because each addend is a UINT32).
+  // Signatures[] begins at the next 8-byte boundary after the name/device path.
   //
-  PayloadOffset = IVRT_IMAGE_HEADER_SIZE + (UINTN)NameLength + (UINTN)DevicePathLength;
+  PayloadOffset = ALIGN_VALUE (SBRT_IMAGE_HEADER_SIZE + (UINTN)NameLength + (UINTN)DevicePathLength, SBRT_RECORD_ALIGNMENT);
   if (PayloadOffset > Length) {
     return FALSE;
   }
 
-  if (!ValidateSignatureRegion (Record + PayloadOffset, Length - PayloadOffset, NumberOfSignatures)) {
+  if (!ValidateSignatureRegion (Record + PayloadOffset, Length - PayloadOffset, Image->NumberOfSignatures)) {
     return FALSE;
   }
 
@@ -499,7 +460,7 @@ ValidateImageRecord (
 }
 
 /**
-  Initialize an iterator over an IVRT and validate its structure.
+  Initialize an iterator over an SBRT and validate its structure.
 
   The table is validated here, so that the different iteration routines can be
   infallible over the valid prefix. During initialization, the structure is
@@ -543,21 +504,15 @@ ImageVerificationResultIteratorInit (
 
   Header = (CONST EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE *)Table;
 
-  //
-  // The table is self-describing: Header->Length bounds the walk (as any
-  // configuration-table consumer must trust, since the table carries no external
-  // size). Reject a foreign or mis-versioned buffer, or a Length too small to
-  // hold the header.
-  //
   if ((Header->Signature != EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_SIGNATURE) ||
       (Header->Version != EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE_VERSION) ||
-      (Header->Length < IVRT_TABLE_HEADER_SIZE))
+      (Header->Length < SBRT_TABLE_HEADER_SIZE))
   {
     return FALSE;
   }
 
-  Cursor     = (CONST UINT8 *)Table + IVRT_TABLE_HEADER_SIZE;
-  Remaining  = Header->Length - IVRT_TABLE_HEADER_SIZE;
+  Cursor     = (CONST UINT8 *)Table + SBRT_TABLE_HEADER_SIZE;
+  Remaining  = Header->Length - SBRT_TABLE_HEADER_SIZE;
   ImageCount = 0;
 
   //
@@ -574,13 +529,9 @@ ImageVerificationResultIteratorInit (
     ImageCount += 1;
   }
 
-  Iterator->NextImageRecord = (CONST UINT8 *)Table + IVRT_TABLE_HEADER_SIZE;
+  Iterator->NextImageRecord = (CONST UINT8 *)Table + SBRT_TABLE_HEADER_SIZE;
   Iterator->ImagesRemaining = ImageCount;
 
-  //
-  // Clean only when the whole images region tiled AND the tiled count matches
-  // the declared image count.
-  //
   return (BOOLEAN)((Remaining == 0) && (ImageCount == Header->NumberOfImages));
 }
 
@@ -598,33 +549,24 @@ ImageVerificationResultIteratorNextImage (
   IN OUT IMAGE_VERIFICATION_RESULT_ITERATOR  *Iterator
   )
 {
-  CONST UINT8  *Record;
-  UINT32       RecordLength;
-  UINT32       NameLength;
-  UINT32       DevicePathLength;
-  UINT32       NumberOfSignatures;
+  CONST EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT  *Image;
+  CONST UINT8                                      *Record;
 
   if ((Iterator == NULL) || (Iterator->ImagesRemaining == 0)) {
     return NULL;
   }
 
-  Record             = Iterator->NextImageRecord;
-  RecordLength       = ReadUnaligned32 ((CONST UINT32 *)(Record + OFFSET_OF (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT, Length)));
-  NumberOfSignatures = ReadUnaligned32 ((CONST UINT32 *)(Record + OFFSET_OF (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT, NumberOfSignatures)));
-  NameLength         = ReadUnaligned32 ((CONST UINT32 *)(Record + OFFSET_OF (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT, NameLength)));
-  DevicePathLength   = ReadUnaligned32 ((CONST UINT32 *)(Record + OFFSET_OF (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT, DevicePathLength)));
+  Record = Iterator->NextImageRecord;
+  Image  = (CONST EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)Record;
 
-  //
-  // Reset the inner cursor to this image's signature region. Init already proved
-  // the offsets and record count are in-bounds, so this arithmetic is safe.
-  //
-  Iterator->NextSignatureRecord = Record + IVRT_IMAGE_HEADER_SIZE + NameLength + DevicePathLength;
-  Iterator->SignaturesRemaining = NumberOfSignatures;
+  // Reset the inner cursor to this image's signature region, which begins at the next 8-byte boundary after the name and device path.
+  Iterator->NextSignatureRecord = Record + ALIGN_VALUE (SBRT_IMAGE_HEADER_SIZE + (UINTN)Image->NameLength + (UINTN)Image->DevicePathLength, SBRT_RECORD_ALIGNMENT);
+  Iterator->SignaturesRemaining = Image->NumberOfSignatures;
 
-  Iterator->NextImageRecord  = Record + RecordLength;
+  Iterator->NextImageRecord  = Record + Image->Length;
   Iterator->ImagesRemaining -= 1;
 
-  return (CONST EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT *)Record;
+  return Image;
 }
 
 /**
@@ -641,18 +583,16 @@ ImageVerificationResultIteratorNextSignature (
   IN OUT IMAGE_VERIFICATION_RESULT_ITERATOR  *Iterator
   )
 {
-  CONST UINT8  *Record;
-  UINT32       RecordLength;
+  CONST EFI_SIGNATURE_VERIFICATION_RESULT  *Signature;
 
   if ((Iterator == NULL) || (Iterator->SignaturesRemaining == 0)) {
     return NULL;
   }
 
-  Record       = Iterator->NextSignatureRecord;
-  RecordLength = ReadUnaligned32 ((CONST UINT32 *)(Record + OFFSET_OF (EFI_SIGNATURE_VERIFICATION_RESULT, Length)));
+  Signature = (CONST EFI_SIGNATURE_VERIFICATION_RESULT *)Iterator->NextSignatureRecord;
 
-  Iterator->NextSignatureRecord  = Record + RecordLength;
+  Iterator->NextSignatureRecord  = (CONST UINT8 *)Signature + Signature->Length;
   Iterator->SignaturesRemaining -= 1;
 
-  return (CONST EFI_SIGNATURE_VERIFICATION_RESULT *)Record;
+  return Signature;
 }

--- a/SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/ImageSecureBootVerificationResultTableLib.c
+++ b/SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/ImageSecureBootVerificationResultTableLib.c
@@ -50,7 +50,7 @@
 #define SBRT_TABLE_HEADER_SIZE  (sizeof (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE))
 #define SBRT_IMAGE_HEADER_SIZE  (sizeof (EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT))
 #define SBRT_SIG_HEADER_SIZE    (sizeof (EFI_SIGNATURE_VERIFICATION_RESULT))
-#define SBRT_RECORD_ALIGNMENT  8U
+#define SBRT_RECORD_ALIGNMENT   8U
 
 /**
   Round an unpadded record size up to the table's 8-byte record alignment.

--- a/SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/ImageSecureBootVerificationResultTableLib.inf
+++ b/SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/ImageSecureBootVerificationResultTableLib.inf
@@ -1,5 +1,5 @@
 ## @file
-#  Build and iterate the Image Secure Boot Verification Result Table (IVRT).
+#  Build and iterate the Image Secure Boot Verification Result Table (SBRT).
 #
 #  Provides a streaming builder for producing the
 #  EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE and a two-level forward-only
@@ -38,3 +38,4 @@
   BaseMemoryLib
   DebugLib
   MemoryAllocationLib
+  SafeIntLib

--- a/SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/README.md
+++ b/SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/README.md
@@ -1,6 +1,6 @@
 # ImageSecureBootVerificationResultTableLib
 
-Image Secure Boot Verification Result Table (IVRT) table defintion to fully describe images
+Image Secure Boot Verification Result Table (SBRT) table defintion to fully describe images
 evaluated by the secure boot image verification process. This table contains an entry for every
 image evaluated by secure boot. This library contains the full definition of this table and
 provides methods to both generate and parse this dynamically sized table.
@@ -15,17 +15,24 @@ for that given entry. See the table layout below.
 
 ```text
 EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE
-  Signature ('IVRT') | Version | Length | NumberOfImages
+  Signature ('SBRT') | Version | Length | NumberOfImages
   +-- EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT
   |     Length | ImageStatus | NumberOfSignatures | NameLength |
-  |     DevicePathLength | ImageDigestAlgorithm
+  |     DevicePathLength | Reserved | ImageDigestAlgorithm
   |     Name[]        (NameLength bytes, optional)
   |     DevicePath    (DevicePathLength bytes)
+  |     Padding       (to the next 8-byte boundary)
   |     +-- EFI_SIGNATURE_VERIFICATION_RESULT
-  |     |     Length | SignatureIndex | Status | ThumbprintAlgorithm | Thumbprint[]
+  |     |     Length | SignatureIndex | Status | ThumbprintSize | ThumbprintAlgorithm
+  |     |     Thumbprint[]  (ThumbprintSize bytes)
+  |     |     Padding       (to the next 8-byte boundary)
   |     +-- ...
   +-- ...
 ```
+
+Every record (the table header, each image record, and each signature record) starts on an 8-byte
+boundary, and each record's `Length` is padded up to a multiple of 8. Consumers can therefore cast a
+record pointer directly to the structures above and read their fields with no unaligned accesses.
 
 ## Table Builder
 
@@ -64,7 +71,7 @@ const EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT  *Image;
 const EFI_SIGNATURE_VERIFICATION_RESULT          *Sig;
 
 if (!ImageVerificationResultIteratorInit (&Iter, Table)) {
-  DEBUG ((DEBUG_WARN, "IVRT truncated; iterating the valid prefix only\n"));
+  DEBUG ((DEBUG_WARN, "SBRT truncated; iterating the valid prefix only\n"));
 }
 
 while ((Image = ImageVerificationResultIteratorNextImage (&Iter)) != NULL) {

--- a/SecurityPkg/SecurityPkg.dec
+++ b/SecurityPkg/SecurityPkg.dec
@@ -149,7 +149,7 @@
   #
   PeilessSecMeasureLib|Include/Library/PeilessSecMeasureLib.h
 
-  ##  @libraryclass  Builds and iterates the Image Secure Boot Verification Result Table (IVRT).
+  ##  @libraryclass  Builds and iterates the Image Secure Boot Verification Result Table (SBRT).
   #
   ImageSecureBootVerificationResultTableLib|Include/Library/ImageSecureBootVerificationResultTableLib.h
 
@@ -182,7 +182,7 @@
   #  Include/Guid/AuthenticatedVariableFormat.h
   gEfiCertDbGuid                     = { 0xd9bee56e, 0x75dc, 0x49d9, { 0xb4, 0xd7, 0xb5, 0x34, 0x21, 0xf, 0x63, 0x7a } }
 
-  ## GUID that identifies the Image Secure Boot Verification Result Table (IVRT) configuration table.
+  ## GUID that identifies the Image Secure Boot Verification Result Table (SBRT) configuration table.
   #  Include/Guid/ImageSecureBootVerificationResultTable.h
   gEfiImageSecureBootVerificationResultTableGuid = { 0x5ee66bd4, 0x895d, 0x421d, { 0x80, 0x05, 0x3a, 0x0c, 0x6b, 0x55, 0x18, 0xa1 } }
 


### PR DESCRIPTION
## Description

This commit updates the Image Secure Boot Verification Table in two ways:

1. Updates table documentation and signature from IVRT to SBRT to reduce possible confusion with the IVRS ACPI Table

2. Updates the table inner fields and alignment requirements to be 8 byte aligned by adding reserved fields to structures and padding to the dynamically sized types.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A

## Integration Instructions

N/A
