### PR TITLE
Add Missing 2502 MTC Var Policy Change [Rebase & FF]

### DIFF
--- a/MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
+++ b/MdeModulePkg/Library/UefiBootManagerLib/UefiBootManagerLib.inf
@@ -20,6 +20,7 @@
   MODULE_TYPE                    = DXE_DRIVER
   VERSION_STRING                 = 1.0
   LIBRARY_CLASS                  = UefiBootManagerLib|DXE_DRIVER DXE_RUNTIME_DRIVER UEFI_APPLICATION UEFI_DRIVER
+  CONSTRUCTOR                    = UefiBootManagerLibConstructor            # MU_CHANGE
 
 #
 # The following information is for reference only and not required by the build tools.

--- a/MdeModulePkg/Universal/MonotonicCounterRuntimeDxe/MonotonicCounter.c
+++ b/MdeModulePkg/Universal/MonotonicCounterRuntimeDxe/MonotonicCounter.c
@@ -10,6 +10,8 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Uefi.h>
 
 #include <Protocol/MonotonicCounter.h>
+#include <Protocol/VariablePolicy.h>                // MU_CHANGE
+
 #include <Guid/MtcVendor.h>
 
 #include <Library/BaseLib.h>
@@ -18,9 +20,10 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 #include <Library/DebugLib.h>
 #include <Library/UefiBootServicesTableLib.h>
 #include <Library/UefiRuntimeServicesTableLib.h>
+#include <Library/VariablePolicyHelperLib.h>        // MU_CHANGE
 
 //
-// The handle to install Monotonic Counter Architctural Protocol
+// The handle to install Monotonic Counter Architectural Protocol
 //
 EFI_HANDLE  mMonotonicCounterHandle = NULL;
 
@@ -189,6 +192,65 @@ EfiMtcEventHandler (
   MonotonicCounterDriverGetNextHighMonotonicCount (&HighCount);
 }
 
+//
+// MU_CHANGE begin
+//
+
+/**
+    OnVariablePolicyProtocolNotification
+
+    Sets the AdvancedLogger Locator variable policy.
+
+    @param[in]      Event   - NULL if called from Entry, Event if called from notification
+    @param[in]      Context - VariablePolicy if called from Entry, NULL if called from notification
+
+  **/
+STATIC
+VOID
+EFIAPI
+OnVariablePolicyProtocolNotification (
+  IN  EFI_EVENT  Event,
+  IN  VOID       *Context
+  )
+{
+  EDKII_VARIABLE_POLICY_PROTOCOL  *VariablePolicy = NULL;
+  EFI_STATUS                      Status;
+
+  DEBUG ((DEBUG_INFO, "%a: Setting policy for MTC variable, Context=%p\n", __FUNCTION__, Context));
+
+  if (Context != NULL) {
+    VariablePolicy = (EDKII_VARIABLE_POLICY_PROTOCOL *)Context;
+  } else {
+    Status = gBS->LocateProtocol (&gEdkiiVariablePolicyProtocolGuid, NULL, (VOID **)&VariablePolicy);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: - Locating Variable Policy failed - Code=%r\n", __FUNCTION__, Status));
+      ASSERT_EFI_ERROR (Status);
+      return;
+    }
+  }
+
+  Status = RegisterBasicVariablePolicy (
+             VariablePolicy,
+             &gMtcVendorGuid,
+             MTC_VARIABLE_NAME,
+             sizeof (UINT32),
+             sizeof (UINT32),
+             EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS | EFI_VARIABLE_NON_VOLATILE,
+             (UINT32) ~(EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS | EFI_VARIABLE_NON_VOLATILE),
+             VARIABLE_POLICY_TYPE_NO_LOCK
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: - Error setting policy for MTC - Code=%r\n", __FUNCTION__, Status));
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  return;
+}
+
+//
+// MU_CHANGE end
+//
+
 /**
   Entry point of monotonic counter driver.
 
@@ -205,9 +267,12 @@ MonotonicCounterDriverInitialize (
   IN EFI_SYSTEM_TABLE  *SystemTable
   )
 {
-  EFI_STATUS  Status;
-  UINT32      HighCount;
-  UINTN       BufferSize;
+  EFI_STATUS                      Status;
+  UINT32                          HighCount;
+  UINTN                           BufferSize;
+  EFI_EVENT                       Event;                   // MU_CHANGE
+  VOID                            *ProtocolRegistration;   // MU_CHANGE
+  EDKII_VARIABLE_POLICY_PROTOCOL  *VariablePolicy = NULL;  // MU_CHANGE
 
   //
   // Make sure the Monotonic Counter Architectural Protocol has not been installed in the system yet.
@@ -269,6 +334,48 @@ MonotonicCounterDriverInitialize (
                   NULL
                   );
   ASSERT_EFI_ERROR (Status);
+
+  //
+  // MU_CHANGE begin
+  //
+  // There is no dependency for VariablePolicy Protocol in case this code is used
+  // in firmware without VariablePolicy.  And, VariablePolicy may or may not be installed
+  // before this driver is run.  If the Variable Policy Protocol is not found, register for
+  // a notification that may not occur.
+
+  Status = gBS->LocateProtocol (&gEdkiiVariablePolicyProtocolGuid, NULL, (VOID **)&VariablePolicy);
+  if (EFI_ERROR (Status)) {
+    Status = gBS->CreateEvent (
+                    EVT_NOTIFY_SIGNAL,
+                    TPL_CALLBACK,
+                    OnVariablePolicyProtocolNotification,
+                    NULL,
+                    &Event
+                    );
+
+    if (EFI_ERROR (Status)) {
+      DEBUG ((DEBUG_ERROR, "%a: failed to create notification callback event (%r)\n", __FUNCTION__, Status));
+      ASSERT_EFI_ERROR (Status);
+    } else {
+      Status = gBS->RegisterProtocolNotify (
+                      &gEdkiiVariablePolicyProtocolGuid,
+                      Event,
+                      &ProtocolRegistration
+                      );
+
+      if (EFI_ERROR (Status)) {
+        DEBUG ((DEBUG_ERROR, "%a: failed to register for notification (%r)\n", __FUNCTION__, Status));
+        gBS->CloseEvent (Event);
+        ASSERT_EFI_ERROR (Status);
+      }
+    }
+  } else {
+    OnVariablePolicyProtocolNotification (NULL, VariablePolicy);
+  }
+
+  //
+  // MU_CHANGE end
+  //
 
   return EFI_SUCCESS;
 }

--- a/MdeModulePkg/Universal/MonotonicCounterRuntimeDxe/MonotonicCounterRuntimeDxe.inf
+++ b/MdeModulePkg/Universal/MonotonicCounterRuntimeDxe/MonotonicCounterRuntimeDxe.inf
@@ -38,6 +38,7 @@
   UefiRuntimeLib
   UefiDriverEntryPoint
   BaseLib
+  VariablePolicyHelperLib              # MU_CHANGE
 
 [Guids]
   ## PRODUCES ## Variable:L"MTC"
@@ -46,7 +47,7 @@
 
 [Protocols]
   gEfiMonotonicCounterArchProtocolGuid  ## PRODUCES
-
+  gEdkiiVariablePolicyProtocolGuid      ## CONSUMES    # MU_CHANGE
 
 [Depex]
   gEfiVariableArchProtocolGuid AND gEfiVariableWriteArchProtocolGuid


### PR DESCRIPTION
## Description

This 2502 commit had two changes missing from 2511 https://github.com/microsoft/mu_basecore/commit/c087d2420a17bb757b70cbd0c82f696f330c53a1.

The first is the constructor missing in the UefiBootManagerLib.inf file and the MTC changes not in 2511.

- The constructor is missing in edk2, apparently because the constructor was a separate Mu change made from the change cherry-picked to edk2. I've created a PR in edk2 to simply add the constructor there.
- The MTC var policy changes are just missing from 2502 (not part of edk2). I'll go ahead and upstream them to edk2 to reduce the delta in the future.

- [x] Impacts functionality?
- [x] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- Build and boot Q35

`MTC` variable before

<img width="423" height="123" alt="image" src="https://github.com/user-attachments/assets/e1eda3b6-7065-415b-9fde-20d5d1ee9067" />

`MTC` variable after

<img width="642" height="369" alt="image" src="https://github.com/user-attachments/assets/9bced651-4944-4add-99a6-eb90f9362c11" />

## Integration Instructions

- N/A