### PR TITLE
[dev/PQC][REBASE&FF] Add initial DXE image verification implementation

### DIFF
--- a/SecurityPkg/Library/DxeImageVerificationLib2/Database.c
+++ b/SecurityPkg/Library/DxeImageVerificationLib2/Database.c
@@ -1,0 +1,689 @@
+/** @file
+  Secureboot DB/DBX/DBT (EFI_SIGNATURE_LIST) helpers, including signed-image
+  (certificate / Authenticode) validation, for the DXE Image Verification Library.
+
+  Caution: This file consumes external input (the PE/COFF image and the
+  Secure Boot signature databases). All inputs must be treated as
+  attacker-controlled.
+
+  Copyright (C) Microsoft Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "Database.h"
+
+/**
+  Load a Secure Boot Signature Database into a pool-allocated buffer.
+
+  The returned buffer is allocated using AllocatePool(). The caller is responsible for freeing
+  this buffer with FreePool().
+
+  @param[in]   DatabaseName  Variable name (e.g. EFI_IMAGE_SECURITY_DATABASE,
+                             EFI_IMAGE_SECURITY_DATABASE1).
+  @param[out]  Buffer        Pool-allocated copy of the variable contents,
+                             or NULL if the variable does not exist.
+                             Caller is responsible for freeing this buffer with
+                             FreePool when non-NULL.
+  @param[out]  BufferSize    BufferSize of *Buffer in bytes, or 0 if the
+                             variable does not exist.
+
+  @retval EFI_SUCCESS            The variable was loaded successfully, or it was absent.
+  @retval EFI_INVALID_PARAMETER  A required pointer is NULL.
+  @retval Other                  Status from gRT->GetVariable.
+**/
+EFI_STATUS
+LoadSignatureDatabase (
+  IN  CONST CHAR16  *DatabaseName,
+  OUT VOID          **Buffer,
+  OUT UINTN         *BufferSize
+  )
+{
+  EFI_STATUS  Status;
+
+  if ((DatabaseName == NULL) || (Buffer == NULL) || (BufferSize == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  *Buffer     = NULL;
+  *BufferSize = 0;
+
+  Status = GetVariable2 (DatabaseName, &gEfiImageSecurityDatabaseGuid, Buffer, BufferSize);
+  if (Status == EFI_NOT_FOUND) {
+    return EFI_SUCCESS;
+  }
+
+  return Status;
+}
+
+/**
+  Load the platform's db and dbx signature databases.
+
+  The Db / Dbx buffers in the returned structure are allocated using AllocatePool(). The caller is
+  responsible for freeing them with FreePool().
+
+  @param[out]  Databases  On success, receives pool-allocated copies of the `db` and `dbx`
+                          variable contents. Either Db or Dbx may be NULL (with a 0 size) if the
+                          corresponding variable is absent.
+
+  @retval EFI_SUCCESS            Databases loaded. Db / Dbx may still be NULL if the
+                                 corresponding variable was absent.
+  @retval EFI_INVALID_PARAMETER  Databases is NULL.
+  @retval Other                  Failure status from gRT->GetVariable.
+**/
+EFI_STATUS
+LoadSignatureDatabases (
+  OUT SIGNATURE_DATABASES  *Databases
+  )
+{
+  EFI_STATUS  Status;
+
+  if (Databases == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Databases->Db      = NULL;
+  Databases->DbSize  = 0;
+  Databases->Dbx     = NULL;
+  Databases->DbxSize = 0;
+
+  Status = LoadSignatureDatabase (EFI_IMAGE_SECURITY_DATABASE, &Databases->Db, &Databases->DbSize);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "DxeImageVerificationLib: failed to load db - %r\n", Status));
+    goto Error;
+  }
+
+  Status = LoadSignatureDatabase (EFI_IMAGE_SECURITY_DATABASE1, &Databases->Dbx, &Databases->DbxSize);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "DxeImageVerificationLib: failed to load dbx - %r\n", Status));
+    goto Error;
+  }
+
+  return EFI_SUCCESS;
+
+Error:
+  if (Databases->Db != NULL) {
+    FreePool (Databases->Db);
+    Databases->Db     = NULL;
+    Databases->DbSize = 0;
+  }
+
+  if (Databases->Dbx != NULL) {
+    FreePool (Databases->Dbx);
+    Databases->Dbx     = NULL;
+    Databases->DbxSize = 0;
+  }
+
+  return Status;
+}
+
+/**
+  Search a signature database for the subject bound to Cache, reporting whether a match was found.
+
+  Depending on the Cache->Type (DigestCacheTypeImage, DigestCacheTypeX509), the following signature list types in the
+  database are supported:
+    * SignatureKindX509Cert    - Any gEfiCert<V2>X509Guid list for an exact match of the bytes in Cache->Buffer
+    * SignatureKindImageHash   - Any gEfiCert<V2><HASH>Guid list for a match of the image's appropriate Authenticode hash digest
+    * SignatureKindX509TbsHash - Any gEfiCert<V2>X509<HASH>Guid for a match of the certificate's appropriate hash digest
+
+  @param[in,out]  Cache         Digest cache bound to the subject. Must be non-NULL and bound.
+  @param[in]      Database      Raw database contents, or NULL for an empty database.
+  @param[in]      DatabaseSize  Size of Database in bytes; 0 when Database is NULL.
+  @param[out]     Truncated     Optional. Set TRUE if the walk could not be proven complete.
+
+  @retval TRUE   A matching entry was found in the valid prefix.
+  @retval FALSE  No matching entry was found in the valid prefix.
+**/
+STATIC
+BOOLEAN
+FindInDatabase (
+  IN OUT DIGEST_CACHE  *Cache,
+  IN     CONST VOID    *Database,
+  IN     UINTN         DatabaseSize,
+  OUT    BOOLEAN       *Truncated   OPTIONAL
+  )
+{
+  EFI_STATUS                Status;
+  SIG_DATABASE_ITER         DbIter;
+  SIG_LIST_ITER             ListIter;
+  CONST EFI_SIGNATURE_LIST  *List;
+  CONST EFI_SIGNATURE_DATA  *Entry;
+  CONST UINT8               *Target;
+  UINTN                     TargetSize;
+  UINTN                     PayloadSize;
+  UINTN                     OwnerSize;
+  SIGNATURE_KIND            Kind;
+
+  if (Truncated != NULL) {
+    *Truncated = FALSE;
+  }
+
+  if ((Cache == NULL) || (Cache->Buffer == NULL) || (Cache->BufferSize == 0)) {
+    if (Truncated != NULL) {
+      *Truncated = TRUE;
+    }
+
+    return FALSE;
+  }
+
+  //
+  // An absent database matches nothing and is not a truncation.
+  //
+  if ((Database == NULL) || (DatabaseSize == 0)) {
+    return FALSE;
+  }
+
+  //
+  // DatabaseIterInit clamps the walk to the valid prefix; a FALSE return means trailing lists
+  // were dropped.
+  //
+  if (!DatabaseIterInit (&DbIter, Database, DatabaseSize) && (Truncated != NULL)) {
+    *Truncated = TRUE;
+  }
+
+  while ((List = DatabaseIterNext (&DbIter)) != NULL) {
+    //
+    // Unsupported types are skipped.
+    //
+    if (EFI_ERROR (GetSignatureTypeInfo (&List->SignatureType, &Kind, &OwnerSize))) {
+      continue;
+    }
+
+    if (List->SignatureSize <= OwnerSize) {
+      continue;
+    }
+
+    PayloadSize = List->SignatureSize - OwnerSize;
+
+    if (Kind == SignatureKindX509Cert) {
+      if ((Cache->Type != DigestCacheTypeX509) || (PayloadSize != Cache->BufferSize)) {
+        continue;
+      }
+
+      Target     = (CONST UINT8 *)Cache->Buffer;
+      TargetSize = Cache->BufferSize;
+    } else {
+      Status = GetHash (&List->SignatureType, Cache, &Target, &TargetSize);
+
+      // GetHash returns EFI_UNSUPPORTED for a unknown signature type GUID
+      if (Status == EFI_UNSUPPORTED) {
+        continue;
+      }
+
+      if (EFI_ERROR (Status) || (PayloadSize < TargetSize)) {
+        if (Truncated != NULL) {
+          *Truncated = TRUE;
+        }
+
+        continue;
+      }
+    }
+
+    //
+    // Compare the selected bytes against every entry in the list.
+    //
+    if (!SigListIterInit (&ListIter, List) && (Truncated != NULL)) {
+      *Truncated = TRUE;
+    }
+
+    while ((Entry = SigListIterNext (&ListIter)) != NULL) {
+      if (CompareMem ((CONST UINT8 *)Entry + OwnerSize, Target, TargetSize) == 0) {
+        goto Found;
+      }
+    }
+  }
+
+  return FALSE;
+
+Found:
+  return TRUE;
+}
+
+/**
+  Determine whether the subject bound to Cache is present in a `db`-style allow-list.
+
+  Best-effort: a malformed `db` truncates the walk to its valid prefix, and the entries before the
+  corruption are still honored (a dropped entry can only remove a potential authorizer, never add
+  one).
+
+  @param[in,out]  Cache      Digest cache bound to the subject (image or certificate).
+  @param[in]      Db         Raw `db` contents, or NULL for an empty database.
+  @param[in]      DbSize     Size of Db in bytes; 0 when Db is NULL.
+
+  @retval TRUE   The subject matches an entry in the valid prefix of Db.
+  @retval FALSE  The subject is absent, or Cache is unusable.
+**/
+BOOLEAN
+IsInDb (
+  IN OUT DIGEST_CACHE  *Cache,
+  IN     CONST VOID    *Db,
+  IN     UINTN         DbSize
+  )
+{
+  //
+  // Allow-list: ignore truncation and honor the valid prefix. FindInDatabase treats an unusable
+  // cache or a malformed db as simply "not found".
+  //
+  return FindInDatabase (Cache, Db, DbSize, NULL);
+}
+
+/**
+  Determine whether the subject bound to Cache is present in a `dbx`-style deny-list.
+
+  Fails closed: if the `dbx` cannot be fully parsed (a malformed entry truncates the walk, a
+  required hash cannot be computed, or Cache is unusable), the subject is reported present, because
+  a dropped entry might have matched it.
+
+  @param[in,out]  Cache      Digest cache bound to the subject (image or certificate).
+  @param[in]      Dbx        Raw `dbx` contents, or NULL for an empty database.
+  @param[in]      DbxSize    Size of Dbx in bytes; 0 when Dbx is NULL.
+
+  @retval TRUE   The subject matches an entry, or the database could not be fully parsed.
+  @retval FALSE  The subject is definitively absent (including an absent/empty Dbx).
+**/
+BOOLEAN
+IsInDbx (
+  IN OUT DIGEST_CACHE  *Cache,
+  IN     CONST VOID    *Dbx,
+  IN     UINTN         DbxSize
+  )
+{
+  BOOLEAN  Found;
+  BOOLEAN  Truncated;
+
+  //
+  // Deny-list: fail closed. Any inability to complete the search - an unusable cache, a malformed
+  // dbx, or an uncomputable hash - is surfaced through Truncated by FindInDatabase and treated
+  // here as "present".
+  //
+  Found = FindInDatabase (Cache, Dbx, DbxSize, &Truncated);
+
+  return (BOOLEAN)(Found || Truncated);
+}
+
+/**
+  Extract the DER-encoded PKCS#7 SignedData payload from a single WIN_CERTIFICATE entry.
+
+  @param[in]   Cert          The certificate to inspect.
+  @param[out]  AuthData      On success, set to point at the PKCS#7 payload inside Cert.
+  @param[out]  AuthDataSize  On success, set to the PKCS#7 payload length in bytes.
+
+  @retval EFI_SUCCESS            AuthData/AuthDataSize were populated.
+  @retval EFI_INVALID_PARAMETER  A required pointer is NULL.
+  @retval EFI_UNSUPPORTED        Unsupported WIN_CERTIFICATE type.
+  @retval EFI_VOLUME_CORRUPTED   dwLength is too small to contain the required header for the
+                                 declared type.
+**/
+EFI_STATUS
+ExtractAuthData (
+  IN  CONST WIN_CERTIFICATE  *Cert,
+  OUT CONST UINT8            **AuthData,
+  OUT UINTN                  *AuthDataSize
+  )
+{
+  CONST WIN_CERTIFICATE_UEFI_GUID  *UefiGuidCert;
+
+  if ((Cert == NULL) || (AuthData == NULL) || (AuthDataSize == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  switch (Cert->wCertificateType) {
+    case WIN_CERT_TYPE_PKCS_SIGNED_DATA:
+      //
+      // The certificate is a bare DER-encoded PKCS#7 SignedData prefixed
+      // by the WIN_CERTIFICATE header.
+      //
+      if (Cert->dwLength <= sizeof (WIN_CERTIFICATE)) {
+        return EFI_VOLUME_CORRUPTED;
+      }
+
+      *AuthData     = (CONST UINT8 *)Cert + sizeof (WIN_CERTIFICATE);
+      *AuthDataSize = Cert->dwLength - sizeof (WIN_CERTIFICATE);
+      return EFI_SUCCESS;
+
+    case WIN_CERT_TYPE_EFI_GUID:
+      //
+      // The certificate is a WIN_CERTIFICATE_UEFI_GUID; the embedded
+      // payload format is identified by CertType. Only the PKCS#7
+      // SignedData GUID is supported.
+      //
+      if (Cert->dwLength <= OFFSET_OF (WIN_CERTIFICATE_UEFI_GUID, CertData)) {
+        return EFI_VOLUME_CORRUPTED;
+      }
+
+      UefiGuidCert = (CONST WIN_CERTIFICATE_UEFI_GUID *)Cert;
+      if (!CompareGuid (&UefiGuidCert->CertType, &gEfiCertPkcs7Guid)) {
+        return EFI_UNSUPPORTED;
+      }
+
+      *AuthData     = UefiGuidCert->CertData;
+      *AuthDataSize = Cert->dwLength - OFFSET_OF (WIN_CERTIFICATE_UEFI_GUID, CertData);
+      return EFI_SUCCESS;
+
+    default:
+      return EFI_UNSUPPORTED;
+  }
+}
+
+/**
+  Determine whether the verified certificate chain that authorizes an image is revoked by the
+  `dbx`.
+
+  Reports the chain revoked if any certificate in it - signer, intermediates, or the anchor - is
+  enrolled in the `dbx` (by exact DER match or by TBS-cert hash; see IsInDbx).
+
+  @param[in]  CertChain          EFI_CERT_STACK ordered signer..anchor.
+  @param[in]  CertChainSize      Size of CertChain in bytes.
+  @param[in]  Dbx                Raw dbx contents, or NULL.
+  @param[in]  DbxSize            Size of Dbx in bytes; 0 when Dbx is NULL.
+
+  @retval TRUE   A certificate in the chain is revoked, or the chain could not be parsed (fail
+                 closed).
+  @retval FALSE  No certificate in the chain is revoked, including when dbx is absent or empty.
+**/
+BOOLEAN
+IsChainRevoked (
+  IN  CONST UINT8  *CertChain,
+  IN  UINTN        CertChainSize,
+  IN  CONST VOID   *Dbx,
+  IN  UINTN        DbxSize
+  )
+{
+  CONST UINT8   *Walker;
+  CONST UINT8   *StackEnd;
+  UINT8         CertNumber;
+  UINTN         Index;
+  UINT32        CertLen;
+  BOOLEAN       Revoked;
+  DIGEST_CACHE  CertCache;
+
+  //
+  // With no dbx there is nothing to revoke against.
+  //
+  if ((Dbx == NULL) || (DbxSize == 0)) {
+    return FALSE;
+  }
+
+  if ((CertChain == NULL) || (CertChainSize == 0)) {
+    return TRUE;
+  }
+
+  Revoked    = FALSE;
+  StackEnd   = CertChain + CertChainSize;
+  CertNumber = *CertChain;
+  Walker     = CertChain + 1;
+
+  //
+  // Walk the EFI_CERT_STACK (ordered signer..anchor). Any parse inconsistency is fail-closed.
+  //
+  for (Index = 0; Index < CertNumber; Index++) {
+    if ((UINTN)(StackEnd - Walker) < sizeof (UINT32)) {
+      DEBUG ((DEBUG_WARN, "DxeImageVerificationLib: malformed certificate chain length prefix.\n"));
+      Revoked = TRUE;
+      break;
+    }
+
+    CertLen = ReadUnaligned32 ((CONST UINT32 *)Walker);
+    Walker += sizeof (UINT32);
+
+    if ((CertLen == 0) || ((UINTN)(StackEnd - Walker) < CertLen)) {
+      DEBUG ((DEBUG_WARN, "DxeImageVerificationLib: malformed certificate chain payload.\n"));
+      Revoked = TRUE;
+      break;
+    }
+
+    //
+    // Bind a certificate cache to this chain certificate and test it against the `dbx`. A fresh
+    // cache per certificate keeps their memoized TBS hashes independent.
+    //
+    ZeroMem (&CertCache, sizeof (CertCache));
+    CertCache.Type       = DigestCacheTypeX509;
+    CertCache.Buffer     = Walker;
+    CertCache.BufferSize = CertLen;
+
+    if (IsInDbx (&CertCache, Dbx, DbxSize)) {
+      DEBUG ((DEBUG_INFO, "DxeImageVerificationLib: chain certificate revoked by dbx.\n"));
+      Revoked = TRUE;
+      break;
+    }
+
+    Walker += CertLen;
+  }
+
+  return Revoked;
+}
+
+/**
+  Evaluate a single image WIN_CERTIFICATE against the `db` / `dbx` databases.
+
+  Consolidates PKCS#7 extraction, image-hash computation, `db` authorization, and chain-relative
+  `dbx` revocation into a single pass. The certificate authorizes the image when some `db` trust
+  anchor verifies the image's signature (via AuthenticodeVerifyEx) and no certificate in the
+  verified signer->anchor chain is enrolled in the `dbx` (see IsChainRevoked). Trust anchors are taken
+  directly from `EFI_CERT_X509_GUID` `db` lists, or recovered from the signature for
+  `EFI_CERT_X509_<HASH>_GUID` (TBS-cert-hash) lists via GetTrustAnchorX509FromAuthData.
+
+  The EFI_STATUS return reports whether evaluation could be performed, not the security outcome:
+  the outcome is reported in Evaluation->Verdict. An error return means evaluation could not be
+  completed for a reason unrelated to the certificate's content.
+
+  @param[in]      Cert        The WIN_CERTIFICATE to evaluate.
+  @param[in,out]  Cache       Image digest cache bound to the image buffer; the cache may memoize
+                              one digest per algorithm across calls.
+  @param[in]      Databases   The `db` / `dbx` signature databases to evaluate against.
+  @param[out]     Evaluation  On EFI_SUCCESS, receives the verdict and, for ImageCertApproved, the
+                              authorizing certificate in Evaluation->Authority (for measurement).
+                              Evaluation->Authority.Data is non-NULL only for ImageCertApproved; a
+                              revoked or unauthorized image records no authority.
+                              Evaluation->Authority.SignatureType is the authorizing `db` list's
+                              signature type, set only for ImageCertApproved.
+
+  @retval EFI_SUCCESS            Evaluation completed; inspect Evaluation->Verdict.
+  @retval EFI_INVALID_PARAMETER  A required pointer is NULL.
+  @retval other                  The image's Authenticode hash could not be computed (propagated
+                                 from GetHash); no verdict was produced.
+**/
+EFI_STATUS
+EvaluateImageCertificate (
+  IN     CONST WIN_CERTIFICATE      *Cert,
+  IN OUT DIGEST_CACHE               *Cache,
+  IN     CONST SIGNATURE_DATABASES  *Databases,
+  OUT    IMAGE_CERT_EVALUATION      *Evaluation
+  )
+{
+  EFI_STATUS                Status;
+  CONST UINT8               *AuthData;
+  UINTN                     AuthDataSize;
+  EFI_GUID                  HashType;
+  CONST UINT8               *ImageHash;
+  UINTN                     ImageHashSize;
+  SIG_DATABASE_ITER         DbIter;
+  SIG_LIST_ITER             ListIter;
+  CONST EFI_SIGNATURE_LIST  *List;
+  CONST EFI_SIGNATURE_DATA  *Entry;
+  VOID                      *CacheHandle;
+  UINT8                     *Anchor;
+  UINTN                     AnchorSize;
+  UINTN                     TbsHashSize;
+  UINT8                     *CertChain;
+  UINTN                     CertChainSize;
+  UINTN                     OwnerSize;
+  SIGNATURE_KIND            Kind;
+
+  if ((Cert == NULL) || (Cache == NULL) || (Databases == NULL) || (Evaluation == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // Set default verdict to unusable so if we fail any parsing step we can simply return early.
+  //
+  Evaluation->Verdict        = ImageCertUnusable;
+  Evaluation->Authority.Data = NULL;
+  Evaluation->Authority.Size = 0;
+  ZeroMem (&Evaluation->Authority.SignatureType, sizeof (EFI_GUID));
+
+  CacheHandle = NULL;
+
+  Status = ExtractAuthData (Cert, &AuthData, &AuthDataSize);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_WARN, "DxeImageVerificationLib: WIN_CERTIFICATE not usable (type=0x%04x, %r).\n", Cert->wCertificateType, Status));
+    return EFI_SUCCESS;
+  }
+
+  Status = GetAuthenticodeHashAlgorithm (AuthData, AuthDataSize, &HashType);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_WARN, "DxeImageVerificationLib: unrecognized Authenticode hash algorithm (%r).\n", Status));
+    return EFI_SUCCESS;
+  }
+
+  //
+  // Compute (or reuse) the image's Authenticode hash under the declared algorithm. A failure here
+  // is an actual error: the image hash is not attributable to this certificate's content.
+  //
+  Status = GetHash (&HashType, Cache, &ImageHash, &ImageHashSize);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "DxeImageVerificationLib: failed to compute image hash (type=%g, %r).\n", &HashType, Status));
+    return Status;
+  }
+
+  //
+  // Parsing passed, Update the default verdict.
+  //
+  Evaluation->Verdict = ImageCertNotInDb;
+
+  //
+  // Walk the valid prefix of trust anchors in the `db`. A malformed list only truncates the range
+  // (best-effort authorization); anchors before the corruption are still honored. Hash entries are
+  // resolved to certificates as needed.
+  //
+  DatabaseIterInit (&DbIter, Databases->Db, Databases->DbSize);
+
+  while ((List = DatabaseIterNext (&DbIter)) != NULL) {
+    //
+    // Unsupported signature types (including Image Hashes in this case) are skipped.
+    //
+    if (EFI_ERROR (GetSignatureTypeInfo (&List->SignatureType, &Kind, &OwnerSize)) ||
+        (Kind == SignatureKindImageHash))
+    {
+      continue;
+    }
+
+    if (List->SignatureSize <= OwnerSize) {
+      continue;
+    }
+
+    //
+    // A malformed list is clamped to its valid entries; iterate whatever prefix is available.
+    //
+    SigListIterInit (&ListIter, List);
+
+    while ((Entry = SigListIterNext (&ListIter)) != NULL) {
+      Anchor     = NULL;
+      AnchorSize = 0;
+
+      if (Kind == SignatureKindX509Cert) {
+        //
+        // The entry is the DER certificate itself, borrowed from the `db` buffer.
+        //
+        Anchor     = (UINT8 *)Entry + OwnerSize;
+        AnchorSize = List->SignatureSize - OwnerSize;
+      } else {
+        //
+        // Recover the trust anchor from the TBS-cert-hash entry. V1 entries have a trailing EFI_TIME
+        // structure after the hash where as V2 entries do not. Adjust the hash size accordingly.
+        //
+        TbsHashSize = List->SignatureSize - OwnerSize;
+        if (OwnerSize == sizeof (EFI_GUID)) {
+          if (TbsHashSize <= sizeof (EFI_TIME)) {
+            continue;
+          }
+
+          TbsHashSize -= sizeof (EFI_TIME);
+        }
+
+        Status = GetTrustAnchorX509FromAuthData (
+                   &CacheHandle,
+                   (CONST UINT8 *)Entry + OwnerSize,
+                   TbsHashSize,
+                   AuthData,
+                   AuthDataSize,
+                   &Anchor,
+                   &AnchorSize
+                   );
+        if (EFI_ERROR (Status)) {
+          continue;
+        }
+      }
+
+      //
+      // The candidate anchor authorizes the image only if it verifies the signature and none of
+      // the certificates in its verified chain are revoked by the `dbx`.
+      //
+      CertChain     = NULL;
+      CertChainSize = 0;
+      Status        = AuthenticodeVerifyEx (
+                        AuthData,
+                        AuthDataSize,
+                        Anchor,
+                        AnchorSize,
+                        ImageHash,
+                        ImageHashSize,
+                        &CertChain,
+                        &CertChainSize
+                        );
+      if (!EFI_ERROR (Status)) {
+        if (IsChainRevoked (
+              CertChain,
+              CertChainSize,
+              Databases->Dbx,
+              Databases->DbxSize
+              ))
+        {
+          //
+          // Verified but revoked: record only the verdict. The revoking authority is intentionally
+          // not captured - an image may carry several signers, each revoked by a different `dbx`
+          // entry, so no single entry meaningfully attributes the denial. A subsequent anchor may
+          // still authorize the image cleanly and replace this verdict.
+          //
+          Evaluation->Verdict = ImageCertRevokedByDbx;
+        } else {
+          //
+          // Authorized: record the authorizing certificate. Anchor is the certificate bytes
+          // (borrowed from the `db` for a full-cert entry, reconstructed for a TBS-cert-hash entry);
+          // BuildImageAuthority copies it before it is released below. The owner GUID comes from a
+          // V1 entry or is zeroed for a V2 entry.
+          //
+          Evaluation->Verdict = ImageCertApproved;
+          BuildImageAuthority (
+            (OwnerSize == sizeof (EFI_GUID)) ? (CONST EFI_GUID *)Entry : NULL,
+            Anchor,
+            AnchorSize,
+            &Evaluation->Authority
+            );
+          CopyGuid (&Evaluation->Authority.SignatureType, &List->SignatureType);
+        }
+      }
+
+      if (CertChain != NULL) {
+        FreePool (CertChain);
+      }
+
+      //
+      // Only the TBS-cert-hash path allocated the anchor; release it.
+      //
+      if (Kind != SignatureKindX509Cert) {
+        FreePool (Anchor);
+      }
+
+      if (Evaluation->Verdict == ImageCertApproved) {
+        goto Done;
+      }
+    }
+  }
+
+Done:
+  if (CacheHandle != NULL) {
+    FreeTrustAnchorX509Cache (CacheHandle);
+  }
+
+  return EFI_SUCCESS;
+}

--- a/SecurityPkg/Library/DxeImageVerificationLib2/Database.h
+++ b/SecurityPkg/Library/DxeImageVerificationLib2/Database.h
@@ -1,0 +1,165 @@
+/** @file
+  Secureboot DB/DBX/DBT (EFI_SIGNATURE_LIST) helpers, including signed-image
+  (certificate / Authenticode) validation, for the DXE Image Verification Library.
+
+  Copyright (C) Microsoft Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#pragma once
+
+#include "DxeImageVerificationLib.h"
+#include "Iterator.h"
+#include "Support.h"
+#include <Library/UefiLib.h>
+#include <Guid/WinCertificate.h>
+
+//
+// The platform's Secure Boot signature databases (`db` and `dbx`). Db / Dbx
+// are pool-allocated copies owned by the caller; either may be NULL when the
+// corresponding variable is absent, in which case its size is 0.
+//
+typedef struct {
+  VOID     *Db;
+  UINTN    DbSize;
+  VOID     *Dbx;
+  UINTN    DbxSize;
+} SIGNATURE_DATABASES;
+
+//
+// The verdict from evaluating a single image WIN_CERTIFICATE against the `db`
+// and `dbx` databases.
+//
+typedef enum {
+  //
+  // A `db` trust anchor authorized the image and no certificate in its verified
+  // signer->anchor chain is revoked by the `dbx`.
+  //
+  ImageCertApproved,
+  //
+  // A `db` trust anchor verified the image, but a certificate in its verified
+  // chain is enrolled in the `dbx`. No un-revoked anchor authorized the image.
+  //
+  ImageCertRevokedByDbx,
+  //
+  // No `db` trust anchor verifies the image's signature.
+  //
+  ImageCertNotInDb,
+  //
+  // The WIN_CERTIFICATE could not be evaluated: an unsupported certificate
+  // type, a malformed PKCS#7 payload, an unrecognized Authenticode hash
+  // algorithm, or another failure before trust-anchor evaluation.
+  //
+  ImageCertUnusable
+} IMAGE_CERT_VERDICT;
+
+//
+// The result of EvaluateImageCertificate: the evaluation verdict plus, for
+// ImageCertApproved, the `db` certificate that authorized the image (for
+// measurement). A revoked or unauthorized image records no authority.
+//
+typedef struct {
+  IMAGE_CERT_VERDICT    Verdict;
+  IMAGE_AUTHORITY       Authority;
+} IMAGE_CERT_EVALUATION;
+
+/**
+  Load the platform's db and dbx signature databases.
+
+  The Db / Dbx buffers in the returned structure are allocated using AllocatePool(). The caller is
+  responsible for freeing them with FreePool().
+
+  @param[out]  Databases  On success, receives pool-allocated copies of the `db` and `dbx`
+                          variable contents. Either Db or Dbx may be NULL (with a 0 size) if the
+                          corresponding variable is absent.
+
+  @retval EFI_SUCCESS            Databases loaded. Db / Dbx may still be NULL if the
+                                 corresponding variable was absent.
+  @retval EFI_INVALID_PARAMETER  Databases is NULL.
+  @retval Other                  Failure status from gRT->GetVariable.
+**/
+EFI_STATUS
+LoadSignatureDatabases (
+  OUT SIGNATURE_DATABASES  *Databases
+  );
+
+/**
+  Determine whether the subject bound to Cache is present in a `db`-style allow-list.
+
+  The subject is described by Cache->Type: an image (DigestCacheTypeImage) is matched by its digest
+  under each list's hash algorithm; a certificate (DigestCacheTypeX509) is matched either by exact
+  DER bytes against an EFI_CERT_X509_GUID list or by its TBSCertificate digest against a cert-hash
+  list.
+
+  As an allow-list search this is best-effort: if the database is malformed partway through, the
+  valid prefix is still honored (a trailing malformed entry can only remove a potential authorizer,
+  never add one).
+
+  @param[in,out]  Cache      Digest cache bound to the subject (image or certificate).
+  @param[in]      Db         Raw `db` contents, or NULL for an empty database.
+  @param[in]      DbSize     Size of Db in bytes; 0 when Db is NULL.
+
+  @retval TRUE   The subject matches an entry in the valid prefix of Db.
+  @retval FALSE  The subject is not present, or Cache is unusable.
+**/
+BOOLEAN
+IsInDb (
+  IN OUT DIGEST_CACHE  *Cache,
+  IN     CONST VOID    *Db,
+  IN     UINTN         DbSize
+  );
+
+/**
+  Determine whether the subject bound to Cache is present in a `dbx`-style deny-list.
+
+  The subject is described by Cache exactly as for IsInDb.
+
+  As a deny-list search this fails closed: if the database cannot be fully parsed (a malformed
+  entry truncates the walk, a required hash cannot be computed, or Cache is unusable), the subject
+  is treated as present, because a dropped entry might have matched it.
+
+  @param[in,out]  Cache      Digest cache bound to the subject (image or certificate).
+  @param[in]      Dbx        Raw `dbx` contents, or NULL for an empty database.
+  @param[in]      DbxSize    Size of Dbx in bytes; 0 when Dbx is NULL.
+
+  @retval TRUE   The subject matches an entry in Dbx, or the database could not be fully parsed.
+  @retval FALSE  The subject is definitively absent from Dbx (including an absent/empty Dbx).
+**/
+BOOLEAN
+IsInDbx (
+  IN OUT DIGEST_CACHE  *Cache,
+  IN     CONST VOID    *Dbx,
+  IN     UINTN         DbxSize
+  );
+
+/**
+  Evaluate a single image WIN_CERTIFICATE against the `db` / `dbx` databases.
+
+  Consolidates PKCS#7 extraction, image-hash computation, `db` authorization, and chain-relative
+  `dbx` revocation into one pass. The certificate authorizes the image when some `db` trust anchor
+  verifies the image's signature and no certificate in the verified signer->anchor chain is
+  enrolled in the `dbx`.
+
+  The EFI_STATUS return reports whether evaluation could be performed, not the security outcome;
+  the outcome is reported in Evaluation->Verdict.
+
+  @param[in]      Cert        The WIN_CERTIFICATE to evaluate.
+  @param[in,out]  Cache       Image digest cache bound to the image buffer; the cache may memoize
+                              one digest per algorithm across calls.
+  @param[in]      Databases   The `db` / `dbx` signature databases to evaluate against.
+  @param[out]     Evaluation  On EFI_SUCCESS, receives the verdict and, for ImageCertApproved, the
+                              authorizing `db` certificate in Evaluation->Authority. A revoked or
+                              unauthorized image records no authority.
+
+  @retval EFI_SUCCESS            Evaluation completed; inspect Evaluation->Verdict.
+  @retval EFI_INVALID_PARAMETER  A required pointer is NULL.
+  @retval other                  The image's Authenticode hash could not be computed (propagated
+                                 from GetHash); no verdict was produced.
+**/
+EFI_STATUS
+EvaluateImageCertificate (
+  IN     CONST WIN_CERTIFICATE      *Cert,
+  IN OUT DIGEST_CACHE               *Cache,
+  IN     CONST SIGNATURE_DATABASES  *Databases,
+  OUT    IMAGE_CERT_EVALUATION      *Evaluation
+  );

--- a/SecurityPkg/Library/DxeImageVerificationLib2/DxeImageVerificationLib.c
+++ b/SecurityPkg/Library/DxeImageVerificationLib2/DxeImageVerificationLib.c
@@ -1,0 +1,277 @@
+/** @file
+  Implement image verification services for secure boot service
+
+  Caution: This file requires additional review when modified.
+  This library will have external input - PE/COFF image.
+  This external input must be validated carefully to avoid security issue like
+  buffer overflow, integer overflow.
+
+  DxeImageVerificationLibImageRead() function will make sure the PE/COFF image content
+  read is within the image buffer.
+
+  DxeImageVerificationHandler(), HashPeImageByType(), HashPeImage() function will accept
+  untrusted PE/COFF image and validate its data structure within this image buffer before use.
+
+Copyright (c) 2009 - 2018, Intel Corporation. All rights reserved.<BR>
+(C) Copyright 2016 Hewlett Packard Enterprise Development LP<BR>
+Copyright (c) Microsoft Corporation.
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include "DxeImageVerificationLib.h"
+#include "Database.h"
+#include "Iterator.h"
+#include "Support.h"
+
+/**
+  Validate a PE/COFF image against the platform signature databases.
+
+    1. Reject immediately if the image's Authenticode hash is enrolled in the `dbx`.
+    2. Walk each WIN_CERTIFICATE in the image's security data directory to determine if the
+       Auth Data from it is not revoked by the `dbx` and is authorized by the `db`. Only one
+       WIN_CERTIFICATE needs to authorize the image for it to be validated.
+    3. Authorize the image if the image's Authenticode hash is enrolled in the `db`.
+
+  @param[in]   File         Device path of the image being verified.
+  @param[in]   FileBuffer   Pointer to the in-memory PE/COFF image.
+  @param[in]   FileSize     Size of FileBuffer in bytes.
+  @param[in]   SecDataDir   Security data directory describing the embedded WIN_CERTIFICATE table.
+                            A Size of 0 indicates an unsigned image.
+  @param[in,out] Measured   Authority measurement state used to record the `db` certificate that
+                            authorized the image into PCR 7 (de-duplicated across images). Only
+                            certificate authorities are measured; image-hash authorizations are not.
+
+  @retval EFI_SUCCESS        The image is authorized.
+  @retval EFI_ACCESS_DENIED  The image is revoked, not authorized, or the
+                             databases could not be loaded.
+**/
+EFI_STATUS
+ValidateImage (
+  IN     CONST EFI_DEVICE_PATH_PROTOCOL  *File,
+  IN     VOID                            *FileBuffer,
+  IN     UINTN                           FileSize,
+  IN     CONST EFI_IMAGE_DATA_DIRECTORY  *SecDataDir,
+  IN OUT MEASURED_AUTHORITIES            *Measured
+  )
+{
+  EFI_STATUS             Status;
+  DIGEST_CACHE           Cache;
+  SIGNATURE_DATABASES    Databases;
+  WIN_CERT_ITER          CertIter;
+  CONST WIN_CERTIFICATE  *Cert;
+  IMAGE_CERT_EVALUATION  CertEval;
+
+  //
+  // Setup digest cache for the image. This prevents redundant authenticode hash computations
+  // across the image-hash revocation check, per-cert authorization, and the image-hash fallback.
+  //
+  ZeroMem (&Cache, sizeof (Cache));
+  Cache.Type       = DigestCacheTypeImage;
+  Cache.Buffer     = FileBuffer;
+  Cache.BufferSize = FileSize;
+
+  //
+  // Zeroed up front so every Exit path can safely release CertEval.Authority, even if the
+  // certificate walk never runs (unsigned image) or an earlier step rejects.
+  //
+  ZeroMem (&CertEval, sizeof (CertEval));
+
+  Status = LoadSignatureDatabases (&Databases);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "DxeImageVerificationLib: Failed to load signature databases (%r).\n", Status));
+    goto Reject;
+  }
+
+  //
+  // Step 1: Reject the image if its Authenticode hash is found in the `dbx`. A `dbx` that cannot
+  // be fully parsed fails closed (IsInDbx returns TRUE), rejecting the image.
+  //
+  if (IsInDbx (&Cache, Databases.Dbx, Databases.DbxSize)) {
+    DEBUG ((DEBUG_ERROR, "DxeImageVerificationLib: Image hash is forbidden by DBX.\n"));
+    goto Reject;
+  }
+
+  //
+  // Step 2: For each WIN_CERTIFICATE in the image's security data directory, extract the auth data
+  // and check if it authorizes the image per the `db` and `dbx`. Exit on the first authorization.
+  //
+  // Note: If the image is unsigned, the iterator is empty and this step is a no-op. A malformed
+  // certificate table only truncates the walk to its valid prefix (best-effort); the certificates
+  // that parse cleanly are still evaluated, and the image can still be authorized by Step 3.
+  //
+  if (!WinCertIterInit (&CertIter, FileBuffer, FileSize, SecDataDir)) {
+    DEBUG ((DEBUG_WARN, "DxeImageVerificationLib: certificate table truncated at a malformed entry; evaluating the valid prefix.\n"));
+  }
+
+  while ((Cert = WinCertIterNext (&CertIter)) != NULL) {
+    Status = EvaluateImageCertificate (Cert, &Cache, &Databases, &CertEval);
+    if (!EFI_ERROR (Status) && (CertEval.Verdict == ImageCertApproved)) {
+      //
+      // Measure the `db` certificate that authorized the image into PCR 7.
+      //
+      SecureBootHook (
+        Measured,
+        EFI_IMAGE_SECURITY_DATABASE,
+        &gEfiImageSecurityDatabaseGuid,
+        &CertEval.Authority
+        );
+      Status = EFI_SUCCESS;
+      goto Exit;
+    }
+  }
+
+  //
+  // Step 3: Authorize the image if the image authenticode hash is in the `db`. Image-hash
+  // authorization is intentionally not measured into PCR 7 - only certificate authorities are.
+  //
+  if (IsInDb (&Cache, Databases.Db, Databases.DbSize)) {
+    Status = EFI_SUCCESS;
+    goto Exit;
+  }
+
+  DEBUG ((DEBUG_ERROR, "DxeImageVerificationLib: Image is not authorized by DB.\n"));
+
+Reject:
+  Status = EFI_ACCESS_DENIED;
+
+Exit:
+  FreeImageAuthority (&CertEval.Authority);
+
+  if (Databases.Db != NULL) {
+    FreePool (Databases.Db);
+  }
+
+  if (Databases.Dbx != NULL) {
+    FreePool (Databases.Dbx);
+  }
+
+  return Status;
+}
+
+/**
+  Provide verification service for signed images, which include both signature validation
+  and platform policy control. For signature types, both UEFI WIN_CERTIFICATE_UEFI_GUID and
+  MSFT Authenticode type signatures are supported.
+
+  In this implementation, only verify external executables when in USER MODE.
+  Executables from FV is bypass, so pass in AuthenticationStatus is ignored.
+
+  The image verification policy is:
+    If the image is signed,
+      At least one valid signature or at least one hash value of the image must match a record
+      in the security database "db", and no valid signature nor any hash value of the image may
+      be reflected in the security database "dbx".
+    Otherwise, the image is not signed,
+      The hash value of the image must match a record in the security database "db", and
+      not be reflected in the security data base "dbx".
+
+  Caution: This function may receive untrusted input.
+  PE/COFF image is external input, so this function will validate its data structure
+  within this image buffer before use.
+
+  @param[in]    AuthenticationStatus
+                           This is the authentication status returned from the security
+                           measurement services for the input file.
+  @param[in]    File       This is a pointer to the device path of the file that is
+                           being dispatched. This will optionally be used for logging.
+  @param[in]    FileBuffer File buffer matches the input file device path.
+  @param[in]    FileSize   Size of File buffer matches the input file device path.
+  @param[in]    BootPolicy A boot policy that was used to call LoadImage() UEFI service.
+
+  @retval EFI_SUCCESS            The file specified by DevicePath and non-NULL
+                                 FileBuffer did authenticate, and the platform policy dictates
+                                 that the DXE Foundation may use the file.
+  @retval EFI_SUCCESS            The device path specified by NULL device path DevicePath
+                                 and non-NULL FileBuffer did authenticate, and the platform
+                                 policy dictates that the DXE Foundation may execute the image in
+                                 FileBuffer.
+  @retval EFI_ACCESS_DENIED      The file specified by File and FileBuffer did not
+                                 authenticate, and the DXE Foundation may not use File. The
+                                 image has been added to the file execution table.
+
+**/
+EFI_STATUS
+EFIAPI
+DxeImageVerificationHandler (
+  IN  UINT32                          AuthenticationStatus,
+  IN  CONST EFI_DEVICE_PATH_PROTOCOL  *File  OPTIONAL,
+  IN  VOID                            *FileBuffer,
+  IN  UINTN                           FileSize,
+  IN  BOOLEAN                         BootPolicy
+  )
+{
+  EFI_STATUS                Status;
+  UINT32                    Policy;
+  EFI_IMAGE_DATA_DIRECTORY  SecDataDir;
+
+  //
+  // Sanity check.
+  //
+  if (File == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // Resolve the platform authorization policy from the image's origin.
+  // This runs before the Secure Boot variable check because it is much
+  // cheaper, and the common case (FV-dispatched drivers) short-circuits
+  // if the policy is ALWAYS_EXECUTE.
+  //
+  Status = GetExecutionPolicy (File, &Policy);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Policy unconditionally permits execution; no further checks needed.
+  //
+  if (Policy == ALWAYS_EXECUTE) {
+    return EFI_SUCCESS;
+  }
+
+  //
+  // Secure Boot is the gate for all remaining checks. When it is not
+  // enabled, the platform has opted out of image authorization.
+  //
+  if (!IsSecureBootEnabled ()) {
+    return EFI_SUCCESS;
+  }
+
+  //
+  // Inspect the image to locate its security data directory. Any failure
+  // to parse the PE/COFF headers is treated as a verification failure.
+  //
+  Status = GetImageSecurityDataDirectory (FileBuffer, FileSize, &SecDataDir);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  //
+  // Run image verification. The unified path handles both signed and
+  // unsigned images; SecDataDir->Size == 0 simply produces an empty
+  // WIN_CERTIFICATE iteration inside ValidateImage.
+  //
+  return ValidateImage (File, FileBuffer, FileSize, &SecDataDir, GetMeasuredAuthorities ());
+}
+
+/**
+  Register security measurement handler.
+
+  @param  ImageHandle   ImageHandle of the loaded driver.
+  @param  SystemTable   Pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS   The handlers were registered successfully.
+**/
+EFI_STATUS
+EFIAPI
+DxeImageVerificationLibConstructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  return RegisterSecurity2Handler (
+           DxeImageVerificationHandler,
+           EFI_AUTH_OPERATION_VERIFY_IMAGE | EFI_AUTH_OPERATION_IMAGE_REQUIRED
+           );
+}

--- a/SecurityPkg/Library/DxeImageVerificationLib2/DxeImageVerificationLib.h
+++ b/SecurityPkg/Library/DxeImageVerificationLib2/DxeImageVerificationLib.h
@@ -1,0 +1,235 @@
+/** @file
+  Internal declarations for the DXE Image Verification Library.
+
+  This header is consumed by the library's source files (and its unit
+  tests) to share prototypes for the constructor and the Security2
+  verification handler.
+
+  Copyright (C) Microsoft Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#pragma once
+
+#include <Uefi.h>
+#include <UefiSecureBoot.h>
+#include <Guid/ImageAuthentication.h>
+#include <IndustryStandard/PeImage.h>
+#include <Library/SecureBootVariableLib.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseCryptLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/DebugLib.h>
+#include <Library/SecurityManagementLib.h>
+#include <Pi/PiFirmwareFile.h>
+#include <Pi/PiFirmwareVolume.h>
+#include <Protocol/FirmwareVolume2.h>
+#include <Protocol/DevicePath.h>
+
+//
+// Authorization policy bit definition
+//
+#define ALWAYS_EXECUTE                      0x00000000
+#define DENY_EXECUTE_ON_SECURITY_VIOLATION  0x00000001
+
+//
+// Image type definitions
+//
+#define IMAGE_UNKNOWN  0x00000000
+#define IMAGE_FROM_FV  0x00000001
+
+#define MAX_DIGEST_SIZE  SHA512_DIGEST_SIZE
+
+//
+// Type definition for all information necessary to describe hash algorithm usage in this library.
+//
+// Each algorithm lists its signature-type GUIDs for both roles (raw image hash, X.509 TBS-cert
+// hash) in both layouts: the V1 GUID whose list entries use EFI_SIGNATURE_DATA (a 16-byte
+// SignatureOwner precedes the payload) and the V2 GUID whose entries use EFI_SIGNATURE_V2_DATA (no
+// SignatureOwner). ImageHashGuid (V1) is the canonical GUID handed to the BaseCryptLib hashing
+// primitives, which only recognize the V1 image-hash GUIDs.
+//
+typedef struct {
+  CONST CHAR8       *Name;
+  CONST EFI_GUID    *ImageHashGuid;        // EFI_CERT_SHA*_GUID          (V1)
+  CONST EFI_GUID    *ImageHashGuidV2;      // EFI_CERT_V2_SHA*_GUID       (V2)
+  CONST EFI_GUID    *X509CertHashGuid;     // EFI_CERT_X509_SHA*_GUID     (V1)
+  CONST EFI_GUID    *X509CertHashGuidV2;   // EFI_CERT_V2_X509_SHA*_GUID  (V2)
+} HASH_ALGORITHM;
+
+//
+// All supported hash algorithms for secureboot validation. Adding a new algorithm to this list
+// will add support for that algorithm across the entire library.
+//
+STATIC CONST HASH_ALGORITHM  mHashAlgorithms[] = {
+  { "SHA256", &gEfiCertSha256Guid, &gEfiCertV2Sha256Guid, &gEfiCertX509Sha256Guid, &gEfiCertV2X509Sha256Guid },
+  { "SHA384", &gEfiCertSha384Guid, &gEfiCertV2Sha384Guid, &gEfiCertX509Sha384Guid, &gEfiCertV2X509Sha384Guid },
+  { "SHA512", &gEfiCertSha512Guid, &gEfiCertV2Sha512Guid, &gEfiCertX509Sha512Guid, &gEfiCertV2X509Sha512Guid },
+};
+
+//
+// An authority entry drawn from a signature database.
+//
+// Data is an owned, pool-allocated V1 EFI_SIGNATURE_DATA: a 16-byte SignatureOwner followed by the
+// authorizing (`db`) or revoking (`dbx`) X.509 certificate. It is built with BuildImageAuthority ()
+// and released with FreeImageAuthority (); Size is its total length in bytes. Data is NULL and Size
+// is 0 when no authority applies.
+//
+// The SignatureOwner is copied from the matching V1 signature-list entry, or zeroed when that entry
+// used the V2 (EFI_SIGNATURE_V2_DATA) layout. When the matching entry is a TBS cert-hash, the
+// reconstructed certificate - not the hash - is stored.
+//
+// SignatureType is the signature-type GUID of the authorizing `db` list the Data entry came from
+// (the EFI_SIGNATURE_LIST.SignatureType); it is zeroed when no authority applies.
+//
+typedef struct {
+  EFI_SIGNATURE_DATA    *Data;
+  UINTN                 Size;
+  EFI_GUID              SignatureType;
+} IMAGE_AUTHORITY;
+
+//
+// A single Secure Boot authority entry that has been measured into PCR 7.
+// VariableName / VendorGuid reference canonical storage owned by the library;
+// Data is a pool-allocated copy of the EFI_SIGNATURE_DATA that authorized an
+// image.
+//
+typedef struct {
+  CHAR16      *VariableName;
+  EFI_GUID    *VendorGuid;
+  VOID        *Data;
+  UINTN       Size;
+} MEASURED_VARIABLE;
+
+//
+// Tracks the set of authority entries that have been measured into PCR 7
+// during this boot so that no single entry is measured more than once. The
+// only instance of this structure is the module global owned by Measurement.c
+// and obtained through GetMeasuredAuthorities ().
+//
+typedef struct {
+  MEASURED_VARIABLE    *List;
+  UINTN                Count;
+  UINTN                Max;
+} MEASURED_AUTHORITIES;
+
+/**
+  Return the module-global authority measurement state.
+
+  The returned pointer references storage that persists for the lifetime of
+  the module so that measurement de-duplication is maintained across every
+  image the verification handler processes.
+
+  @return  Pointer to the module-global MEASURED_AUTHORITIES instance.
+**/
+MEASURED_AUTHORITIES *
+GetMeasuredAuthorities (
+  VOID
+  );
+
+/**
+  Resolve an image's authorization policy.
+
+  @param[in]   File    Device path describing the image origin.
+  @param[out]  Policy  On success, filled with the resolved policy value.
+
+  @retval EFI_SUCCESS            Policy contains a valid policy value.
+  @retval EFI_INVALID_PARAMETER  File or Policy is NULL.
+**/
+EFI_STATUS
+GetExecutionPolicy (
+  IN  CONST EFI_DEVICE_PATH_PROTOCOL  *File,
+  OUT UINT32                          *Policy
+  );
+
+/**
+  Measure a Secure Boot authority entry into PCR 7, skipping entries that have
+  already been measured this boot.
+
+  If VariableName / VendorGuid do not identify a Secure Boot authority
+  variable, or the supplied data has already been measured, the call is a
+  no-op. Otherwise the data is measured via TpmMeasureAndLogData and recorded
+  in Measured so subsequent identical entries are not measured again.
+
+  @param[in,out]  Measured      Authority measurement state to consult and update.
+  @param[in]      VariableName  Name of the variable that authorized the image.
+  @param[in]      VendorGuid    Vendor GUID of the variable that authorized the image.
+  @param[in]      Authority     The `db` authority that authorized the image, whose Data / Size
+                                identify the EFI_SIGNATURE_DATA entry to measure.
+**/
+VOID
+SecureBootHook (
+  IN OUT MEASURED_AUTHORITIES   *Measured,
+  IN     CHAR16                 *VariableName,
+  IN     EFI_GUID               *VendorGuid,
+  IN     CONST IMAGE_AUTHORITY  *Authority
+  );
+
+/**
+  Provide verification service for signed images, which include both signature validation
+  and platform policy control. For signature types, both UEFI WIN_CERTIFICATE_UEFI_GUID and
+  MSFT Authenticode type signatures are supported.
+
+  In this implementation, only verify external executables when in USER MODE.
+  Executables from FV is bypass, so pass in AuthenticationStatus is ignored.
+
+  The image verification policy is:
+    If the image is signed,
+      At least one valid signature or at least one hash value of the image must match a record
+      in the security database "db", and no valid signature nor any hash value of the image may
+      be reflected in the security database "dbx".
+    Otherwise, the image is not signed,
+      The hash value of the image must match a record in the security database "db", and
+      not be reflected in the security data base "dbx".
+
+  Caution: This function may receive untrusted input.
+  PE/COFF image is external input, so this function will validate its data structure
+  within this image buffer before use.
+
+  @param[in]    AuthenticationStatus
+                           This is the authentication status returned from the security
+                           measurement services for the input file.
+  @param[in]    File       This is a pointer to the device path of the file that is
+                           being dispatched. This will optionally be used for logging.
+  @param[in]    FileBuffer File buffer matches the input file device path.
+  @param[in]    FileSize   Size of File buffer matches the input file device path.
+  @param[in]    BootPolicy A boot policy that was used to call LoadImage() UEFI service.
+
+  @retval EFI_SUCCESS            The file specified by DevicePath and non-NULL
+                                 FileBuffer did authenticate, and the platform policy dictates
+                                 that the DXE Foundation may use the file.
+  @retval EFI_SUCCESS            The device path specified by NULL device path DevicePath
+                                 and non-NULL FileBuffer did authenticate, and the platform
+                                 policy dictates that the DXE Foundation may execute the image in
+                                 FileBuffer.
+  @retval EFI_ACCESS_DENIED      The file specified by File and FileBuffer did not
+                                 authenticate, and the DXE Foundation may not use File. The
+                                 image has been added to the file execution table.
+
+**/
+EFI_STATUS
+EFIAPI
+DxeImageVerificationHandler (
+  IN  UINT32                          AuthenticationStatus,
+  IN  CONST EFI_DEVICE_PATH_PROTOCOL  *File  OPTIONAL,
+  IN  VOID                            *FileBuffer,
+  IN  UINTN                           FileSize,
+  IN  BOOLEAN                         BootPolicy
+  );
+
+/**
+  Register security measurement handler.
+
+  @param  ImageHandle   ImageHandle of the loaded driver.
+  @param  SystemTable   Pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS   The handlers were registered successfully.
+**/
+EFI_STATUS
+EFIAPI
+DxeImageVerificationLibConstructor (
+  IN  EFI_HANDLE        ImageHandle,
+  IN  EFI_SYSTEM_TABLE  *SystemTable
+  );

--- a/SecurityPkg/Library/DxeImageVerificationLib2/DxeImageVerificationLib.inf
+++ b/SecurityPkg/Library/DxeImageVerificationLib2/DxeImageVerificationLib.inf
@@ -1,0 +1,95 @@
+## @file
+#  Provides security service of image verification
+#
+#  This library hooks LoadImage() API to verify every image by the verification policy.
+#
+#  Caution: This module requires additional review when modified.
+#  This library will have external input - PE/COFF image.
+#  This external input must be validated carefully to avoid security issues such as
+#  buffer overflow or integer overflow.
+#
+# Copyright (C) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = DxeImageVerificationLib
+  MODULE_UNI_FILE                = DxeImageVerificationLib.uni
+  FILE_GUID                      = CFEF751D-B633-489D-8DB4-BE39262D1599
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = NULL|DXE_DRIVER DXE_RUNTIME_DRIVER DXE_SMM_DRIVER UEFI_APPLICATION UEFI_DRIVER
+  CONSTRUCTOR                    = DxeImageVerificationLibConstructor
+
+[Sources]
+  Database.c
+  Database.h
+  DxeImageVerificationLib.c
+  DxeImageVerificationLib.h
+  Iterator.c
+  Iterator.h
+  Measurement.c
+  Policy.c
+  Support.c
+  Support.h
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  CryptoPkg/CryptoPkg.dec
+  SecurityPkg/SecurityPkg.dec
+
+[LibraryClasses]
+  MemoryAllocationLib
+  BaseLib
+  UefiLib
+  UefiBootServicesTableLib
+  UefiRuntimeServicesTableLib
+  BaseCryptLib
+  BaseMemoryLib
+  DebugLib
+  DevicePathLib
+  PeCoffLib
+  SecureBootVariableLib
+  SecurityManagementLib
+  TpmMeasurementLib
+
+[Protocols]
+
+[Guids]
+  ## SOMETIMES_CONSUMES   ## Variable:L"DB"
+  ## SOMETIMES_CONSUMES   ## Variable:L"DBX"
+  ## PRODUCES             ## SystemTable
+  ## CONSUMES             ## SystemTable
+  gEfiImageSecurityDatabaseGuid
+
+  ## SOMETIMES_CONSUMES   ## GUID       # Unique ID for the type of the signature.
+  ## SOMETIMES_PRODUCES   ## GUID       # Unique ID for the type of the signature.
+  gEfiCertSha1Guid
+
+  ## SOMETIMES_CONSUMES   ## GUID       # Unique ID for the type of the signature.
+  ## SOMETIMES_PRODUCES   ## GUID       # Unique ID for the type of the signature.
+  gEfiCertSha256Guid
+
+  ## SOMETIMES_CONSUMES   ## GUID       # Unique ID for the type of the signature.
+  ## SOMETIMES_PRODUCES   ## GUID       # Unique ID for the type of the signature.
+  gEfiCertSha384Guid
+
+  ## SOMETIMES_CONSUMES   ## GUID       # Unique ID for the type of the signature.
+  ## SOMETIMES_PRODUCES   ## GUID       # Unique ID for the type of the signature.
+  gEfiCertSha512Guid
+
+  gEfiCertX509Guid                      ## SOMETIMES_CONSUMES    ## GUID     # Unique ID for the type of the signature.
+  gEfiCertX509Sha256Guid                ## SOMETIMES_CONSUMES    ## GUID     # Unique ID for the type of the signature.
+  gEfiCertX509Sha384Guid                ## SOMETIMES_CONSUMES    ## GUID     # Unique ID for the type of the signature.
+  gEfiCertX509Sha512Guid                ## SOMETIMES_CONSUMES    ## GUID     # Unique ID for the type of the signature.
+  gEfiCertV2Sha256Guid                  ## SOMETIMES_CONSUMES    ## GUID     # Unique ID for the type of the signature.
+  gEfiCertV2Sha384Guid                  ## SOMETIMES_CONSUMES    ## GUID     # Unique ID for the type of the signature.
+  gEfiCertV2Sha512Guid                  ## SOMETIMES_CONSUMES    ## GUID     # Unique ID for the type of the signature.
+  gEfiCertV2X509Guid                    ## SOMETIMES_CONSUMES    ## GUID     # Unique ID for the type of the signature.
+  gEfiCertV2X509Sha256Guid              ## SOMETIMES_CONSUMES    ## GUID     # Unique ID for the type of the signature.
+  gEfiCertV2X509Sha384Guid              ## SOMETIMES_CONSUMES    ## GUID     # Unique ID for the type of the signature.
+  gEfiCertV2X509Sha512Guid              ## SOMETIMES_CONSUMES    ## GUID     # Unique ID for the type of the signature.
+  gEfiCertPkcs7Guid                     ## SOMETIMES_CONSUMES    ## GUID     # Unique ID for the type of the certificate.

--- a/SecurityPkg/Library/DxeImageVerificationLib2/GoogleTest/DatabaseGoogleTest.cpp
+++ b/SecurityPkg/Library/DxeImageVerificationLib2/GoogleTest/DatabaseGoogleTest.cpp
@@ -1,0 +1,2563 @@
+/** @file
+  Unit tests for the signature-database helpers in
+  DxeImageVerificationLib (Database.c): IsInDb, IsInDbx,
+  LoadSignatureDatabase, LoadSignatureDatabases,
+  IsChainRevoked,
+  ExtractAuthData, and
+  EvaluateImageCertificate. The database helpers are exercised against
+  synthetic in-memory EFI_SIGNATURE_LIST buffers built by helpers in
+  this file; the variable loaders against a mocked GetVariable2; and the
+  certificate helpers against a mocked BaseCryptLib.
+  Copyright (C) Microsoft Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/GoogleTestLib.h>
+#include <GoogleTest/Library/MockUefiLib.h>
+#include <GoogleTest/Library/MockBaseCryptLib.h>
+
+#include <vector>
+#include <cstring>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Guid/ImageAuthentication.h>
+  #include <Guid/WinCertificate.h>
+  #include <Library/BaseMemoryLib.h>
+  #include <Library/MemoryAllocationLib.h>
+  #include "../Database.h"
+  #include "../Support.h"
+
+  EFI_STATUS
+  LoadSignatureDatabase (
+    IN  CONST CHAR16  *DatabaseName,
+    OUT VOID          **Buffer,
+    OUT UINTN         *BufferSize
+    );
+
+  BOOLEAN
+  IsChainRevoked (
+    IN  CONST UINT8  *CertChain,
+    IN  UINTN        CertChainSize,
+    IN  CONST VOID   *Dbx,
+    IN  UINTN        DbxSize
+    );
+
+  EFI_STATUS
+  ExtractAuthData (
+    IN  CONST WIN_CERTIFICATE  *Cert,
+    OUT CONST UINT8            **AuthData,
+    OUT UINTN                  *AuthDataSize
+    );
+}
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::SetArgPointee;
+
+static bool
+GetImageHashIndexForTest (
+  const EFI_GUID  *Guid,
+  UINTN           *Index
+  )
+{
+  UINTN  I;
+
+  if ((Guid == nullptr) || (Index == nullptr)) {
+    return false;
+  }
+
+  for (I = 0; I < ARRAY_SIZE (mHashAlgorithms); I++) {
+    if (CompareGuid (Guid, mHashAlgorithms[I].ImageHashGuid)) {
+      *Index = I;
+      return true;
+    }
+  }
+
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers for constructing signature-list buffers.
+// ---------------------------------------------------------------------------
+
+//
+// Append one EFI_SIGNATURE_LIST containing SignatureCount entries of
+// EntrySize bytes each (entry payloads are zero-initialized) to Buffer.
+// Returns the offset of the new list within Buffer.
+//
+static size_t
+AppendSignatureList (
+  std::vector<UINT8>  &Buffer,
+  const EFI_GUID      &SignatureType,
+  UINT32              SignatureHeaderSize,
+  UINT32              EntrySize,
+  UINT32              SignatureCount
+  )
+{
+  const size_t  PayloadBytes = (size_t)EntrySize * (size_t)SignatureCount;
+  const size_t  ListBytes    = sizeof (EFI_SIGNATURE_LIST) + SignatureHeaderSize + PayloadBytes;
+  const size_t  Offset       = Buffer.size ();
+
+  Buffer.resize (Offset + ListBytes, 0);
+
+  EFI_SIGNATURE_LIST  *List = (EFI_SIGNATURE_LIST *)(Buffer.data () + Offset);
+
+  CopyMem (&List->SignatureType, &SignatureType, sizeof (EFI_GUID));
+  List->SignatureListSize   = (UINT32)ListBytes;
+  List->SignatureHeaderSize = SignatureHeaderSize;
+  List->SignatureSize       = EntrySize;
+
+  return Offset;
+}
+
+//
+// Walk callback that simply counts invocations and records the
+// per-list SignatureType GUIDs in visit order.
+//
+// SHA-256 entry size: 16-byte owner GUID + 32-byte digest.
+static constexpr UINT32  kSha256EntrySize = sizeof (EFI_GUID) + 32;
+static constexpr UINT32  kSha384EntrySize = sizeof (EFI_GUID) + 48;
+
+// V1 EFI_CERT_X509_SHA256 entry: owner GUID + 32-byte TBS hash + EFI_TIME (TimeOfRevocation).
+static constexpr UINT32  kSha256TbsV1EntrySize = sizeof (EFI_GUID) + 32 + sizeof (EFI_TIME);
+
+// ---------------------------------------------------------------------------
+// IsInDb / IsInDbx helpers
+// ---------------------------------------------------------------------------
+
+//
+// Write Bytes into the entry payload (the part after the owner GUID) of
+// signature index EntryIndex inside the EFI_SIGNATURE_LIST that begins
+// at ListOffset within Buffer.
+//
+static void
+SetEntryPayload (
+  std::vector<UINT8>        &Buffer,
+  size_t                    ListOffset,
+  UINTN                     EntryIndex,
+  const std::vector<UINT8>  &Bytes
+  )
+{
+  EFI_SIGNATURE_LIST  *List      = (EFI_SIGNATURE_LIST *)(Buffer.data () + ListOffset);
+  const size_t        FirstEntry = ListOffset + sizeof (EFI_SIGNATURE_LIST) + List->SignatureHeaderSize;
+  const size_t        EntryStart = FirstEntry + (size_t)EntryIndex * (size_t)List->SignatureSize;
+  const size_t        PayloadOff = EntryStart + sizeof (EFI_GUID);
+
+  ASSERT_LE (PayloadOff + Bytes.size (), Buffer.size ());
+  std::memcpy (Buffer.data () + PayloadOff, Bytes.data (), Bytes.size ());
+}
+
+// SHA-256 digest payload size (no owner GUID).
+static constexpr UINTN  kSha256DigestSize = 32;
+static constexpr UINTN  kSha384DigestSize = 48;
+
+// V2 (EFI_SIGNATURE_V2_DATA) entry size: the payload only, with no SignatureOwner prefix.
+static constexpr UINT32  kSha256V2EntrySize = 32;
+
+//
+// Write Bytes into the entry payload of a V2 (EFI_SIGNATURE_V2_DATA) signature list, whose entries
+// omit the SignatureOwner, so the payload begins at the entry start rather than sizeof (EFI_GUID)
+// bytes in.
+//
+static void
+SetV2EntryPayload (
+  std::vector<UINT8>        &Buffer,
+  size_t                    ListOffset,
+  UINTN                     EntryIndex,
+  const std::vector<UINT8>  &Bytes
+  )
+{
+  EFI_SIGNATURE_LIST  *List      = (EFI_SIGNATURE_LIST *)(Buffer.data () + ListOffset);
+  const size_t        FirstEntry = ListOffset + sizeof (EFI_SIGNATURE_LIST) + List->SignatureHeaderSize;
+  const size_t        EntryStart = FirstEntry + (size_t)EntryIndex * (size_t)List->SignatureSize;
+
+  ASSERT_LE (EntryStart + Bytes.size (), Buffer.size ());
+  std::memcpy (Buffer.data () + EntryStart, Bytes.data (), Bytes.size ());
+}
+
+static DIGEST_CACHE
+MakeBoundCache (
+  const EFI_GUID            *HashType,
+  const std::vector<UINT8>  &Digest
+  )
+{
+  DIGEST_CACHE  Cache;
+  UINTN         Index;
+
+  ZeroMem (&Cache, sizeof (Cache));
+  Cache.Buffer     = (const VOID *)(UINTN)1;
+  Cache.BufferSize = 1;
+
+  EXPECT_TRUE (GetImageHashIndexForTest (HashType, &Index));
+  EXPECT_LE (Digest.size (), (size_t)MAX_DIGEST_SIZE);
+
+  std::memcpy (Cache.Entries[Index].Bytes, Digest.data (), Digest.size ());
+  Cache.Entries[Index].BufferSize = Digest.size ();
+  return Cache;
+}
+
+//
+// Bind an X509 (certificate) digest cache to a DER certificate. The cache borrows Cert's storage,
+// so Cert must outlive the returned cache.
+//
+static DIGEST_CACHE
+MakeCertCache (
+  const std::vector<UINT8>  &Cert
+  )
+{
+  DIGEST_CACHE  Cache;
+
+  ZeroMem (&Cache, sizeof (Cache));
+  Cache.Type       = DigestCacheTypeX509;
+  Cache.Buffer     = Cert.data ();
+  Cache.BufferSize = Cert.size ();
+  return Cache;
+}
+
+//
+// Build a buffer in EFI_CERT_STACK format:
+//   UINT8 CertNumber; { UINT32 CertLen (LE); UINT8 CertData[CertLen]; } * N
+//
+static std::vector<UINT8>
+MakeCertStack (
+  const std::vector<std::vector<UINT8> >  &Certs
+  )
+{
+  std::vector<UINT8>  Buf;
+
+  Buf.push_back ((UINT8)Certs.size ());
+  for (const auto &Cert : Certs) {
+    UINT32  Len = (UINT32)Cert.size ();
+    Buf.push_back ((UINT8)(Len & 0xFF));
+    Buf.push_back ((UINT8)((Len >>  8) & 0xFF));
+    Buf.push_back ((UINT8)((Len >> 16) & 0xFF));
+    Buf.push_back ((UINT8)((Len >> 24) & 0xFF));
+    Buf.insert (Buf.end (), Cert.begin (), Cert.end ());
+  }
+
+  return Buf;
+}
+
+//
+// Default PKCS#7 auth-data / image-hash payloads shared by the
+// certificate-authorization tests.
+//
+static const std::vector<UINT8>  kAuthDataDefault  = std::vector<UINT8>(16, 0xA1);
+static const std::vector<UINT8>  kImageHashDefault = std::vector<UINT8>(SHA256_DIGEST_SIZE, 0x55);
+
+// Build a PKCS_SIGNED_DATA WIN_CERTIFICATE wrapping `Payload`.
+static std::vector<UINT8>
+MakePkcsSignedDataCert (
+  const std::vector<UINT8>  &Payload
+  )
+{
+  std::vector<UINT8>  Buffer (sizeof (WIN_CERTIFICATE) + Payload.size (), 0);
+  WIN_CERTIFICATE     *Cert = (WIN_CERTIFICATE *)Buffer.data ();
+
+  Cert->dwLength         = (UINT32)Buffer.size ();
+  Cert->wRevision        = 0x0200;
+  Cert->wCertificateType = WIN_CERT_TYPE_PKCS_SIGNED_DATA;
+  std::memcpy (Buffer.data () + sizeof (WIN_CERTIFICATE), Payload.data (), Payload.size ());
+  return Buffer;
+}
+
+// Tiny throwaway "image" buffer for the digest cache; mocks of
+// GetAuthenticodeHash never dereference it.
+static UINT8  kFakeImage[16] = { 0 };
+
+static void
+InitImageCache (
+  DIGEST_CACHE  &Cache
+  )
+{
+  ZeroMem (&Cache, sizeof (Cache));
+  Cache.Type       = DigestCacheTypeImage;
+  Cache.Buffer     = kFakeImage;
+  Cache.BufferSize = sizeof (kFakeImage);
+}
+
+TEST (IsInDbTest, NullDatabaseWithNonZeroSize_NotFound) {
+  DIGEST_CACHE  Cache;
+
+  ZeroMem (&Cache, sizeof (Cache));
+  Cache.Buffer     = (const VOID *)(UINTN)1;
+  Cache.BufferSize = 1;
+
+  EXPECT_FALSE (IsInDb (&Cache, NULL, 1));
+  // Validate that Cache remains consistent
+  EXPECT_EQ (Cache.Buffer, (const VOID *)(UINTN)1);
+  EXPECT_EQ (Cache.BufferSize, (UINTN)1);
+}
+
+TEST (IsInDbTest, NullDatabaseWithZeroSize_NotFound) {
+  DIGEST_CACHE  Cache;
+
+  ZeroMem (&Cache, sizeof (Cache));
+  Cache.Buffer     = (const VOID *)(UINTN)1;
+  Cache.BufferSize = 1;
+
+  EXPECT_FALSE (IsInDb (&Cache, NULL, 0));
+  // Validate that Cache remains consistent
+  EXPECT_EQ (Cache.Buffer, (const VOID *)(UINTN)1);
+  EXPECT_EQ (Cache.BufferSize, (UINTN)1);
+}
+
+TEST (IsInDbTest, NullCache_NotFound) {
+  UINT8  Dummy = 0;
+
+  EXPECT_FALSE (IsInDb (NULL, &Dummy, 1));
+}
+
+TEST (IsInDbTest, UnboundCache_NotFound) {
+  UINT8         Dummy = 0;
+  DIGEST_CACHE  Cache;
+
+  ZeroMem (&Cache, sizeof (Cache));
+  EXPECT_FALSE (IsInDb (&Cache, &Dummy, 1));
+}
+
+TEST (IsInDbTest, ZeroSizeCache_NotFound) {
+  UINT8         Dummy = 0;
+  DIGEST_CACHE  Cache;
+
+  ZeroMem (&Cache, sizeof (Cache));
+  Cache.Buffer     = (const VOID *)(UINTN)1;
+  Cache.BufferSize = 0;
+
+  EXPECT_FALSE (IsInDb (&Cache, &Dummy, 1));
+}
+
+TEST (IsInDbTest, HashComputationFailure_NotAuthorized) {
+  MockBaseCryptLib    BaseCryptLibMock;
+  std::vector<UINT8>  Db;
+
+  AppendSignatureList (Db, gEfiCertSha256Guid, 0, kSha256EntrySize, 1);
+
+  DIGEST_CACHE  Cache;
+
+  ZeroMem (&Cache, sizeof (Cache));
+  Cache.Buffer     = (const VOID *)(UINTN)1;
+  Cache.BufferSize = 1;
+
+  EXPECT_CALL (BaseCryptLibMock, GetAuthenticodeHash (_, _, _, _, _))
+    .WillOnce (Return (EFI_DEVICE_ERROR));
+
+  // A hash failure means this list cannot authorize; a best-effort search reports "not found".
+  EXPECT_FALSE (IsInDb (&Cache, Db.data (), Db.size ()));
+}
+
+TEST (IsInDbTest, ExactMatch_Found) {
+  std::vector<UINT8>  Db;
+  size_t              Off = AppendSignatureList (Db, gEfiCertSha256Guid, 0, kSha256EntrySize, 2);
+  std::vector<UINT8>  Target (kSha256DigestSize, 0xAA);
+
+  SetEntryPayload (Db, Off, 1, Target);
+
+  DIGEST_CACHE  Cache = MakeBoundCache (&gEfiCertSha256Guid, Target);
+
+  EXPECT_TRUE (IsInDb (&Cache, Db.data (), Db.size ()));
+}
+
+TEST (IsInDbTest, V2ImageHashExactMatch_Found) {
+  // A V2 (EFI_SIGNATURE_V2_DATA) image-hash list stores the digest with no SignatureOwner prefix,
+  // so the payload must be read from the entry start rather than sizeof (EFI_GUID) bytes in.
+  std::vector<UINT8>  Db;
+  size_t              Off = AppendSignatureList (Db, gEfiCertV2Sha256Guid, 0, kSha256V2EntrySize, 2);
+  std::vector<UINT8>  Target (kSha256DigestSize, 0xAA);
+
+  SetV2EntryPayload (Db, Off, 1, Target);
+
+  DIGEST_CACHE  Cache = MakeBoundCache (&gEfiCertSha256Guid, Target);
+
+  EXPECT_TRUE (IsInDb (&Cache, Db.data (), Db.size ()));
+}
+
+TEST (IsInDbTest, V2X509CertExactMatch_Found) {
+  // A V2 full-certificate list stores the DER certificate with no owner prefix.
+  std::vector<UINT8>  Cert (24, 0xC7);
+  std::vector<UINT8>  Db;
+  size_t              Off = AppendSignatureList (Db, gEfiCertV2X509Guid, 0, (UINT32)Cert.size (), 1);
+
+  SetV2EntryPayload (Db, Off, 0, Cert);
+
+  DIGEST_CACHE  Cache = MakeCertCache (Cert);
+
+  EXPECT_TRUE (IsInDb (&Cache, Db.data (), Db.size ()));
+}
+
+TEST (IsInDbTest, V2X509CertHashMatch_Found) {
+  // A V2 X.509 TBS-cert-hash list stores the hash with neither the owner GUID nor a v1
+  // TimeOfRevocation trailer.
+  MockBaseCryptLib    BaseCryptLibMock;
+  std::vector<UINT8>  Cert (24, 0xC7);
+  std::vector<UINT8>  TbsHash (kSha256DigestSize, 0x5A);
+  std::vector<UINT8>  Db;
+  size_t              Off = AppendSignatureList (Db, gEfiCertV2X509Sha256Guid, 0, kSha256V2EntrySize, 1);
+
+  SetV2EntryPayload (Db, Off, 0, TbsHash);
+
+  EXPECT_CALL (BaseCryptLibMock, X509GetTbsCertHash (_, _, _, _, _))
+    .WillOnce (
+       Invoke (
+         [] (
+             IN  VOID            *CertBuffer,
+             IN  UINTN           CertSize,
+             IN  CONST EFI_GUID  *HashType,
+             OUT UINT8           *OutDigest,
+             OUT UINTN           *OutDigestSize
+         ) -> EFI_STATUS {
+    (VOID)CertBuffer;
+    (VOID)CertSize;
+    (VOID)HashType;
+    SetMem (OutDigest, SHA256_DIGEST_SIZE, 0x5A);
+    *OutDigestSize = SHA256_DIGEST_SIZE;
+    return EFI_SUCCESS;
+  }
+         )
+       );
+
+  DIGEST_CACHE  Cache = MakeCertCache (Cert);
+
+  EXPECT_TRUE (IsInDb (&Cache, Db.data (), Db.size ()));
+}
+
+TEST (IsInDbxTest, V2ImageHashExactMatch_Revoked) {
+  // Deny-list parsing honors the V2 ownerless layout the same as the allow-list.
+  std::vector<UINT8>  Dbx;
+  size_t              Off = AppendSignatureList (Dbx, gEfiCertV2Sha256Guid, 0, kSha256V2EntrySize, 1);
+  std::vector<UINT8>  Target (kSha256DigestSize, 0xAA);
+
+  SetV2EntryPayload (Dbx, Off, 0, Target);
+
+  DIGEST_CACHE  Cache = MakeBoundCache (&gEfiCertSha256Guid, Target);
+
+  EXPECT_TRUE (IsInDbx (&Cache, Dbx.data (), Dbx.size ()));
+}
+
+TEST (IsInDbTest, NoMatchingEntry_NotFound) {
+  std::vector<UINT8>  Db;
+  size_t              Off = AppendSignatureList (Db, gEfiCertSha256Guid, 0, kSha256EntrySize, 1);
+  std::vector<UINT8>  Stored (kSha256DigestSize, 0xAA);
+
+  SetEntryPayload (Db, Off, 0, Stored);
+
+  std::vector<UINT8>  Digest (kSha256DigestSize, 0xBB);
+  DIGEST_CACHE        Cache = MakeBoundCache (&gEfiCertSha256Guid, Digest);
+
+  EXPECT_FALSE (IsInDb (&Cache, Db.data (), Db.size ()));
+}
+
+TEST (IsInDbTest, UnknownSignatureTypeList_Skipped) {
+  std::vector<UINT8>  Db;
+
+  AppendSignatureList (Db, gEfiCertX509Guid, 0, sizeof (EFI_GUID) + 16, 1);
+
+  std::vector<UINT8>  Digest (kSha256DigestSize, 0xAA);
+  DIGEST_CACHE        Cache = MakeBoundCache (&gEfiCertSha256Guid, Digest);
+
+  EXPECT_FALSE (IsInDb (&Cache, Db.data (), Db.size ()));
+}
+
+TEST (IsInDbTest, MismatchedSignatureSize_Skipped) {
+  // List type matches but per-entry size doesn't, so the list describes
+  // a different algorithm and must be skipped.
+  std::vector<UINT8>  Db;
+
+  AppendSignatureList (Db, gEfiCertSha256Guid, 0, kSha384EntrySize, 1);
+
+  std::vector<UINT8>  Digest (kSha256DigestSize, 0xCC);
+  DIGEST_CACHE        Cache = MakeBoundCache (&gEfiCertSha256Guid, Digest);
+
+  EXPECT_FALSE (IsInDb (&Cache, Db.data (), Db.size ()));
+}
+
+TEST (IsInDbTest, MatchInSecondList_Found) {
+  // First list is the wrong algorithm, second list contains the target.
+  std::vector<UINT8>  Db;
+
+  AppendSignatureList (Db, gEfiCertX509Guid, 0, sizeof (EFI_GUID) + 16, 1);
+  size_t  SecondOff = AppendSignatureList (Db, gEfiCertSha256Guid, 0, kSha256EntrySize, 2);
+
+  std::vector<UINT8>  Target (kSha256DigestSize, 0x77);
+
+  SetEntryPayload (Db, SecondOff, 1, Target);
+
+  DIGEST_CACHE  Cache = MakeBoundCache (&gEfiCertSha256Guid, Target);
+
+  EXPECT_TRUE (IsInDb (&Cache, Db.data (), Db.size ()));
+}
+
+TEST (IsInDbTest, NonZeroSignatureHeaderSize_EntryMathCorrect) {
+  // SignatureHeaderSize is non-zero: the per-list header occupies
+  // additional bytes between EFI_SIGNATURE_LIST and the first entry.
+  // A naive cursor that forgets to skip it would either miss the
+  // payload entirely or read the header bytes as a fake entry.
+  constexpr UINT32    kHeader = 8;
+  std::vector<UINT8>  Db;
+  size_t              Off = AppendSignatureList (Db, gEfiCertSha256Guid, kHeader, kSha256EntrySize, 2);
+
+  // Fill the per-list header with a recognizable pattern so a math
+  // bug that read it as an entry would compare against this, not the
+  // real digest. The search target intentionally differs from it.
+  std::memset (Db.data () + Off + sizeof (EFI_SIGNATURE_LIST), 0xEE, kHeader);
+
+  std::vector<UINT8>  Target (kSha256DigestSize, 0x55);
+
+  SetEntryPayload (Db, Off, 1, Target);
+
+  DIGEST_CACHE  Cache = MakeBoundCache (&gEfiCertSha256Guid, Target);
+
+  EXPECT_TRUE (IsInDb (&Cache, Db.data (), Db.size ()));
+}
+
+TEST (IsInDbTest, ZeroEntryList_NotFound) {
+  // A well-formed list with zero entries must be skipped without a
+  // false positive (EntryCount == 0 means the inner loop never runs).
+  std::vector<UINT8>  Db;
+
+  AppendSignatureList (Db, gEfiCertSha256Guid, 0, kSha256EntrySize, 0);
+
+  std::vector<UINT8>  Digest (kSha256DigestSize, 0x00);
+  DIGEST_CACHE        Cache = MakeBoundCache (&gEfiCertSha256Guid, Digest);
+
+  EXPECT_FALSE (IsInDb (&Cache, Db.data (), Db.size ()));
+}
+
+//
+// A malformed db (the sole list overruns the buffer) truncates to an empty
+// prefix; a best-effort allow-list search simply finds no authority.
+//
+TEST (IsInDbTest, MalformedDb_BestEffortNotFound) {
+  std::vector<UINT8>  Db;
+
+  AppendSignatureList (Db, gEfiCertSha256Guid, 0, kSha256EntrySize, 1);
+  ((EFI_SIGNATURE_LIST *)Db.data ())->SignatureListSize = (UINT32)(Db.size () + 1);
+
+  std::vector<UINT8>  Digest (kSha256DigestSize, 0x00);
+  DIGEST_CACHE        Cache = MakeBoundCache (&gEfiCertSha256Guid, Digest);
+
+  EXPECT_FALSE (IsInDb (&Cache, Db.data (), Db.size ()));
+}
+
+//
+// A well-formed authorizing list followed by a malformed trailing fragment:
+// the valid prefix still authorizes (best-effort allow-list search).
+//
+TEST (IsInDbTest, MalformedTail_ValidPrefixAuthorizes) {
+  std::vector<UINT8>  Db;
+  size_t              Off = AppendSignatureList (Db, gEfiCertSha256Guid, 0, kSha256EntrySize, 1);
+  std::vector<UINT8>  Target (kSha256DigestSize, 0x5A);
+
+  SetEntryPayload (Db, Off, 0, Target);
+
+  // Append a stray fragment too small to be a list header.
+  Db.resize (Db.size () + sizeof (EFI_SIGNATURE_LIST) - 1, 0);
+
+  DIGEST_CACHE  Cache = MakeBoundCache (&gEfiCertSha256Guid, Target);
+
+  EXPECT_TRUE (IsInDb (&Cache, Db.data (), Db.size ()));
+}
+
+TEST (IsInDbTest, ZeroSizeNonNullDatabase_EmptyDatabaseNotFound) {
+  UINT8         Dummy = 0;
+  DIGEST_CACHE  Cache;
+
+  ZeroMem (&Cache, sizeof (Cache));
+  Cache.Buffer     = (const VOID *)(UINTN)1;
+  Cache.BufferSize = 1;
+
+  EXPECT_FALSE (IsInDb (&Cache, &Dummy, 0));
+}
+
+//
+// A db list whose SignatureType is a supported image-hash GUID (so GetHash
+// succeeds against the bound cache) but whose SignatureHeaderSize is
+// inflated so SigListIterInit yields an empty range for it. The list must be
+// skipped and no authority returned.
+//
+TEST (IsInDbTest, MalformedListHeader_Skipped) {
+  std::vector<UINT8>  Digest (kSha256DigestSize, 0xAB);
+  DIGEST_CACHE        Cache = MakeBoundCache (&gEfiCertSha256Guid, Digest);
+
+  // One image-hash list sized for a single SHA-256 entry, but with an
+  // inflated SignatureHeaderSize that overflows the list payload area.
+  const UINT32        EntrySize = kSha256EntrySize;
+  const UINT32        ListSize  = (UINT32)(sizeof (EFI_SIGNATURE_LIST) + EntrySize);
+  std::vector<UINT8>  Db (ListSize, 0);
+
+  EFI_SIGNATURE_LIST  *List = (EFI_SIGNATURE_LIST *)Db.data ();
+
+  CopyMem (&List->SignatureType, &gEfiCertSha256Guid, sizeof (EFI_GUID));
+  List->SignatureListSize   = ListSize;
+  List->SignatureHeaderSize = ListSize;        // > ListSize - sizeof (EFI_SIGNATURE_LIST)
+  List->SignatureSize       = EntrySize;
+
+  EXPECT_FALSE (IsInDb (&Cache, Db.data (), Db.size ()));
+}
+
+// ---------------------------------------------------------------------------
+// LoadSignatureDatabase (uses MockUefiLib::GetVariable2)
+// ---------------------------------------------------------------------------
+
+class LoadSignatureDatabaseTest : public ::testing::Test {
+protected:
+  MockUefiLib UefiLibMock;
+};
+
+TEST_F (LoadSignatureDatabaseTest, NullDatabaseName_ReturnsInvalidParameter) {
+  VOID   *Buffer    = NULL;
+  UINTN  BufferSize = 0;
+
+  EXPECT_EQ (
+    LoadSignatureDatabase (NULL, &Buffer, &BufferSize),
+    EFI_INVALID_PARAMETER
+    );
+}
+
+TEST_F (LoadSignatureDatabaseTest, NullBuffer_ReturnsInvalidParameter) {
+  UINTN  BufferSize = 0;
+
+  EXPECT_EQ (
+    LoadSignatureDatabase ((const CHAR16 *)u"db", NULL, &BufferSize),
+    EFI_INVALID_PARAMETER
+    );
+}
+
+TEST_F (LoadSignatureDatabaseTest, NullSize_ReturnsInvalidParameter) {
+  VOID  *Buffer = NULL;
+
+  EXPECT_EQ (
+    LoadSignatureDatabase ((const CHAR16 *)u"db", &Buffer, NULL),
+    EFI_INVALID_PARAMETER
+    );
+}
+
+TEST_F (LoadSignatureDatabaseTest, VariableMissing_SuccessWithNullBuffer) {
+  // EFI_NOT_FOUND is normalized to EFI_SUCCESS with *Buffer == NULL.
+  EXPECT_CALL (UefiLibMock, GetVariable2 (_, _, _, _))
+    .WillOnce (Return (EFI_NOT_FOUND));
+
+  VOID   *Buffer    = (VOID *)(UINTN)0xDEADBEEF; // pre-set: must be cleared
+  UINTN  BufferSize = 0xAA;
+
+  EXPECT_EQ (
+    LoadSignatureDatabase ((const CHAR16 *)u"db", &Buffer, &BufferSize),
+    EFI_SUCCESS
+    );
+  EXPECT_EQ (Buffer, (VOID *)NULL);
+  EXPECT_EQ (BufferSize, 0u);
+}
+
+TEST_F (LoadSignatureDatabaseTest, VariablePresent_BufferAndSizePopulated) {
+  static const UINT8  kPayload[] = { 0xAA, 0xBB, 0xCC, 0xDD };
+
+  EXPECT_CALL (UefiLibMock, GetVariable2 (_, _, _, _))
+    .WillOnce (
+       Invoke (
+         [] (
+             IN CONST CHAR16    *Name,
+             IN CONST EFI_GUID  *Guid,
+             OUT      VOID      **Value,
+             OUT      UINTN     *BufferSize
+         ) -> EFI_STATUS {
+    (VOID)Name;
+    (VOID)Guid;
+    *Value      = AllocateCopyPool (sizeof (kPayload), kPayload);
+    *BufferSize = sizeof (kPayload);
+    return EFI_SUCCESS;
+  }
+         )
+       );
+
+  VOID   *Buffer    = NULL;
+  UINTN  BufferSize = 0;
+
+  EXPECT_EQ (
+    LoadSignatureDatabase ((const CHAR16 *)u"db", &Buffer, &BufferSize),
+    EFI_SUCCESS
+    );
+  ASSERT_NE (Buffer, (VOID *)NULL);
+  EXPECT_EQ (BufferSize, sizeof (kPayload));
+  EXPECT_EQ (CompareMem (Buffer, kPayload, sizeof (kPayload)), 0);
+
+  FreePool (Buffer);
+}
+
+TEST_F (LoadSignatureDatabaseTest, GetVariableUnexpectedError_PropagatedVerbatim) {
+  // Errors other than EFI_NOT_FOUND must be reported unchanged.
+  EXPECT_CALL (UefiLibMock, GetVariable2 (_, _, _, _))
+    .WillOnce (Return (EFI_DEVICE_ERROR));
+
+  VOID   *Buffer    = NULL;
+  UINTN  BufferSize = 0;
+
+  EXPECT_EQ (
+    LoadSignatureDatabase ((const CHAR16 *)u"db", &Buffer, &BufferSize),
+    EFI_DEVICE_ERROR
+    );
+}
+
+// ---------------------------------------------------------------------------
+// LoadSignatureDatabases (db + dbx)
+// ---------------------------------------------------------------------------
+
+class LoadSignatureDatabasesTest : public ::testing::Test {
+protected:
+  MockUefiLib UefiLibMock;
+};
+
+//
+// Lambda factory: a GetVariable2 action that allocates a copy of the
+// supplied payload and returns EFI_SUCCESS. Used to feed synthetic
+// db/dbx buffers into LoadSignatureDatabases through the mock.
+//
+static auto
+ReturnVariablePayload (
+  const UINT8  *Payload,
+  size_t       PayloadSize
+  )
+{
+  return Invoke (
+           [Payload, PayloadSize] (
+                                   IN CONST CHAR16    *Name,
+                                   IN CONST EFI_GUID  *Guid,
+                                   OUT      VOID      **Value,
+                                   OUT      UINTN     *BufferSize
+           ) -> EFI_STATUS {
+    (VOID)Name;
+    (VOID)Guid;
+    *Value      = AllocateCopyPool (PayloadSize, Payload);
+    *BufferSize = PayloadSize;
+    return EFI_SUCCESS;
+  }
+           );
+}
+
+TEST_F (LoadSignatureDatabasesTest, NullDatabases_ReturnsInvalidParameter) {
+  EXPECT_EQ (
+    LoadSignatureDatabases (NULL),
+    EFI_INVALID_PARAMETER
+    );
+}
+
+TEST_F (LoadSignatureDatabasesTest, BothVariablesMissing_Success) {
+  EXPECT_CALL (UefiLibMock, GetVariable2 (_, _, _, _))
+    .WillOnce (Return (EFI_NOT_FOUND))   // db
+    .WillOnce (Return (EFI_NOT_FOUND));  // dbx
+
+  // Pre-set to bogus values: must be cleared.
+  SIGNATURE_DATABASES  Databases = {
+    (VOID *)(UINTN)0xDEADBEEF, 0xAA,
+    (VOID *)(UINTN)0xCAFEF00D, 0xBB
+  };
+
+  EXPECT_EQ (
+    LoadSignatureDatabases (&Databases),
+    EFI_SUCCESS
+    );
+  EXPECT_EQ (Databases.Db, (VOID *)NULL);
+  EXPECT_EQ (Databases.DbSize, 0u);
+  EXPECT_EQ (Databases.Dbx, (VOID *)NULL);
+  EXPECT_EQ (Databases.DbxSize, 0u);
+}
+
+TEST_F (LoadSignatureDatabasesTest, OnlyDbPresent_DbAllocated) {
+  std::vector<UINT8>  DbBuf;
+
+  AppendSignatureList (DbBuf, gEfiCertSha256Guid, 0, kSha256EntrySize, 1);
+
+  EXPECT_CALL (UefiLibMock, GetVariable2 (_, _, _, _))
+    .WillOnce (ReturnVariablePayload (DbBuf.data (), DbBuf.size ()))  // db
+    .WillOnce (Return (EFI_NOT_FOUND));                               // dbx
+
+  SIGNATURE_DATABASES  Databases = { NULL, 0, NULL, 0 };
+
+  EXPECT_EQ (
+    LoadSignatureDatabases (&Databases),
+    EFI_SUCCESS
+    );
+  ASSERT_NE (Databases.Db, (VOID *)NULL);
+  EXPECT_EQ (Databases.DbSize, DbBuf.size ());
+  EXPECT_EQ (Databases.Dbx, (VOID *)NULL);
+  EXPECT_EQ (Databases.DbxSize, 0u);
+  FreePool (Databases.Db);
+}
+
+TEST_F (LoadSignatureDatabasesTest, OnlyDbxPresent_DbxAllocated) {
+  std::vector<UINT8>  DbxBuf;
+
+  AppendSignatureList (DbxBuf, gEfiCertSha384Guid, 0, kSha384EntrySize, 1);
+
+  EXPECT_CALL (UefiLibMock, GetVariable2 (_, _, _, _))
+    .WillOnce (Return (EFI_NOT_FOUND))                                  // db
+    .WillOnce (ReturnVariablePayload (DbxBuf.data (), DbxBuf.size ())); // dbx
+
+  SIGNATURE_DATABASES  Databases = { NULL, 0, NULL, 0 };
+
+  EXPECT_EQ (
+    LoadSignatureDatabases (&Databases),
+    EFI_SUCCESS
+    );
+  EXPECT_EQ (Databases.Db, (VOID *)NULL);
+  EXPECT_EQ (Databases.DbSize, 0u);
+  ASSERT_NE (Databases.Dbx, (VOID *)NULL);
+  EXPECT_EQ (Databases.DbxSize, DbxBuf.size ());
+  FreePool (Databases.Dbx);
+}
+
+TEST_F (LoadSignatureDatabasesTest, BothPresent_BuffersAllocated) {
+  std::vector<UINT8>  DbBuf;
+  std::vector<UINT8>  DbxBuf;
+
+  AppendSignatureList (DbBuf, gEfiCertSha256Guid, 0, kSha256EntrySize, 1);
+  AppendSignatureList (DbxBuf, gEfiCertSha384Guid, 0, kSha384EntrySize, 1);
+
+  EXPECT_CALL (UefiLibMock, GetVariable2 (_, _, _, _))
+    .WillOnce (ReturnVariablePayload (DbBuf.data (), DbBuf.size ()))    // db
+    .WillOnce (ReturnVariablePayload (DbxBuf.data (), DbxBuf.size ())); // dbx
+
+  SIGNATURE_DATABASES  Databases = { NULL, 0, NULL, 0 };
+
+  EXPECT_EQ (
+    LoadSignatureDatabases (&Databases),
+    EFI_SUCCESS
+    );
+  ASSERT_NE (Databases.Db, (VOID *)NULL);
+  EXPECT_EQ (Databases.DbSize, DbBuf.size ());
+  ASSERT_NE (Databases.Dbx, (VOID *)NULL);
+  EXPECT_EQ (Databases.DbxSize, DbxBuf.size ());
+  FreePool (Databases.Db);
+  FreePool (Databases.Dbx);
+}
+
+TEST_F (LoadSignatureDatabasesTest, DbLoadFails_ErrorPropagatedNothingAllocated) {
+  // The db lookup fails with a non-NOT_FOUND status; dbx must not even
+  // be attempted, and both out-pointers must be NULL.
+  EXPECT_CALL (UefiLibMock, GetVariable2 (_, _, _, _))
+    .WillOnce (Return (EFI_DEVICE_ERROR));
+
+  SIGNATURE_DATABASES  Databases = { NULL, 0, NULL, 0 };
+
+  EXPECT_EQ (
+    LoadSignatureDatabases (&Databases),
+    EFI_DEVICE_ERROR
+    );
+  EXPECT_EQ (Databases.Db, (VOID *)NULL);
+  EXPECT_EQ (Databases.DbSize, 0u);
+  EXPECT_EQ (Databases.Dbx, (VOID *)NULL);
+  EXPECT_EQ (Databases.DbxSize, 0u);
+}
+
+TEST_F (LoadSignatureDatabasesTest, DbxLoadFails_DbFreedAndErrorPropagated) {
+  std::vector<UINT8>  DbBuf;
+
+  AppendSignatureList (DbBuf, gEfiCertSha256Guid, 0, kSha256EntrySize, 1);
+
+  // db succeeds (allocation must be cleaned up internally); dbx fails.
+  EXPECT_CALL (UefiLibMock, GetVariable2 (_, _, _, _))
+    .WillOnce (ReturnVariablePayload (DbBuf.data (), DbBuf.size ()))  // db
+    .WillOnce (Return (EFI_DEVICE_ERROR));                            // dbx
+
+  SIGNATURE_DATABASES  Databases = { NULL, 0, NULL, 0 };
+
+  EXPECT_EQ (
+    LoadSignatureDatabases (&Databases),
+    EFI_DEVICE_ERROR
+    );
+  EXPECT_EQ (Databases.Db, (VOID *)NULL);   // freed and nulled
+  EXPECT_EQ (Databases.DbSize, 0u);
+  EXPECT_EQ (Databases.Dbx, (VOID *)NULL);
+  EXPECT_EQ (Databases.DbxSize, 0u);
+}
+
+TEST_F (LoadSignatureDatabasesTest, DbxLoadFailsWithAllocatedBuffer_DbxFreedAndNulled) {
+  std::vector<UINT8>  DbBuf;
+
+  AppendSignatureList (DbBuf, gEfiCertSha256Guid, 0, kSha256EntrySize, 1);
+
+  EXPECT_CALL (UefiLibMock, GetVariable2 (_, _, _, _))
+    .WillOnce (ReturnVariablePayload (DbBuf.data (), DbBuf.size ()))
+    .WillOnce (
+       Invoke (
+         [] (
+             IN CONST CHAR16    *Name,
+             IN CONST EFI_GUID  *Guid,
+             OUT      VOID      **Value,
+             OUT      UINTN     *BufferSize
+         ) -> EFI_STATUS {
+    (VOID)Name;
+    (VOID)Guid;
+    *Value      = AllocatePool (8);
+    *BufferSize = 8;
+    return EFI_DEVICE_ERROR;
+  }
+         )
+       );
+
+  SIGNATURE_DATABASES  Databases = { NULL, 0, NULL, 0 };
+
+  EXPECT_EQ (
+    LoadSignatureDatabases (&Databases),
+    EFI_DEVICE_ERROR
+    );
+  EXPECT_EQ (Databases.Db, (VOID *)NULL);
+  EXPECT_EQ (Databases.DbSize, 0u);
+  EXPECT_EQ (Databases.Dbx, (VOID *)NULL);
+  EXPECT_EQ (Databases.DbxSize, 0u);
+}
+
+// ---------------------------------------------------------------------------
+// IsInDbx
+// ---------------------------------------------------------------------------
+
+//
+// An unusable subject cache (NULL buffer) is treated as revoked (fail closed).
+//
+TEST (IsInDbxTest, UnusableCacheNullBuffer_ReturnsTrue) {
+  std::vector<UINT8>  Dbx (32, 0);
+  DIGEST_CACHE        Cache;
+
+  ZeroMem (&Cache, sizeof (Cache));
+  Cache.Type       = DigestCacheTypeX509;
+  Cache.Buffer     = NULL;
+  Cache.BufferSize = 4;
+
+  EXPECT_TRUE (IsInDbx (&Cache, Dbx.data (), Dbx.size ()));
+}
+
+//
+// An unusable subject cache (zero size) is treated as revoked (fail closed).
+//
+TEST (IsInDbxTest, UnusableCacheZeroSize_ReturnsTrue) {
+  UINT8               CertByte = 0x30;
+  std::vector<UINT8>  Dbx (32, 0);
+  DIGEST_CACHE        Cache;
+
+  ZeroMem (&Cache, sizeof (Cache));
+  Cache.Type       = DigestCacheTypeX509;
+  Cache.Buffer     = &CertByte;
+  Cache.BufferSize = 0;
+
+  EXPECT_TRUE (IsInDbx (&Cache, Dbx.data (), Dbx.size ()));
+}
+
+//
+// A NULL dbx means nothing is revoked.
+//
+TEST (IsInDbxTest, NullDbx_ReturnsFalse) {
+  std::vector<UINT8>  Cert  = { 0x30, 0x82 };
+  DIGEST_CACHE        Cache = MakeCertCache (Cert);
+
+  EXPECT_FALSE (IsInDbx (&Cache, NULL, 0));
+}
+
+//
+// An empty dbx means nothing is revoked.
+//
+TEST (IsInDbxTest, EmptyDbx_ReturnsFalse) {
+  std::vector<UINT8>  Cert = { 0x30, 0x82 };
+  std::vector<UINT8>  Dbx (32, 0);
+  DIGEST_CACHE        Cache = MakeCertCache (Cert);
+
+  EXPECT_FALSE (IsInDbx (&Cache, Dbx.data (), 0));
+}
+
+//
+// A dbx too small to contain a signature-list header must fail closed.
+//
+TEST (IsInDbxTest, MalformedDbx_ReturnsTrue) {
+  std::vector<UINT8>  Cert = { 0x30, 0x82 };
+  std::vector<UINT8>  Dbx (4, 0);
+  DIGEST_CACHE        Cache = MakeCertCache (Cert);
+
+  EXPECT_TRUE (IsInDbx (&Cache, Dbx.data (), Dbx.size ()));
+}
+
+//
+// An EFI_CERT_X509 list whose entry payload matches the certificate
+// byte-for-byte (same length) marks the certificate as revoked.
+//
+TEST (IsInDbxTest, X509ExactMatch_ReturnsTrue) {
+  std::vector<UINT8>  Cert (16, 0x11);
+  std::vector<UINT8>  Dbx;
+
+  size_t  Off = AppendSignatureList (Dbx, gEfiCertX509Guid, 0, (UINT32)(sizeof (EFI_GUID) + 16), 1);
+
+  SetEntryPayload (Dbx, Off, 0, Cert);
+
+  DIGEST_CACHE  Cache = MakeCertCache (Cert);
+
+  EXPECT_TRUE (IsInDbx (&Cache, Dbx.data (), Dbx.size ()));
+}
+
+//
+// An EFI_CERT_X509 list whose entry payload differs from the
+// certificate is not a match.
+//
+TEST (IsInDbxTest, X509BytesDiffer_ReturnsFalse) {
+  std::vector<UINT8>  Cert (16, 0x11);
+  std::vector<UINT8>  Dbx;
+
+  size_t  Off = AppendSignatureList (Dbx, gEfiCertX509Guid, 0, (UINT32)(sizeof (EFI_GUID) + 16), 1);
+
+  SetEntryPayload (Dbx, Off, 0, std::vector<UINT8>(16, 0x22));
+
+  DIGEST_CACHE  Cache = MakeCertCache (Cert);
+
+  EXPECT_FALSE (IsInDbx (&Cache, Dbx.data (), Dbx.size ()));
+}
+
+//
+// An EFI_CERT_X509 list whose entry payload size differs from the
+// certificate size is skipped (not a match).
+//
+TEST (IsInDbxTest, X509PayloadSizeMismatch_ReturnsFalse) {
+  std::vector<UINT8>  Cert (16, 0x11);
+  std::vector<UINT8>  Dbx;
+
+  size_t  Off = AppendSignatureList (Dbx, gEfiCertX509Guid, 0, (UINT32)(sizeof (EFI_GUID) + 32), 1);
+
+  SetEntryPayload (Dbx, Off, 0, std::vector<UINT8>(32, 0x11));
+
+  DIGEST_CACHE  Cache = MakeCertCache (Cert);
+
+  EXPECT_FALSE (IsInDbx (&Cache, Dbx.data (), Dbx.size ()));
+}
+
+//
+// An EFI_CERT_X509_SHA256 list whose entry holds the certificate's TBS
+// hash marks it revoked. The TBS hash is produced by the mocked
+// X509GetTbsCertHash.
+//
+TEST (IsInDbxTest, TbsHashMatch_ReturnsTrue) {
+  MockBaseCryptLib    BaseCryptLibMock;
+  std::vector<UINT8>  Cert (8, 0x30);
+  std::vector<UINT8>  Dbx;
+
+  size_t  Off = AppendSignatureList (Dbx, gEfiCertX509Sha256Guid, 0, kSha256EntrySize, 1);
+
+  SetEntryPayload (Dbx, Off, 0, std::vector<UINT8>(kSha256DigestSize, 0xE1));
+
+  EXPECT_CALL (BaseCryptLibMock, X509GetTbsCertHash (_, _, _, _, _))
+    .WillOnce (
+       Invoke (
+         [] (VOID *, UINTN, CONST EFI_GUID *, UINT8 *Digest, UINTN *DigestSize) -> EFI_STATUS {
+    std::memset (Digest, 0xE1, SHA256_DIGEST_SIZE);
+    *DigestSize = SHA256_DIGEST_SIZE;
+    return EFI_SUCCESS;
+  }
+         )
+       );
+
+  DIGEST_CACHE  Cache = MakeCertCache (Cert);
+
+  EXPECT_TRUE (IsInDbx (&Cache, Dbx.data (), Dbx.size ()));
+}
+
+//
+// An EFI_CERT_X509_SHA256 list whose entry digest differs from the
+// certificate's TBS hash is not a match.
+//
+TEST (IsInDbxTest, TbsHashDiffers_ReturnsFalse) {
+  MockBaseCryptLib    BaseCryptLibMock;
+  std::vector<UINT8>  Cert (8, 0x30);
+  std::vector<UINT8>  Dbx;
+
+  size_t  Off = AppendSignatureList (Dbx, gEfiCertX509Sha256Guid, 0, kSha256EntrySize, 1);
+
+  SetEntryPayload (Dbx, Off, 0, std::vector<UINT8>(kSha256DigestSize, 0xAA));
+
+  EXPECT_CALL (BaseCryptLibMock, X509GetTbsCertHash (_, _, _, _, _))
+    .WillOnce (
+       Invoke (
+         [] (VOID *, UINTN, CONST EFI_GUID *, UINT8 *Digest, UINTN *DigestSize) -> EFI_STATUS {
+    std::memset (Digest, 0x77, SHA256_DIGEST_SIZE);
+    *DigestSize = SHA256_DIGEST_SIZE;
+    return EFI_SUCCESS;
+  }
+         )
+       );
+
+  DIGEST_CACHE  Cache = MakeCertCache (Cert);
+
+  EXPECT_FALSE (IsInDbx (&Cache, Dbx.data (), Dbx.size ()));
+}
+
+//
+// A list whose type is neither EFI_CERT_X509 nor a supported
+// X509-cert-hash type is skipped; X509GetTbsCertHash is never called.
+//
+TEST (IsInDbxTest, UnsupportedListType_ReturnsFalse) {
+  MockBaseCryptLib    BaseCryptLibMock;
+  std::vector<UINT8>  Cert (8, 0x30);
+  std::vector<UINT8>  Dbx;
+
+  AppendSignatureList (Dbx, gEfiCertSha256Guid, 0, kSha256EntrySize, 1);
+
+  EXPECT_CALL (BaseCryptLibMock, X509GetTbsCertHash (_, _, _, _, _)).Times (0);
+
+  DIGEST_CACHE  Cache = MakeCertCache (Cert);
+
+  EXPECT_FALSE (IsInDbx (&Cache, Dbx.data (), Dbx.size ()));
+}
+
+//
+// If computing the certificate's TBS hash fails for a cert-hash list,
+// the search fails closed (returns TRUE).
+//
+TEST (IsInDbxTest, TbsHashComputeFails_ReturnsTrue) {
+  MockBaseCryptLib    BaseCryptLibMock;
+  std::vector<UINT8>  Cert (8, 0x30);
+  std::vector<UINT8>  Dbx;
+
+  AppendSignatureList (Dbx, gEfiCertX509Sha256Guid, 0, kSha256EntrySize, 1);
+
+  EXPECT_CALL (BaseCryptLibMock, X509GetTbsCertHash (_, _, _, _, _))
+    .WillOnce (Return (EFI_DEVICE_ERROR));
+
+  DIGEST_CACHE  Cache = MakeCertCache (Cert);
+
+  EXPECT_TRUE (IsInDbx (&Cache, Dbx.data (), Dbx.size ()));
+}
+
+//
+// An image subject whose digest is enrolled in the dbx is revoked.
+//
+TEST (IsInDbxTest, ImageHashMatch_ReturnsTrue) {
+  std::vector<UINT8>  Dbx;
+  size_t              Off = AppendSignatureList (Dbx, gEfiCertSha256Guid, 0, kSha256EntrySize, 1);
+  std::vector<UINT8>  Digest (kSha256DigestSize, 0xC3);
+
+  SetEntryPayload (Dbx, Off, 0, Digest);
+
+  DIGEST_CACHE  Cache = MakeBoundCache (&gEfiCertSha256Guid, Digest);
+
+  EXPECT_TRUE (IsInDbx (&Cache, Dbx.data (), Dbx.size ()));
+}
+
+//
+// An image subject whose digest is not in the dbx is not revoked.
+//
+TEST (IsInDbxTest, ImageHashNoMatch_ReturnsFalse) {
+  std::vector<UINT8>  Dbx;
+  size_t              Off = AppendSignatureList (Dbx, gEfiCertSha256Guid, 0, kSha256EntrySize, 1);
+
+  SetEntryPayload (Dbx, Off, 0, std::vector<UINT8>(kSha256DigestSize, 0xC3));
+
+  std::vector<UINT8>  Digest (kSha256DigestSize, 0xD4);
+  DIGEST_CACHE        Cache = MakeBoundCache (&gEfiCertSha256Guid, Digest);
+
+  EXPECT_FALSE (IsInDbx (&Cache, Dbx.data (), Dbx.size ()));
+}
+
+//
+// A valid non-matching list followed by a malformed trailing fragment fails
+// closed: even though the subject is not in the valid prefix, the dropped tail
+// might have matched it.
+//
+TEST (IsInDbxTest, MalformedTail_FailsClosed) {
+  std::vector<UINT8>  Dbx;
+  size_t              Off = AppendSignatureList (Dbx, gEfiCertSha256Guid, 0, kSha256EntrySize, 1);
+
+  SetEntryPayload (Dbx, Off, 0, std::vector<UINT8>(kSha256DigestSize, 0x01));
+
+  // Append a stray fragment too small to be a list header.
+  Dbx.resize (Dbx.size () + sizeof (EFI_SIGNATURE_LIST) - 1, 0);
+
+  std::vector<UINT8>  Digest (kSha256DigestSize, 0x99);   // not the enrolled entry
+  DIGEST_CACHE        Cache = MakeBoundCache (&gEfiCertSha256Guid, Digest);
+
+  EXPECT_TRUE (IsInDbx (&Cache, Dbx.data (), Dbx.size ()));
+}
+
+// ---------------------------------------------------------------------------
+// IsChainRevoked
+// ---------------------------------------------------------------------------
+
+TEST (IsChainRevokedTest, NullAuthData_ReturnsTrue) {
+  std::vector<UINT8>  Dbx (32, 0);
+
+  EXPECT_TRUE (
+    IsChainRevoked (
+      NULL,
+      16,
+      Dbx.data (),
+      Dbx.size ()
+      )
+    );
+}
+
+TEST (IsChainRevokedTest, ZeroAuthDataSize_ReturnsTrue) {
+  std::vector<UINT8>  Dbx (32, 0);
+
+  EXPECT_TRUE (
+    IsChainRevoked (
+      kAuthDataDefault.data (),
+      0,
+      Dbx.data (),
+      Dbx.size ()
+      )
+    );
+}
+
+TEST (IsChainRevokedTest, NullSignerCert_ReturnsTrue) {
+  std::vector<UINT8>  Dbx (32, 0);
+
+  EXPECT_TRUE (
+    IsChainRevoked (
+      NULL,
+      8,
+      Dbx.data (),
+      Dbx.size ()
+      )
+    );
+}
+
+TEST (IsChainRevokedTest, NullAnchor_ReturnsTrue) {
+  std::vector<UINT8>  Dbx (32, 0);
+
+  EXPECT_TRUE (
+    IsChainRevoked (
+      NULL,
+      8,
+      Dbx.data (),
+      Dbx.size ()
+      )
+    );
+}
+
+//
+// With valid inputs but no dbx, nothing is revoked and the chain is
+// never built.
+//
+TEST (IsChainRevokedTest, NullDbx_ReturnsFalse) {
+  std::vector<UINT8>  Stack = MakeCertStack ({ std::vector<UINT8>(8, 0x22) });
+
+  EXPECT_FALSE (
+    IsChainRevoked (
+      Stack.data (),
+      Stack.size (),
+      NULL,
+      0
+      )
+    );
+}
+
+TEST (IsChainRevokedTest, EmptyDbx_ReturnsFalse) {
+  std::vector<UINT8>  Stack = MakeCertStack ({ std::vector<UINT8>(8, 0x22) });
+  std::vector<UINT8>  Dbx;
+
+  EXPECT_FALSE (
+    IsChainRevoked (
+      Stack.data (),
+      Stack.size (),
+      Dbx.data (),
+      0
+      )
+    );
+}
+
+//
+// If the certificate chain cannot be built, the helper fails closed.
+//
+TEST (IsChainRevokedTest, ChainBuildError_ReturnsTrue) {
+  std::vector<UINT8>  Dbx;
+
+  AppendSignatureList (Dbx, gEfiCertX509Guid, 0, (UINT32)(sizeof (EFI_GUID) + 16), 1);
+
+  EXPECT_TRUE (
+    IsChainRevoked (
+      NULL,
+      0,
+      Dbx.data (),
+      Dbx.size ()
+      )
+    );
+}
+
+//
+// A well-formed but empty (zero-length) chain fails closed.
+//
+TEST (IsChainRevokedTest, EmptyChain_ReturnsTrue) {
+  std::vector<UINT8>  Dbx;
+
+  AppendSignatureList (Dbx, gEfiCertX509Guid, 0, (UINT32)(sizeof (EFI_GUID) + 16), 1);
+
+  EXPECT_TRUE (
+    IsChainRevoked (
+      NULL,
+      0,
+      Dbx.data (),
+      Dbx.size ()
+      )
+    );
+}
+
+//
+// A chain cert that is listed in dbx (exact DER match) revokes the chain.
+//
+TEST (IsChainRevokedTest, ChainCertInDbx_ReturnsTrue) {
+  std::vector<UINT8>  ChainCert (16, 0x11);
+  std::vector<UINT8>  Dbx;
+
+  static std::vector<UINT8>  Stack = MakeCertStack ({ std::vector<UINT8>(16, 0x11) });
+
+  size_t  Off = AppendSignatureList (Dbx, gEfiCertX509Guid, 0, (UINT32)(sizeof (EFI_GUID) + 16), 1);
+
+  SetEntryPayload (Dbx, Off, 0, ChainCert);
+
+  EXPECT_TRUE (
+    IsChainRevoked (
+      Stack.data (),
+      Stack.size (),
+      Dbx.data (),
+      Dbx.size ()
+      )
+    );
+}
+
+//
+// A chain whose certs are not in dbx is not revoked.
+//
+TEST (IsChainRevokedTest, ChainCertNotInDbx_ReturnsFalse) {
+  std::vector<UINT8>  Dbx;
+
+  static std::vector<UINT8>  Stack = MakeCertStack ({ std::vector<UINT8>(16, 0x11) });
+
+  size_t  Off = AppendSignatureList (Dbx, gEfiCertX509Guid, 0, (UINT32)(sizeof (EFI_GUID) + 16), 1);
+
+  SetEntryPayload (Dbx, Off, 0, std::vector<UINT8>(16, 0x22));
+
+  EXPECT_FALSE (
+    IsChainRevoked (
+      Stack.data (),
+      Stack.size (),
+      Dbx.data (),
+      Dbx.size ()
+      )
+    );
+}
+
+//
+// A malformed chain (declares more certs than the buffer holds) fails
+// closed.
+//
+TEST (IsChainRevokedTest, MalformedChain_ReturnsTrue) {
+  std::vector<UINT8>  Dbx;
+
+  // CertNumber = 2, but only one 4-byte cert is present.
+  static std::vector<UINT8>  BadStack = {
+    0x02, 0x04, 0x00, 0x00, 0x00, 0xAA, 0xBB, 0xCC, 0xDD
+  };
+
+  // X509 list whose payload size (16) will not match the 4-byte cert, so
+  // the first cert is skipped and the walk reaches the truncation.
+  AppendSignatureList (Dbx, gEfiCertX509Guid, 0, (UINT32)(sizeof (EFI_GUID) + 16), 1);
+
+  EXPECT_TRUE (
+    IsChainRevoked (
+      BadStack.data (),
+      BadStack.size (),
+      Dbx.data (),
+      Dbx.size ()
+      )
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ExtractAuthData
+// ---------------------------------------------------------------------------
+
+TEST (ExtractAuthDataTest, NullCert_ReturnsInvalidParameter) {
+  const UINT8  *AuthData    = NULL;
+  UINTN        AuthDataSize = 0;
+
+  EXPECT_EQ (
+    ExtractAuthData (NULL, &AuthData, &AuthDataSize),
+    EFI_INVALID_PARAMETER
+    );
+}
+
+TEST (ExtractAuthDataTest, NullOutputs_ReturnsInvalidParameter) {
+  WIN_CERTIFICATE  Cert         = { sizeof (WIN_CERTIFICATE) + 1, 0x0200, WIN_CERT_TYPE_PKCS_SIGNED_DATA };
+  const UINT8      *AuthData    = NULL;
+  UINTN            AuthDataSize = 0;
+
+  EXPECT_EQ (
+    ExtractAuthData (&Cert, NULL, &AuthDataSize),
+    EFI_INVALID_PARAMETER
+    );
+  EXPECT_EQ (
+    ExtractAuthData (&Cert, &AuthData, NULL),
+    EFI_INVALID_PARAMETER
+    );
+}
+
+TEST (ExtractAuthDataTest, PkcsSignedData_ExtractsPayload) {
+  // Build a WIN_CERTIFICATE followed by 4 bytes of payload.
+  const UINT8         Payload[] = { 0xAA, 0xBB, 0xCC, 0xDD };
+  std::vector<UINT8>  Buffer (sizeof (WIN_CERTIFICATE) + sizeof (Payload), 0);
+  WIN_CERTIFICATE     *Cert = (WIN_CERTIFICATE *)Buffer.data ();
+
+  Cert->dwLength         = (UINT32)Buffer.size ();
+  Cert->wRevision        = 0x0200;
+  Cert->wCertificateType = WIN_CERT_TYPE_PKCS_SIGNED_DATA;
+  std::memcpy (Buffer.data () + sizeof (WIN_CERTIFICATE), Payload, sizeof (Payload));
+
+  const UINT8  *AuthData    = NULL;
+  UINTN        AuthDataSize = 0;
+
+  EXPECT_EQ (
+    ExtractAuthData (Cert, &AuthData, &AuthDataSize),
+    EFI_SUCCESS
+    );
+  ASSERT_EQ (AuthDataSize, sizeof (Payload));
+  EXPECT_EQ (0, std::memcmp (AuthData, Payload, sizeof (Payload)));
+}
+
+TEST (ExtractAuthDataTest, PkcsSignedData_HeaderOnly_ReturnsCorrupted) {
+  WIN_CERTIFICATE  Cert         = { sizeof (WIN_CERTIFICATE), 0x0200, WIN_CERT_TYPE_PKCS_SIGNED_DATA };
+  const UINT8      *AuthData    = NULL;
+  UINTN            AuthDataSize = 0;
+
+  EXPECT_EQ (
+    ExtractAuthData (&Cert, &AuthData, &AuthDataSize),
+    EFI_VOLUME_CORRUPTED
+    );
+}
+
+TEST (ExtractAuthDataTest, EfiGuidPkcs7_ExtractsPayload) {
+  const UINT8                Payload[]  = { 0x11, 0x22, 0x33 };
+  const size_t               HeaderSize = OFFSET_OF (WIN_CERTIFICATE_UEFI_GUID, CertData);
+  std::vector<UINT8>         Buffer (HeaderSize + sizeof (Payload), 0);
+  WIN_CERTIFICATE_UEFI_GUID  *UefiCert = (WIN_CERTIFICATE_UEFI_GUID *)Buffer.data ();
+
+  UefiCert->Hdr.dwLength         = (UINT32)Buffer.size ();
+  UefiCert->Hdr.wRevision        = 0x0200;
+  UefiCert->Hdr.wCertificateType = WIN_CERT_TYPE_EFI_GUID;
+  CopyMem (&UefiCert->CertType, &gEfiCertPkcs7Guid, sizeof (EFI_GUID));
+  std::memcpy (Buffer.data () + HeaderSize, Payload, sizeof (Payload));
+
+  const UINT8  *AuthData    = NULL;
+  UINTN        AuthDataSize = 0;
+
+  EXPECT_EQ (
+    ExtractAuthData (&UefiCert->Hdr, &AuthData, &AuthDataSize),
+    EFI_SUCCESS
+    );
+  ASSERT_EQ (AuthDataSize, sizeof (Payload));
+  EXPECT_EQ (0, std::memcmp (AuthData, Payload, sizeof (Payload)));
+}
+
+TEST (ExtractAuthDataTest, EfiGuidNonPkcs7_ReturnsUnsupported) {
+  const size_t               HeaderSize = OFFSET_OF (WIN_CERTIFICATE_UEFI_GUID, CertData);
+  std::vector<UINT8>         Buffer (HeaderSize + 4, 0);
+  WIN_CERTIFICATE_UEFI_GUID  *UefiCert = (WIN_CERTIFICATE_UEFI_GUID *)Buffer.data ();
+  const EFI_GUID             OtherGuid = { 0x12345678, 0x1234, 0x1234, { 1, 2, 3, 4, 5, 6, 7, 8 }
+  };
+
+  UefiCert->Hdr.dwLength         = (UINT32)Buffer.size ();
+  UefiCert->Hdr.wRevision        = 0x0200;
+  UefiCert->Hdr.wCertificateType = WIN_CERT_TYPE_EFI_GUID;
+  CopyMem (&UefiCert->CertType, &OtherGuid, sizeof (EFI_GUID));
+
+  const UINT8  *AuthData    = NULL;
+  UINTN        AuthDataSize = 0;
+
+  EXPECT_EQ (
+    ExtractAuthData (&UefiCert->Hdr, &AuthData, &AuthDataSize),
+    EFI_UNSUPPORTED
+    );
+}
+
+TEST (ExtractAuthDataTest, EfiGuid_HeaderOnly_ReturnsCorrupted) {
+  WIN_CERTIFICATE_UEFI_GUID  UefiCert;
+
+  ZeroMem (&UefiCert, sizeof (UefiCert));
+  UefiCert.Hdr.dwLength         = (UINT32)OFFSET_OF (WIN_CERTIFICATE_UEFI_GUID, CertData);
+  UefiCert.Hdr.wRevision        = 0x0200;
+  UefiCert.Hdr.wCertificateType = WIN_CERT_TYPE_EFI_GUID;
+
+  const UINT8  *AuthData    = NULL;
+  UINTN        AuthDataSize = 0;
+
+  EXPECT_EQ (
+    ExtractAuthData (&UefiCert.Hdr, &AuthData, &AuthDataSize),
+    EFI_VOLUME_CORRUPTED
+    );
+}
+
+TEST (ExtractAuthDataTest, UnknownCertType_ReturnsUnsupported) {
+  WIN_CERTIFICATE  Cert         = { sizeof (WIN_CERTIFICATE) + 8, 0x0200, WIN_CERT_TYPE_EFI_PKCS115 };
+  const UINT8      *AuthData    = NULL;
+  UINTN            AuthDataSize = 0;
+
+  EXPECT_EQ (
+    ExtractAuthData (&Cert, &AuthData, &AuthDataSize),
+    EFI_UNSUPPORTED
+    );
+}
+
+// ---------------------------------------------------------------------------
+// EvaluateImageCertificate -- end-to-end PKCS#7 + database scenarios
+// ---------------------------------------------------------------------------
+
+//
+// Install the mock expectations shared by every db-walk scenario: the image
+// hash algorithm resolves to SHA-256 and the image hash is produced.
+//
+static void
+ExpectSignedImagePrelude (
+  MockBaseCryptLib  &BaseCryptLibMock
+  )
+{
+  EXPECT_CALL (BaseCryptLibMock, GetAuthenticodeHashAlgorithm (_, _, _))
+    .WillOnce (
+       Invoke (
+         [] (CONST UINT8 *, UINTN, EFI_GUID *Out) -> EFI_STATUS {
+    CopyMem (Out, &gEfiCertSha256Guid, sizeof (EFI_GUID));
+    return EFI_SUCCESS;
+  }
+         )
+       );
+  EXPECT_CALL (BaseCryptLibMock, GetAuthenticodeHash (_, _, _, _, _))
+    .WillOnce (
+       Invoke (
+         [] (VOID *, UINTN, CONST EFI_GUID *, UINT8 *Out, UINTN *OutSize) -> EFI_STATUS {
+    SetMem (Out, kSha256DigestSize, 0x55);
+    *OutSize = kSha256DigestSize;
+    return EFI_SUCCESS;
+  }
+         )
+       );
+}
+
+//
+// A NULL certificate pointer is rejected up front with EFI_INVALID_PARAMETER;
+// no crypto is consulted and no verdict is produced.
+//
+TEST (EvaluateImageCertificateTest, NullCert_ReturnsInvalidParameter) {
+  DIGEST_CACHE           Cache;
+  SIGNATURE_DATABASES    Databases = { NULL, 0, NULL, 0 };
+  IMAGE_CERT_EVALUATION  Eval;
+
+  InitImageCache (Cache);
+  ZeroMem (&Eval, sizeof (Eval));
+
+  EXPECT_EQ (EvaluateImageCertificate (NULL, &Cache, &Databases, &Eval), EFI_INVALID_PARAMETER);
+}
+
+//
+// A NULL digest cache is rejected up front with EFI_INVALID_PARAMETER.
+//
+TEST (EvaluateImageCertificateTest, NullCache_ReturnsInvalidParameter) {
+  std::vector<UINT8>     CertBuf   = MakePkcsSignedDataCert (std::vector<UINT8>(16, 0xA1));
+  SIGNATURE_DATABASES    Databases = { NULL, 0, NULL, 0 };
+  IMAGE_CERT_EVALUATION  Eval;
+
+  ZeroMem (&Eval, sizeof (Eval));
+
+  EXPECT_EQ (
+    EvaluateImageCertificate (
+      (CONST WIN_CERTIFICATE *)CertBuf.data (),
+      NULL,
+      &Databases,
+      &Eval
+      ),
+    EFI_INVALID_PARAMETER
+    );
+}
+
+//
+// A NULL databases pointer is rejected up front with EFI_INVALID_PARAMETER.
+//
+TEST (EvaluateImageCertificateTest, NullDatabases_ReturnsInvalidParameter) {
+  std::vector<UINT8>     CertBuf = MakePkcsSignedDataCert (std::vector<UINT8>(16, 0xA1));
+  DIGEST_CACHE           Cache;
+  IMAGE_CERT_EVALUATION  Eval;
+
+  InitImageCache (Cache);
+  ZeroMem (&Eval, sizeof (Eval));
+
+  EXPECT_EQ (
+    EvaluateImageCertificate (
+      (CONST WIN_CERTIFICATE *)CertBuf.data (),
+      &Cache,
+      NULL,
+      &Eval
+      ),
+    EFI_INVALID_PARAMETER
+    );
+}
+
+//
+// A NULL evaluation output pointer is rejected up front with
+// EFI_INVALID_PARAMETER.
+//
+TEST (EvaluateImageCertificateTest, NullEvaluation_ReturnsInvalidParameter) {
+  std::vector<UINT8>   CertBuf = MakePkcsSignedDataCert (std::vector<UINT8>(16, 0xA1));
+  DIGEST_CACHE         Cache;
+  SIGNATURE_DATABASES  Databases = { NULL, 0, NULL, 0 };
+
+  InitImageCache (Cache);
+
+  EXPECT_EQ (
+    EvaluateImageCertificate (
+      (CONST WIN_CERTIFICATE *)CertBuf.data (),
+      &Cache,
+      &Databases,
+      NULL
+      ),
+    EFI_INVALID_PARAMETER
+    );
+}
+
+//
+// An unknown WIN_CERTIFICATE type cannot be parsed into a PKCS#7 payload, so
+// the certificate is unusable. No crypto is consulted and no anchor is
+// inspected.
+//
+TEST (EvaluateImageCertificateTest, UnsupportedCertType_Unusable) {
+  MockBaseCryptLib       BaseCryptLibMock;
+  DIGEST_CACHE           Cache;
+  WIN_CERTIFICATE        Cert      = { sizeof (WIN_CERTIFICATE) + 8, 0x0200, WIN_CERT_TYPE_EFI_PKCS115 };
+  SIGNATURE_DATABASES    Databases = { NULL, 0, NULL, 0 };
+  IMAGE_CERT_EVALUATION  Eval;
+
+  InitImageCache (Cache);
+  ZeroMem (&Eval, sizeof (Eval));
+
+  EXPECT_CALL (BaseCryptLibMock, GetAuthenticodeHashAlgorithm (_, _, _)).Times (0);
+  EXPECT_CALL (BaseCryptLibMock, GetAuthenticodeHash (_, _, _, _, _)).Times (0);
+  EXPECT_CALL (BaseCryptLibMock, AuthenticodeVerifyEx (_, _, _, _, _, _, _, _)).Times (0);
+
+  EXPECT_EQ (EvaluateImageCertificate (&Cert, &Cache, &Databases, &Eval), EFI_SUCCESS);
+  EXPECT_EQ (Eval.Verdict, ImageCertUnusable);
+  EXPECT_EQ (Eval.Authority.Data, nullptr);
+}
+
+//
+// GetAuthenticodeHashAlgorithm fails, so the image-hash algorithm cannot be
+// determined and the certificate is unusable. The image hash is never computed
+// and no anchor is verified.
+//
+TEST (EvaluateImageCertificateTest, HashAlgorithmFails_Unusable) {
+  MockBaseCryptLib       BaseCryptLibMock;
+  DIGEST_CACHE           Cache;
+  std::vector<UINT8>     CertBuf   = MakePkcsSignedDataCert (std::vector<UINT8>(16, 0xA1));
+  SIGNATURE_DATABASES    Databases = { NULL, 0, NULL, 0 };
+  IMAGE_CERT_EVALUATION  Eval;
+
+  InitImageCache (Cache);
+  ZeroMem (&Eval, sizeof (Eval));
+
+  EXPECT_CALL (BaseCryptLibMock, GetAuthenticodeHashAlgorithm (_, _, _))
+    .WillOnce (Return (EFI_UNSUPPORTED));
+  EXPECT_CALL (BaseCryptLibMock, GetAuthenticodeHash (_, _, _, _, _)).Times (0);
+  EXPECT_CALL (BaseCryptLibMock, AuthenticodeVerifyEx (_, _, _, _, _, _, _, _)).Times (0);
+
+  EXPECT_EQ (
+    EvaluateImageCertificate (
+      (CONST WIN_CERTIFICATE *)CertBuf.data (),
+      &Cache,
+      &Databases,
+      &Eval
+      ),
+    EFI_SUCCESS
+    );
+  EXPECT_EQ (Eval.Verdict, ImageCertUnusable);
+  EXPECT_EQ (Eval.Authority.Data, nullptr);
+}
+
+//
+// The image hash cannot be computed: GetAuthenticodeHash fails, GetHash
+// surfaces EFI_SECURITY_VIOLATION, and EvaluateImageCertificate propagates it.
+// This is the only non-INVALID_PARAMETER error path; no verdict is asserted.
+//
+TEST (EvaluateImageCertificateTest, ImageHashFails_ReturnsError) {
+  MockBaseCryptLib       BaseCryptLibMock;
+  DIGEST_CACHE           Cache;
+  std::vector<UINT8>     CertBuf   = MakePkcsSignedDataCert (std::vector<UINT8>(16, 0xA1));
+  SIGNATURE_DATABASES    Databases = { NULL, 0, NULL, 0 };
+  IMAGE_CERT_EVALUATION  Eval;
+
+  InitImageCache (Cache);
+  ZeroMem (&Eval, sizeof (Eval));
+
+  EXPECT_CALL (BaseCryptLibMock, GetAuthenticodeHashAlgorithm (_, _, _))
+    .WillOnce (
+       Invoke (
+         [] (CONST UINT8 *, UINTN, EFI_GUID *Out) -> EFI_STATUS {
+    CopyMem (Out, &gEfiCertSha256Guid, sizeof (EFI_GUID));
+    return EFI_SUCCESS;
+  }
+         )
+       );
+  EXPECT_CALL (BaseCryptLibMock, GetAuthenticodeHash (_, _, _, _, _))
+    .WillOnce (Return (EFI_SECURITY_VIOLATION));
+  EXPECT_CALL (BaseCryptLibMock, AuthenticodeVerifyEx (_, _, _, _, _, _, _, _)).Times (0);
+
+  EXPECT_EQ (
+    EvaluateImageCertificate (
+      (CONST WIN_CERTIFICATE *)CertBuf.data (),
+      &Cache,
+      &Databases,
+      &Eval
+      ),
+    EFI_SECURITY_VIOLATION
+    );
+}
+
+//
+// Signer extraction is no longer a separate prerequisite. With an empty db,
+// evaluation completes without invoking a verifier.
+//
+TEST (EvaluateImageCertificateTest, SignerExtractionNotRequired_NotInDb) {
+  MockBaseCryptLib       BaseCryptLibMock;
+  DIGEST_CACHE           Cache;
+  std::vector<UINT8>     CertBuf   = MakePkcsSignedDataCert (std::vector<UINT8>(16, 0xA1));
+  SIGNATURE_DATABASES    Databases = { NULL, 0, NULL, 0 };
+  IMAGE_CERT_EVALUATION  Eval;
+
+  InitImageCache (Cache);
+  ZeroMem (&Eval, sizeof (Eval));
+
+  EXPECT_CALL (BaseCryptLibMock, GetAuthenticodeHashAlgorithm (_, _, _))
+    .WillOnce (
+       Invoke (
+         [] (CONST UINT8 *, UINTN, EFI_GUID *Out) -> EFI_STATUS {
+    CopyMem (Out, &gEfiCertSha256Guid, sizeof (EFI_GUID));
+    return EFI_SUCCESS;
+  }
+         )
+       );
+  EXPECT_CALL (BaseCryptLibMock, GetAuthenticodeHash (_, _, _, _, _))
+    .WillOnce (
+       Invoke (
+         [] (VOID *, UINTN, CONST EFI_GUID *, UINT8 *Out, UINTN *OutSize) -> EFI_STATUS {
+    SetMem (Out, kSha256DigestSize, 0x55);
+    *OutSize = kSha256DigestSize;
+    return EFI_SUCCESS;
+  }
+         )
+       );
+  EXPECT_CALL (BaseCryptLibMock, Pkcs7GetSigners (_, _, _, _, _, _)).Times (0);
+  EXPECT_CALL (BaseCryptLibMock, AuthenticodeVerifyEx (_, _, _, _, _, _, _, _)).Times (0);
+
+  EXPECT_EQ (
+    EvaluateImageCertificate (
+      (CONST WIN_CERTIFICATE *)CertBuf.data (),
+      &Cache,
+      &Databases,
+      &Eval
+      ),
+    EFI_SUCCESS
+    );
+  EXPECT_EQ (Eval.Verdict, ImageCertNotInDb);
+  EXPECT_EQ (Eval.Authority.Data, nullptr);
+}
+
+//
+// The evaluator never calls the legacy signer-extraction API.
+//
+TEST (EvaluateImageCertificateTest, LegacySignerApiNotCalled_NotInDb) {
+  MockBaseCryptLib       BaseCryptLibMock;
+  DIGEST_CACHE           Cache;
+  std::vector<UINT8>     CertBuf   = MakePkcsSignedDataCert (std::vector<UINT8>(16, 0xA1));
+  SIGNATURE_DATABASES    Databases = { NULL, 0, NULL, 0 };
+  IMAGE_CERT_EVALUATION  Eval;
+
+  InitImageCache (Cache);
+  ZeroMem (&Eval, sizeof (Eval));
+
+  EXPECT_CALL (BaseCryptLibMock, GetAuthenticodeHashAlgorithm (_, _, _))
+    .WillOnce (
+       Invoke (
+         [] (CONST UINT8 *, UINTN, EFI_GUID *Out) -> EFI_STATUS {
+    CopyMem (Out, &gEfiCertSha256Guid, sizeof (EFI_GUID));
+    return EFI_SUCCESS;
+  }
+         )
+       );
+  EXPECT_CALL (BaseCryptLibMock, GetAuthenticodeHash (_, _, _, _, _))
+    .WillOnce (
+       Invoke (
+         [] (VOID *, UINTN, CONST EFI_GUID *, UINT8 *Out, UINTN *OutSize) -> EFI_STATUS {
+    SetMem (Out, kSha256DigestSize, 0x55);
+    *OutSize = kSha256DigestSize;
+    return EFI_SUCCESS;
+  }
+         )
+       );
+  EXPECT_CALL (BaseCryptLibMock, Pkcs7GetSigners (_, _, _, _, _, _)).Times (0);
+  EXPECT_CALL (BaseCryptLibMock, Pkcs7FreeSigners (_)).Times (0);
+  EXPECT_CALL (BaseCryptLibMock, AuthenticodeVerifyEx (_, _, _, _, _, _, _, _)).Times (0);
+
+  EXPECT_EQ (
+    EvaluateImageCertificate (
+      (CONST WIN_CERTIFICATE *)CertBuf.data (),
+      &Cache,
+      &Databases,
+      &Eval
+      ),
+    EFI_SUCCESS
+    );
+  EXPECT_EQ (Eval.Verdict, ImageCertNotInDb);
+  EXPECT_EQ (Eval.Authority.Data, nullptr);
+}
+
+//
+// The prelude succeeds and a signer is available, but the db is empty. No
+// anchor matches, so the verdict is ImageCertNotInDb and AuthenticodeVerifyEx is
+// never called.
+//
+TEST (EvaluateImageCertificateTest, EmptyDb_NotInDb) {
+  MockBaseCryptLib       BaseCryptLibMock;
+  DIGEST_CACHE           Cache;
+  std::vector<UINT8>     CertBuf   = MakePkcsSignedDataCert (std::vector<UINT8>(16, 0xA1));
+  SIGNATURE_DATABASES    Databases = { NULL, 0, NULL, 0 };
+  IMAGE_CERT_EVALUATION  Eval;
+
+  InitImageCache (Cache);
+  ZeroMem (&Eval, sizeof (Eval));
+
+  ExpectSignedImagePrelude (BaseCryptLibMock);
+  EXPECT_CALL (BaseCryptLibMock, AuthenticodeVerifyEx (_, _, _, _, _, _, _, _)).Times (0);
+
+  EXPECT_EQ (
+    EvaluateImageCertificate (
+      (CONST WIN_CERTIFICATE *)CertBuf.data (),
+      &Cache,
+      &Databases,
+      &Eval
+      ),
+    EFI_SUCCESS
+    );
+  EXPECT_EQ (Eval.Verdict, ImageCertNotInDb);
+  EXPECT_EQ (Eval.Authority.Data, nullptr);
+}
+
+//
+// A single EFI_CERT_X509 db trust anchor verifies the image and there is no
+// dbx (so no chain is built). The image is approved and the authority points
+// at the matching db entry.
+//
+TEST (EvaluateImageCertificateTest, X509VerifiesNoDbx_Approved) {
+  MockBaseCryptLib       BaseCryptLibMock;
+  DIGEST_CACHE           Cache;
+  std::vector<UINT8>     CertBuf = MakePkcsSignedDataCert (std::vector<UINT8>(16, 0xA1));
+  IMAGE_CERT_EVALUATION  Eval;
+
+  InitImageCache (Cache);
+  ZeroMem (&Eval, sizeof (Eval));
+
+  std::vector<UINT8>  Db;
+  size_t              DbOff = AppendSignatureList (Db, gEfiCertX509Guid, 0, (UINT32)(sizeof (EFI_GUID) + 16), 1);
+
+  SetEntryPayload (Db, DbOff, 0, std::vector<UINT8>(16, 0x11));
+
+  ExpectSignedImagePrelude (BaseCryptLibMock);
+  EXPECT_CALL (BaseCryptLibMock, AuthenticodeVerifyEx (_, _, _, _, _, _, _, _))
+    .WillOnce (Return (EFI_SUCCESS));
+
+  SIGNATURE_DATABASES  Databases = { Db.data (), Db.size (), NULL, 0 };
+
+  EXPECT_EQ (
+    EvaluateImageCertificate (
+      (CONST WIN_CERTIFICATE *)CertBuf.data (),
+      &Cache,
+      &Databases,
+      &Eval
+      ),
+    EFI_SUCCESS
+    );
+  EXPECT_EQ (Eval.Verdict, ImageCertApproved);
+  EXPECT_NE (Eval.Authority.Data, nullptr);
+  EXPECT_EQ (Eval.Authority.Size, (UINTN)(sizeof (EFI_GUID) + 16));
+}
+
+//
+// A V2 (EFI_SIGNATURE_V2_DATA) full-certificate db anchor carries no owner GUID; the whole entry
+// is the DER certificate handed to AuthenticodeVerifyEx. The recorded authority normalizes it to a
+// V1 EFI_SIGNATURE_DATA by prepending a zeroed owner GUID, so its size is the certificate plus a
+// SignatureOwner.
+//
+TEST (EvaluateImageCertificateTest, V2X509VerifiesNoDbx_Approved) {
+  MockBaseCryptLib       BaseCryptLibMock;
+  DIGEST_CACHE           Cache;
+  std::vector<UINT8>     CertBuf = MakePkcsSignedDataCert (std::vector<UINT8>(16, 0xA1));
+  IMAGE_CERT_EVALUATION  Eval;
+
+  InitImageCache (Cache);
+  ZeroMem (&Eval, sizeof (Eval));
+
+  std::vector<UINT8>  Db;
+  size_t              DbOff = AppendSignatureList (Db, gEfiCertV2X509Guid, 0, 16, 1);
+
+  SetV2EntryPayload (Db, DbOff, 0, std::vector<UINT8>(16, 0x11));
+
+  ExpectSignedImagePrelude (BaseCryptLibMock);
+  EXPECT_CALL (BaseCryptLibMock, AuthenticodeVerifyEx (_, _, _, _, _, _, _, _))
+    .WillOnce (Return (EFI_SUCCESS));
+
+  SIGNATURE_DATABASES  Databases = { Db.data (), Db.size (), NULL, 0 };
+
+  EXPECT_EQ (
+    EvaluateImageCertificate (
+      (CONST WIN_CERTIFICATE *)CertBuf.data (),
+      &Cache,
+      &Databases,
+      &Eval
+      ),
+    EFI_SUCCESS
+    );
+  EXPECT_EQ (Eval.Verdict, ImageCertApproved);
+  EXPECT_NE (Eval.Authority.Data, nullptr);
+  // The V2 anchor carries no owner GUID, so the authority prepends a zeroed one to the certificate.
+  EXPECT_EQ (Eval.Authority.Size, (UINTN)(sizeof (EFI_GUID) + 16));
+  FreeImageAuthority (&Eval.Authority);
+}
+
+//
+// A V2 (EFI_SIGNATURE_V2_DATA) TBS-cert-hash db entry holds only the hash (no owner GUID, no v1
+// TimeOfRevocation). The full hash region is passed to GetTrustAnchorX509FromAuthData; this asserts
+// the size passed reflects the ownerless entry.
+//
+TEST (EvaluateImageCertificateTest, V2X509HashListResolvesAnchor_Approved) {
+  MockBaseCryptLib       BaseCryptLibMock;
+  DIGEST_CACHE           Cache;
+  std::vector<UINT8>     CertBuf = MakePkcsSignedDataCert (std::vector<UINT8>(16, 0xA1));
+  IMAGE_CERT_EVALUATION  Eval;
+
+  InitImageCache (Cache);
+  ZeroMem (&Eval, sizeof (Eval));
+
+  std::vector<UINT8>  Db;
+
+  AppendSignatureList (Db, gEfiCertV2X509Sha256Guid, 0, kSha256V2EntrySize, 1);
+
+  ExpectSignedImagePrelude (BaseCryptLibMock);
+  EXPECT_CALL (BaseCryptLibMock, GetTrustAnchorX509FromAuthData (_, _, _, _, _, _, _))
+    .WillOnce (
+       Invoke (
+         [] (VOID **CacheHandle, CONST UINT8 *, UINTN TbsHashSize, CONST UINT8 *, UINTN, UINT8 **TrustAnchor, UINTN *TrustAnchorSize) -> EFI_STATUS {
+    // The V2 entry supplies exactly the hash payload (SignatureSize with no owner subtracted).
+    EXPECT_EQ (TbsHashSize, (UINTN)kSha256V2EntrySize);
+    static const UINT8  CertBytes[] = { 0x30, 0x82, 0x01, 0x02 };
+    *TrustAnchor                    = (UINT8 *)AllocateCopyPool (sizeof (CertBytes), CertBytes);
+    *TrustAnchorSize                = sizeof (CertBytes);
+    if (CacheHandle != NULL) {
+      *CacheHandle = (VOID *)(UINTN)1;
+    }
+
+    return EFI_SUCCESS;
+  }
+         )
+       );
+  EXPECT_CALL (BaseCryptLibMock, AuthenticodeVerifyEx (_, _, _, _, _, _, _, _))
+    .WillOnce (Return (EFI_SUCCESS));
+  EXPECT_CALL (BaseCryptLibMock, FreeTrustAnchorX509Cache (_)).Times (1);
+
+  SIGNATURE_DATABASES  Databases = { Db.data (), Db.size (), NULL, 0 };
+
+  EXPECT_EQ (
+    EvaluateImageCertificate (
+      (CONST WIN_CERTIFICATE *)CertBuf.data (),
+      &Cache,
+      &Databases,
+      &Eval
+      ),
+    EFI_SUCCESS
+    );
+  EXPECT_EQ (Eval.Verdict, ImageCertApproved);
+  EXPECT_NE (Eval.Authority.Data, nullptr);
+}
+
+//
+// A single EFI_CERT_X509 trust anchor is present but AuthenticodeVerifyEx rejects
+// the image. No anchor authorizes it, so the verdict is ImageCertNotInDb.
+//
+TEST (EvaluateImageCertificateTest, X509DoesNotVerify_NotInDb) {
+  MockBaseCryptLib       BaseCryptLibMock;
+  DIGEST_CACHE           Cache;
+  std::vector<UINT8>     CertBuf = MakePkcsSignedDataCert (std::vector<UINT8>(16, 0xA1));
+  IMAGE_CERT_EVALUATION  Eval;
+
+  InitImageCache (Cache);
+  ZeroMem (&Eval, sizeof (Eval));
+
+  std::vector<UINT8>  Db;
+  size_t              DbOff = AppendSignatureList (Db, gEfiCertX509Guid, 0, (UINT32)(sizeof (EFI_GUID) + 16), 1);
+
+  SetEntryPayload (Db, DbOff, 0, std::vector<UINT8>(16, 0x11));
+
+  ExpectSignedImagePrelude (BaseCryptLibMock);
+  EXPECT_CALL (BaseCryptLibMock, AuthenticodeVerifyEx (_, _, _, _, _, _, _, _))
+    .WillOnce (Return (EFI_SECURITY_VIOLATION));
+
+  SIGNATURE_DATABASES  Databases = { Db.data (), Db.size (), NULL, 0 };
+
+  EXPECT_EQ (
+    EvaluateImageCertificate (
+      (CONST WIN_CERTIFICATE *)CertBuf.data (),
+      &Cache,
+      &Databases,
+      &Eval
+      ),
+    EFI_SUCCESS
+    );
+  EXPECT_EQ (Eval.Verdict, ImageCertNotInDb);
+  EXPECT_EQ (Eval.Authority.Data, nullptr);
+}
+
+//
+// An EFI_CERT_X509 anchor verifies the image, but a certificate in the signer's
+// chain is enrolled in dbx. The anchor is verified-but-revoked and, with no
+// other anchor, the verdict is ImageCertRevokedByDbx and the authority names the
+// revoking dbx entry.
+//
+TEST (EvaluateImageCertificateTest, X509VerifiesChainRevoked_RevokedByDbx) {
+  MockBaseCryptLib       BaseCryptLibMock;
+  DIGEST_CACHE           Cache;
+  std::vector<UINT8>     CertBuf = MakePkcsSignedDataCert (std::vector<UINT8>(16, 0xA1));
+  IMAGE_CERT_EVALUATION  Eval;
+
+  InitImageCache (Cache);
+  ZeroMem (&Eval, sizeof (Eval));
+
+  std::vector<UINT8>  Db;
+  size_t              DbOff = AppendSignatureList (Db, gEfiCertX509Guid, 0, (UINT32)(sizeof (EFI_GUID) + 16), 1);
+
+  SetEntryPayload (Db, DbOff, 0, std::vector<UINT8>(16, 0x11));
+
+  // dbx: one X509 list holding the (20-byte) chain cert exactly.
+  std::vector<UINT8>  Dbx;
+  size_t              DbxOff = AppendSignatureList (Dbx, gEfiCertX509Guid, 0, (UINT32)(sizeof (EFI_GUID) + 20), 1);
+
+  SetEntryPayload (Dbx, DbxOff, 0, std::vector<UINT8>(20, 0xAB));
+
+  static std::vector<UINT8>  Stack = MakeCertStack ({ std::vector<UINT8>(20, 0xAB) });
+
+  ExpectSignedImagePrelude (BaseCryptLibMock);
+  EXPECT_CALL (BaseCryptLibMock, AuthenticodeVerifyEx (_, _, _, _, _, _, _, _))
+    .WillOnce (
+       Invoke (
+         [] (CONST UINT8 *, UINTN, CONST UINT8 *, UINTN, CONST UINT8 *, UINTN, UINT8 **OutChain, UINTN *OutChainSize) -> EFI_STATUS {
+    *OutChain     = (UINT8 *)AllocateCopyPool (Stack.size (), Stack.data ());
+    *OutChainSize = Stack.size ();
+    return EFI_SUCCESS;
+  }
+         )
+       );
+
+  SIGNATURE_DATABASES  Databases = { Db.data (), Db.size (), Dbx.data (), Dbx.size () };
+
+  EXPECT_EQ (
+    EvaluateImageCertificate (
+      (CONST WIN_CERTIFICATE *)CertBuf.data (),
+      &Cache,
+      &Databases,
+      &Eval
+      ),
+    EFI_SUCCESS
+    );
+  EXPECT_EQ (Eval.Verdict, ImageCertRevokedByDbx);
+  EXPECT_EQ (Eval.Authority.Data, nullptr);
+  EXPECT_EQ (Eval.Authority.Size, (UINTN)0);
+}
+
+//
+// An EFI_CERT_X509 anchor verifies the image and none of the signer's chain
+// certs are in dbx. The image is approved.
+//
+TEST (EvaluateImageCertificateTest, X509VerifiesChainClean_Approved) {
+  MockBaseCryptLib       BaseCryptLibMock;
+  DIGEST_CACHE           Cache;
+  std::vector<UINT8>     CertBuf = MakePkcsSignedDataCert (std::vector<UINT8>(16, 0xA1));
+  IMAGE_CERT_EVALUATION  Eval;
+
+  InitImageCache (Cache);
+  ZeroMem (&Eval, sizeof (Eval));
+
+  std::vector<UINT8>  Db;
+  size_t              DbOff = AppendSignatureList (Db, gEfiCertX509Guid, 0, (UINT32)(sizeof (EFI_GUID) + 16), 1);
+
+  SetEntryPayload (Db, DbOff, 0, std::vector<UINT8>(16, 0x11));
+
+  // dbx holds an unrelated cert, so the chain is clean.
+  std::vector<UINT8>  Dbx;
+  size_t              DbxOff = AppendSignatureList (Dbx, gEfiCertX509Guid, 0, (UINT32)(sizeof (EFI_GUID) + 16), 1);
+
+  SetEntryPayload (Dbx, DbxOff, 0, std::vector<UINT8>(16, 0x22));
+
+  static std::vector<UINT8>  Stack = MakeCertStack ({ std::vector<UINT8>(16, 0x33) });
+
+  ExpectSignedImagePrelude (BaseCryptLibMock);
+  EXPECT_CALL (BaseCryptLibMock, AuthenticodeVerifyEx (_, _, _, _, _, _, _, _))
+    .WillOnce (
+       Invoke (
+         [] (CONST UINT8 *, UINTN, CONST UINT8 *, UINTN, CONST UINT8 *, UINTN, UINT8 **OutChain, UINTN *OutChainSize) -> EFI_STATUS {
+    *OutChain     = (UINT8 *)AllocateCopyPool (Stack.size (), Stack.data ());
+    *OutChainSize = Stack.size ();
+    return EFI_SUCCESS;
+  }
+         )
+       );
+
+  SIGNATURE_DATABASES  Databases = { Db.data (), Db.size (), Dbx.data (), Dbx.size () };
+
+  EXPECT_EQ (
+    EvaluateImageCertificate (
+      (CONST WIN_CERTIFICATE *)CertBuf.data (),
+      &Cache,
+      &Databases,
+      &Eval
+      ),
+    EFI_SUCCESS
+    );
+  EXPECT_EQ (Eval.Verdict, ImageCertApproved);
+  EXPECT_NE (Eval.Authority.Data, nullptr);
+}
+
+//
+// db holds an EFI_CERT_X509_SHA256 (TBS-cert-hash) list. A trust anchor is
+// recovered from the auth data, it authenticates the image, and there is no
+// dbx. The image is approved; the resolver's cache handle is released via
+// FreeTrustAnchorX509Cache.
+//
+TEST (EvaluateImageCertificateTest, X509HashListResolvesAnchor_Approved) {
+  MockBaseCryptLib       BaseCryptLibMock;
+  DIGEST_CACHE           Cache;
+  std::vector<UINT8>     CertBuf = MakePkcsSignedDataCert (std::vector<UINT8>(16, 0xA1));
+  IMAGE_CERT_EVALUATION  Eval;
+
+  InitImageCache (Cache);
+  ZeroMem (&Eval, sizeof (Eval));
+
+  std::vector<UINT8>  Db;
+
+  AppendSignatureList (Db, gEfiCertX509Sha256Guid, 0, kSha256TbsV1EntrySize, 1);
+
+  ExpectSignedImagePrelude (BaseCryptLibMock);
+  EXPECT_CALL (BaseCryptLibMock, GetTrustAnchorX509FromAuthData (_, _, _, _, _, _, _))
+    .WillOnce (
+       Invoke (
+         [] (VOID **CacheHandle, CONST UINT8 *, UINTN TbsHashSize, CONST UINT8 *, UINTN, UINT8 **TrustAnchor, UINTN *TrustAnchorSize) -> EFI_STATUS {
+    // The V1 entry appends an EFI_TIME after the hash; only the 32-byte SHA-256 hash is passed.
+    EXPECT_EQ (TbsHashSize, (UINTN)kSha256DigestSize);
+    static const UINT8  CertBytes[] = { 0x30, 0x82, 0x01, 0x02 };
+    *TrustAnchor                    = (UINT8 *)AllocateCopyPool (sizeof (CertBytes), CertBytes);
+    *TrustAnchorSize                = sizeof (CertBytes);
+    if (CacheHandle != NULL) {
+      *CacheHandle = (VOID *)(UINTN)1;
+    }
+
+    return EFI_SUCCESS;
+  }
+         )
+       );
+  EXPECT_CALL (BaseCryptLibMock, AuthenticodeVerifyEx (_, _, _, _, _, _, _, _))
+    .WillOnce (Return (EFI_SUCCESS));
+  EXPECT_CALL (BaseCryptLibMock, FreeTrustAnchorX509Cache (_)).Times (1);
+
+  SIGNATURE_DATABASES  Databases = { Db.data (), Db.size (), NULL, 0 };
+
+  EXPECT_EQ (
+    EvaluateImageCertificate (
+      (CONST WIN_CERTIFICATE *)CertBuf.data (),
+      &Cache,
+      &Databases,
+      &Eval
+      ),
+    EFI_SUCCESS
+    );
+  EXPECT_EQ (Eval.Verdict, ImageCertApproved);
+  EXPECT_NE (Eval.Authority.Data, nullptr);
+}
+
+//
+// db holds an EFI_CERT_X509_SHA256 list with two entries, but neither recovers
+// a trust anchor from the auth data (EFI_NOT_FOUND). Both entries are walked
+// and no anchor authorizes: ImageCertNotInDb.
+//
+TEST (EvaluateImageCertificateTest, X509HashListAllNotFound_NotInDb) {
+  MockBaseCryptLib       BaseCryptLibMock;
+  DIGEST_CACHE           Cache;
+  std::vector<UINT8>     CertBuf = MakePkcsSignedDataCert (std::vector<UINT8>(16, 0xA1));
+  IMAGE_CERT_EVALUATION  Eval;
+
+  InitImageCache (Cache);
+  ZeroMem (&Eval, sizeof (Eval));
+
+  std::vector<UINT8>  Db;
+
+  AppendSignatureList (Db, gEfiCertX509Sha256Guid, 0, kSha256TbsV1EntrySize, 2);
+
+  ExpectSignedImagePrelude (BaseCryptLibMock);
+  EXPECT_CALL (BaseCryptLibMock, GetTrustAnchorX509FromAuthData (_, _, _, _, _, _, _))
+    .Times (2)
+    .WillRepeatedly (Return (EFI_NOT_FOUND));
+  EXPECT_CALL (BaseCryptLibMock, AuthenticodeVerifyEx (_, _, _, _, _, _, _, _)).Times (0);
+
+  SIGNATURE_DATABASES  Databases = { Db.data (), Db.size (), NULL, 0 };
+
+  EXPECT_EQ (
+    EvaluateImageCertificate (
+      (CONST WIN_CERTIFICATE *)CertBuf.data (),
+      &Cache,
+      &Databases,
+      &Eval
+      ),
+    EFI_SUCCESS
+    );
+  EXPECT_EQ (Eval.Verdict, ImageCertNotInDb);
+  EXPECT_EQ (Eval.Authority.Data, nullptr);
+}
+
+//
+// db holds an EFI_CERT_X509_SHA256 list; the trust-anchor lookup fails with a
+// hard error (not EFI_NOT_FOUND). The entry is skipped and no anchor
+// authorizes: ImageCertNotInDb.
+//
+TEST (EvaluateImageCertificateTest, X509HashListHardError_NotInDb) {
+  MockBaseCryptLib       BaseCryptLibMock;
+  DIGEST_CACHE           Cache;
+  std::vector<UINT8>     CertBuf = MakePkcsSignedDataCert (std::vector<UINT8>(16, 0xA1));
+  IMAGE_CERT_EVALUATION  Eval;
+
+  InitImageCache (Cache);
+  ZeroMem (&Eval, sizeof (Eval));
+
+  std::vector<UINT8>  Db;
+
+  AppendSignatureList (Db, gEfiCertX509Sha256Guid, 0, kSha256TbsV1EntrySize, 1);
+
+  ExpectSignedImagePrelude (BaseCryptLibMock);
+  EXPECT_CALL (BaseCryptLibMock, GetTrustAnchorX509FromAuthData (_, _, _, _, _, _, _))
+    .WillOnce (Return (EFI_DEVICE_ERROR));
+  EXPECT_CALL (BaseCryptLibMock, AuthenticodeVerifyEx (_, _, _, _, _, _, _, _)).Times (0);
+
+  SIGNATURE_DATABASES  Databases = { Db.data (), Db.size (), NULL, 0 };
+
+  EXPECT_EQ (
+    EvaluateImageCertificate (
+      (CONST WIN_CERTIFICATE *)CertBuf.data (),
+      &Cache,
+      &Databases,
+      &Eval
+      ),
+    EFI_SUCCESS
+    );
+  EXPECT_EQ (Eval.Verdict, ImageCertNotInDb);
+  EXPECT_EQ (Eval.Authority.Data, nullptr);
+}
+
+//
+// Two EFI_CERT_X509 anchors: the first verifies but its chain is revoked by
+// dbx; the second verifies with a clean chain. The image is approved via the
+// second anchor.
+//
+TEST (EvaluateImageCertificateTest, TwoAnchorsFirstRevokedSecondClean_Approved) {
+  MockBaseCryptLib       BaseCryptLibMock;
+  DIGEST_CACHE           Cache;
+  std::vector<UINT8>     CertBuf = MakePkcsSignedDataCert (std::vector<UINT8>(16, 0xA1));
+  IMAGE_CERT_EVALUATION  Eval;
+
+  InitImageCache (Cache);
+  ZeroMem (&Eval, sizeof (Eval));
+
+  // db: one X509 list with two anchors (payload 0x11 and 0x22).
+  std::vector<UINT8>  Db;
+  size_t              DbOff = AppendSignatureList (Db, gEfiCertX509Guid, 0, (UINT32)(sizeof (EFI_GUID) + 16), 2);
+
+  SetEntryPayload (Db, DbOff, 0, std::vector<UINT8>(16, 0x11));
+  SetEntryPayload (Db, DbOff, 1, std::vector<UINT8>(16, 0x22));
+
+  // dbx: holds the revoked chain cert (24 bytes 0xDD).
+  std::vector<UINT8>  Dbx;
+  size_t              DbxOff = AppendSignatureList (Dbx, gEfiCertX509Guid, 0, (UINT32)(sizeof (EFI_GUID) + 24), 1);
+
+  SetEntryPayload (Dbx, DbxOff, 0, std::vector<UINT8>(24, 0xDD));
+
+  static std::vector<UINT8>  RevokedStack = MakeCertStack ({ std::vector<UINT8>(24, 0xDD) });
+  static std::vector<UINT8>  CleanStack   = MakeCertStack ({ std::vector<UINT8>(24, 0xEE) });
+
+  ExpectSignedImagePrelude (BaseCryptLibMock);
+  EXPECT_CALL (BaseCryptLibMock, AuthenticodeVerifyEx (_, _, _, _, _, _, _, _))
+    .WillOnce (
+       Invoke (
+         [] (CONST UINT8 *, UINTN, CONST UINT8 *, UINTN, CONST UINT8 *, UINTN, UINT8 **OutChain, UINTN *OutChainSize) -> EFI_STATUS {
+    *OutChain     = (UINT8 *)AllocateCopyPool (RevokedStack.size (), RevokedStack.data ());
+    *OutChainSize = RevokedStack.size ();
+    return EFI_SUCCESS;
+  }
+         )
+       )
+    .WillOnce (
+       Invoke (
+         [] (CONST UINT8 *, UINTN, CONST UINT8 *, UINTN, CONST UINT8 *, UINTN, UINT8 **OutChain, UINTN *OutChainSize) -> EFI_STATUS {
+    *OutChain     = (UINT8 *)AllocateCopyPool (CleanStack.size (), CleanStack.data ());
+    *OutChainSize = CleanStack.size ();
+    return EFI_SUCCESS;
+  }
+         )
+       );
+
+  SIGNATURE_DATABASES  Databases = { Db.data (), Db.size (), Dbx.data (), Dbx.size () };
+
+  EXPECT_EQ (
+    EvaluateImageCertificate (
+      (CONST WIN_CERTIFICATE *)CertBuf.data (),
+      &Cache,
+      &Databases,
+      &Eval
+      ),
+    EFI_SUCCESS
+    );
+  EXPECT_EQ (Eval.Verdict, ImageCertApproved);
+  EXPECT_NE (Eval.Authority.Data, nullptr);
+}
+
+//
+// db contains only a non-X.509 (image-hash) list. It is skipped and, with no
+// trust anchors, the verdict is ImageCertNotInDb.
+//
+TEST (EvaluateImageCertificateTest, DbHasOnlyNonX509List_NotInDb) {
+  MockBaseCryptLib       BaseCryptLibMock;
+  DIGEST_CACHE           Cache;
+  std::vector<UINT8>     CertBuf = MakePkcsSignedDataCert (std::vector<UINT8>(16, 0xA1));
+  IMAGE_CERT_EVALUATION  Eval;
+
+  InitImageCache (Cache);
+  ZeroMem (&Eval, sizeof (Eval));
+
+  std::vector<UINT8>  Db;
+
+  AppendSignatureList (Db, gEfiCertSha256Guid, 0, kSha256EntrySize, 1);
+
+  ExpectSignedImagePrelude (BaseCryptLibMock);
+  EXPECT_CALL (BaseCryptLibMock, AuthenticodeVerifyEx (_, _, _, _, _, _, _, _)).Times (0);
+
+  SIGNATURE_DATABASES  Databases = { Db.data (), Db.size (), NULL, 0 };
+
+  EXPECT_EQ (
+    EvaluateImageCertificate (
+      (CONST WIN_CERTIFICATE *)CertBuf.data (),
+      &Cache,
+      &Databases,
+      &Eval
+      ),
+    EFI_SUCCESS
+    );
+  EXPECT_EQ (Eval.Verdict, ImageCertNotInDb);
+  EXPECT_EQ (Eval.Authority.Data, nullptr);
+}
+
+//
+// db contains an EFI_CERT_X509 list whose SignatureSize equals sizeof(EFI_GUID)
+// (no cert payload). The list is skipped and the verdict is ImageCertNotInDb.
+//
+TEST (EvaluateImageCertificateTest, DbX509ListNoCertPayload_NotInDb) {
+  MockBaseCryptLib       BaseCryptLibMock;
+  DIGEST_CACHE           Cache;
+  std::vector<UINT8>     CertBuf = MakePkcsSignedDataCert (std::vector<UINT8>(16, 0xA1));
+  IMAGE_CERT_EVALUATION  Eval;
+
+  InitImageCache (Cache);
+  ZeroMem (&Eval, sizeof (Eval));
+
+  std::vector<UINT8>  Db;
+
+  AppendSignatureList (Db, gEfiCertX509Guid, 0, (UINT32)sizeof (EFI_GUID), 1);
+
+  ExpectSignedImagePrelude (BaseCryptLibMock);
+  EXPECT_CALL (BaseCryptLibMock, AuthenticodeVerifyEx (_, _, _, _, _, _, _, _)).Times (0);
+
+  SIGNATURE_DATABASES  Databases = { Db.data (), Db.size (), NULL, 0 };
+
+  EXPECT_EQ (
+    EvaluateImageCertificate (
+      (CONST WIN_CERTIFICATE *)CertBuf.data (),
+      &Cache,
+      &Databases,
+      &Eval
+      ),
+    EFI_SUCCESS
+    );
+  EXPECT_EQ (Eval.Verdict, ImageCertNotInDb);
+  EXPECT_EQ (Eval.Authority.Data, nullptr);
+}
+
+//
+// db is malformed (smaller than one EFI_SIGNATURE_LIST header) so
+// DatabaseIterInit truncates it to an empty range. The verdict is
+// ImageCertNotInDb.
+//
+TEST (EvaluateImageCertificateTest, MalformedDb_NotInDb) {
+  MockBaseCryptLib       BaseCryptLibMock;
+  DIGEST_CACHE           Cache;
+  std::vector<UINT8>     CertBuf = MakePkcsSignedDataCert (std::vector<UINT8>(16, 0xA1));
+  IMAGE_CERT_EVALUATION  Eval;
+
+  InitImageCache (Cache);
+  ZeroMem (&Eval, sizeof (Eval));
+
+  std::vector<UINT8>  Db (4, 0);
+
+  ExpectSignedImagePrelude (BaseCryptLibMock);
+  EXPECT_CALL (BaseCryptLibMock, AuthenticodeVerifyEx (_, _, _, _, _, _, _, _)).Times (0);
+
+  SIGNATURE_DATABASES  Databases = { Db.data (), Db.size (), NULL, 0 };
+
+  EXPECT_EQ (
+    EvaluateImageCertificate (
+      (CONST WIN_CERTIFICATE *)CertBuf.data (),
+      &Cache,
+      &Databases,
+      &Eval
+      ),
+    EFI_SUCCESS
+    );
+  EXPECT_EQ (Eval.Verdict, ImageCertNotInDb);
+  EXPECT_EQ (Eval.Authority.Data, nullptr);
+}
+
+//
+// Happy path: the prelude succeeds, the single db trust anchor verifies via
+// AuthenticodeVerifyEx, and the empty dbx makes the chain check pass. The image
+// is approved with a non-NULL authority whose SignatureType is the authorizing
+// db list's type.
+//
+TEST (EvaluateImageCertificateTest, AuthorizedByDb_Approved) {
+  MockBaseCryptLib       BaseCryptLibMock;
+  DIGEST_CACHE           Cache;
+  std::vector<UINT8>     CertBuf = MakePkcsSignedDataCert (std::vector<UINT8>(16, 0xA1));
+  IMAGE_CERT_EVALUATION  Eval;
+
+  InitImageCache (Cache);
+  ZeroMem (&Eval, sizeof (Eval));
+
+  std::vector<UINT8>  Db;
+  size_t              DbOff = AppendSignatureList (Db, gEfiCertX509Guid, 0, (UINT32)(sizeof (EFI_GUID) + 16), 1);
+
+  SetEntryPayload (Db, DbOff, 0, std::vector<UINT8>(16, 0x11));
+
+  ExpectSignedImagePrelude (BaseCryptLibMock);
+  EXPECT_CALL (BaseCryptLibMock, AuthenticodeVerifyEx (_, _, _, _, _, _, _, _))
+    .WillOnce (Return (EFI_SUCCESS));
+
+  SIGNATURE_DATABASES  Databases = { Db.data (), Db.size (), NULL, 0 };
+
+  EXPECT_EQ (
+    EvaluateImageCertificate (
+      (CONST WIN_CERTIFICATE *)CertBuf.data (),
+      &Cache,
+      &Databases,
+      &Eval
+      ),
+    EFI_SUCCESS
+    );
+  EXPECT_EQ (Eval.Verdict, ImageCertApproved);
+  EXPECT_NE (Eval.Authority.Data, nullptr);
+  EXPECT_EQ (Eval.Authority.Size, (UINTN)(sizeof (EFI_GUID) + 16));
+  EXPECT_TRUE (CompareGuid (&Eval.Authority.SignatureType, &gEfiCertX509Guid));
+}
+
+//
+// A db anchor verifies the image, but a certificate in its verified chain is
+// enrolled in the dbx, so the chain is revoked. With no other anchor the
+// verdict is ImageCertRevokedByDbx and no authority is recorded (Data is NULL,
+// Size is 0, and SignatureType stays zeroed).
+//
+TEST (EvaluateImageCertificateTest, RevokedByDbx_RevokedByDbx) {
+  MockBaseCryptLib       BaseCryptLibMock;
+  DIGEST_CACHE           Cache;
+  std::vector<UINT8>     CertBuf = MakePkcsSignedDataCert (std::vector<UINT8>(16, 0xA1));
+  IMAGE_CERT_EVALUATION  Eval;
+
+  InitImageCache (Cache);
+  ZeroMem (&Eval, sizeof (Eval));
+
+  // db: one X509 trust anchor that verifies the image.
+  std::vector<UINT8>  Db;
+  size_t              DbOff = AppendSignatureList (Db, gEfiCertX509Guid, 0, (UINT32)(sizeof (EFI_GUID) + 16), 1);
+
+  SetEntryPayload (Db, DbOff, 0, std::vector<UINT8>(16, 0x11));
+
+  // dbx: one X509 list holding the (20-byte) chain cert exactly.
+  std::vector<UINT8>  Dbx;
+  size_t              DbxOff = AppendSignatureList (Dbx, gEfiCertX509Guid, 0, (UINT32)(sizeof (EFI_GUID) + 20), 1);
+
+  SetEntryPayload (Dbx, DbxOff, 0, std::vector<UINT8>(20, 0xAB));
+
+  static std::vector<UINT8>  RevokedChain = MakeCertStack ({ std::vector<UINT8>(20, 0xAB) });
+
+  ExpectSignedImagePrelude (BaseCryptLibMock);
+  EXPECT_CALL (BaseCryptLibMock, AuthenticodeVerifyEx (_, _, _, _, _, _, _, _))
+    .WillOnce (
+       Invoke (
+         [] (CONST UINT8 *, UINTN, CONST UINT8 *, UINTN, CONST UINT8 *, UINTN, UINT8 **OutChain, UINTN *OutChainSize) -> EFI_STATUS {
+    *OutChain     = (UINT8 *)AllocateCopyPool (RevokedChain.size (), RevokedChain.data ());
+    *OutChainSize = RevokedChain.size ();
+    return EFI_SUCCESS;
+  }
+         )
+       );
+
+  SIGNATURE_DATABASES  Databases = { Db.data (), Db.size (), Dbx.data (), Dbx.size () };
+
+  EXPECT_EQ (
+    EvaluateImageCertificate (
+      (CONST WIN_CERTIFICATE *)CertBuf.data (),
+      &Cache,
+      &Databases,
+      &Eval
+      ),
+    EFI_SUCCESS
+    );
+  EXPECT_EQ (Eval.Verdict, ImageCertRevokedByDbx);
+  EXPECT_EQ (Eval.Authority.Data, nullptr);
+  EXPECT_EQ (Eval.Authority.Size, (UINTN)0);
+}
+
+//
+// The prelude succeeds, the dbx is empty (nothing revoked), but no db anchor
+// verifies the signature. The verdict is ImageCertNotInDb.
+//
+TEST (EvaluateImageCertificateTest, NotRevokedNotAuthorized_NotInDb) {
+  MockBaseCryptLib       BaseCryptLibMock;
+  DIGEST_CACHE           Cache;
+  std::vector<UINT8>     CertBuf = MakePkcsSignedDataCert (std::vector<UINT8>(16, 0xA1));
+  IMAGE_CERT_EVALUATION  Eval;
+
+  InitImageCache (Cache);
+  ZeroMem (&Eval, sizeof (Eval));
+
+  std::vector<UINT8>  Db;
+  size_t              DbOff = AppendSignatureList (Db, gEfiCertX509Guid, 0, (UINT32)(sizeof (EFI_GUID) + 16), 2);
+
+  SetEntryPayload (Db, DbOff, 0, std::vector<UINT8>(16, 0x11));
+  SetEntryPayload (Db, DbOff, 1, std::vector<UINT8>(16, 0x22));
+
+  ExpectSignedImagePrelude (BaseCryptLibMock);
+  EXPECT_CALL (BaseCryptLibMock, AuthenticodeVerifyEx (_, _, _, _, _, _, _, _))
+    .Times (2)
+    .WillRepeatedly (Return (EFI_SECURITY_VIOLATION));
+
+  SIGNATURE_DATABASES  Databases = { Db.data (), Db.size (), NULL, 0 };
+
+  EXPECT_EQ (
+    EvaluateImageCertificate (
+      (CONST WIN_CERTIFICATE *)CertBuf.data (),
+      &Cache,
+      &Databases,
+      &Eval
+      ),
+    EFI_SUCCESS
+    );
+  EXPECT_EQ (Eval.Verdict, ImageCertNotInDb);
+  EXPECT_EQ (Eval.Authority.Data, nullptr);
+}

--- a/SecurityPkg/Library/DxeImageVerificationLib2/GoogleTest/DxeImageVerificationLibGoogleTest.cpp
+++ b/SecurityPkg/Library/DxeImageVerificationLib2/GoogleTest/DxeImageVerificationLibGoogleTest.cpp
@@ -1,0 +1,24 @@
+/** @file
+  Integration tests for DxeImageVerificationHandler.
+
+  Test cases in this file dispatch through RunVerificationScenario
+  declared in ScenarioHarness.h. The harness implementation, including
+  every mock and input builder, lives in ScenarioHarness.cpp so this
+  file stays limited to test bodies and the gtest entry point.
+
+  Copyright (c) 2025, Yandex. All rights reserved.
+  Copyright (C) Microsoft Corporation. All rights reserved.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/GoogleTestLib.h>
+
+int
+main (
+  int   argc,
+  char  *argv[]
+  )
+{
+  testing::InitGoogleTest (&argc, argv);
+  return RUN_ALL_TESTS ();
+}

--- a/SecurityPkg/Library/DxeImageVerificationLib2/GoogleTest/DxeImageVerificationLibGoogleTest.inf
+++ b/SecurityPkg/Library/DxeImageVerificationLib2/GoogleTest/DxeImageVerificationLibGoogleTest.inf
@@ -1,0 +1,85 @@
+## @file
+# Unit test suite for the DxeImageVerificationLib using Google Test
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = DxeImageVerificationLibGoogleTest
+  FILE_GUID                      = 30170C3A-E353-4C8E-B20A-7D0E5E821FD8
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  DatabaseGoogleTest.cpp
+  DxeImageVerificationLibGoogleTest.cpp
+  IteratorGoogleTest.cpp
+  MeasurementGoogleTest.cpp
+  PolicyGoogleTest.cpp
+  SupportGoogleTest.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  SecurityPkg/SecurityPkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+  CryptoPkg/CryptoPkg.dec
+
+[LibraryClasses]
+  DxeImageVerificationLib
+  GoogleTestLib
+  BaseCryptLib
+  DebugLib
+  SecureBootVariableLib
+
+[Guids]
+  ## SOMETIMES_CONSUMES   ## Variable:L"SecureBoot"
+  gEfiGlobalVariableGuid
+
+  ## SOMETIMES_CONSUMES   ## Variable:L"DB"
+  ## SOMETIMES_CONSUMES   ## Variable:L"DBX"
+  ## PRODUCES             ## SystemTable
+  ## CONSUMES             ## SystemTable
+  gEfiImageSecurityDatabaseGuid
+
+  ## SOMETIMES_CONSUMES   ## GUID       # Unique ID for the type of the signature.
+  ## SOMETIMES_PRODUCES   ## GUID       # Unique ID for the type of the signature.
+  gEfiCertSha1Guid
+
+  ## SOMETIMES_CONSUMES   ## GUID       # Unique ID for the type of the signature.
+  ## SOMETIMES_PRODUCES   ## GUID       # Unique ID for the type of the signature.
+  gEfiCertSha256Guid
+
+  ## SOMETIMES_CONSUMES   ## GUID       # Unique ID for the type of the signature.
+  ## SOMETIMES_PRODUCES   ## GUID       # Unique ID for the type of the signature.
+  gEfiCertSha384Guid
+
+  ## SOMETIMES_CONSUMES   ## GUID       # Unique ID for the type of the signature.
+  ## SOMETIMES_PRODUCES   ## GUID       # Unique ID for the type of the signature.
+  gEfiCertSha512Guid
+
+  gEfiCertX509Guid                      ## SOMETIMES_CONSUMES    ## GUID     # Unique ID for the type of the signature.
+  gEfiCertX509Sha256Guid                ## SOMETIMES_CONSUMES    ## GUID     # Unique ID for the type of the signature.
+  gEfiCertX509Sha384Guid                ## SOMETIMES_CONSUMES    ## GUID     # Unique ID for the type of the signature.
+  gEfiCertX509Sha512Guid                ## SOMETIMES_CONSUMES    ## GUID     # Unique ID for the type of the signature.
+  gEfiCertV2Sha256Guid                  ## SOMETIMES_CONSUMES    ## GUID     # Unique ID for the type of the signature.
+  gEfiCertV2Sha384Guid                  ## SOMETIMES_CONSUMES    ## GUID     # Unique ID for the type of the signature.
+  gEfiCertV2Sha512Guid                  ## SOMETIMES_CONSUMES    ## GUID     # Unique ID for the type of the signature.
+  gEfiCertV2X509Guid                    ## SOMETIMES_CONSUMES    ## GUID     # Unique ID for the type of the signature.
+  gEfiCertV2X509Sha256Guid              ## SOMETIMES_CONSUMES    ## GUID     # Unique ID for the type of the signature.
+  gEfiCertV2X509Sha384Guid              ## SOMETIMES_CONSUMES    ## GUID     # Unique ID for the type of the signature.
+  gEfiCertV2X509Sha512Guid              ## SOMETIMES_CONSUMES    ## GUID     # Unique ID for the type of the signature.
+  gEfiCertPkcs7Guid                     ## SOMETIMES_CONSUMES    ## GUID     # Unique ID for the type of the certificate.
+
+[Protocols]
+  gEfiFirmwareVolume2ProtocolGuid       ## SOMETIMES_CONSUMES
+  gEfiBlockIoProtocolGuid               ## SOMETIMES_CONSUMES
+  gEfiSimpleFileSystemProtocolGuid      ## SOMETIMES_CONSUMES

--- a/SecurityPkg/Library/DxeImageVerificationLib2/GoogleTest/IteratorGoogleTest.cpp
+++ b/SecurityPkg/Library/DxeImageVerificationLib2/GoogleTest/IteratorGoogleTest.cpp
@@ -1,0 +1,611 @@
+/** @file
+  Unit tests for the iterators in Iterator.c:
+  DatabaseIterInit/Next, SigListIterInit/Next, and WinCertIterInit/Next.
+
+  All three iterators follow the same contract: Init validates the
+  container and clamps the iteration range to the valid prefix, returning
+  TRUE when it had to truncate (drop trailing entries) and FALSE when the
+  whole container parsed cleanly. Next is infallible over that range.
+
+  Copyright (C) Microsoft Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/GoogleTestLib.h>
+
+#include <vector>
+#include <cstring>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Guid/ImageAuthentication.h>
+  #include <IndustryStandard/PeImage.h>
+  #include <Library/BaseMemoryLib.h>
+  #include "../Iterator.h"
+}
+
+// ---------------------------------------------------------------------------
+// Helpers for constructing synthetic signature-list buffers.
+// ---------------------------------------------------------------------------
+
+// SHA-256 entry size: 16-byte owner GUID + 32-byte digest.
+static constexpr UINT32  kSha256EntrySize = sizeof (EFI_GUID) + 32;
+
+//
+// Append one EFI_SIGNATURE_LIST containing SignatureCount entries of
+// EntrySize bytes each (entry payloads are zero-initialized) to Buffer.
+// Returns the offset of the new list within Buffer.
+//
+static size_t
+AppendSignatureList (
+  std::vector<UINT8>  &Buffer,
+  const EFI_GUID      &SignatureType,
+  UINT32              SignatureHeaderSize,
+  UINT32              EntrySize,
+  UINT32              SignatureCount
+  )
+{
+  const size_t  PayloadBytes = (size_t)EntrySize * (size_t)SignatureCount;
+  const size_t  ListBytes    = sizeof (EFI_SIGNATURE_LIST) + SignatureHeaderSize + PayloadBytes;
+  const size_t  Offset       = Buffer.size ();
+
+  Buffer.resize (Offset + ListBytes, 0);
+
+  EFI_SIGNATURE_LIST  *List = (EFI_SIGNATURE_LIST *)(Buffer.data () + Offset);
+
+  CopyMem (&List->SignatureType, &SignatureType, sizeof (EFI_GUID));
+  List->SignatureListSize   = (UINT32)ListBytes;
+  List->SignatureHeaderSize = SignatureHeaderSize;
+  List->SignatureSize       = EntrySize;
+
+  return Offset;
+}
+
+// ---------------------------------------------------------------------------
+// DatabaseIterInit
+// ---------------------------------------------------------------------------
+
+TEST (DatabaseIterInitTest, NullIter_ReturnsTruncated) {
+  std::vector<UINT8>  Buffer (16, 0);
+
+  EXPECT_FALSE (DatabaseIterInit (NULL, Buffer.data (), Buffer.size ()));
+}
+
+TEST (DatabaseIterInitTest, NullBufferWithNonZeroSize_ReturnsTruncated) {
+  SIG_DATABASE_ITER  Iter;
+
+  EXPECT_FALSE (DatabaseIterInit (&Iter, NULL, 16));
+  EXPECT_EQ (Iter.Remaining, (UINTN)0);
+  EXPECT_EQ (DatabaseIterNext (&Iter), nullptr);
+}
+
+TEST (DatabaseIterInitTest, NullBufferWithZeroSize_NotTruncated) {
+  SIG_DATABASE_ITER  Iter;
+
+  EXPECT_TRUE (DatabaseIterInit (&Iter, NULL, 0));
+  EXPECT_EQ (Iter.Remaining, (UINTN)0);
+  EXPECT_EQ (DatabaseIterNext (&Iter), nullptr);
+}
+
+TEST (DatabaseIterInitTest, EmptyBuffer_NotTruncated) {
+  std::vector<UINT8>  Buffer;
+  SIG_DATABASE_ITER   Iter;
+
+  EXPECT_TRUE (DatabaseIterInit (&Iter, Buffer.data (), 0));
+  EXPECT_EQ (DatabaseIterNext (&Iter), nullptr);
+}
+
+TEST (DatabaseIterInitTest, SingleWellFormedList_NotTruncated) {
+  std::vector<UINT8>  Buffer;
+  SIG_DATABASE_ITER   Iter;
+
+  AppendSignatureList (Buffer, gEfiCertSha256Guid, 0, kSha256EntrySize, 2);
+
+  EXPECT_TRUE (DatabaseIterInit (&Iter, Buffer.data (), Buffer.size ()));
+}
+
+// A well-formed list followed by stray bytes too small to be a header: the
+// range is clamped to the valid list and the trailing bytes are dropped.
+TEST (DatabaseIterInitTest, TrailingBytesBelowHeader_TruncatesToValidPrefix) {
+  std::vector<UINT8>  Buffer;
+  SIG_DATABASE_ITER   Iter;
+  size_t              Off1;
+
+  Off1 = AppendSignatureList (Buffer, gEfiCertSha256Guid, 0, kSha256EntrySize, 1);
+  // Append a few stray bytes too small to be even a list header.
+  Buffer.resize (Buffer.size () + sizeof (EFI_SIGNATURE_LIST) - 1, 0);
+
+  EXPECT_FALSE (DatabaseIterInit (&Iter, Buffer.data (), Buffer.size ()));
+  // The one well-formed list preceding the stray bytes is still iterable.
+  EXPECT_EQ ((CONST UINT8 *)DatabaseIterNext (&Iter), Buffer.data () + Off1);
+  EXPECT_EQ (DatabaseIterNext (&Iter), nullptr);
+}
+
+// The only list has a SignatureListSize below the header size: nothing can be
+// parsed, so the range is clamped to empty.
+TEST (DatabaseIterInitTest, ListSizeBelowHeaderSize_TruncatesToEmpty) {
+  std::vector<UINT8>  Buffer;
+  SIG_DATABASE_ITER   Iter;
+
+  AppendSignatureList (Buffer, gEfiCertSha256Guid, 0, kSha256EntrySize, 1);
+  ((EFI_SIGNATURE_LIST *)Buffer.data ())->SignatureListSize = sizeof (EFI_SIGNATURE_LIST) - 1;
+
+  EXPECT_FALSE (DatabaseIterInit (&Iter, Buffer.data (), Buffer.size ()));
+  EXPECT_EQ (Iter.Remaining, (UINTN)0);
+  EXPECT_EQ (DatabaseIterNext (&Iter), nullptr);
+}
+
+// The only list claims a size larger than the buffer: nothing can be parsed,
+// so the range is clamped to empty.
+TEST (DatabaseIterInitTest, ListSizeOverrunsBuffer_TruncatesToEmpty) {
+  std::vector<UINT8>  Buffer;
+  SIG_DATABASE_ITER   Iter;
+
+  AppendSignatureList (Buffer, gEfiCertSha256Guid, 0, kSha256EntrySize, 1);
+  ((EFI_SIGNATURE_LIST *)Buffer.data ())->SignatureListSize = (UINT32)(Buffer.size () + 1);
+
+  EXPECT_FALSE (DatabaseIterInit (&Iter, Buffer.data (), Buffer.size ()));
+  EXPECT_EQ (Iter.Remaining, (UINTN)0);
+  EXPECT_EQ (DatabaseIterNext (&Iter), nullptr);
+}
+
+// Init only checks the outer tiling; bad internals belong to SigListIterInit.
+TEST (DatabaseIterInitTest, MalformedInternalsButValidTiling_NotTruncated) {
+  std::vector<UINT8>  Buffer;
+  SIG_DATABASE_ITER   Iter;
+
+  AppendSignatureList (Buffer, gEfiCertSha256Guid, 0, kSha256EntrySize, 1);
+  // SignatureSize < sizeof(EFI_GUID) is internal corruption that
+  // DatabaseIterInit deliberately ignores.
+  ((EFI_SIGNATURE_LIST *)Buffer.data ())->SignatureSize = 1;
+
+  EXPECT_TRUE (DatabaseIterInit (&Iter, Buffer.data (), Buffer.size ()));
+}
+
+// ---------------------------------------------------------------------------
+// DatabaseIterNext
+// ---------------------------------------------------------------------------
+
+TEST (DatabaseIterNextTest, NullIter_ReturnsNull) {
+  EXPECT_EQ (DatabaseIterNext (NULL), nullptr);
+}
+
+TEST (DatabaseIterNextTest, EmptyDatabase_ReturnsNull) {
+  SIG_DATABASE_ITER  Iter;
+
+  ASSERT_TRUE (DatabaseIterInit (&Iter, NULL, 0));
+  EXPECT_EQ (DatabaseIterNext (&Iter), nullptr);
+}
+
+TEST (DatabaseIterNextTest, IteratesAllListsInOrder) {
+  std::vector<UINT8>  Buffer;
+  SIG_DATABASE_ITER   Iter;
+  size_t              Off1, Off2, Off3;
+
+  Off1 = AppendSignatureList (Buffer, gEfiCertSha256Guid, 0, kSha256EntrySize, 1);
+  Off2 = AppendSignatureList (Buffer, gEfiCertX509Guid, 0, sizeof (EFI_GUID) + 8, 2);
+  Off3 = AppendSignatureList (Buffer, gEfiCertSha256Guid, 0, kSha256EntrySize, 3);
+
+  ASSERT_TRUE (DatabaseIterInit (&Iter, Buffer.data (), Buffer.size ()));
+
+  CONST EFI_SIGNATURE_LIST  *L1 = DatabaseIterNext (&Iter);
+  CONST EFI_SIGNATURE_LIST  *L2 = DatabaseIterNext (&Iter);
+  CONST EFI_SIGNATURE_LIST  *L3 = DatabaseIterNext (&Iter);
+  CONST EFI_SIGNATURE_LIST  *L4 = DatabaseIterNext (&Iter);
+
+  EXPECT_EQ ((CONST UINT8 *)L1, Buffer.data () + Off1);
+  EXPECT_EQ ((CONST UINT8 *)L2, Buffer.data () + Off2);
+  EXPECT_EQ ((CONST UINT8 *)L3, Buffer.data () + Off3);
+  EXPECT_EQ (L4, nullptr);
+
+  // Drained iterator stays drained.
+  EXPECT_EQ (DatabaseIterNext (&Iter), nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// SigListIterInit
+// ---------------------------------------------------------------------------
+
+TEST (SigListIterInitTest, NullIter_ReturnsTruncated) {
+  std::vector<UINT8>  Buffer;
+
+  AppendSignatureList (Buffer, gEfiCertSha256Guid, 0, kSha256EntrySize, 1);
+
+  EXPECT_FALSE (SigListIterInit (NULL, (EFI_SIGNATURE_LIST *)Buffer.data ()));
+}
+
+TEST (SigListIterInitTest, NullList_ReturnsTruncated) {
+  SIG_LIST_ITER  Iter;
+
+  EXPECT_FALSE (SigListIterInit (&Iter, NULL));
+  EXPECT_EQ (Iter.Remaining, (UINTN)0);
+  EXPECT_EQ (SigListIterNext (&Iter), nullptr);
+}
+
+TEST (SigListIterInitTest, ListSizeBelowHeader_TruncatesToEmpty) {
+  std::vector<UINT8>  Buffer;
+  SIG_LIST_ITER       Iter;
+
+  AppendSignatureList (Buffer, gEfiCertSha256Guid, 0, kSha256EntrySize, 1);
+  ((EFI_SIGNATURE_LIST *)Buffer.data ())->SignatureListSize = sizeof (EFI_SIGNATURE_LIST) - 1;
+
+  EXPECT_FALSE (SigListIterInit (&Iter, (EFI_SIGNATURE_LIST *)Buffer.data ()));
+  EXPECT_EQ (Iter.Remaining, (UINTN)0);
+  EXPECT_EQ (SigListIterNext (&Iter), nullptr);
+}
+
+TEST (SigListIterInitTest, SignatureSizeBelowGuid_TruncatesToEmpty) {
+  std::vector<UINT8>  Buffer;
+  SIG_LIST_ITER       Iter;
+
+  AppendSignatureList (Buffer, gEfiCertSha256Guid, 0, kSha256EntrySize, 1);
+  ((EFI_SIGNATURE_LIST *)Buffer.data ())->SignatureSize = sizeof (EFI_GUID) - 1;
+
+  EXPECT_FALSE (SigListIterInit (&Iter, (EFI_SIGNATURE_LIST *)Buffer.data ()));
+  EXPECT_EQ (Iter.Remaining, (UINTN)0);
+  EXPECT_EQ (SigListIterNext (&Iter), nullptr);
+}
+
+TEST (SigListIterInitTest, HeaderSizeExceedsList_TruncatesToEmpty) {
+  std::vector<UINT8>  Buffer;
+  SIG_LIST_ITER       Iter;
+
+  AppendSignatureList (Buffer, gEfiCertSha256Guid, 0, kSha256EntrySize, 1);
+  EFI_SIGNATURE_LIST  *List = (EFI_SIGNATURE_LIST *)Buffer.data ();
+
+  List->SignatureHeaderSize = List->SignatureListSize;  // leaves no room
+
+  EXPECT_FALSE (SigListIterInit (&Iter, List));
+  EXPECT_EQ (Iter.Remaining, (UINTN)0);
+  EXPECT_EQ (SigListIterNext (&Iter), nullptr);
+}
+
+// A payload that does not divide evenly into whole entries: the trailing
+// partial entry is dropped and only the whole entries are iterated.
+TEST (SigListIterInitTest, PayloadNotMultipleOfSignatureSize_TruncatesPartialEntry) {
+  std::vector<UINT8>  Buffer;
+  SIG_LIST_ITER       Iter;
+
+  AppendSignatureList (Buffer, gEfiCertSha256Guid, 0, kSha256EntrySize, 2);
+  // Trim one byte off SignatureListSize so payload no longer divides
+  // evenly into SignatureSize chunks.
+  ((EFI_SIGNATURE_LIST *)Buffer.data ())->SignatureListSize -= 1;
+
+  EXPECT_FALSE (SigListIterInit (&Iter, (EFI_SIGNATURE_LIST *)Buffer.data ()));
+  // The one whole entry preceding the partial tail is still iterable.
+  EXPECT_EQ (Iter.Remaining, (UINTN)1);
+  EXPECT_NE (SigListIterNext (&Iter), nullptr);
+  EXPECT_EQ (SigListIterNext (&Iter), nullptr);
+}
+
+TEST (SigListIterInitTest, WellFormed_NotTruncated) {
+  std::vector<UINT8>  Buffer;
+  SIG_LIST_ITER       Iter;
+
+  AppendSignatureList (Buffer, gEfiCertSha256Guid, 0, kSha256EntrySize, 3);
+
+  EXPECT_TRUE (SigListIterInit (&Iter, (EFI_SIGNATURE_LIST *)Buffer.data ()));
+  EXPECT_EQ (Iter.Stride, (UINTN)kSha256EntrySize);
+  EXPECT_EQ (Iter.Remaining, (UINTN)3);
+}
+
+// ---------------------------------------------------------------------------
+// SigListIterNext
+// ---------------------------------------------------------------------------
+
+TEST (SigListIterNextTest, NullIter_ReturnsNull) {
+  EXPECT_EQ (SigListIterNext (NULL), nullptr);
+}
+
+TEST (SigListIterNextTest, EmptyList_ReturnsNull) {
+  std::vector<UINT8>  Buffer;
+  SIG_LIST_ITER       Iter;
+
+  AppendSignatureList (Buffer, gEfiCertSha256Guid, 0, kSha256EntrySize, 0);
+  ASSERT_TRUE (SigListIterInit (&Iter, (EFI_SIGNATURE_LIST *)Buffer.data ()));
+
+  EXPECT_EQ (SigListIterNext (&Iter), nullptr);
+}
+
+TEST (SigListIterNextTest, IteratesEntriesWithCorrectStride) {
+  std::vector<UINT8>  Buffer;
+  SIG_LIST_ITER       Iter;
+  const UINT32        EntryCount = 4;
+
+  AppendSignatureList (Buffer, gEfiCertSha256Guid, 0, kSha256EntrySize, EntryCount);
+
+  EFI_SIGNATURE_LIST  *List       = (EFI_SIGNATURE_LIST *)Buffer.data ();
+  UINT8               *FirstEntry =
+    (UINT8 *)List + sizeof (EFI_SIGNATURE_LIST) + List->SignatureHeaderSize;
+
+  ASSERT_TRUE (SigListIterInit (&Iter, List));
+
+  for (UINT32 i = 0; i < EntryCount; i++) {
+    CONST EFI_SIGNATURE_DATA  *Entry = SigListIterNext (&Iter);
+    ASSERT_NE (Entry, nullptr) << "entry " << i;
+    EXPECT_EQ ((CONST UINT8 *)Entry, FirstEntry + (size_t)i * kSha256EntrySize);
+  }
+
+  EXPECT_EQ (SigListIterNext (&Iter), nullptr);
+  EXPECT_EQ (SigListIterNext (&Iter), nullptr);
+}
+
+TEST (SigListIterNextTest, RespectsSignatureHeaderSize) {
+  std::vector<UINT8>  Buffer;
+  SIG_LIST_ITER       Iter;
+  const UINT32        HeaderSize = 12;
+
+  AppendSignatureList (Buffer, gEfiCertSha256Guid, HeaderSize, kSha256EntrySize, 2);
+
+  EFI_SIGNATURE_LIST  *List = (EFI_SIGNATURE_LIST *)Buffer.data ();
+
+  ASSERT_TRUE (SigListIterInit (&Iter, List));
+
+  CONST EFI_SIGNATURE_DATA  *Entry = SigListIterNext (&Iter);
+
+  ASSERT_NE (Entry, nullptr);
+  EXPECT_EQ (
+    (CONST UINT8 *)Entry,
+    (CONST UINT8 *)List + sizeof (EFI_SIGNATURE_LIST) + HeaderSize
+    );
+}
+
+// ---------------------------------------------------------------------------
+// WinCertIter helpers
+// ---------------------------------------------------------------------------
+
+//
+// Build a synthetic PE/COFF "file" whose security directory immediately
+// follows a header area. The returned dir VA/Size point into FileBuffer.
+//
+struct SyntheticImage {
+  std::vector<UINT8>          FileBuffer;
+  EFI_IMAGE_DATA_DIRECTORY    Dir;
+};
+
+//
+// Append a single WIN_CERTIFICATE entry of total length dwLength
+// (including the header) to Dir. dwLength is written as-is, so callers
+// may inject malformed values for negative tests.
+//
+static void
+AppendWinCert (
+  std::vector<UINT8>  &Dir,
+  UINT32              dwLength,
+  UINT16              wRevision,
+  UINT16              wCertificateType
+  )
+{
+  const UINT32  Padded = (UINT32)ALIGN_VALUE (dwLength, 8);
+  const size_t  Offset = Dir.size ();
+
+  // Reserve the padded size so the next entry starts on an 8-byte boundary.
+  Dir.resize (Offset + Padded, 0);
+
+  WIN_CERTIFICATE  *Cert = (WIN_CERTIFICATE *)(Dir.data () + Offset);
+
+  Cert->dwLength         = dwLength;
+  Cert->wRevision        = wRevision;
+  Cert->wCertificateType = wCertificateType;
+}
+
+static SyntheticImage
+BuildImageWithDir (
+  const std::vector<UINT8>  &DirContents
+  )
+{
+  SyntheticImage  Img;
+
+  // 64 bytes of leading "header" so the dir VA is non-zero.
+  Img.FileBuffer.assign (64, 0);
+  Img.Dir.VirtualAddress = (UINT32)Img.FileBuffer.size ();
+  Img.Dir.Size           = (UINT32)DirContents.size ();
+  Img.FileBuffer.insert (
+                   Img.FileBuffer.end (),
+                   DirContents.begin (),
+                   DirContents.end ()
+                   );
+
+  return Img;
+}
+
+// ---------------------------------------------------------------------------
+// WinCertIterInit
+// ---------------------------------------------------------------------------
+
+TEST (WinCertIterInitTest, NullParams_ReturnTruncated) {
+  WIN_CERT_ITER             Iter;
+  std::vector<UINT8>        File (64, 0);
+  EFI_IMAGE_DATA_DIRECTORY  Dir = { 0, 0 };
+
+  EXPECT_FALSE (WinCertIterInit (NULL, File.data (), File.size (), &Dir));
+  EXPECT_FALSE (WinCertIterInit (&Iter, NULL, File.size (), &Dir));
+  EXPECT_FALSE (WinCertIterInit (&Iter, File.data (), File.size (), NULL));
+}
+
+TEST (WinCertIterInitTest, EmptyDirectory_NotTruncated) {
+  WIN_CERT_ITER             Iter;
+  std::vector<UINT8>        File (64, 0);
+  EFI_IMAGE_DATA_DIRECTORY  Dir = { 0, 0 };
+
+  EXPECT_TRUE (WinCertIterInit (&Iter, File.data (), File.size (), &Dir));
+  EXPECT_EQ (WinCertIterNext (&Iter), nullptr);
+}
+
+TEST (WinCertIterInitTest, DirVirtualAddressPastEnd_TruncatesToEmpty) {
+  WIN_CERT_ITER             Iter;
+  std::vector<UINT8>        File (64, 0);
+  EFI_IMAGE_DATA_DIRECTORY  Dir;
+
+  Dir.VirtualAddress = (UINT32)(File.size () + 1);
+  Dir.Size           = 0;
+
+  EXPECT_FALSE (WinCertIterInit (&Iter, File.data (), File.size (), &Dir));
+  EXPECT_EQ (WinCertIterNext (&Iter), nullptr);
+}
+
+TEST (WinCertIterInitTest, DirSizeOverrunsFile_TruncatesToEmpty) {
+  WIN_CERT_ITER             Iter;
+  std::vector<UINT8>        File (128, 0);
+  EFI_IMAGE_DATA_DIRECTORY  Dir;
+
+  Dir.VirtualAddress = 64;
+  Dir.Size           = (UINT32)(File.size () - 64 + 1);
+
+  EXPECT_FALSE (WinCertIterInit (&Iter, File.data (), File.size (), &Dir));
+  EXPECT_EQ (WinCertIterNext (&Iter), nullptr);
+}
+
+TEST (WinCertIterInitTest, EntryDwLengthBelowHeader_TruncatesToEmpty) {
+  std::vector<UINT8>  Dir;
+
+  AppendWinCert (Dir, sizeof (WIN_CERTIFICATE), 0x0200, WIN_CERT_TYPE_PKCS_SIGNED_DATA);
+  // Corrupt dwLength after the fact.
+  ((WIN_CERTIFICATE *)Dir.data ())->dwLength = sizeof (WIN_CERTIFICATE) - 1;
+
+  SyntheticImage  Img = BuildImageWithDir (Dir);
+  WIN_CERT_ITER   Iter;
+
+  EXPECT_FALSE (WinCertIterInit (&Iter, Img.FileBuffer.data (), Img.FileBuffer.size (), &Img.Dir));
+  EXPECT_EQ (WinCertIterNext (&Iter), nullptr);
+}
+
+TEST (WinCertIterInitTest, EntryDwLengthOverrunsRemaining_TruncatesToEmpty) {
+  std::vector<UINT8>  Dir;
+
+  AppendWinCert (Dir, sizeof (WIN_CERTIFICATE) + 8, 0x0200, WIN_CERT_TYPE_PKCS_SIGNED_DATA);
+  ((WIN_CERTIFICATE *)Dir.data ())->dwLength = (UINT32)Dir.size () + 1;
+
+  SyntheticImage  Img = BuildImageWithDir (Dir);
+  WIN_CERT_ITER   Iter;
+
+  EXPECT_FALSE (WinCertIterInit (&Iter, Img.FileBuffer.data (), Img.FileBuffer.size (), &Img.Dir));
+  EXPECT_EQ (WinCertIterNext (&Iter), nullptr);
+}
+
+TEST (WinCertIterInitTest, WellFormedEntries_NotTruncated) {
+  std::vector<UINT8>  Dir;
+
+  AppendWinCert (Dir, sizeof (WIN_CERTIFICATE) + 16, 0x0200, WIN_CERT_TYPE_PKCS_SIGNED_DATA);
+  AppendWinCert (Dir, sizeof (WIN_CERTIFICATE) + 32, 0x0200, WIN_CERT_TYPE_EFI_GUID);
+
+  SyntheticImage  Img = BuildImageWithDir (Dir);
+  WIN_CERT_ITER   Iter;
+
+  EXPECT_TRUE (WinCertIterInit (&Iter, Img.FileBuffer.data (), Img.FileBuffer.size (), &Img.Dir));
+}
+
+// A well-formed entry followed by one with a malformed dwLength: the range is
+// clamped to the valid entry and the malformed tail is dropped.
+TEST (WinCertIterInitTest, MalformedSecondEntry_TruncatesToValidPrefix) {
+  std::vector<UINT8>  Dir;
+
+  AppendWinCert (Dir, sizeof (WIN_CERTIFICATE) + 16, 0x0200, WIN_CERT_TYPE_PKCS_SIGNED_DATA);
+  const size_t  SecondOffset = Dir.size ();
+
+  AppendWinCert (Dir, sizeof (WIN_CERTIFICATE) + 16, 0x0200, WIN_CERT_TYPE_PKCS_SIGNED_DATA);
+  // Corrupt the second entry's dwLength so it cannot be parsed.
+  ((WIN_CERTIFICATE *)(Dir.data () + SecondOffset))->dwLength = sizeof (WIN_CERTIFICATE) - 1;
+
+  SyntheticImage  Img   = BuildImageWithDir (Dir);
+  CONST UINT8     *Base = Img.FileBuffer.data () + Img.Dir.VirtualAddress;
+  WIN_CERT_ITER   Iter;
+
+  EXPECT_FALSE (WinCertIterInit (&Iter, Img.FileBuffer.data (), Img.FileBuffer.size (), &Img.Dir));
+  // The first, well-formed entry is still iterable; the second is dropped.
+  EXPECT_EQ ((CONST UINT8 *)WinCertIterNext (&Iter), Base);
+  EXPECT_EQ (WinCertIterNext (&Iter), nullptr);
+}
+
+//
+// A directory smaller than a WIN_CERTIFICATE header: the walk sees a
+// non-zero Remaining that cannot hold another header, so the range is
+// clamped to empty.
+//
+TEST (WinCertIterInitTest, TrailingBytesBelowHeader_TruncatesToEmpty) {
+  std::vector<UINT8>  Dir (sizeof (WIN_CERTIFICATE) - 1, 0);
+
+  SyntheticImage  Img = BuildImageWithDir (Dir);
+  WIN_CERT_ITER   Iter;
+
+  EXPECT_FALSE (WinCertIterInit (&Iter, Img.FileBuffer.data (), Img.FileBuffer.size (), &Img.Dir));
+  EXPECT_EQ (WinCertIterNext (&Iter), nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// WinCertIterNext
+// ---------------------------------------------------------------------------
+
+TEST (WinCertIterNextTest, NullIter_ReturnsNull) {
+  EXPECT_EQ (WinCertIterNext (NULL), nullptr);
+}
+
+TEST (WinCertIterNextTest, IteratesAllEntriesWithAlignment) {
+  std::vector<UINT8>  Dir;
+
+  // Three entries with different dwLength values (some not multiples of 8)
+  // to exercise the ALIGN_VALUE advance.
+  const UINT32  Len1 = sizeof (WIN_CERTIFICATE) + 5;   // 13 -> aligned to 16
+  const UINT32  Len2 = sizeof (WIN_CERTIFICATE) + 16;  // 24
+  const UINT32  Len3 = sizeof (WIN_CERTIFICATE) + 1;   // 9  -> aligned to 16
+
+  AppendWinCert (Dir, Len1, 0x0200, WIN_CERT_TYPE_PKCS_SIGNED_DATA);
+  AppendWinCert (Dir, Len2, 0x0200, WIN_CERT_TYPE_PKCS_SIGNED_DATA);
+  AppendWinCert (Dir, Len3, 0x0200, WIN_CERT_TYPE_EFI_GUID);
+
+  SyntheticImage  Img = BuildImageWithDir (Dir);
+  WIN_CERT_ITER   Iter;
+
+  ASSERT_TRUE (
+    WinCertIterInit (&Iter, Img.FileBuffer.data (), Img.FileBuffer.size (), &Img.Dir)
+    );
+
+  CONST UINT8            *Base = Img.FileBuffer.data () + Img.Dir.VirtualAddress;
+  CONST WIN_CERTIFICATE  *C1   = WinCertIterNext (&Iter);
+  CONST WIN_CERTIFICATE  *C2   = WinCertIterNext (&Iter);
+  CONST WIN_CERTIFICATE  *C3   = WinCertIterNext (&Iter);
+  CONST WIN_CERTIFICATE  *C4   = WinCertIterNext (&Iter);
+
+  ASSERT_NE (C1, nullptr);
+  ASSERT_NE (C2, nullptr);
+  ASSERT_NE (C3, nullptr);
+  EXPECT_EQ ((CONST UINT8 *)C1, Base);
+  EXPECT_EQ ((CONST UINT8 *)C2, Base + ALIGN_VALUE (Len1, 8));
+  EXPECT_EQ ((CONST UINT8 *)C3, Base + ALIGN_VALUE (Len1, 8) + ALIGN_VALUE (Len2, 8));
+  EXPECT_EQ (C1->dwLength, Len1);
+  EXPECT_EQ (C2->dwLength, Len2);
+  EXPECT_EQ (C3->dwLength, Len3);
+  EXPECT_EQ (C4, nullptr);
+
+  // Drained iterator stays drained.
+  EXPECT_EQ (WinCertIterNext (&Iter), nullptr);
+}
+
+//
+// A single entry whose dwLength consumes the entire (unpadded) directory:
+// ALIGN_VALUE(dwLength, 8) exceeds the remaining bytes, exercising the
+// clamp in both WinCertIterInit and WinCertIterNext.
+//
+TEST (WinCertIterNextTest, LastEntryUnpaddedClampsToRemaining) {
+  const UINT32        Len = sizeof (WIN_CERTIFICATE) + 4;   // 12; ALIGN(12,8)=16 > 12
+  std::vector<UINT8>  Dir (Len, 0);
+
+  WIN_CERTIFICATE  *Cert = (WIN_CERTIFICATE *)Dir.data ();
+
+  Cert->dwLength         = Len;
+  Cert->wRevision        = 0x0200;
+  Cert->wCertificateType = WIN_CERT_TYPE_PKCS_SIGNED_DATA;
+
+  SyntheticImage  Img = BuildImageWithDir (Dir);
+  WIN_CERT_ITER   Iter;
+
+  ASSERT_TRUE (
+    WinCertIterInit (&Iter, Img.FileBuffer.data (), Img.FileBuffer.size (), &Img.Dir)
+    );
+
+  CONST WIN_CERTIFICATE  *C = WinCertIterNext (&Iter);
+
+  ASSERT_NE (C, nullptr);
+  EXPECT_EQ (C->dwLength, Len);
+  EXPECT_EQ (WinCertIterNext (&Iter), nullptr);
+}

--- a/SecurityPkg/Library/DxeImageVerificationLib2/GoogleTest/MeasurementGoogleTest.cpp
+++ b/SecurityPkg/Library/DxeImageVerificationLib2/GoogleTest/MeasurementGoogleTest.cpp
@@ -1,0 +1,608 @@
+/** @file
+  Unit tests for the Secure Boot authority measurement helpers in
+  DxeImageVerificationLib (Measurement.c): GetMeasuredAuthorities,
+  AssignVariableName, AssignVendorGuid, IsSecureAuthorityVariable,
+  IsDataMeasured, AddDataMeasured, MeasureVariable, and SecureBootHook.
+
+  The de-duplication helpers are exercised against a caller-supplied
+  MEASURED_AUTHORITIES instance so no module-global state is relied upon,
+  and the PCR 7 extend path is exercised against a mocked
+  TpmMeasureAndLogData.
+
+  Copyright (C) Microsoft Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/GoogleTestLib.h>
+#include <GoogleTest/Library/MockTpmMeasurementLib.h>
+
+#include <vector>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Guid/ImageAuthentication.h>
+  #include <IndustryStandard/UefiTcgPlatform.h>
+  #include <Library/BaseLib.h>
+  #include <Library/BaseMemoryLib.h>
+  #include <Library/MemoryAllocationLib.h>
+  #include "../DxeImageVerificationLib.h"
+
+  CHAR16 *
+  AssignVariableName (
+    IN CHAR16  *VariableName
+    );
+
+  EFI_GUID *
+  AssignVendorGuid (
+    IN EFI_GUID  *VendorGuid
+    );
+
+  BOOLEAN
+  IsSecureAuthorityVariable (
+    IN CHAR16    *VariableName,
+    IN EFI_GUID  *VendorGuid
+    );
+
+  BOOLEAN
+  IsDataMeasured (
+    IN CONST MEASURED_AUTHORITIES  *Measured,
+    IN CHAR16                      *VariableName,
+    IN EFI_GUID                    *VendorGuid,
+    IN VOID                        *Data,
+    IN UINTN                       Size
+    );
+
+  EFI_STATUS
+  AddDataMeasured (
+    IN OUT MEASURED_AUTHORITIES  *Measured,
+    IN     CHAR16                *VariableName,
+    IN     EFI_GUID              *VendorGuid,
+    IN     VOID                  *Data,
+    IN     UINTN                 Size
+    );
+
+  EFI_STATUS
+  MeasureVariable (
+    IN CHAR16    *VarName,
+    IN EFI_GUID  *VendorGuid,
+    IN VOID      *VarData,
+    IN UINTN     VarSize
+    );
+
+  VOID
+  SecureBootHook (
+    IN OUT MEASURED_AUTHORITIES   *Measured,
+    IN     CHAR16                 *VariableName,
+    IN     EFI_GUID               *VendorGuid,
+    IN     CONST IMAGE_AUTHORITY  *Authority
+    );
+}
+
+using ::testing::_;
+using ::testing::Return;
+
+//
+// The growth increment from Measurement.c. Kept in sync here so the list
+// growth path can be exercised without exposing the module constant.
+//
+#define TEST_AUTHORITY_COUNT_INCREMENT  0x100
+
+//
+// A known Secure Boot authority variable name. The cast drops the char16_t
+// literal's const qualifier so it matches the non-const parameter type of the
+// helpers under test.
+//
+static CHAR16  *mDbName = (CHAR16 *)u"db";
+
+//
+// A vendor GUID that is not a Secure Boot authority vendor GUID.
+//
+static EFI_GUID  mNonAuthorityGuid = {
+  0x12345678, 0x1234, 0x1234, { 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0 }
+};
+
+//
+// A variable name that is not a Secure Boot authority variable name.
+//
+static CHAR16  *mNonAuthorityName = (CHAR16 *)u"NotADb";
+
+//
+// Free every Data copy and the backing list of a MEASURED_AUTHORITIES that was
+// populated through AddDataMeasured, and reset it to the empty state.
+//
+static void
+FreeMeasured (
+  MEASURED_AUTHORITIES  &Measured
+  )
+{
+  if (Measured.List != NULL) {
+    for (UINTN Index = 0; Index < Measured.Count; Index++) {
+      if (Measured.List[Index].Data != NULL) {
+        FreePool (Measured.List[Index].Data);
+      }
+    }
+
+    FreePool (Measured.List);
+  }
+
+  Measured.List  = NULL;
+  Measured.Count = 0;
+  Measured.Max   = 0;
+}
+
+// ---------------------------------------------------------------------------
+// GetMeasuredAuthorities
+// ---------------------------------------------------------------------------
+
+class GetMeasuredAuthoritiesTest : public ::testing::Test {
+protected:
+  MockTpmMeasurementLib TpmMock;
+};
+
+TEST_F (GetMeasuredAuthoritiesTest, ReflectsSecureBootHookUpdates) {
+  UINT8            Data[8] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+  IMAGE_AUTHORITY  Authority;
+
+  Authority.Data = (EFI_SIGNATURE_DATA *)Data;
+  Authority.Size = sizeof (Data);
+
+  //
+  // The module-global state starts empty: no list is allocated and nothing
+  // has been measured yet.
+  //
+  MEASURED_AUTHORITIES  *Measured = GetMeasuredAuthorities ();
+
+  ASSERT_NE (Measured, nullptr);
+  EXPECT_EQ (Measured->List, nullptr);
+  EXPECT_EQ (Measured->Count, (UINTN)0);
+
+  EXPECT_CALL (
+    TpmMock,
+    TpmMeasureAndLogData ((UINT32)7, (UINT32)EV_EFI_VARIABLE_AUTHORITY, _, _, _, _)
+    )
+    .WillOnce (Return (EFI_SUCCESS));
+
+  SecureBootHook (Measured, mDbName, &gEfiImageSecurityDatabaseGuid, &Authority);
+
+  //
+  // The same global instance is returned and now reflects the measured
+  // authority recorded by SecureBootHook.
+  //
+  MEASURED_AUTHORITIES  *Updated = GetMeasuredAuthorities ();
+
+  EXPECT_EQ (Updated, Measured);
+  EXPECT_NE (Updated->List, nullptr);
+  EXPECT_EQ (Updated->Count, (UINTN)1);
+  EXPECT_TRUE (
+    IsDataMeasured (Updated, mDbName, &gEfiImageSecurityDatabaseGuid, Data, sizeof (Data))
+    );
+
+  FreeMeasured (*Updated);
+}
+
+// ---------------------------------------------------------------------------
+// AssignVariableName
+// ---------------------------------------------------------------------------
+
+class AssignVariableNameTest : public ::testing::Test {
+};
+
+TEST_F (AssignVariableNameTest, NullName_ReturnsNull) {
+  EXPECT_EQ (AssignVariableName (NULL), nullptr);
+}
+
+TEST_F (AssignVariableNameTest, UnknownName_ReturnsNull) {
+  EXPECT_EQ (AssignVariableName (mNonAuthorityName), nullptr);
+}
+
+TEST_F (AssignVariableNameTest, KnownName_ReturnsCanonicalStorage) {
+  CHAR16  Local[] = { u'd', u'b', u'\0' };
+
+  CHAR16  *First  = AssignVariableName (Local);
+  CHAR16  *Second = AssignVariableName (mDbName);
+
+  //
+  // A known name resolves to canonical storage owned by the module, so the
+  // returned pointer must be independent of the caller's buffer and stable.
+  //
+  EXPECT_NE (First, nullptr);
+  EXPECT_NE (First, Local);
+  EXPECT_EQ (First, Second);
+  EXPECT_EQ (StrCmp (First, mDbName), 0);
+}
+
+// ---------------------------------------------------------------------------
+// AssignVendorGuid
+// ---------------------------------------------------------------------------
+
+class AssignVendorGuidTest : public ::testing::Test {
+};
+
+TEST_F (AssignVendorGuidTest, NullGuid_ReturnsNull) {
+  EXPECT_EQ (AssignVendorGuid (NULL), nullptr);
+}
+
+TEST_F (AssignVendorGuidTest, UnknownGuid_ReturnsNull) {
+  EXPECT_EQ (AssignVendorGuid (&mNonAuthorityGuid), nullptr);
+}
+
+TEST_F (AssignVendorGuidTest, KnownGuid_ReturnsCanonicalStorage) {
+  EFI_GUID  Local;
+
+  CopyGuid (&Local, &gEfiImageSecurityDatabaseGuid);
+
+  EFI_GUID  *First  = AssignVendorGuid (&Local);
+  EFI_GUID  *Second = AssignVendorGuid (&gEfiImageSecurityDatabaseGuid);
+
+  EXPECT_NE (First, nullptr);
+  EXPECT_NE (First, &Local);
+  EXPECT_EQ (First, Second);
+  EXPECT_TRUE (CompareGuid (First, &gEfiImageSecurityDatabaseGuid));
+}
+
+// ---------------------------------------------------------------------------
+// IsSecureAuthorityVariable
+// ---------------------------------------------------------------------------
+
+class IsSecureAuthorityVariableTest : public ::testing::Test {
+};
+
+TEST_F (IsSecureAuthorityVariableTest, NullArgs_ReturnFalse) {
+  EXPECT_FALSE (IsSecureAuthorityVariable (NULL, &gEfiImageSecurityDatabaseGuid));
+  EXPECT_FALSE (IsSecureAuthorityVariable (mDbName, NULL));
+}
+
+TEST_F (IsSecureAuthorityVariableTest, KnownNameAndGuid_ReturnsTrue) {
+  EXPECT_TRUE (IsSecureAuthorityVariable (mDbName, &gEfiImageSecurityDatabaseGuid));
+}
+
+TEST_F (IsSecureAuthorityVariableTest, KnownNameWrongGuid_ReturnsFalse) {
+  EXPECT_FALSE (IsSecureAuthorityVariable (mDbName, &mNonAuthorityGuid));
+}
+
+TEST_F (IsSecureAuthorityVariableTest, WrongNameKnownGuid_ReturnsFalse) {
+  EXPECT_FALSE (IsSecureAuthorityVariable (mNonAuthorityName, &gEfiImageSecurityDatabaseGuid));
+}
+
+// ---------------------------------------------------------------------------
+// IsDataMeasured / AddDataMeasured
+// ---------------------------------------------------------------------------
+
+class MeasuredListTest : public ::testing::Test {
+protected:
+  MEASURED_AUTHORITIES Measured = { NULL, 0, 0 };
+
+  void
+  TearDown (
+    ) override
+  {
+    FreeMeasured (Measured);
+  }
+};
+
+TEST_F (MeasuredListTest, IsDataMeasured_NullArgs_ReturnFalse) {
+  UINT8  Data[4] = { 1, 2, 3, 4 };
+
+  EXPECT_FALSE (IsDataMeasured (NULL, mDbName, &gEfiImageSecurityDatabaseGuid, Data, sizeof (Data)));
+  EXPECT_FALSE (IsDataMeasured (&Measured, NULL, &gEfiImageSecurityDatabaseGuid, Data, sizeof (Data)));
+  EXPECT_FALSE (IsDataMeasured (&Measured, mDbName, NULL, Data, sizeof (Data)));
+  EXPECT_FALSE (IsDataMeasured (&Measured, mDbName, &gEfiImageSecurityDatabaseGuid, NULL, sizeof (Data)));
+}
+
+TEST_F (MeasuredListTest, IsDataMeasured_EmptyList_ReturnsFalse) {
+  UINT8  Data[4] = { 1, 2, 3, 4 };
+
+  EXPECT_FALSE (
+    IsDataMeasured (&Measured, mDbName, &gEfiImageSecurityDatabaseGuid, Data, sizeof (Data))
+    );
+}
+
+TEST_F (MeasuredListTest, AddDataMeasured_NullOrZeroArgs_ReturnInvalidParameter) {
+  UINT8  Data[4] = { 1, 2, 3, 4 };
+
+  EXPECT_EQ (
+    AddDataMeasured (NULL, mDbName, &gEfiImageSecurityDatabaseGuid, Data, sizeof (Data)),
+    EFI_INVALID_PARAMETER
+    );
+  EXPECT_EQ (
+    AddDataMeasured (&Measured, NULL, &gEfiImageSecurityDatabaseGuid, Data, sizeof (Data)),
+    EFI_INVALID_PARAMETER
+    );
+  EXPECT_EQ (
+    AddDataMeasured (&Measured, mDbName, NULL, Data, sizeof (Data)),
+    EFI_INVALID_PARAMETER
+    );
+  EXPECT_EQ (
+    AddDataMeasured (&Measured, mDbName, &gEfiImageSecurityDatabaseGuid, NULL, sizeof (Data)),
+    EFI_INVALID_PARAMETER
+    );
+  EXPECT_EQ (
+    AddDataMeasured (&Measured, mDbName, &gEfiImageSecurityDatabaseGuid, Data, 0),
+    EFI_INVALID_PARAMETER
+    );
+
+  EXPECT_EQ (Measured.Count, (UINTN)0);
+}
+
+TEST_F (MeasuredListTest, AddDataMeasured_RecordsEntry) {
+  UINT8  Data[4] = { 1, 2, 3, 4 };
+
+  EXPECT_EQ (
+    AddDataMeasured (&Measured, mDbName, &gEfiImageSecurityDatabaseGuid, Data, sizeof (Data)),
+    EFI_SUCCESS
+    );
+
+  ASSERT_EQ (Measured.Count, (UINTN)1);
+  EXPECT_EQ (Measured.List[0].Size, (UINTN)sizeof (Data));
+
+  //
+  // A private copy of the data is stored, and the name / GUID are canonicalized
+  // to module-owned storage.
+  //
+  EXPECT_NE (Measured.List[0].Data, (VOID *)Data);
+  EXPECT_EQ (CompareMem (Measured.List[0].Data, Data, sizeof (Data)), 0);
+  EXPECT_EQ (Measured.List[0].VariableName, AssignVariableName (mDbName));
+  EXPECT_EQ (Measured.List[0].VendorGuid, AssignVendorGuid (&gEfiImageSecurityDatabaseGuid));
+}
+
+TEST_F (MeasuredListTest, IsDataMeasured_MatchingEntry_ReturnsTrue) {
+  UINT8  Data[4] = { 1, 2, 3, 4 };
+
+  ASSERT_EQ (
+    AddDataMeasured (&Measured, mDbName, &gEfiImageSecurityDatabaseGuid, Data, sizeof (Data)),
+    EFI_SUCCESS
+    );
+
+  EXPECT_TRUE (
+    IsDataMeasured (&Measured, mDbName, &gEfiImageSecurityDatabaseGuid, Data, sizeof (Data))
+    );
+}
+
+TEST_F (MeasuredListTest, IsDataMeasured_DifferentSize_ReturnsFalse) {
+  UINT8  Data[4] = { 1, 2, 3, 4 };
+
+  ASSERT_EQ (
+    AddDataMeasured (&Measured, mDbName, &gEfiImageSecurityDatabaseGuid, Data, sizeof (Data)),
+    EFI_SUCCESS
+    );
+
+  EXPECT_FALSE (
+    IsDataMeasured (&Measured, mDbName, &gEfiImageSecurityDatabaseGuid, Data, sizeof (Data) - 1)
+    );
+}
+
+TEST_F (MeasuredListTest, IsDataMeasured_DifferentData_ReturnsFalse) {
+  UINT8  Data[4]  = { 1, 2, 3, 4 };
+  UINT8  Other[4] = { 1, 2, 3, 5 };
+
+  ASSERT_EQ (
+    AddDataMeasured (&Measured, mDbName, &gEfiImageSecurityDatabaseGuid, Data, sizeof (Data)),
+    EFI_SUCCESS
+    );
+
+  EXPECT_FALSE (
+    IsDataMeasured (&Measured, mDbName, &gEfiImageSecurityDatabaseGuid, Other, sizeof (Other))
+    );
+}
+
+TEST_F (MeasuredListTest, IsDataMeasured_DifferentGuid_ReturnsFalse) {
+  UINT8  Data[4] = { 1, 2, 3, 4 };
+
+  ASSERT_EQ (
+    AddDataMeasured (&Measured, mDbName, &gEfiImageSecurityDatabaseGuid, Data, sizeof (Data)),
+    EFI_SUCCESS
+    );
+
+  EXPECT_FALSE (
+    IsDataMeasured (&Measured, mDbName, &mNonAuthorityGuid, Data, sizeof (Data))
+    );
+}
+
+TEST_F (MeasuredListTest, AddDataMeasured_GrowsListAcrossIncrement) {
+  //
+  // Add one more than the growth increment so the backing list must be
+  // reallocated at least once, and confirm every entry remains tracked.
+  //
+  const UINTN  Total = TEST_AUTHORITY_COUNT_INCREMENT + 1;
+
+  for (UINTN Index = 0; Index < Total; Index++) {
+    UINT32  Data = (UINT32)Index;
+
+    ASSERT_EQ (
+      AddDataMeasured (&Measured, mDbName, &gEfiImageSecurityDatabaseGuid, &Data, sizeof (Data)),
+      EFI_SUCCESS
+      );
+  }
+
+  EXPECT_EQ (Measured.Count, Total);
+  EXPECT_GE (Measured.Max, Total);
+
+  for (UINTN Index = 0; Index < Total; Index++) {
+    UINT32  Data = (UINT32)Index;
+
+    EXPECT_TRUE (
+      IsDataMeasured (&Measured, mDbName, &gEfiImageSecurityDatabaseGuid, &Data, sizeof (Data))
+      );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// MeasureVariable
+// ---------------------------------------------------------------------------
+
+class MeasureVariableTest : public ::testing::Test {
+protected:
+  MockTpmMeasurementLib TpmMock;
+};
+
+TEST_F (MeasureVariableTest, NullArgs_ReturnInvalidParameter) {
+  UINT8  Data[4] = { 1, 2, 3, 4 };
+
+  EXPECT_EQ (
+    MeasureVariable (NULL, &gEfiImageSecurityDatabaseGuid, Data, sizeof (Data)),
+    EFI_INVALID_PARAMETER
+    );
+  EXPECT_EQ (
+    MeasureVariable (mDbName, NULL, Data, sizeof (Data)),
+    EFI_INVALID_PARAMETER
+    );
+  EXPECT_EQ (
+    MeasureVariable (mDbName, &gEfiImageSecurityDatabaseGuid, NULL, sizeof (Data)),
+    EFI_INVALID_PARAMETER
+    );
+}
+
+TEST_F (MeasureVariableTest, Success_ExtendsPcr7AsVariableAuthority) {
+  UINT8  Data[4] = { 1, 2, 3, 4 };
+
+  EXPECT_CALL (
+    TpmMock,
+    TpmMeasureAndLogData (
+      (UINT32)7,
+      (UINT32)EV_EFI_VARIABLE_AUTHORITY,
+      _,
+      _,
+      _,
+      _
+      )
+    )
+    .WillOnce (Return (EFI_SUCCESS));
+
+  EXPECT_EQ (
+    MeasureVariable (mDbName, &gEfiImageSecurityDatabaseGuid, Data, sizeof (Data)),
+    EFI_SUCCESS
+    );
+}
+
+TEST_F (MeasureVariableTest, MeasureFails_PropagatesError) {
+  UINT8  Data[4] = { 1, 2, 3, 4 };
+
+  EXPECT_CALL (TpmMock, TpmMeasureAndLogData (_, _, _, _, _, _))
+    .WillOnce (Return (EFI_DEVICE_ERROR));
+
+  EXPECT_EQ (
+    MeasureVariable (mDbName, &gEfiImageSecurityDatabaseGuid, Data, sizeof (Data)),
+    EFI_DEVICE_ERROR
+    );
+}
+
+// ---------------------------------------------------------------------------
+// SecureBootHook
+// ---------------------------------------------------------------------------
+
+class SecureBootHookTest : public ::testing::Test {
+protected:
+  MockTpmMeasurementLib TpmMock;
+  MEASURED_AUTHORITIES Measured = { NULL, 0, 0 };
+
+  void
+  TearDown (
+    ) override
+  {
+    FreeMeasured (Measured);
+  }
+
+  static IMAGE_AUTHORITY
+  MakeAuthority (
+    EFI_SIGNATURE_DATA  *Data,
+    UINTN               Size
+    )
+  {
+    IMAGE_AUTHORITY  Authority;
+
+    Authority.Data = Data;
+    Authority.Size = Size;
+    return Authority;
+  }
+};
+
+TEST_F (SecureBootHookTest, NullMeasured_NoOp) {
+  UINT8            Data[8]   = { 0 };
+  IMAGE_AUTHORITY  Authority = MakeAuthority ((EFI_SIGNATURE_DATA *)Data, sizeof (Data));
+
+  EXPECT_CALL (TpmMock, TpmMeasureAndLogData (_, _, _, _, _, _)).Times (0);
+
+  SecureBootHook (NULL, mDbName, &gEfiImageSecurityDatabaseGuid, &Authority);
+}
+
+TEST_F (SecureBootHookTest, NullAuthority_NoOp) {
+  EXPECT_CALL (TpmMock, TpmMeasureAndLogData (_, _, _, _, _, _)).Times (0);
+
+  SecureBootHook (&Measured, mDbName, &gEfiImageSecurityDatabaseGuid, NULL);
+  EXPECT_EQ (Measured.Count, (UINTN)0);
+}
+
+TEST_F (SecureBootHookTest, AuthorityWithNullDataOrZeroSize_NoOp) {
+  UINT8            Data[8]  = { 0 };
+  IMAGE_AUTHORITY  NullData = MakeAuthority (NULL, sizeof (Data));
+  IMAGE_AUTHORITY  ZeroSize = MakeAuthority ((EFI_SIGNATURE_DATA *)Data, 0);
+
+  EXPECT_CALL (TpmMock, TpmMeasureAndLogData (_, _, _, _, _, _)).Times (0);
+
+  SecureBootHook (&Measured, mDbName, &gEfiImageSecurityDatabaseGuid, &NullData);
+  SecureBootHook (&Measured, mDbName, &gEfiImageSecurityDatabaseGuid, &ZeroSize);
+  EXPECT_EQ (Measured.Count, (UINTN)0);
+}
+
+TEST_F (SecureBootHookTest, NonAuthorityVariable_NoOp) {
+  UINT8            Data[8]   = { 0 };
+  IMAGE_AUTHORITY  Authority = MakeAuthority ((EFI_SIGNATURE_DATA *)Data, sizeof (Data));
+
+  EXPECT_CALL (TpmMock, TpmMeasureAndLogData (_, _, _, _, _, _)).Times (0);
+
+  SecureBootHook (&Measured, mNonAuthorityName, &gEfiImageSecurityDatabaseGuid, &Authority);
+  EXPECT_EQ (Measured.Count, (UINTN)0);
+}
+
+TEST_F (SecureBootHookTest, FirstMeasure_RecordsAndExtends) {
+  UINT8            Data[8]   = { 1, 2, 3, 4, 5, 6, 7, 8 };
+  IMAGE_AUTHORITY  Authority = MakeAuthority ((EFI_SIGNATURE_DATA *)Data, sizeof (Data));
+
+  EXPECT_CALL (
+    TpmMock,
+    TpmMeasureAndLogData ((UINT32)7, (UINT32)EV_EFI_VARIABLE_AUTHORITY, _, _, _, _)
+    )
+    .WillOnce (Return (EFI_SUCCESS));
+
+  SecureBootHook (&Measured, mDbName, &gEfiImageSecurityDatabaseGuid, &Authority);
+
+  EXPECT_EQ (Measured.Count, (UINTN)1);
+  EXPECT_TRUE (
+    IsDataMeasured (&Measured, mDbName, &gEfiImageSecurityDatabaseGuid, Data, sizeof (Data))
+    );
+}
+
+TEST_F (SecureBootHookTest, DuplicateMeasure_ExtendsOnce) {
+  UINT8            Data[8]   = { 1, 2, 3, 4, 5, 6, 7, 8 };
+  IMAGE_AUTHORITY  Authority = MakeAuthority ((EFI_SIGNATURE_DATA *)Data, sizeof (Data));
+
+  //
+  // An already-measured authority must not be extended a second time.
+  //
+  EXPECT_CALL (
+    TpmMock,
+    TpmMeasureAndLogData ((UINT32)7, (UINT32)EV_EFI_VARIABLE_AUTHORITY, _, _, _, _)
+    )
+    .Times (1)
+    .WillOnce (Return (EFI_SUCCESS));
+
+  SecureBootHook (&Measured, mDbName, &gEfiImageSecurityDatabaseGuid, &Authority);
+  SecureBootHook (&Measured, mDbName, &gEfiImageSecurityDatabaseGuid, &Authority);
+
+  EXPECT_EQ (Measured.Count, (UINTN)1);
+}
+
+TEST_F (SecureBootHookTest, MeasureFails_NotRecorded) {
+  UINT8            Data[8]   = { 1, 2, 3, 4, 5, 6, 7, 8 };
+  IMAGE_AUTHORITY  Authority = MakeAuthority ((EFI_SIGNATURE_DATA *)Data, sizeof (Data));
+
+  EXPECT_CALL (TpmMock, TpmMeasureAndLogData (_, _, _, _, _, _))
+    .WillOnce (Return (EFI_DEVICE_ERROR));
+
+  SecureBootHook (&Measured, mDbName, &gEfiImageSecurityDatabaseGuid, &Authority);
+
+  EXPECT_EQ (Measured.Count, (UINTN)0);
+  EXPECT_FALSE (
+    IsDataMeasured (&Measured, mDbName, &gEfiImageSecurityDatabaseGuid, Data, sizeof (Data))
+    );
+}

--- a/SecurityPkg/Library/DxeImageVerificationLib2/GoogleTest/PolicyGoogleTest.cpp
+++ b/SecurityPkg/Library/DxeImageVerificationLib2/GoogleTest/PolicyGoogleTest.cpp
@@ -1,0 +1,215 @@
+/** @file
+  Unit tests for the Image Verification Library policy resolution helpers.
+  Copyright (C) Microsoft Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/GoogleTestLib.h>
+#include <GoogleTest/Library/MockUefiBootServicesTableLib.h>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <Library/BaseLib.h>
+  #include <Library/BaseMemoryLib.h>
+  #include <Library/DebugLib.h>
+  #include <Protocol/DevicePath.h>
+
+  //
+  // Authorization policy bit definition
+  //
+  #define ALWAYS_EXECUTE                      0x00000000
+  #define DENY_EXECUTE_ON_SECURITY_VIOLATION  0x00000001
+
+  //
+  // Image type definitions
+  //
+  #define IMAGE_UNKNOWN  0x00000000
+  #define IMAGE_FROM_FV  0x00000001
+
+  EFI_STATUS
+  IsFromFv (
+    IN  CONST EFI_DEVICE_PATH_PROTOCOL  *File
+    );
+
+  EFI_STATUS
+  GetImageType (
+    IN  CONST EFI_DEVICE_PATH_PROTOCOL  *File,
+    OUT UINT32                          *ImageType
+    );
+
+  UINT32
+  GetPolicyForImageType (
+    IN UINT32  ImageType
+    );
+
+  EFI_STATUS
+  GetExecutionPolicy (
+    IN  CONST EFI_DEVICE_PATH_PROTOCOL  *File,
+    OUT UINT32                          *Policy
+    );
+}
+
+using ::testing::_;
+using ::testing::Return;
+
+//
+// A minimal stand-in for an EFI_DEVICE_PATH_PROTOCOL. The address is the
+// only thing the helpers care about because LocateDevicePath /
+// OpenProtocol are fully mocked.
+//
+static EFI_DEVICE_PATH_PROTOCOL  mDevicePath;
+
+class PolicyTest : public ::testing::Test {
+protected:
+  MockUefiBootServicesTableLib BsMock;
+};
+
+// ---------------------------------------------------------------------------
+// IsFromFv
+// ---------------------------------------------------------------------------
+
+TEST_F (PolicyTest, IsFromFv_NullArg_ReturnsInvalidParameter) {
+  EXPECT_EQ (IsFromFv (NULL), EFI_INVALID_PARAMETER);
+}
+
+TEST_F (PolicyTest, IsFromFv_LocateFails_ReturnsNotFound) {
+  EXPECT_CALL (BsMock, gBS_LocateDevicePath)
+    .WillOnce (Return (EFI_NOT_FOUND));
+
+  EXPECT_EQ (IsFromFv (&mDevicePath), EFI_NOT_FOUND);
+}
+
+TEST_F (PolicyTest, IsFromFv_OpenFails_ReturnsNotFound) {
+  EXPECT_CALL (BsMock, gBS_LocateDevicePath)
+    .WillOnce (Return (EFI_SUCCESS));
+  EXPECT_CALL (BsMock, gBS_OpenProtocol)
+    .WillOnce (Return (EFI_UNSUPPORTED));
+
+  EXPECT_EQ (IsFromFv (&mDevicePath), EFI_NOT_FOUND);
+}
+
+TEST_F (PolicyTest, IsFromFv_Success_ReturnsSuccess) {
+  EXPECT_CALL (BsMock, gBS_LocateDevicePath)
+    .WillOnce (Return (EFI_SUCCESS));
+  EXPECT_CALL (BsMock, gBS_OpenProtocol)
+    .WillOnce (Return (EFI_SUCCESS));
+
+  EXPECT_EQ (IsFromFv (&mDevicePath), EFI_SUCCESS);
+}
+
+// ---------------------------------------------------------------------------
+// GetImageType
+// ---------------------------------------------------------------------------
+
+TEST_F (PolicyTest, GetImageType_NullArgs_ReturnsInvalidParameter) {
+  UINT32  ImageType = IMAGE_UNKNOWN;
+
+  EXPECT_EQ (GetImageType (NULL, &ImageType), EFI_INVALID_PARAMETER);
+  EXPECT_EQ (GetImageType (&mDevicePath, NULL), EFI_INVALID_PARAMETER);
+}
+
+TEST_F (PolicyTest, GetImageType_FirmwareVolume_ReturnsFv) {
+  UINT32  ImageType = IMAGE_UNKNOWN;
+
+  EXPECT_CALL (BsMock, gBS_LocateDevicePath)
+    .WillOnce (Return (EFI_SUCCESS));
+  EXPECT_CALL (BsMock, gBS_OpenProtocol)
+    .WillOnce (Return (EFI_SUCCESS));
+
+  EXPECT_EQ (GetImageType (&mDevicePath, &ImageType), EFI_SUCCESS);
+  EXPECT_EQ (ImageType, (UINT32)IMAGE_FROM_FV);
+}
+
+TEST_F (PolicyTest, GetImageType_NotFv_ReturnsUnknown) {
+  UINT32  ImageType = IMAGE_FROM_FV; // Pre-populate to confirm reset.
+
+  EXPECT_CALL (BsMock, gBS_LocateDevicePath)
+    .WillOnce (Return (EFI_NOT_FOUND));
+
+  EXPECT_EQ (GetImageType (&mDevicePath, &ImageType), EFI_SUCCESS);
+  EXPECT_EQ (ImageType, (UINT32)IMAGE_UNKNOWN);
+}
+
+TEST_F (PolicyTest, GetImageType_LocateSucceedsOpenFails_ReturnsUnknown) {
+  //
+  // Exercises the OpenProtocol-failure branch of IsFromFv via the
+  // GetImageType orchestrator: LocateDevicePath resolves a handle but
+  // the protocol is not actually present.
+  //
+  UINT32  ImageType = IMAGE_FROM_FV;
+
+  EXPECT_CALL (BsMock, gBS_LocateDevicePath)
+    .WillOnce (Return (EFI_SUCCESS));
+  EXPECT_CALL (BsMock, gBS_OpenProtocol)
+    .WillOnce (Return (EFI_UNSUPPORTED));
+
+  EXPECT_EQ (GetImageType (&mDevicePath, &ImageType), EFI_SUCCESS);
+  EXPECT_EQ (ImageType, (UINT32)IMAGE_UNKNOWN);
+}
+
+// ---------------------------------------------------------------------------
+// GetPolicyForImageType
+// ---------------------------------------------------------------------------
+
+TEST_F (PolicyTest, GetPolicyForImageType_Fv_ReturnsAlwaysExecute) {
+  EXPECT_EQ (GetPolicyForImageType (IMAGE_FROM_FV), (UINT32)ALWAYS_EXECUTE);
+}
+
+TEST_F (PolicyTest, GetPolicyForImageType_Unknown_FailsClosed) {
+  EXPECT_EQ (
+    GetPolicyForImageType (IMAGE_UNKNOWN),
+    (UINT32)DENY_EXECUTE_ON_SECURITY_VIOLATION
+    );
+}
+
+TEST_F (PolicyTest, GetPolicyForImageType_OtherValue_FailsClosed) {
+  EXPECT_EQ (
+    GetPolicyForImageType (0xDEADBEEF),
+    (UINT32)DENY_EXECUTE_ON_SECURITY_VIOLATION
+    );
+}
+
+// ---------------------------------------------------------------------------
+// GetExecutionPolicy
+// ---------------------------------------------------------------------------
+
+TEST_F (PolicyTest, GetExecutionPolicy_NullArgs_ReturnsInvalidParameter) {
+  UINT32  Policy = ALWAYS_EXECUTE;
+
+  EXPECT_EQ (GetExecutionPolicy (NULL, &Policy), EFI_INVALID_PARAMETER);
+  EXPECT_EQ (GetExecutionPolicy (&mDevicePath, NULL), EFI_INVALID_PARAMETER);
+}
+
+TEST_F (PolicyTest, GetExecutionPolicy_FirmwareVolume_ReturnsAlwaysExecute) {
+  UINT32  Policy = DENY_EXECUTE_ON_SECURITY_VIOLATION;
+
+  EXPECT_CALL (BsMock, gBS_LocateDevicePath)
+    .WillOnce (Return (EFI_SUCCESS));
+  EXPECT_CALL (BsMock, gBS_OpenProtocol)
+    .WillOnce (Return (EFI_SUCCESS));
+
+  EXPECT_EQ (GetExecutionPolicy (&mDevicePath, &Policy), EFI_SUCCESS);
+  EXPECT_EQ (Policy, (UINT32)ALWAYS_EXECUTE);
+}
+
+TEST_F (PolicyTest, GetExecutionPolicy_NonFv_FailsClosed) {
+  UINT32  Policy = ALWAYS_EXECUTE;
+
+  EXPECT_CALL (BsMock, gBS_LocateDevicePath)
+    .WillOnce (Return (EFI_NOT_FOUND));
+
+  EXPECT_EQ (GetExecutionPolicy (&mDevicePath, &Policy), EFI_SUCCESS);
+  EXPECT_EQ (Policy, (UINT32)DENY_EXECUTE_ON_SECURITY_VIOLATION);
+}
+
+TEST_F (PolicyTest, GetExecutionPolicy_LocateSucceedsOpenFails_FailsClosed) {
+  UINT32  Policy = ALWAYS_EXECUTE;
+
+  EXPECT_CALL (BsMock, gBS_LocateDevicePath)
+    .WillOnce (Return (EFI_SUCCESS));
+  EXPECT_CALL (BsMock, gBS_OpenProtocol)
+    .WillOnce (Return (EFI_ACCESS_DENIED));
+
+  EXPECT_EQ (GetExecutionPolicy (&mDevicePath, &Policy), EFI_SUCCESS);
+  EXPECT_EQ (Policy, (UINT32)DENY_EXECUTE_ON_SECURITY_VIOLATION);
+}

--- a/SecurityPkg/Library/DxeImageVerificationLib2/GoogleTest/SupportGoogleTest.cpp
+++ b/SecurityPkg/Library/DxeImageVerificationLib2/GoogleTest/SupportGoogleTest.cpp
@@ -1,0 +1,786 @@
+/** @file
+  Unit tests for GetImageSecurityDataDirectory in the
+  DxeImageVerificationLib.
+  These tests construct minimal-but-valid PE/COFF images in memory and
+  exercise the real PeCoffLib through GetImageSecurityDataDirectory so
+  that the security-data-directory capture path is covered end-to-end.
+  Copyright (C) Microsoft Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Library/GoogleTestLib.h>
+#include <GoogleTest/Library/MockBaseCryptLib.h>
+
+#include <vector>
+#include <cstring>
+
+extern "C" {
+  #include <Uefi.h>
+  #include <IndustryStandard/PeImage.h>
+  #include <Library/BaseMemoryLib.h>
+  #include "../Support.h"
+}
+
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::Return;
+
+static bool
+GetImageHashIndexForTest (
+  const EFI_GUID  *Guid,
+  UINTN           *Index
+  )
+{
+  UINTN  I;
+
+  if ((Guid == nullptr) || (Index == nullptr)) {
+    return false;
+  }
+
+  for (I = 0; I < ARRAY_SIZE (mHashAlgorithms); I++) {
+    if (CompareGuid (Guid, mHashAlgorithms[I].ImageHashGuid)) {
+      *Index = I;
+      return true;
+    }
+  }
+
+  return false;
+}
+
+static bool
+GetX509HashIndexForTest (
+  const EFI_GUID  *Guid,
+  UINTN           *Index
+  )
+{
+  UINTN  I;
+
+  if ((Guid == nullptr) || (Index == nullptr)) {
+    return false;
+  }
+
+  for (I = 0; I < ARRAY_SIZE (mHashAlgorithms); I++) {
+    if (CompareGuid (Guid, mHashAlgorithms[I].X509CertHashGuid)) {
+      *Index = I;
+      return true;
+    }
+  }
+
+  return false;
+}
+
+//
+// Layout constants for the synthetic PE32+ image.
+//
+// The buffer is a single contiguous blob laid out as:
+//   [DOS hdr][NT64 hdrs][1 section hdr][padding to SizeOfHeaders][image body]
+//
+// All sizes are picked to satisfy PeCoffLoaderGetImageInfo's
+// consistency checks (NumberOfRvaAndSizes, SizeOfOptionalHeader,
+// SectionHeaderOffset, SizeOfHeaders < SizeOfImage, last-byte reads of
+// SizeOfHeaders and the security directory).
+//
+static constexpr UINT32  kDosHdrSize    = sizeof (EFI_IMAGE_DOS_HEADER);
+static constexpr UINT32  kNt64Size      = sizeof (EFI_IMAGE_NT_HEADERS64);
+static constexpr UINT32  kPeCoffOffset  = kDosHdrSize;
+static constexpr UINT32  kSizeOfHeaders = 0x200;
+static constexpr UINT32  kSizeOfImage   = 0x400;
+static constexpr UINT32  kSecDirVa      = 0x300;
+static constexpr UINT32  kSecDirSize    = 0x100;
+
+/**
+  Build a minimal valid PE32+ image in heap-backed storage.
+  When IncludeSecurityDir is true, the returned image's
+  EFI_IMAGE_DIRECTORY_ENTRY_SECURITY entry points at [kSecDirVa,
+  kSecDirVa + kSecDirSize). Otherwise that entry is left zero.
+**/
+static std::vector<UINT8>
+BuildPe32PlusImage (
+  bool  IncludeSecurityDir
+  )
+{
+  std::vector<UINT8>  Image (kSizeOfImage, 0);
+
+  EFI_IMAGE_DOS_HEADER    *Dos = (EFI_IMAGE_DOS_HEADER *)Image.data ();
+  EFI_IMAGE_NT_HEADERS64  *Nt  = (EFI_IMAGE_NT_HEADERS64 *)(Image.data () + kPeCoffOffset);
+
+  Dos->e_magic  = EFI_IMAGE_DOS_SIGNATURE;
+  Dos->e_lfanew = kPeCoffOffset;
+
+  Nt->Signature                          = EFI_IMAGE_NT_SIGNATURE;
+  Nt->FileHeader.Machine                 = IMAGE_FILE_MACHINE_X64;
+  Nt->FileHeader.NumberOfSections        = 1;
+  Nt->FileHeader.SizeOfOptionalHeader    = sizeof (EFI_IMAGE_OPTIONAL_HEADER64);
+  Nt->OptionalHeader.Magic               = EFI_IMAGE_NT_OPTIONAL_HDR64_MAGIC;
+  Nt->OptionalHeader.SizeOfImage         = kSizeOfImage;
+  Nt->OptionalHeader.SizeOfHeaders       = kSizeOfHeaders;
+  Nt->OptionalHeader.SectionAlignment    = 0x200;
+  Nt->OptionalHeader.NumberOfRvaAndSizes = EFI_IMAGE_NUMBER_OF_DIRECTORY_ENTRIES;
+
+  if (IncludeSecurityDir) {
+    Nt->OptionalHeader.DataDirectory[EFI_IMAGE_DIRECTORY_ENTRY_SECURITY].VirtualAddress = kSecDirVa;
+    Nt->OptionalHeader.DataDirectory[EFI_IMAGE_DIRECTORY_ENTRY_SECURITY].Size           = kSecDirSize;
+  }
+
+  return Image;
+}
+
+class GetImageSecurityDataDirectoryTest : public ::testing::Test {
+};
+
+// ---------------------------------------------------------------------------
+// Argument validation
+// ---------------------------------------------------------------------------
+
+TEST_F (GetImageSecurityDataDirectoryTest, NullFileBuffer_ReturnsInvalidParameter) {
+  EFI_IMAGE_DATA_DIRECTORY  SecDataDir;
+
+  EXPECT_EQ (
+    GetImageSecurityDataDirectory (NULL, 0x100, &SecDataDir),
+    EFI_INVALID_PARAMETER
+    );
+}
+
+TEST_F (GetImageSecurityDataDirectoryTest, NullSecDataDir_ReturnsInvalidParameter) {
+  std::vector<UINT8>  Image = BuildPe32PlusImage (false);
+
+  EXPECT_EQ (
+    GetImageSecurityDataDirectory (Image.data (), Image.size (), NULL),
+    EFI_INVALID_PARAMETER
+    );
+}
+
+TEST_F (GetImageSecurityDataDirectoryTest, NullFileBuffer_DoesNotTouchSecDataDir) {
+  //
+  // Caller-supplied SecDataDir must be untouched on the early
+  // invalid-parameter return; only the success path is allowed to
+  // overwrite it.
+  //
+  EFI_IMAGE_DATA_DIRECTORY  SecDataDir;
+
+  SetMem (&SecDataDir, sizeof (SecDataDir), 0xAA);
+
+  EXPECT_EQ (
+    GetImageSecurityDataDirectory (NULL, 0x100, &SecDataDir),
+    EFI_INVALID_PARAMETER
+    );
+  EXPECT_EQ (SecDataDir.VirtualAddress, 0xAAAAAAAAu);
+  EXPECT_EQ (SecDataDir.Size, 0xAAAAAAAAu);
+}
+
+// ---------------------------------------------------------------------------
+// Malformed images
+// ---------------------------------------------------------------------------
+
+TEST_F (GetImageSecurityDataDirectoryTest, GarbageBuffer_ReturnsLoadError) {
+  //
+  // A buffer that is large enough to attempt header parsing but does
+  // not actually carry valid DOS/NT signatures must be rejected.
+  //
+  std::vector<UINT8>        Buffer (kSizeOfImage, 0xAB);
+  EFI_IMAGE_DATA_DIRECTORY  SecDataDir;
+
+  EXPECT_EQ (
+    GetImageSecurityDataDirectory (Buffer.data (), Buffer.size (), &SecDataDir),
+    EFI_LOAD_ERROR
+    );
+}
+
+TEST_F (GetImageSecurityDataDirectoryTest, TinyBuffer_ReturnsLoadError) {
+  //
+  // A buffer too small to contain a DOS header must be rejected
+  // without dereferencing any of the bytes.
+  //
+  UINT8                     TinyBuffer[4] = { 0 };
+  EFI_IMAGE_DATA_DIRECTORY  SecDataDir;
+
+  EXPECT_EQ (
+    GetImageSecurityDataDirectory (TinyBuffer, sizeof (TinyBuffer), &SecDataDir),
+    EFI_LOAD_ERROR
+    );
+}
+
+TEST_F (GetImageSecurityDataDirectoryTest, ZeroFileSize_ReturnsLoadError) {
+  UINT8                     Byte = 0;
+  EFI_IMAGE_DATA_DIRECTORY  SecDataDir;
+
+  EXPECT_EQ (
+    GetImageSecurityDataDirectory (&Byte, 0, &SecDataDir),
+    EFI_LOAD_ERROR
+    );
+}
+
+TEST_F (GetImageSecurityDataDirectoryTest, ElfanewPastEof_ReturnsLoadError) {
+  //
+  // Valid DOS signature but e_lfanew points well past the end of the
+  // buffer. The bounded reader must refuse to fetch the NT headers.
+  //
+  std::vector<UINT8>    Image = BuildPe32PlusImage (false);
+  EFI_IMAGE_DOS_HEADER  *Dos  = (EFI_IMAGE_DOS_HEADER *)Image.data ();
+
+  Dos->e_lfanew = (UINT32)(Image.size () + 0x1000);
+
+  EFI_IMAGE_DATA_DIRECTORY  SecDataDir;
+
+  EXPECT_EQ (
+    GetImageSecurityDataDirectory (Image.data (), Image.size (), &SecDataDir),
+    EFI_LOAD_ERROR
+    );
+}
+
+TEST_F (GetImageSecurityDataDirectoryTest, TruncatedAtNtHeaders_ReturnsLoadError) {
+  //
+  // Buffer is truncated to the DOS header only, so the read of the NT
+  // headers at e_lfanew straddles EOF.
+  //
+  std::vector<UINT8>  Image = BuildPe32PlusImage (false);
+
+  Image.resize (sizeof (EFI_IMAGE_DOS_HEADER));
+
+  EFI_IMAGE_DATA_DIRECTORY  SecDataDir;
+
+  EXPECT_EQ (
+    GetImageSecurityDataDirectory (Image.data (), Image.size (), &SecDataDir),
+    EFI_LOAD_ERROR
+    );
+}
+
+TEST_F (GetImageSecurityDataDirectoryTest, ValidDosBadNtSignature_ReturnsLoadError) {
+  //
+  // Valid DOS header but corrupted NT signature -- exercises the NT
+  // signature validation path inside PeCoffLib.
+  //
+  std::vector<UINT8>      Image = BuildPe32PlusImage (false);
+  EFI_IMAGE_NT_HEADERS64  *Nt   = (EFI_IMAGE_NT_HEADERS64 *)(Image.data () + kPeCoffOffset);
+
+  Nt->Signature = 0xDEADBEEF;
+
+  EFI_IMAGE_DATA_DIRECTORY  SecDataDir;
+
+  EXPECT_EQ (
+    GetImageSecurityDataDirectory (Image.data (), Image.size (), &SecDataDir),
+    EFI_LOAD_ERROR
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Happy paths exercised through real PeCoffLib security-directory capture
+// ---------------------------------------------------------------------------
+
+TEST_F (GetImageSecurityDataDirectoryTest, ValidImageWithoutSecurityDir_ReturnsZeroedDir) {
+  std::vector<UINT8>        Image = BuildPe32PlusImage (false);
+  EFI_IMAGE_DATA_DIRECTORY  SecDataDir;
+
+  //
+  // Pre-poison SecDataDir so we can prove the function actually wrote
+  // back zeros (rather than leaving stale caller-supplied bytes).
+  //
+  SetMem (&SecDataDir, sizeof (SecDataDir), 0xCD);
+
+  EXPECT_EQ (
+    GetImageSecurityDataDirectory (Image.data (), Image.size (), &SecDataDir),
+    EFI_SUCCESS
+    );
+  EXPECT_EQ (SecDataDir.VirtualAddress, 0u);
+  EXPECT_EQ (SecDataDir.Size, 0u);
+}
+
+TEST_F (GetImageSecurityDataDirectoryTest, ValidImageWithSecurityDir_ReturnsCapturedDir) {
+  std::vector<UINT8>        Image = BuildPe32PlusImage (true);
+  EFI_IMAGE_DATA_DIRECTORY  SecDataDir;
+
+  EXPECT_EQ (
+    GetImageSecurityDataDirectory (Image.data (), Image.size (), &SecDataDir),
+    EFI_SUCCESS
+    );
+  EXPECT_EQ (SecDataDir.VirtualAddress, kSecDirVa);
+  EXPECT_EQ (SecDataDir.Size, kSecDirSize);
+}
+
+TEST_F (GetImageSecurityDataDirectoryTest, OtherDataDirectoriesDoNotLeak) {
+  //
+  // Populate a non-SECURITY data directory entry (export table) with
+  // a recognizable value to prove PeCoffLib only records the SECURITY
+  // entry and ignores every other directory it walks.
+  //
+  std::vector<UINT8>      Image = BuildPe32PlusImage (true);
+  EFI_IMAGE_NT_HEADERS64  *Nt   = (EFI_IMAGE_NT_HEADERS64 *)(Image.data () + kPeCoffOffset);
+
+  Nt->OptionalHeader.DataDirectory[EFI_IMAGE_DIRECTORY_ENTRY_EXPORT].VirtualAddress = 0xCAFEBABE;
+  Nt->OptionalHeader.DataDirectory[EFI_IMAGE_DIRECTORY_ENTRY_EXPORT].Size           = 0xBEEFu;
+
+  EFI_IMAGE_DATA_DIRECTORY  SecDataDir;
+
+  EXPECT_EQ (
+    GetImageSecurityDataDirectory (Image.data (), Image.size (), &SecDataDir),
+    EFI_SUCCESS
+    );
+  EXPECT_EQ (SecDataDir.VirtualAddress, kSecDirVa);
+  EXPECT_EQ (SecDataDir.Size, kSecDirSize);
+}
+
+// ---------------------------------------------------------------------------
+// GetHash
+// ---------------------------------------------------------------------------
+
+TEST (GetHashTest, NullParameters_ReturnsInvalidParameter) {
+  DIGEST_CACHE  Cache;
+  CONST UINT8   *Digest    = NULL;
+  UINTN         DigestSize = 0;
+
+  ZeroMem (&Cache, sizeof (Cache));
+  Cache.Buffer     = (CONST VOID *)(UINTN)1;
+  Cache.BufferSize = 1;
+
+  EXPECT_EQ (GetHash (NULL, &Cache, &Digest, &DigestSize), EFI_INVALID_PARAMETER);
+  EXPECT_EQ (GetHash (&gEfiCertSha256Guid, NULL, &Digest, &DigestSize), EFI_INVALID_PARAMETER);
+  EXPECT_EQ (GetHash (&gEfiCertSha256Guid, &Cache, NULL, &DigestSize), EFI_INVALID_PARAMETER);
+  EXPECT_EQ (GetHash (&gEfiCertSha256Guid, &Cache, &Digest, NULL), EFI_INVALID_PARAMETER);
+}
+
+TEST (GetHashTest, CacheWithoutFileBuffer_ReturnsInvalidParameter) {
+  DIGEST_CACHE  Cache;
+  CONST UINT8   *Digest    = NULL;
+  UINTN         DigestSize = 0;
+
+  ZeroMem (&Cache, sizeof (Cache));
+
+  EXPECT_EQ (GetHash (&gEfiCertSha256Guid, &Cache, &Digest, &DigestSize), EFI_INVALID_PARAMETER);
+}
+
+TEST (GetHashTest, UnsupportedHashGuid_ReturnsUnsupported) {
+  EFI_GUID      UnknownGuid = {
+    0xA1B2C3D4,
+    0x9999,
+    0x8888,
+    { 0x10,    0x20,0x30, 0x40, 0x50, 0x60, 0x70, 0x80 }
+  };
+  DIGEST_CACHE  Cache;
+  CONST UINT8   *Digest    = NULL;
+  UINTN         DigestSize = 0;
+
+  ZeroMem (&Cache, sizeof (Cache));
+  Cache.Buffer     = (CONST VOID *)(UINTN)1;
+  Cache.BufferSize = 1;
+
+  EXPECT_EQ (GetHash (&UnknownGuid, &Cache, &Digest, &DigestSize), EFI_UNSUPPORTED);
+}
+
+TEST (GetHashTest, CacheHit_ReturnsExistingDigestBytes) {
+  DIGEST_CACHE  Cache;
+  CONST UINT8   *Digest    = NULL;
+  UINTN         DigestSize = 0;
+  UINTN         SlotIndex;
+  CONST UINT8   ExpectedDigest[] = { 0x10, 0x20, 0x30, 0x40 };
+
+  ZeroMem (&Cache, sizeof (Cache));
+  Cache.Buffer     = (CONST VOID *)(UINTN)1;
+  Cache.BufferSize = 1;
+
+  ASSERT_TRUE (GetImageHashIndexForTest (&gEfiCertSha256Guid, &SlotIndex));
+  CopyMem (Cache.Entries[SlotIndex].Bytes, ExpectedDigest, sizeof (ExpectedDigest));
+  Cache.Entries[SlotIndex].BufferSize = sizeof (ExpectedDigest);
+
+  EXPECT_EQ (GetHash (&gEfiCertSha256Guid, &Cache, &Digest, &DigestSize), EFI_SUCCESS);
+  ASSERT_NE (Digest, (CONST UINT8 *)NULL);
+  EXPECT_EQ (DigestSize, sizeof (ExpectedDigest));
+  EXPECT_EQ (CompareMem (Digest, ExpectedDigest, sizeof (ExpectedDigest)), 0);
+}
+
+TEST (GetHashTest, CacheMiss_ComputesAndCachesDigest) {
+  MockBaseCryptLib  BaseCryptLibMock;
+  DIGEST_CACHE      Cache;
+  CONST UINT8       *Digest    = NULL;
+  UINTN             DigestSize = 0;
+
+  ZeroMem (&Cache, sizeof (Cache));
+  Cache.Buffer     = (CONST VOID *)(UINTN)1;
+  Cache.BufferSize = 1;
+
+  EXPECT_CALL (BaseCryptLibMock, GetAuthenticodeHash (_, _, _, _, _))
+    .WillOnce (
+       Invoke (
+         [] (
+             IN  VOID            *FileBuffer,
+             IN  UINTN           FileSize,
+             IN  CONST EFI_GUID  *HashType,
+             OUT UINT8           *OutDigest,
+             OUT UINTN           *OutDigestSize
+         ) -> EFI_STATUS {
+    (VOID)FileBuffer;
+    (VOID)FileSize;
+    (VOID)HashType;
+    OutDigest[0]   = 0x11;
+    OutDigest[1]   = 0x22;
+    OutDigest[2]   = 0x33;
+    *OutDigestSize = 3;
+    return EFI_SUCCESS;
+  }
+         )
+       );
+
+  EXPECT_EQ (GetHash (&gEfiCertSha256Guid, &Cache, &Digest, &DigestSize), EFI_SUCCESS);
+  ASSERT_NE (Digest, (CONST UINT8 *)NULL);
+  EXPECT_EQ (DigestSize, (UINTN)3);
+  EXPECT_EQ (Digest[0], 0x11);
+  EXPECT_EQ (Digest[1], 0x22);
+  EXPECT_EQ (Digest[2], 0x33);
+}
+
+TEST (GetHashTest, V2ImageGuidCacheMiss_HashesWithBaseGuid) {
+  //
+  // Regression: a V2 image-hash GUID (EFI_CERT_V2_SHA256) must be mapped to the base (V1) GUID
+  // before GetAuthenticodeHash, which accepts only the base GUIDs. Passing the V2 GUID straight
+  // through fails hashing and breaks db image-digest approval of V2 entries.
+  //
+  MockBaseCryptLib  BaseCryptLibMock;
+  DIGEST_CACHE      Cache;
+  CONST UINT8       *Digest    = NULL;
+  UINTN             DigestSize = 0;
+
+  ZeroMem (&Cache, sizeof (Cache));
+  Cache.Buffer     = (CONST VOID *)(UINTN)1;
+  Cache.BufferSize = 1;
+
+  EXPECT_CALL (BaseCryptLibMock, GetAuthenticodeHash (_, _, _, _, _))
+    .WillOnce (
+       Invoke (
+         [] (
+             IN  VOID            *FileBuffer,
+             IN  UINTN           FileSize,
+             IN  CONST EFI_GUID  *HashType,
+             OUT UINT8           *OutDigest,
+             OUT UINTN           *OutDigestSize
+         ) -> EFI_STATUS {
+    (VOID)FileBuffer;
+    (VOID)FileSize;
+    EXPECT_TRUE (CompareGuid (HashType, &gEfiCertSha256Guid));
+    OutDigest[0]   = 0x11;
+    *OutDigestSize = 1;
+    return EFI_SUCCESS;
+  }
+         )
+       );
+
+  EXPECT_EQ (GetHash (&gEfiCertV2Sha256Guid, &Cache, &Digest, &DigestSize), EFI_SUCCESS);
+  EXPECT_EQ (DigestSize, (UINTN)1);
+}
+
+TEST (GetHashTest, CacheMiss_HashFailure_ClearsSlotAndReturnsSecurityViolation) {
+  MockBaseCryptLib  BaseCryptLibMock;
+  DIGEST_CACHE      Cache;
+  CONST UINT8       *Digest    = (CONST UINT8 *)(UINTN)1;
+  UINTN             DigestSize = 9;
+  UINTN             SlotIndex;
+
+  ZeroMem (&Cache, sizeof (Cache));
+  Cache.Buffer     = (CONST VOID *)(UINTN)1;
+  Cache.BufferSize = 1;
+
+  ASSERT_TRUE (GetImageHashIndexForTest (&gEfiCertSha256Guid, &SlotIndex));
+
+  EXPECT_CALL (BaseCryptLibMock, GetAuthenticodeHash (_, _, _, _, _))
+    .WillOnce (
+       Invoke (
+         [] (
+             IN  VOID            *FileBuffer,
+             IN  UINTN           FileSize,
+             IN  CONST EFI_GUID  *HashType,
+             OUT UINT8           *OutDigest,
+             OUT UINTN           *OutDigestSize
+         ) -> EFI_STATUS {
+    (VOID)FileBuffer;
+    (VOID)FileSize;
+    (VOID)HashType;
+    (VOID)OutDigest;
+    *OutDigestSize = 64;
+    return EFI_DEVICE_ERROR;
+  }
+         )
+       );
+
+  EXPECT_EQ (GetHash (&gEfiCertSha256Guid, &Cache, &Digest, &DigestSize), EFI_SECURITY_VIOLATION);
+  EXPECT_EQ (Cache.Entries[SlotIndex].BufferSize, (UINTN)0);
+}
+
+TEST (GetHashTest, X509CacheMiss_ComputesAndCachesDigest) {
+  MockBaseCryptLib  BaseCryptLibMock;
+  DIGEST_CACHE      Cache;
+  CONST UINT8       *Digest    = NULL;
+  UINTN             DigestSize = 0;
+  UINTN             SlotIndex;
+  UINT8             Data[3] = { 0xA1, 0xB2, 0xC3 };
+
+  ZeroMem (&Cache, sizeof (Cache));
+  Cache.Type       = DigestCacheTypeX509;
+  Cache.Buffer     = Data;
+  Cache.BufferSize = sizeof (Data);
+
+  ASSERT_TRUE (GetX509HashIndexForTest (&gEfiCertX509Sha256Guid, &SlotIndex));
+
+  EXPECT_CALL (BaseCryptLibMock, X509GetTbsCertHash (_, _, _, _, _))
+    .WillOnce (
+       Invoke (
+         [] (
+             IN  VOID            *CertBuffer,
+             IN  UINTN           CertSize,
+             IN  CONST EFI_GUID  *HashType,
+             OUT UINT8           *OutDigest,
+             OUT UINTN           *OutDigestSize
+         ) -> EFI_STATUS {
+    (VOID)CertBuffer;
+    (VOID)CertSize;
+    (VOID)HashType;
+    SetMem (OutDigest, SHA256_DIGEST_SIZE, 0x5A);
+    *OutDigestSize = SHA256_DIGEST_SIZE;
+    return EFI_SUCCESS;
+  }
+         )
+       );
+
+  EXPECT_EQ (GetHash (&gEfiCertX509Sha256Guid, &Cache, &Digest, &DigestSize), EFI_SUCCESS);
+  ASSERT_NE (Digest, (CONST UINT8 *)NULL);
+  EXPECT_EQ (DigestSize, (UINTN)SHA256_DIGEST_SIZE);
+  EXPECT_EQ (Cache.Entries[SlotIndex].BufferSize, (UINTN)SHA256_DIGEST_SIZE);
+  EXPECT_EQ (Digest[0], (UINT8)0x5A);
+}
+
+TEST (GetHashTest, X509CacheMiss_HashFailure_ClearsSlotAndReturnsSecurityViolation) {
+  MockBaseCryptLib  BaseCryptLibMock;
+  DIGEST_CACHE      Cache;
+  CONST UINT8       *Digest    = (CONST UINT8 *)(UINTN)1;
+  UINTN             DigestSize = 17;
+  UINTN             SlotIndex;
+  UINT8             Data[3] = { 0xA1, 0xB2, 0xC3 };
+
+  ZeroMem (&Cache, sizeof (Cache));
+  Cache.Type       = DigestCacheTypeX509;
+  Cache.Buffer     = Data;
+  Cache.BufferSize = sizeof (Data);
+
+  ASSERT_TRUE (GetX509HashIndexForTest (&gEfiCertX509Sha256Guid, &SlotIndex));
+
+  EXPECT_CALL (BaseCryptLibMock, X509GetTbsCertHash (_, _, _, _, _))
+    .WillOnce (Return (EFI_DEVICE_ERROR));
+
+  EXPECT_EQ (GetHash (&gEfiCertX509Sha256Guid, &Cache, &Digest, &DigestSize), EFI_SECURITY_VIOLATION);
+  EXPECT_EQ (Cache.Entries[SlotIndex].BufferSize, (UINTN)0);
+}
+
+TEST (GetHashTest, X509CacheWithImageGuid_ReturnsUnsupported) {
+  DIGEST_CACHE  Cache;
+  CONST UINT8   *Digest    = NULL;
+  UINTN         DigestSize = 0;
+  UINT8         Data[1]    = { 0x11 };
+
+  ZeroMem (&Cache, sizeof (Cache));
+  Cache.Type       = DigestCacheTypeX509;
+  Cache.Buffer     = Data;
+  Cache.BufferSize = sizeof (Data);
+
+  EXPECT_EQ (GetHash (&gEfiCertSha256Guid, &Cache, &Digest, &DigestSize), EFI_UNSUPPORTED);
+}
+
+TEST (GetHashTest, ImageCacheWithX509Guid_ReturnsUnsupported) {
+  DIGEST_CACHE  Cache;
+  CONST UINT8   *Digest    = NULL;
+  UINTN         DigestSize = 0;
+  UINT8         Data[1]    = { 0x22 };
+
+  ZeroMem (&Cache, sizeof (Cache));
+  Cache.Type       = DigestCacheTypeImage;
+  Cache.Buffer     = Data;
+  Cache.BufferSize = sizeof (Data);
+
+  EXPECT_EQ (GetHash (&gEfiCertX509Sha256Guid, &Cache, &Digest, &DigestSize), EFI_UNSUPPORTED);
+}
+
+TEST (GetHashTest, InvalidCacheType_ReturnsUnsupported) {
+  DIGEST_CACHE  Cache;
+  CONST UINT8   *Digest    = NULL;
+  UINTN         DigestSize = 0;
+  UINT8         Data[1]    = { 0x33 };
+
+  ZeroMem (&Cache, sizeof (Cache));
+  Cache.Type       = (DIGEST_CACHE_TYPE)0xFF;
+  Cache.Buffer     = Data;
+  Cache.BufferSize = sizeof (Data);
+
+  EXPECT_EQ (GetHash (&gEfiCertSha256Guid, &Cache, &Digest, &DigestSize), EFI_UNSUPPORTED);
+}
+
+// ---------------------------------------------------------------------------
+// GetSignatureTypeInfo
+// ---------------------------------------------------------------------------
+
+TEST (GetSignatureTypeInfoTest, NullArgs_ReturnsInvalidParameter) {
+  SIGNATURE_KIND  Kind;
+  UINTN           OwnerSize;
+
+  EXPECT_EQ (GetSignatureTypeInfo (NULL, &Kind, &OwnerSize), EFI_INVALID_PARAMETER);
+  EXPECT_EQ (GetSignatureTypeInfo (&gEfiCertSha256Guid, NULL, &OwnerSize), EFI_INVALID_PARAMETER);
+  EXPECT_EQ (GetSignatureTypeInfo (&gEfiCertSha256Guid, &Kind, NULL), EFI_INVALID_PARAMETER);
+}
+
+TEST (GetSignatureTypeInfoTest, UnknownGuid_ReturnsUnsupported) {
+  const EFI_GUID  OtherGuid = {
+    0x11111111, 0x2222, 0x3333, { 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB }
+  };
+  SIGNATURE_KIND  Kind;
+  UINTN           OwnerSize;
+
+  EXPECT_EQ (GetSignatureTypeInfo (&OtherGuid, &Kind, &OwnerSize), EFI_UNSUPPORTED);
+}
+
+TEST (GetSignatureTypeInfoTest, V1ImageHash_ReportsImageHashWithOwner) {
+  SIGNATURE_KIND  Kind;
+  UINTN           OwnerSize;
+
+  EXPECT_EQ (GetSignatureTypeInfo (&gEfiCertSha256Guid, &Kind, &OwnerSize), EFI_SUCCESS);
+  EXPECT_EQ (Kind, SignatureKindImageHash);
+  EXPECT_EQ (OwnerSize, sizeof (EFI_GUID));
+}
+
+TEST (GetSignatureTypeInfoTest, V2ImageHash_ReportsImageHashOwnerless) {
+  SIGNATURE_KIND  Kind;
+  UINTN           OwnerSize;
+
+  EXPECT_EQ (GetSignatureTypeInfo (&gEfiCertV2Sha256Guid, &Kind, &OwnerSize), EFI_SUCCESS);
+  EXPECT_EQ (Kind, SignatureKindImageHash);
+  EXPECT_EQ (OwnerSize, (UINTN)0);
+}
+
+TEST (GetSignatureTypeInfoTest, V1FullCert_ReportsX509CertWithOwner) {
+  SIGNATURE_KIND  Kind;
+  UINTN           OwnerSize;
+
+  EXPECT_EQ (GetSignatureTypeInfo (&gEfiCertX509Guid, &Kind, &OwnerSize), EFI_SUCCESS);
+  EXPECT_EQ (Kind, SignatureKindX509Cert);
+  EXPECT_EQ (OwnerSize, sizeof (EFI_GUID));
+}
+
+TEST (GetSignatureTypeInfoTest, V2FullCert_ReportsX509CertOwnerless) {
+  SIGNATURE_KIND  Kind;
+  UINTN           OwnerSize;
+
+  EXPECT_EQ (GetSignatureTypeInfo (&gEfiCertV2X509Guid, &Kind, &OwnerSize), EFI_SUCCESS);
+  EXPECT_EQ (Kind, SignatureKindX509Cert);
+  EXPECT_EQ (OwnerSize, (UINTN)0);
+}
+
+TEST (GetSignatureTypeInfoTest, V1TbsHash_ReportsX509TbsHashWithOwner) {
+  SIGNATURE_KIND  Kind;
+  UINTN           OwnerSize;
+
+  EXPECT_EQ (GetSignatureTypeInfo (&gEfiCertX509Sha384Guid, &Kind, &OwnerSize), EFI_SUCCESS);
+  EXPECT_EQ (Kind, SignatureKindX509TbsHash);
+  EXPECT_EQ (OwnerSize, sizeof (EFI_GUID));
+}
+
+TEST (GetSignatureTypeInfoTest, V2TbsHash_ReportsX509TbsHashOwnerless) {
+  SIGNATURE_KIND  Kind;
+  UINTN           OwnerSize;
+
+  EXPECT_EQ (GetSignatureTypeInfo (&gEfiCertV2X509Sha512Guid, &Kind, &OwnerSize), EFI_SUCCESS);
+  EXPECT_EQ (Kind, SignatureKindX509TbsHash);
+  EXPECT_EQ (OwnerSize, (UINTN)0);
+}
+
+// ---------------------------------------------------------------------------
+// BuildImageAuthority / FreeImageAuthority
+// ---------------------------------------------------------------------------
+
+TEST (BuildImageAuthorityTest, NullPayload_InvalidParameter) {
+  IMAGE_AUTHORITY  Authority = { NULL, 0 };
+
+  EXPECT_EQ (BuildImageAuthority (NULL, NULL, 4, &Authority), EFI_INVALID_PARAMETER);
+  EXPECT_EQ (Authority.Data, nullptr);
+}
+
+TEST (BuildImageAuthorityTest, ZeroPayloadSize_InvalidParameter) {
+  UINT8            Payload[4] = { 0 };
+  IMAGE_AUTHORITY  Authority  = { NULL, 0 };
+
+  EXPECT_EQ (BuildImageAuthority (NULL, Payload, 0, &Authority), EFI_INVALID_PARAMETER);
+  EXPECT_EQ (Authority.Data, nullptr);
+}
+
+TEST (BuildImageAuthorityTest, NullAuthority_InvalidParameter) {
+  UINT8  Payload[4] = { 0 };
+
+  EXPECT_EQ (BuildImageAuthority (NULL, Payload, sizeof (Payload), NULL), EFI_INVALID_PARAMETER);
+}
+
+//
+// A payload large enough to overflow the EFI_SIGNATURE_DATA header addition is rejected before any
+// allocation or read of the payload.
+//
+TEST (BuildImageAuthorityTest, OverflowingPayloadSize_InvalidParameter) {
+  UINT8            Sentinel  = 0;
+  IMAGE_AUTHORITY  Authority = { NULL, 0 };
+
+  EXPECT_EQ (BuildImageAuthority (NULL, &Sentinel, MAX_UINTN, &Authority), EFI_INVALID_PARAMETER);
+  EXPECT_EQ (Authority.Data, nullptr);
+}
+
+//
+// With no owner, the SignatureOwner is zeroed and the payload follows it. Size is the payload plus
+// a SignatureOwner GUID.
+//
+TEST (BuildImageAuthorityTest, NoOwner_ZeroesOwnerAndCopiesPayload) {
+  UINT8            Payload[5] = { 0x11, 0x22, 0x33, 0x44, 0x55 };
+  EFI_GUID         ZeroGuid   = { 0 };
+  IMAGE_AUTHORITY  Authority  = { NULL, 0 };
+
+  EXPECT_EQ (BuildImageAuthority (NULL, Payload, sizeof (Payload), &Authority), EFI_SUCCESS);
+  ASSERT_NE (Authority.Data, nullptr);
+  EXPECT_EQ (Authority.Size, (UINTN)(sizeof (EFI_GUID) + sizeof (Payload)));
+  EXPECT_TRUE (CompareGuid (&Authority.Data->SignatureOwner, &ZeroGuid));
+  EXPECT_EQ (CompareMem (Authority.Data->SignatureData, Payload, sizeof (Payload)), 0);
+
+  FreeImageAuthority (&Authority);
+  EXPECT_EQ (Authority.Data, nullptr);
+  EXPECT_EQ (Authority.Size, (UINTN)0);
+}
+
+//
+// A supplied owner GUID is stored verbatim ahead of the payload.
+//
+TEST (BuildImageAuthorityTest, WithOwner_StoresOwnerAndPayload) {
+  EFI_GUID         Owner = { 0x11223344, 0x5566, 0x7788, { 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x00 }
+  };
+  UINT8            Payload[3] = { 0xDE, 0xAD, 0xBE };
+  IMAGE_AUTHORITY  Authority  = { NULL, 0 };
+
+  EXPECT_EQ (BuildImageAuthority (&Owner, Payload, sizeof (Payload), &Authority), EFI_SUCCESS);
+  ASSERT_NE (Authority.Data, nullptr);
+  EXPECT_TRUE (CompareGuid (&Authority.Data->SignatureOwner, &Owner));
+  EXPECT_EQ (CompareMem (Authority.Data->SignatureData, Payload, sizeof (Payload)), 0);
+
+  FreeImageAuthority (&Authority);
+}
+
+//
+// FreeImageAuthority tolerates a NULL pointer and an already-empty authority.
+//
+TEST (FreeImageAuthorityTest, NullAndEmpty_NoOp) {
+  IMAGE_AUTHORITY  Empty = { NULL, 0 };
+
+  FreeImageAuthority (NULL);
+  FreeImageAuthority (&Empty);
+  EXPECT_EQ (Empty.Data, nullptr);
+  EXPECT_EQ (Empty.Size, (UINTN)0);
+}
+
+//
+// FreeImageAuthority clears the record it frees, so a second call is a safe no-op (no double free).
+//
+TEST (FreeImageAuthorityTest, DoubleFree_Safe) {
+  UINT8            Payload[4] = { 1, 2, 3, 4 };
+  IMAGE_AUTHORITY  Authority  = { NULL, 0 };
+
+  ASSERT_EQ (BuildImageAuthority (NULL, Payload, sizeof (Payload), &Authority), EFI_SUCCESS);
+  FreeImageAuthority (&Authority);
+  FreeImageAuthority (&Authority);
+  EXPECT_EQ (Authority.Data, nullptr);
+}

--- a/SecurityPkg/Library/DxeImageVerificationLib2/Iterator.c
+++ b/SecurityPkg/Library/DxeImageVerificationLib2/Iterator.c
@@ -1,0 +1,347 @@
+/** @file
+  Forward-only iterators for walking different data structures.
+
+  Iterators perform data validation during initialization. Rather than rejecting a malformed
+  container, initialization clamps the iteration range to the valid prefix: it stops at the first
+  entry that fails to parse and only iterates over the entries that precede it. This does mean that
+  certain iterator implementations walk the data structures twice. Once during initialization to
+  validate the data and establish the valid range, and again during iteration to produce the
+  results.
+
+  All iterators use the same Init / Next contract. `<Structure>Init(..)` initializes the iterator
+  and returns whether the range is complete: TRUE if the whole structure parsed cleanly, FALSE if
+  it had to truncate the range because one or more trailing entries were dropped (a parse error or
+  unusable inputs). `<Structure>Next(..)` returns the next item or NULL once the range is
+  exhausted. Init never logs; callers decide what to log based on the returned boolean.
+
+  Three iterators are provided:
+
+    * SIG_DATABASE_ITER - walks every EFI_SIGNATURE_LIST in a signature
+                          database buffer (db / dbx / dbt contents).
+    * SIG_LIST_ITER     - walks every EFI_SIGNATURE_DATA entry inside a
+                          single EFI_SIGNATURE_LIST.
+    * WIN_CERT_ITER     - walks every WIN_CERTIFICATE in a PE/COFF
+                          image's security data directory.
+
+  Copyright (C) Microsoft Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "Iterator.h"
+
+/**
+  Initialize an iterator over the EFI_SIGNATURE_LIST records contained in a signature database
+  buffer.
+
+  The initialization validates the list and will truncate the iteration range to the
+  last valid entry if the list if malformed.
+
+  @param[out]  Iter        Iterator state to initialize.
+  @param[in]   Buffer      Raw database contents, or NULL for an empty database.
+  @param[in]   BufferSize  Size of Buffer in bytes; 0 when Buffer is NULL.
+
+  @retval TRUE   The iterator covers every entry in the list.
+  @retval FALSE  The iterator was truncated due to invalid arguments or a malformed table.
+**/
+BOOLEAN
+DatabaseIterInit (
+  OUT SIG_DATABASE_ITER  *Iter,
+  IN  CONST VOID         *Buffer,
+  IN  UINTN              BufferSize
+  )
+{
+  CONST UINT8               *Cursor;
+  UINTN                     Remaining;
+  CONST EFI_SIGNATURE_LIST  *List;
+
+  if (Iter == NULL) {
+    return FALSE;
+  }
+
+  Iter->Cursor    = (CONST UINT8 *)Buffer;
+  Iter->Remaining = 0;
+
+  //
+  // An empty database has nothing to iterate and is not a truncation. A NULL buffer with a
+  // non-zero size is inconsistent input; expose an empty iterator and report truncation.
+  //
+  if (Buffer == NULL) {
+    return (BOOLEAN)(BufferSize == 0);
+  }
+
+  //
+  // Walk the buffer using SignatureListSize. The lists must tile the buffer cleanly; the first
+  // list that does not marks the end of the valid iteration range.
+  //
+  Cursor    = (CONST UINT8 *)Buffer;
+  Remaining = BufferSize;
+
+  while (Remaining > 0) {
+    if (Remaining < sizeof (EFI_SIGNATURE_LIST)) {
+      break;
+    }
+
+    List = (CONST EFI_SIGNATURE_LIST *)(CONST VOID *)Cursor;
+    if ((List->SignatureListSize < sizeof (EFI_SIGNATURE_LIST)) ||
+        (List->SignatureListSize > Remaining))
+    {
+      break;
+    }
+
+    Cursor    += List->SignatureListSize;
+    Remaining -= List->SignatureListSize;
+  }
+
+  //
+  // Remaining is the size of the tail that could not be parsed; the valid prefix is everything
+  // that came before it.
+  //
+  Iter->Cursor    = (CONST UINT8 *)Buffer;
+  Iter->Remaining = BufferSize - Remaining;
+  return (BOOLEAN)(Remaining == 0);
+}
+
+/**
+  Return the next EFI_SIGNATURE_LIST from the buffer being iterated.
+
+  Infallible over the range established by DatabaseIterInit.
+
+  @param[in,out]  Iter  Iterator initialized by DatabaseIterInit.
+
+  @retval non-NULL  Pointer to the next EFI_SIGNATURE_LIST.
+  @retval NULL      Iteration is complete.
+**/
+CONST EFI_SIGNATURE_LIST *
+DatabaseIterNext (
+  IN OUT SIG_DATABASE_ITER  *Iter
+  )
+{
+  CONST EFI_SIGNATURE_LIST  *List;
+
+  if ((Iter == NULL) || (Iter->Remaining == 0)) {
+    return NULL;
+  }
+
+  List             = (CONST EFI_SIGNATURE_LIST *)(CONST VOID *)Iter->Cursor;
+  Iter->Cursor    += List->SignatureListSize;
+  Iter->Remaining -= List->SignatureListSize;
+  return List;
+}
+
+/**
+  Initialize an iterator over the EFI_SIGNATURE_DATA entries contained in a single
+  EFI_SIGNATURE_LIST.
+
+  The initialization validates the list and will truncate the iteration range to the
+  last valid entry if the list if malformed.
+
+  @param[out]  Iter  Iterator state to initialize.
+  @param[in]   List  The signature list to walk.
+
+  @retval TRUE   The iterator covers every entry in the list.
+  @retval FALSE  The iterator was truncated due to invalid arguments or a malformed table.
+**/
+BOOLEAN
+SigListIterInit (
+  OUT SIG_LIST_ITER             *Iter,
+  IN  CONST EFI_SIGNATURE_LIST  *List
+  )
+{
+  UINTN  PayloadSize;
+
+  if (Iter == NULL) {
+    return FALSE;
+  }
+
+  Iter->Cursor    = NULL;
+  Iter->Stride    = 0;
+  Iter->Remaining = 0;
+
+  //
+  // Without a list, or with size fields that leave the entry stride or payload region
+  // undeterminable, there is no entry that can be safely produced. Expose an empty iterator.
+  //
+  if (List == NULL) {
+    return FALSE;
+  }
+
+  if (List->SignatureListSize < sizeof (EFI_SIGNATURE_LIST)) {
+    return FALSE;
+  }
+
+  if (List->SignatureSize < sizeof (EFI_GUID)) {
+    return FALSE;
+  }
+
+  if (List->SignatureHeaderSize > List->SignatureListSize - sizeof (EFI_SIGNATURE_LIST)) {
+    return FALSE;
+  }
+
+  //
+  // The payload holds a whole number of fixed-size entries. If it does not divide evenly, drop the
+  // trailing partial entry and iterate only the whole entries that precede it.
+  //
+  PayloadSize = List->SignatureListSize
+                - sizeof (EFI_SIGNATURE_LIST)
+                - List->SignatureHeaderSize;
+
+  Iter->Stride    = List->SignatureSize;
+  Iter->Remaining = PayloadSize / List->SignatureSize;
+  Iter->Cursor    = (CONST UINT8 *)List
+                    + sizeof (EFI_SIGNATURE_LIST)
+                    + List->SignatureHeaderSize;
+
+  return (BOOLEAN)((PayloadSize % List->SignatureSize) == 0);
+}
+
+/**
+  Return the next EFI_SIGNATURE_DATA entry from the list being iterated.
+
+  Infallible over the range established by SigListIterInit.
+
+  @param[in,out]  Iter  Iterator initialized by SigListIterInit.
+
+  @retval non-NULL  Pointer to the next EFI_SIGNATURE_DATA entry.
+  @retval NULL      Iteration is complete.
+**/
+CONST EFI_SIGNATURE_DATA *
+SigListIterNext (
+  IN OUT SIG_LIST_ITER  *Iter
+  )
+{
+  CONST EFI_SIGNATURE_DATA  *Entry;
+
+  if ((Iter == NULL) || (Iter->Remaining == 0)) {
+    return NULL;
+  }
+
+  Entry         = (CONST EFI_SIGNATURE_DATA *)(CONST VOID *)Iter->Cursor;
+  Iter->Cursor += Iter->Stride;
+  Iter->Remaining--;
+  return Entry;
+}
+
+/**
+  Initialize an iterator over the WIN_CERTIFICATE records contained in a PE/COFF image's security
+  data directory.
+
+  The initialization validates the list and will truncate the iteration range to the
+  last valid entry if the list if malformed.
+
+  @param[out]  Iter        Iterator state to initialize.
+  @param[in]   FileBuffer  Pointer to the in-memory PE/COFF image.
+  @param[in]   FileSize    Size of FileBuffer in bytes.
+  @param[in]   SecDataDir  Security data directory describing the embedded WIN_CERTIFICATE table.
+
+  @retval TRUE   The iterator covers every entry in the list.
+  @retval FALSE  The iterator was truncated due to invalid arguments or a malformed table.
+**/
+BOOLEAN
+WinCertIterInit (
+  OUT WIN_CERT_ITER                   *Iter,
+  IN  CONST VOID                      *FileBuffer,
+  IN  UINTN                           FileSize,
+  IN  CONST EFI_IMAGE_DATA_DIRECTORY  *SecDataDir
+  )
+{
+  CONST UINT8            *Cursor;
+  UINTN                  Remaining;
+  CONST WIN_CERTIFICATE  *Cert;
+  UINTN                  EntrySize;
+
+  if (Iter == NULL) {
+    return FALSE;
+  }
+
+  Iter->Cursor    = NULL;
+  Iter->Remaining = 0;
+
+  //
+  // Without a file buffer or directory, or with a directory that does not lie within the file, the
+  // certificate table cannot be located. Expose an empty iterator.
+  //
+  if ((FileBuffer == NULL) || (SecDataDir == NULL)) {
+    return FALSE;
+  }
+
+  if ((SecDataDir->VirtualAddress > FileSize) ||
+      (SecDataDir->Size > FileSize - SecDataDir->VirtualAddress))
+  {
+    return FALSE;
+  }
+
+  //
+  // Walk the certificate table. The first entry with a malformed dwLength, or a trailing fragment
+  // too small to hold a header, marks the end of the valid iteration range.
+  //
+  Cursor    = (CONST UINT8 *)FileBuffer + SecDataDir->VirtualAddress;
+  Remaining = SecDataDir->Size;
+
+  while (Remaining > 0) {
+    if (Remaining < sizeof (WIN_CERTIFICATE)) {
+      break;
+    }
+
+    Cert = (CONST WIN_CERTIFICATE *)(CONST VOID *)Cursor;
+
+    if ((Cert->dwLength < sizeof (WIN_CERTIFICATE)) ||
+        (Cert->dwLength > Remaining))
+    {
+      break;
+    }
+
+    //
+    // Each entry is padded to an 8-byte boundary. The rounded-up size
+    // may exceed Remaining if the final entry uses up the rest of the
+    // table without padding; clamp to Remaining in that case.
+    //
+    EntrySize = ALIGN_VALUE (Cert->dwLength, 8);
+    if (EntrySize > Remaining) {
+      EntrySize = Remaining;
+    }
+
+    Cursor    += EntrySize;
+    Remaining -= EntrySize;
+  }
+
+  //
+  // Remaining is the size of the tail that could not be parsed; the valid prefix is everything
+  // that came before it.
+  //
+  Iter->Cursor    = (CONST UINT8 *)FileBuffer + SecDataDir->VirtualAddress;
+  Iter->Remaining = SecDataDir->Size - Remaining;
+  return (BOOLEAN)(Remaining == 0);
+}
+
+/**
+  Return the next WIN_CERTIFICATE from the directory being iterated.
+
+  Infallible over the range established by WinCertIterInit.
+
+  @param[in,out]  Iter  Iterator initialized by WinCertIterInit.
+
+  @retval non-NULL  Pointer to the next WIN_CERTIFICATE.
+  @retval NULL      Iteration is complete.
+**/
+CONST WIN_CERTIFICATE *
+WinCertIterNext (
+  IN OUT WIN_CERT_ITER  *Iter
+  )
+{
+  CONST WIN_CERTIFICATE  *Cert;
+  UINTN                  EntrySize;
+
+  if ((Iter == NULL) || (Iter->Remaining == 0)) {
+    return NULL;
+  }
+
+  Cert      = (CONST WIN_CERTIFICATE *)(CONST VOID *)Iter->Cursor;
+  EntrySize = ALIGN_VALUE (Cert->dwLength, 8);
+  if (EntrySize > Iter->Remaining) {
+    EntrySize = Iter->Remaining;
+  }
+
+  Iter->Cursor    += EntrySize;
+  Iter->Remaining -= EntrySize;
+  return Cert;
+}

--- a/SecurityPkg/Library/DxeImageVerificationLib2/Iterator.h
+++ b/SecurityPkg/Library/DxeImageVerificationLib2/Iterator.h
@@ -1,0 +1,177 @@
+/** @file
+  Forward-only iterators for walking different data structures.
+
+  Iterators perform data validation during initialization. Rather than rejecting a malformed
+  container, initialization clamps the iteration range to the valid prefix: it stops at the first
+  entry that fails to parse and only iterates over the entries that precede it. This does mean that
+  certain iterator implementations walk the data structures twice. Once during initialization to
+  validate the data and establish the valid range, and again during iteration to produce the
+  results.
+
+  All iterators use the same Init / Next contract. `<Structure>Init(..)` initializes the iterator
+  and returns whether the range is complete: TRUE if the whole structure parsed cleanly, FALSE if
+  it had to truncate the range because one or more trailing entries were dropped (a parse error or
+  unusable inputs). `<Structure>Next(..)` returns the next item or NULL once the range is
+  exhausted. Init never logs; callers decide what to log based on the returned boolean.
+
+  Three iterators are provided:
+
+    * SIG_DATABASE_ITER - walks every EFI_SIGNATURE_LIST in a signature
+                          database buffer (db / dbx / dbt contents).
+    * SIG_LIST_ITER     - walks every EFI_SIGNATURE_DATA entry inside a
+                          single EFI_SIGNATURE_LIST.
+    * WIN_CERT_ITER     - walks every WIN_CERTIFICATE in a PE/COFF
+                          image's security data directory.
+
+  Copyright (C) Microsoft Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#pragma once
+
+#include <Uefi.h>
+#include <Guid/ImageAuthentication.h>
+#include <IndustryStandard/PeImage.h>
+#include <Library/BaseLib.h>
+#include <Library/DebugLib.h>
+
+/**
+  Iterator state for walking EFI_SIGNATURE_LIST records inside a
+  signature-database buffer.
+
+  Fields are owned by the iterator implementation; callers should treat them as opaque.
+**/
+typedef struct {
+  CONST UINT8    *Cursor;     // Next byte to consume.
+  UINTN          Remaining;   // Bytes left in the buffer.
+} SIG_DATABASE_ITER;
+
+/**
+  Iterator state for walking EFI_SIGNATURE_DATA entries inside a single EFI_SIGNATURE_LIST.
+
+  Fields are owned by the iterator implementation; callers should treat them as opaque.
+**/
+typedef struct {
+  CONST UINT8    *Cursor;     // Next entry pointer.
+  UINTN          Stride;      // SignatureSize from the parent list.
+  UINTN          Remaining;   // Entries left to produce.
+} SIG_LIST_ITER;
+
+/**
+  Iterator state for walking WIN_CERTIFICATE records inside a PE/COFF image's security data
+  directory.
+
+  Fields are owned by the iterator implementation; callers should treat them as opaque.
+**/
+typedef struct {
+  CONST UINT8    *Cursor;     // Next byte to consume.
+  UINTN          Remaining;   // Bytes left in the certificate table.
+} WIN_CERT_ITER;
+
+/**
+  Initialize an iterator over the EFI_SIGNATURE_LIST records contained in a signature database
+  buffer.
+
+  The initialization validates the list and will truncate the iteration range to the
+  last valid entry if the list if malformed.
+
+  @param[out]  Iter        Iterator state to initialize.
+  @param[in]   Buffer      Raw database contents, or NULL for an empty database.
+  @param[in]   BufferSize  Size of Buffer in bytes; 0 when Buffer is NULL.
+
+  @retval TRUE   The iterator covers every entry in the list.
+  @retval FALSE  The iterator was truncated due to invalid arguments or a malformed table.
+**/
+BOOLEAN
+DatabaseIterInit (
+  OUT SIG_DATABASE_ITER  *Iter,
+  IN  CONST VOID         *Buffer,
+  IN  UINTN              BufferSize
+  );
+
+/**
+  Return the next EFI_SIGNATURE_LIST from the buffer being iterated.
+
+  Infallible over the range established by DatabaseIterInit.
+
+  @param[in,out]  Iter  Iterator initialized by DatabaseIterInit.
+
+  @retval non-NULL  Pointer to the next EFI_SIGNATURE_LIST.
+  @retval NULL      Iteration is complete.
+**/
+CONST EFI_SIGNATURE_LIST *
+DatabaseIterNext (
+  IN OUT SIG_DATABASE_ITER  *Iter
+  );
+
+/**
+  Initialize an iterator over the EFI_SIGNATURE_DATA entries contained in a single
+  EFI_SIGNATURE_LIST.
+
+  The initialization validates the list and will truncate the iteration range to the
+  last valid entry if the list if malformed.
+
+  @param[out]  Iter  Iterator state to initialize.
+  @param[in]   List  The signature list to walk.
+
+  @retval TRUE   The iterator covers every entry in the list.
+  @retval FALSE  The iterator was truncated due to invalid arguments or a malformed table.
+**/
+BOOLEAN
+SigListIterInit (
+  OUT SIG_LIST_ITER             *Iter,
+  IN  CONST EFI_SIGNATURE_LIST  *List
+  );
+
+/**
+  Return the next EFI_SIGNATURE_DATA entry from the list being iterated.
+
+  Infallible over the range established by SigListIterInit.
+
+  @param[in,out]  Iter  Iterator initialized by SigListIterInit.
+
+  @retval non-NULL  Pointer to the next EFI_SIGNATURE_DATA entry.
+  @retval NULL      Iteration is complete.
+**/
+CONST EFI_SIGNATURE_DATA *
+SigListIterNext (
+  IN OUT SIG_LIST_ITER  *Iter
+  );
+
+/**
+  Initialize an iterator over the WIN_CERTIFICATE records contained in a PE/COFF image's security
+  data directory.
+
+  The initialization validates the list and will truncate the iteration range to the
+  last valid entry if the list if malformed.
+
+  @param[out]  Iter        Iterator state to initialize.
+  @param[in]   FileBuffer  Pointer to the in-memory PE/COFF image.
+  @param[in]   FileSize    Size of FileBuffer in bytes.
+  @param[in]   SecDataDir  Security data directory describing the embedded WIN_CERTIFICATE table.
+
+  @retval TRUE   The iterator covers every entry in the list.
+  @retval FALSE  The iterator was truncated due to invalid arguments or a malformed table.
+**/
+BOOLEAN
+WinCertIterInit (
+  OUT WIN_CERT_ITER                   *Iter,
+  IN  CONST VOID                      *FileBuffer,
+  IN  UINTN                           FileSize,
+  IN  CONST EFI_IMAGE_DATA_DIRECTORY  *SecDataDir
+  );
+
+/**
+  Return the next WIN_CERTIFICATE from the directory being iterated.
+
+  Infallible over the range established by WinCertIterInit.
+
+  @param[in,out]  Iter  Iterator initialized by WinCertIterInit.
+
+  @retval non-NULL  Pointer to the next WIN_CERTIFICATE.
+  @retval NULL      Iteration is complete.
+**/
+CONST WIN_CERTIFICATE *
+WinCertIterNext (
+  IN OUT WIN_CERT_ITER  *Iter
+  );

--- a/SecurityPkg/Library/DxeImageVerificationLib2/Measurement.c
+++ b/SecurityPkg/Library/DxeImageVerificationLib2/Measurement.c
@@ -1,0 +1,400 @@
+/** @file
+  Secure Boot authority measurement for the DXE Image Verification Library.
+
+  When an image is authorized by an entry in the `db` signature database, the
+  EFI_SIGNATURE_DATA entry that authorized it is measured into PCR 7 as an
+  EV_EFI_VARIABLE_AUTHORITY event. This records which trust anchor authorized
+  the image (not the image content). Each unique authority entry is measured
+  at most once per boot; the module-global MEASURED_AUTHORITIES state, obtained
+  through GetMeasuredAuthorities (), provides the de-duplication.
+
+  Caution: This file consumes external input (the signature databases that the
+  authority entries are copied from). All inputs must be treated as
+  attacker-controlled.
+
+  Copyright (c) 2013 - 2018, Intel Corporation. All rights reserved.<BR>
+  Copyright (C) Microsoft Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "DxeImageVerificationLib.h"
+
+#include <IndustryStandard/UefiTcgPlatform.h>
+#include <Library/UefiRuntimeServicesTableLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/TpmMeasurementLib.h>
+
+//
+// Number of MEASURED_VARIABLE slots to grow the tracking list by each time it
+// fills up.
+//
+#define MEASURED_AUTHORITY_COUNT_INCREMENT  0x100
+
+//
+// Mapping of (VariableName, VendorGuid) pairs that are treated as Secure Boot
+// authority variables. Only entries authorized by these variables are measured
+// into PCR 7.
+//
+typedef struct {
+  CHAR16      *VariableName;
+  EFI_GUID    *VendorGuid;
+} AUTHORITY_VARIABLE;
+
+STATIC AUTHORITY_VARIABLE  mAuthorityVariables[] = {
+  { EFI_IMAGE_SECURITY_DATABASE, &gEfiImageSecurityDatabaseGuid },
+};
+
+//
+// Module-global authority measurement state. The only consumer that touches
+// this global directly is GetMeasuredAuthorities (); every other function
+// operates on a caller-supplied MEASURED_AUTHORITIES pointer so it can be unit
+// tested without global state.
+//
+STATIC MEASURED_AUTHORITIES  mMeasuredAuthorities = { NULL, 0, 0 };
+
+/**
+  Return the module-global authority measurement state.
+
+  The returned pointer references storage that persists for the lifetime of
+  the module so that measurement de-duplication is maintained across every
+  image the verification handler processes.
+
+  @return  Pointer to the module-global MEASURED_AUTHORITIES instance.
+**/
+MEASURED_AUTHORITIES *
+GetMeasuredAuthorities (
+  VOID
+  )
+{
+  return &mMeasuredAuthorities;
+}
+
+/**
+  Return the canonical storage for a Secure Boot authority variable name.
+
+  Measured records reference canonical name storage owned by this module so
+  that the records remain valid independent of the caller's buffers.
+
+  @param[in]  VariableName  A Null-terminated authority variable name.
+
+  @return  The canonical pointer for VariableName, or NULL if VariableName is
+           not a known authority variable.
+**/
+CHAR16 *
+AssignVariableName (
+  IN CHAR16  *VariableName
+  )
+{
+  UINTN  Index;
+
+  if (VariableName == NULL) {
+    return NULL;
+  }
+
+  for (Index = 0; Index < ARRAY_SIZE (mAuthorityVariables); Index++) {
+    if (StrCmp (VariableName, mAuthorityVariables[Index].VariableName) == 0) {
+      return mAuthorityVariables[Index].VariableName;
+    }
+  }
+
+  return NULL;
+}
+
+/**
+  Return the canonical storage for a Secure Boot authority vendor GUID.
+
+  Measured records reference canonical GUID storage owned by this module so
+  that the records remain valid independent of the caller's buffers.
+
+  @param[in]  VendorGuid  A vendor GUID to canonicalize.
+
+  @return  The canonical pointer for VendorGuid, or NULL if VendorGuid is not a
+           known authority vendor GUID.
+**/
+EFI_GUID *
+AssignVendorGuid (
+  IN EFI_GUID  *VendorGuid
+  )
+{
+  UINTN  Index;
+
+  if (VendorGuid == NULL) {
+    return NULL;
+  }
+
+  for (Index = 0; Index < ARRAY_SIZE (mAuthorityVariables); Index++) {
+    if (CompareGuid (VendorGuid, mAuthorityVariables[Index].VendorGuid)) {
+      return mAuthorityVariables[Index].VendorGuid;
+    }
+  }
+
+  return NULL;
+}
+
+/**
+  Determine whether a variable is a Secure Boot authority variable.
+
+  @param[in]  VariableName  A Null-terminated variable name.
+  @param[in]  VendorGuid    The variable's vendor GUID.
+
+  @retval TRUE   The variable is a Secure Boot authority variable.
+  @retval FALSE  The variable is not a Secure Boot authority variable, or a
+                 required pointer was NULL.
+**/
+BOOLEAN
+IsSecureAuthorityVariable (
+  IN CHAR16    *VariableName,
+  IN EFI_GUID  *VendorGuid
+  )
+{
+  UINTN  Index;
+
+  if ((VariableName == NULL) || (VendorGuid == NULL)) {
+    return FALSE;
+  }
+
+  for (Index = 0; Index < ARRAY_SIZE (mAuthorityVariables); Index++) {
+    if ((StrCmp (VariableName, mAuthorityVariables[Index].VariableName) == 0) &&
+        CompareGuid (VendorGuid, mAuthorityVariables[Index].VendorGuid))
+    {
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}
+
+/**
+  Determine whether an authority entry has already been measured this boot.
+
+  @param[in]  Measured      Authority measurement state to consult.
+  @param[in]  VariableName  Name of the variable that authorized the image.
+  @param[in]  VendorGuid    Vendor GUID of the variable that authorized the image.
+  @param[in]  Data          The EFI_SIGNATURE_DATA entry that authorized the image.
+  @param[in]  Size          Size, in bytes, of Data.
+
+  @retval TRUE   The entry has already been measured.
+  @retval FALSE  The entry has not been measured, or a required pointer was NULL.
+**/
+BOOLEAN
+IsDataMeasured (
+  IN CONST MEASURED_AUTHORITIES  *Measured,
+  IN CHAR16                      *VariableName,
+  IN EFI_GUID                    *VendorGuid,
+  IN VOID                        *Data,
+  IN UINTN                       Size
+  )
+{
+  UINTN  Index;
+
+  if ((Measured == NULL) || (VariableName == NULL) || (VendorGuid == NULL) || (Data == NULL)) {
+    return FALSE;
+  }
+
+  for (Index = 0; Index < Measured->Count; Index++) {
+    if ((Measured->List[Index].VariableName != NULL) &&
+        (Measured->List[Index].VendorGuid != NULL) &&
+        (Measured->List[Index].Data != NULL) &&
+        (Size == Measured->List[Index].Size) &&
+        (StrCmp (VariableName, Measured->List[Index].VariableName) == 0) &&
+        CompareGuid (VendorGuid, Measured->List[Index].VendorGuid) &&
+        (CompareMem (Data, Measured->List[Index].Data, Size) == 0))
+    {
+      return TRUE;
+    }
+  }
+
+  return FALSE;
+}
+
+/**
+  Record an authority entry as measured, growing the tracking list as needed.
+
+  A private copy of Data is allocated so the record remains valid independent
+  of the caller's buffer.
+
+  @param[in,out]  Measured      Authority measurement state to update.
+  @param[in]      VariableName  Name of the variable that authorized the image.
+  @param[in]      VendorGuid    Vendor GUID of the variable that authorized the image.
+  @param[in]      Data          The EFI_SIGNATURE_DATA entry that authorized the image.
+  @param[in]      Size          Size, in bytes, of Data.
+
+  @retval EFI_SUCCESS            The entry was recorded.
+  @retval EFI_INVALID_PARAMETER  A required pointer was NULL or Size was 0.
+  @retval EFI_OUT_OF_RESOURCES   A required allocation failed.
+**/
+EFI_STATUS
+AddDataMeasured (
+  IN OUT MEASURED_AUTHORITIES  *Measured,
+  IN     CHAR16                *VariableName,
+  IN     EFI_GUID              *VendorGuid,
+  IN     VOID                  *Data,
+  IN     UINTN                 Size
+  )
+{
+  MEASURED_VARIABLE  *NewList;
+
+  if ((Measured == NULL) || (VariableName == NULL) || (VendorGuid == NULL) ||
+      (Data == NULL) || (Size == 0))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ASSERT (Measured->Count <= Measured->Max);
+
+  if (Measured->Count == Measured->Max) {
+    NewList = AllocateZeroPool (
+                sizeof (MEASURED_VARIABLE) * (Measured->Max + MEASURED_AUTHORITY_COUNT_INCREMENT)
+                );
+    if (NewList == NULL) {
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    if (Measured->List != NULL) {
+      CopyMem (NewList, Measured->List, sizeof (MEASURED_VARIABLE) * Measured->Count);
+      FreePool (Measured->List);
+    }
+
+    Measured->List = NewList;
+    Measured->Max += MEASURED_AUTHORITY_COUNT_INCREMENT;
+  }
+
+  Measured->List[Measured->Count].Data = AllocateCopyPool (Size, Data);
+  if (Measured->List[Measured->Count].Data == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Measured->List[Measured->Count].VariableName = AssignVariableName (VariableName);
+  Measured->List[Measured->Count].VendorGuid   = AssignVendorGuid (VendorGuid);
+  Measured->List[Measured->Count].Size         = Size;
+  Measured->Count++;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Measure and log an EFI variable, and extend the measurement into PCR 7.
+
+  @param[in]  VarName     A Null-terminated authority variable name.
+  @param[in]  VendorGuid  The variable's vendor GUID.
+  @param[in]  VarData     The EFI_SIGNATURE_DATA entry that authorized the image.
+  @param[in]  VarSize     Size, in bytes, of VarData.
+
+  @retval EFI_SUCCESS            The measurement completed successfully.
+  @retval EFI_INVALID_PARAMETER  A required pointer was NULL.
+  @retval EFI_OUT_OF_RESOURCES   A required allocation failed.
+  @retval EFI_DEVICE_ERROR       The measurement was unsuccessful.
+**/
+EFI_STATUS
+MeasureVariable (
+  IN CHAR16    *VarName,
+  IN EFI_GUID  *VendorGuid,
+  IN VOID      *VarData,
+  IN UINTN     VarSize
+  )
+{
+  EFI_STATUS          Status;
+  UINTN               VarNameLength;
+  UEFI_VARIABLE_DATA  *VarLog;
+  UINT32              VarLogSize;
+
+  if ((VarName == NULL) || (VendorGuid == NULL) || (VarData == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // The UEFI_VARIABLE_DATA.VariableData value shall be the EFI_SIGNATURE_DATA
+  // value from the EFI_SIGNATURE_LIST that contained the authority that was
+  // used to validate the image.
+  //
+  VarNameLength = StrLen (VarName);
+  VarLogSize    = (UINT32)(sizeof (*VarLog) + VarNameLength * sizeof (*VarName) + VarSize
+                           - sizeof (VarLog->UnicodeName) - sizeof (VarLog->VariableData));
+
+  VarLog = (UEFI_VARIABLE_DATA *)AllocateZeroPool (VarLogSize);
+  if (VarLog == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  CopyMem (&VarLog->VariableName, VendorGuid, sizeof (VarLog->VariableName));
+  VarLog->UnicodeNameLength  = VarNameLength;
+  VarLog->VariableDataLength = VarSize;
+  CopyMem (
+    VarLog->UnicodeName,
+    VarName,
+    VarNameLength * sizeof (*VarName)
+    );
+  CopyMem (
+    (CHAR16 *)VarLog->UnicodeName + VarNameLength,
+    VarData,
+    VarSize
+    );
+
+  DEBUG ((DEBUG_INFO, "DxeImageVerificationLib: MeasureVariable (Pcr - %x, EventType - %x, ", (UINTN)7, (UINTN)EV_EFI_VARIABLE_AUTHORITY));
+  DEBUG ((DEBUG_INFO, "VariableName - %s, VendorGuid - %g)\n", VarName, VendorGuid));
+
+  Status = TpmMeasureAndLogData (
+             7,
+             EV_EFI_VARIABLE_AUTHORITY,
+             VarLog,
+             VarLogSize,
+             VarLog,
+             VarLogSize
+             );
+  FreePool (VarLog);
+
+  return Status;
+}
+
+/**
+  Measure a Secure Boot authority entry into PCR 7, skipping entries that have
+  already been measured this boot.
+
+  If VariableName / VendorGuid do not identify a Secure Boot authority
+  variable, or the supplied data has already been measured, the call is a
+  no-op. Otherwise the data is measured via TpmMeasureAndLogData and recorded
+  in Measured so subsequent identical entries are not measured again.
+
+  @param[in,out]  Measured      Authority measurement state to consult and update.
+  @param[in]      VariableName  Name of the variable that authorized the image.
+  @param[in]      VendorGuid    Vendor GUID of the variable that authorized the image.
+  @param[in]      Authority     The `db` authority that authorized the image, whose Data / Size
+                                identify the EFI_SIGNATURE_DATA entry to measure.
+**/
+VOID
+SecureBootHook (
+  IN OUT MEASURED_AUTHORITIES   *Measured,
+  IN     CHAR16                 *VariableName,
+  IN     EFI_GUID               *VendorGuid,
+  IN     CONST IMAGE_AUTHORITY  *Authority
+  )
+{
+  EFI_STATUS  Status;
+  VOID        *Data;
+  UINTN       DataSize;
+
+  if ((Measured == NULL) || (Authority == NULL) ||
+      (Authority->Data == NULL) || (Authority->Size == 0))
+  {
+    return;
+  }
+
+  Data     = (VOID *)Authority->Data;
+  DataSize = Authority->Size;
+
+  if (!IsSecureAuthorityVariable (VariableName, VendorGuid)) {
+    return;
+  }
+
+  if (IsDataMeasured (Measured, VariableName, VendorGuid, Data, DataSize)) {
+    DEBUG ((DEBUG_INFO, "DxeImageVerificationLib: authority already measured.\n"));
+    return;
+  }
+
+  Status = MeasureVariable (VariableName, VendorGuid, Data, DataSize);
+  DEBUG ((DEBUG_INFO, "DxeImageVerificationLib: MeasureVariable - %r\n", Status));
+
+  if (!EFI_ERROR (Status)) {
+    AddDataMeasured (Measured, VariableName, VendorGuid, Data, DataSize);
+  }
+}

--- a/SecurityPkg/Library/DxeImageVerificationLib2/Policy.c
+++ b/SecurityPkg/Library/DxeImageVerificationLib2/Policy.c
@@ -1,0 +1,141 @@
+/** @file
+  Image verification policy helpers for the DXE Image Verification Library.
+
+  Copyright (C) Microsoft Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "DxeImageVerificationLib.h"
+
+/**
+  Determine whether the given device path resolves to a Firmware Volume.
+
+  @param[in]   File       Device path describing the image origin.
+
+  @retval EFI_SUCCESS            The image is from a Firmware Volume.
+  @retval EFI_NOT_FOUND          The image is not from a Firmware Volume.
+  @retval EFI_INVALID_PARAMETER  File is NULL.
+**/
+EFI_STATUS
+IsFromFv (
+  IN  CONST EFI_DEVICE_PATH_PROTOCOL  *File
+  )
+{
+  EFI_STATUS                Status;
+  EFI_HANDLE                DeviceHandle;
+  EFI_DEVICE_PATH_PROTOCOL  *TempDevicePath;
+
+  if (File == NULL) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  DeviceHandle   = NULL;
+  TempDevicePath = (EFI_DEVICE_PATH_PROTOCOL *)File;
+  Status         = gBS->LocateDevicePath (
+                          &gEfiFirmwareVolume2ProtocolGuid,
+                          &TempDevicePath,
+                          &DeviceHandle
+                          );
+  if (EFI_ERROR (Status)) {
+    return EFI_NOT_FOUND;
+  }
+
+  //
+  // Confirm the protocol is actually present on the resolved handle.
+  //
+  Status = gBS->OpenProtocol (
+                  DeviceHandle,
+                  &gEfiFirmwareVolume2ProtocolGuid,
+                  NULL,
+                  NULL,
+                  NULL,
+                  EFI_OPEN_PROTOCOL_TEST_PROTOCOL
+                  );
+  if (EFI_ERROR (Status)) {
+    return EFI_NOT_FOUND;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Determines the Image type classification.
+
+  @param[in]   File       Device path describing the image origin.
+  @param[out]  ImageType  The classification of the image source.
+
+  @retval EFI_SUCCESS            ImageType contains a valid value.
+  @retval EFI_INVALID_PARAMETER  File or ImageType is NULL.
+**/
+EFI_STATUS
+GetImageType (
+  IN  CONST EFI_DEVICE_PATH_PROTOCOL  *File,
+  OUT UINT32                          *ImageType
+  )
+{
+  if ((File == NULL) || (ImageType == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!EFI_ERROR (IsFromFv (File))) {
+    *ImageType = IMAGE_FROM_FV;
+    return EFI_SUCCESS;
+  }
+
+  *ImageType = IMAGE_UNKNOWN;
+  return EFI_SUCCESS;
+}
+
+/**
+  Look up the configured authorization policy for the given image source.
+
+  IMAGE_FROM_FV is mapped to ALWAYS_EXECUTE; all other image types map to
+  DENY_EXECUTE_ON_SECURITY_VIOLATION.
+
+  @param[in]  ImageType  An IMAGE_* image source classification value.
+
+  @return  ALWAYS_EXECUTE or DENY_EXECUTE_ON_SECURITY_VIOLATION.
+**/
+UINT32
+GetPolicyForImageType (
+  IN UINT32  ImageType
+  )
+{
+  if (ImageType == IMAGE_FROM_FV) {
+    return ALWAYS_EXECUTE;
+  }
+
+  return DENY_EXECUTE_ON_SECURITY_VIOLATION;
+}
+
+/**
+  Resolve an image's authorization policy.
+
+  @param[in]   File    Device path describing the image origin.
+  @param[out]  Policy  On success, filled with the resolved policy value.
+
+  @retval EFI_SUCCESS            Policy contains a valid policy value.
+  @retval EFI_INVALID_PARAMETER  File or Policy is NULL.
+**/
+EFI_STATUS
+GetExecutionPolicy (
+  IN  CONST EFI_DEVICE_PATH_PROTOCOL  *File,
+  OUT UINT32                          *Policy
+  )
+{
+  EFI_STATUS  Status;
+  UINT32      ImageType;
+
+  if ((File == NULL) || (Policy == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = GetImageType (File, &ImageType);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  *Policy = GetPolicyForImageType (ImageType);
+
+  return EFI_SUCCESS;
+}

--- a/SecurityPkg/Library/DxeImageVerificationLib2/README.md
+++ b/SecurityPkg/Library/DxeImageVerificationLib2/README.md
@@ -1,0 +1,281 @@
+# DxeImageVerificationHandler Flow
+
+This document describes the runtime flow of
+`DxeImageVerificationHandler` in `SecurityPkg/Library/DxeImageVerificationLib2`.
+It focuses on the following phases:
+
+1. **Policy validation** (entry-point gating)
+2. **`ValidateImage`** (the single, unified validator for both signed
+   and unsigned images)
+3. `IsInDbx` / `IsInDb` (deny-list / allow-list membership search)
+4. `EvaluateImageCertificate` (per-certificate evaluation)
+
+`ValidateImage` builds a single `DIGEST_CACHE` bound to the image to prevent
+calculating the image digest more then once per supported algorithm. This
+cache is used throughout applicable functions in this flow.
+
+## About this library
+
+`DxeImageVerificationLib` is a `NULL` library: it has no public class
+interface. Linking it into a module runs its constructor, which
+registers `DxeImageVerificationHandler` with the platform's Security2
+architectural protocol. From then on, every image the DXE core loads is
+routed through that handler, which returns `EFI_SUCCESS` to permit
+execution or `EFI_ACCESS_DENIED` to block it.
+
+### Recording the outcome
+
+Image status reporting is done through the config table called
+`EFI_IMAGE_SECURE_BOOT_VERIFICATION_RESULT_TABLE`. This table records the
+overall status of the image and the status of the individual signatures
+in the image that were evaluated.
+
+### Measuring the outcome
+
+When an image is authorized **by a certificate**, the authorizing certificate
+is measured into **PCR 7** via `SecureBootHook`, The certificate is wrapped in
+a constructed V1 `EFI_SIGNATURE_DATA` structure. If a TBS certificate hash was
+the `db` entry that authorized the image, the derived certificate is the
+recorded data, not the hash itself. Images authorized **by image hash** are not
+measured. Each distinct authority is measured **at most once per boot**: the
+handler tracks the set of already-measured authorities and skips any it has
+seen before, so loading many images authorized by the same certificate extends
+PCR 7 only once for that authority.
+
+> **Diagram conventions**
+>
+> - **Yellow** nodes are functions provided by external **library
+>   classes** (e.g. `BaseCryptLib`, `SecureBootVariableLib`).
+> - **Blue** nodes are functions owned by this library that are
+>   **expanded in a later section**.
+> - For simplicity the diagrams assume the setup calls (iterator init,
+>   database load, etc.) neither truncate nor fail; the early-abort
+>   branches are omitted.
+
+## 1. Top-level flow
+
+```mermaid
+flowchart TD
+    A[DxeImageVerificationHandler] --> C[GetExecutionPolicy]
+    C --> D{{Policy == ALWAYS_EXECUTE?}}
+    D -- yes --> D1[return EFI_SUCCESS]
+    D -- no  --> E{{IsSecureBootEnabled?}}
+    E -- no  --> E1[return EFI_SUCCESS]
+    E -- yes --> F[GetImageSecurityDataDirectory]
+    F --> I[ValidateImage]
+
+    classDef drill fill:#d9ecff,stroke:#2f6fb2,color:#000;
+    class I drill;
+    classDef libclass fill:#ffe6a7,stroke:#d9822b,color:#000;
+    class E libclass;
+```
+
+Notes:
+
+- `GetExecutionPolicy` runs **before** the Secure Boot check because
+  it is cheap *and* the FV-dispatched-driver fast path (policy =
+  `ALWAYS_EXECUTE`) is by far the most common path. Short-circuiting
+  there avoids the Secure Boot variable read and PE/COFF parse for the
+  majority of invocations.
+- If Secure Boot is disabled the handler returns `EFI_SUCCESS` without
+  inspecting the image.
+- A PE/COFF parse failure in `GetImageSecurityDataDirectory` is treated
+  as a verification failure (its status is returned).
+- There is **one** authorizer. `ValidateImage` handles both signed and
+  unsigned images; a `SecDataDir.Size == 0` simply yields an empty
+  `WIN_CERTIFICATE` iterator.
+
+## 2. `ValidateImage`
+
+`ValidateImage` orchestrates three steps against a shared
+`DIGEST_CACHE`:
+
+1. **Image-hash revocation.** Look up the image's Authenticode digest
+   in `dbx` via `IsInDbx`. A hit - or a `dbx` that cannot be fully
+   parsed (fail-closed) - rejects the image.
+2. **Per-`WIN_CERTIFICATE` walk.** For each embedded `WIN_CERTIFICATE`,
+   ask `EvaluateImageCertificate` for a verdict; the first certificate
+   whose verdict is `ImageCertApproved` authorizes the image.
+3. **Image-hash fallback.** If no embedded signature authorizes the
+   image, look up the image's digest in `db` via `IsInDb`. A hit
+   authorizes on the image-hash path.
+
+When the image is authorized by a certificate, the authorizing certificate
+is measured into PCR 7 via `SecureBootHook` and the function returns
+`EFI_SUCCESS`; image-hash authorizations are not measured. When the image is
+rejected, the function simply returns `EFI_ACCESS_DENIED`.
+
+```mermaid
+flowchart TD
+    A[ValidateImage] --> B[LoadSignatureDatabases]
+    B --> S1[IsInDbx]
+    S1 --> S1Q{{Found or unparsable?}}
+    S1Q -- yes --> R[Reject]
+    S1Q -- no  --> D1[WinCertIterNext: next WIN_CERTIFICATE]
+    D1 --> D2{{Entry?}}
+    D2 -- yes --> IA[EvaluateImageCertificate]
+    IA --> IA1{{Approved?}}
+    IA1 -- yes --> G[SecureBootHook]
+    IA1 -- no --> D1
+    D2 -- no  --> H[IsInDb]
+    H --> H1{{Found?}}
+    H1 -- yes --> G
+    H1 -- no  --> R
+    G --> S[return EFI_SUCCESS]
+    R --> X[return EFI_ACCESS_DENIED]
+
+    classDef drill fill:#d9ecff,stroke:#2f6fb2,color:#000;
+    class IA,S1,H drill;
+```
+
+Notes:
+
+- `dbx` is consulted **before** the certificate walk and the `db`
+  hash fallback. A revoked image hash is denied regardless of any
+  certificates.
+- The first `WIN_CERTIFICATE` that authorizes wins; the walk is empty
+  for an unsigned image (`SecDataDir.Size == 0`), so such an image can
+  only be authorized by the `db` image-hash fallback.
+
+## 3. `IsInDb` / `IsInDbx`
+
+Cache-driven membership search over a signature database. The subject is
+described by a `DIGEST_CACHE`, being either an authenticode image digest, or
+a X509 digest.
+
+If the cache type is an authenticode image digest, then these functions support
+the following `EFI_SIGNATURE_LIST` signature types:
+
+* **gEfiCert<V2><HASH>Guid**: The authenticode image digest is hashed using the
+matching hash algorithm and the bytes are compared for a match.
+
+If the cache type is a X509 digest, then these functions support the following
+`EFI_SIGNATURE_LIST` signature types:
+
+* **gEfiCert<V2>X509Guid**: The X509 digest is compared directly to the
+contents for a match.
+
+* **gEfiCert<V2>X509<HASH>Guid**: The X509 digest is hashed using the matching
+hash algorithm and the bytes are compared for a match.
+
+
+These functions are wrappers around `FindInDatabase` which differ only in how
+they treat an incomplete walk:
+
+- **`IsInDb` (allow-list, best-effort).** Ignores truncation and honors
+  the valid prefix: dropped entries can only remove a potential
+  authorizer, never add one. Returns TRUE if the subject is present,
+  otherwise FALSE.
+- **`IsInDbx` (deny-list, fail-closed).** Returns TRUE if a matching
+  entry is found **or** the walk could not be completed, because a dropped
+  entry might have matched the subject.
+
+```mermaid
+flowchart TD
+    A[FindInDatabase Cache, Database] --> E[DatabaseIterNext: next EFI_SIGNATURE_LIST]
+    E --> E1{{Entry?}}
+    E1 -- no --> RF[found = FALSE]
+    E1 -- yes --> TY{{Signature type category}}
+    TY -- full X.509 cert V1/V2 --> STC[Target = subject cert DER]
+    TY -- image-hash or TBS-hash V1/V2 --> GH[GetHash: image or TBS digest]
+    GH --> STH[Target = digest]
+    STC --> EN[SigListIterNext: next entry]
+    STH --> EN
+    EN --> EN1{{Entry?}}
+    EN1 -- no --> E
+    EN1 -- yes --> CM{{CompareMem Target == entry?}}
+    CM -- no --> EN
+    CM -- yes --> FD[found = TRUE]
+    FD --> RET{{Exit}}
+    RF --> RET
+    RET -- IsInDb allow-list --> RB[return found]
+    RET -- IsInDbx deny-list --> RX[return found OR Truncated]
+```
+
+## 4. `EvaluateImageCertificate`
+
+Evaluates a single `WIN_CERTIFICATE` and reports a verdict as an
+`IMAGE_CERT_EVALUATION` out-parameter. The `EFI_STATUS` return indicates
+whether evaluation could be performed; the security outcome is the verdict.
+
+`EvaluateImageCertificate` extracts the `AuthData` from the `WIN_CERTIFICATE`
+then walks the `db`. This `db` walk supports both X509 and X509 hash signature
+list signature types. When the signature list signature type is an X509 hash,
+the underlying X509 is derived; then in both scenarios, the X509 bytes are
+searched for in the signature list. On a match, the chain from signer to the
+matched X509 is extracted. Each X509 is searched for in the `dbx` using
+`IsInDbx`.
+
+Ultimetly, if a certificate is found in the `db` and nothing in the chain
+between signer and the certificate is found in the `dbx`, then the signature
+authorizes the image to execute. Otherwise the search in the `db` will continue.
+
+The verdict (`Evaluation->Verdict`) is one of:
+
+| Verdict | Meaning |
+| --- | --- |
+| `ImageCertApproved` | A `db` anchor verified the image with an un-revoked chain. `Evaluation->Authority` wraps the authorizing certificate (an owned V1 `EFI_SIGNATURE_DATA`) for PCR 7 measurement. |
+| `ImageCertRevokedByDbx` | A `db` anchor verified the image, but a certificate in its verified chain is enrolled in `dbx`, and no other anchor authorizes it. |
+| `ImageCertNotInDb` | No `db` anchor verifies the image. |
+| `ImageCertUnusable` | The certificate could not be evaluated before trust-anchor processing: unsupported `WIN_CERTIFICATE` type, malformed PKCS#7, or unrecognized hash algorithm. |
+
+Evaluation is only valid if the return is `EFI_SUCCESS`. Any `EFI_ERROR`
+indicates that there was an error and the Evaluation cannot be trusted.[8-5]
+
+```mermaid
+flowchart TD
+    A[EvaluateImageCertificate Cert, Cache, Databases] --> P[ExtractAuthData]
+    P --> HA[GetAuthenticodeHashAlgorithm]
+    HA --> GH[GetHash]
+    GH --> DL[DatabaseIterNext: next EFI_SIGNATURE_LIST]
+    DL --> DL1{{Entry?}}
+    DL1 -- no --> EX[exit EFI_SUCCESS]
+    DL1 -- yes --> TY{{X509 or cert-hash list?}}
+    TY -- no --> DL
+    TY -- yes --> EN[SigListIterNext: next entry]
+    EN --> EN1{{Entry?}}
+    EN1 -- no --> DL
+    EN1 -- yes --> RT{{Signature type}}
+    RT -- full X.509 cert V1/V2 --> AX[Anchor = entry DER]
+    RT -- cert-hash --> GX[GetTrustAnchorX509FromAuthData → Anchor]
+    GX --> AV
+    AX --> AV{{AuthenticodeVerifyEx → verified chain?}}
+    AV -- no --> EN
+    AV -- yes --> CR[IsChainRevoked]
+    CR --> CR1{{revoked?}}
+    CR1 -- yes --> REV[Verdict = ImageCertRevokedByDbx]
+    REV --> EN
+    CR1 -- no --> APP[Verdict = ImageCertApproved, set Authority]
+    APP --> EX
+
+    classDef drill fill:#d9ecff,stroke:#2f6fb2,color:#000;
+    class CR drill;
+    classDef libclass fill:#ffe6a7,stroke:#d9822b,color:#000;
+    class HA,GX,AV libclass;
+```
+
+### 4a. `IsChainRevoked`
+
+Decides whether the certificate chain that authorizes the image is revoked
+by `dbx`. It consumes the `EFI_CERT_STACK` returned by the successful
+`AuthenticodeVerifyEx` call and reports the chain as revoked if **any**
+certificate in it is enrolled in the `dbx` (checked via `IsInDbx`, 3). Using
+the verifier-produced chain ensures the revocation decision applies to the
+exact chain that authorized the image.
+
+It fails **closed**: a missing or malformed chain buffer returns TRUE
+(revoked). An absent/empty `dbx` returns FALSE (nothing to revoke against).
+
+```mermaid
+flowchart TD
+  A[IsChainRevoked verified chain, dbx] --> W[walk EFI_CERT_STACK certs]
+    W --> W1{{Next cert?}}
+    W1 -- no --> RF[return FALSE]
+    W1 -- yes --> ID[IsInDbx]
+    ID --> ID1{{In dbx?}}
+    ID1 -- yes --> RT[return TRUE]
+    ID1 -- no --> W
+
+    classDef drill fill:#d9ecff,stroke:#2f6fb2,color:#000;
+    class ID drill;
+```

--- a/SecurityPkg/Library/DxeImageVerificationLib2/Support.c
+++ b/SecurityPkg/Library/DxeImageVerificationLib2/Support.c
@@ -1,0 +1,455 @@
+/** @file
+  Utility functions for DxeImageVerificationLib.
+
+  Copyright (C) Microsoft Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include "Support.h"
+
+/**
+  Resolve the hash-algorithm table index for Guid according to cache type.
+
+  @param[in]   CacheType  Digest cache type selecting the compatible GUID namespace.
+  @param[in]   Guid       Candidate signature-type GUID.
+  @param[out]  Index      On TRUE return, receives Guid's position in mHashAlgorithms.
+
+  @retval TRUE   Guid matched an entry compatible with CacheType.
+  @retval FALSE  CacheType is unsupported, Guid is NULL, Index is NULL, or Guid is not compatible
+                 with CacheType.
+**/
+STATIC
+BOOLEAN
+GetIndex (
+  IN  DIGEST_CACHE_TYPE  CacheType,
+  IN  CONST EFI_GUID     *Guid,
+  OUT UINTN              *Index
+  )
+{
+  UINTN  I;
+
+  if ((Guid == NULL) || (Index == NULL)) {
+    return FALSE;
+  }
+
+  for (I = 0; I < ARRAY_SIZE (mHashAlgorithms); I++) {
+    switch (CacheType) {
+      case DigestCacheTypeImage:
+        if (((mHashAlgorithms[I].ImageHashGuid != NULL) && CompareGuid (Guid, mHashAlgorithms[I].ImageHashGuid)) ||
+            ((mHashAlgorithms[I].ImageHashGuidV2 != NULL) && CompareGuid (Guid, mHashAlgorithms[I].ImageHashGuidV2)))
+        {
+          *Index = I;
+          return TRUE;
+        }
+
+        break;
+
+      case DigestCacheTypeX509:
+        if (((mHashAlgorithms[I].X509CertHashGuid != NULL) && CompareGuid (Guid, mHashAlgorithms[I].X509CertHashGuid)) ||
+            ((mHashAlgorithms[I].X509CertHashGuidV2 != NULL) && CompareGuid (Guid, mHashAlgorithms[I].X509CertHashGuidV2)))
+        {
+          *Index = I;
+          return TRUE;
+        }
+
+        break;
+
+      default:
+        return FALSE;
+    }
+  }
+
+  return FALSE;
+}
+
+/**
+  Get or compute a cached digest for HashType.
+
+  `Cache->Buffer` is the data to be hashed for cache miss while `Cache->Type` indicates how to
+  compute the digest.
+
+  Digest calculations are as follows:
+  - DigestCacheTypeImage: compute using GetAuthenticodeHash() with the specified HashType.
+  - DigestCacheTypeX509: compute using X509GetTbsCertHash() with the specified HashType.
+
+  @param[in]      HashType     Signature-type GUID identifying the hash algorithm to use.
+  @param[in,out]  Cache        Caller-owned digest cache bound to one buffer via Cache->Buffer /
+                               Cache->BufferSize.
+  @param[out]     Digest       On success, receives a pointer to the cached digest bytes. The
+                               pointer is valid for the lifetime of Cache.
+  @param[out]     DigestSize   On success, receives the digest length in bytes.
+
+  @retval EFI_SUCCESS            Digest / DigestSize describe a valid cached digest.
+  @retval EFI_INVALID_PARAMETER  A required pointer is NULL.
+  @retval EFI_UNSUPPORTED        HashType does not map to an entry in mHashAlgorithms compatible
+                                 with Cache->Type.
+  @retval EFI_COMPROMISED_DATA   Cache already holds a digest for this slot but the stored size is invalid.
+  @retval EFI_SECURITY_VIOLATION The hash operation failed.
+  @retval other                  Forwarded from GetAuthenticodeHash or X509GetTbsCertHash.
+**/
+EFI_STATUS
+GetHash (
+  IN     CONST EFI_GUID  *HashType,
+  IN OUT DIGEST_CACHE    *Cache,
+  OUT    CONST UINT8     **Digest,
+  OUT    UINTN           *DigestSize
+  )
+{
+  EFI_STATUS          Status;
+  UINTN               SlotIndex;
+  DIGEST_CACHE_ENTRY  *Slot;
+
+  if ((HashType == NULL) || (Cache == NULL) || (Cache->Buffer == NULL) ||
+      (Digest == NULL) || (DigestSize == NULL))
+  {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (!GetIndex (Cache->Type, HashType, &SlotIndex)) {
+    return EFI_UNSUPPORTED;
+  }
+
+  Slot = &Cache->Entries[SlotIndex];
+
+  //
+  // Populate the cache entry if it is not already populated.
+  //
+  if (Slot->BufferSize == 0) {
+    switch (Cache->Type) {
+      case DigestCacheTypeImage:
+        Status = GetAuthenticodeHash (
+                   (VOID *)Cache->Buffer,
+                   Cache->BufferSize,
+                   mHashAlgorithms[SlotIndex].ImageHashGuid, // Map possible V2 GUID to the base GUID
+                   Slot->Bytes,
+                   &Slot->BufferSize
+                   );
+        if (EFI_ERROR (Status)) {
+          Slot->BufferSize = 0;
+          return EFI_SECURITY_VIOLATION;
+        }
+
+        break;
+
+      case DigestCacheTypeX509:
+        Status = X509GetTbsCertHash (
+                   (VOID *)Cache->Buffer,
+                   Cache->BufferSize,
+                   mHashAlgorithms[SlotIndex].ImageHashGuid, // Map the X509 hash type GUID to the base hash type GUID
+                   Slot->Bytes,
+                   &Slot->BufferSize
+                   );
+        if (EFI_ERROR (Status)) {
+          Slot->BufferSize = 0;
+          return EFI_SECURITY_VIOLATION;
+        }
+
+        break;
+
+      default:
+        Slot->BufferSize = 0;
+        return EFI_UNSUPPORTED;
+    }
+  }
+
+  *Digest     = Slot->Bytes;
+  *DigestSize = Slot->BufferSize;
+  return EFI_SUCCESS;
+}
+
+//
+// Image Handle that contains the image bytes and size.
+//
+typedef struct {
+  CONST UINT8    *Base;
+  UINTN          BufferSize;
+} PE_COFF_IMAGE_HANDLE;
+
+/**
+  Buffer size aware implementation of PE_COFF_LOADER_READ_FILE.
+
+  Truncates reads for requests that start within the image bounds, but extends beyond the image
+  bounds. Sets read size to 0 for requests that start beyond the image bounds.
+
+  @param[in]      FileHandle  Pointer to a PE_COFF_IMAGE_HANDLE describing
+                              the image bytes available to PeCoffLib.
+  @param[in]      FileOffset  Byte offset within the image to read from.
+  @param[in,out]  ReadSize    On input, bytes requested. On output, bytes
+                              actually copied (may be 0 or less than
+                              requested if the range extends past EOF).
+  @param[out]     Buffer      Destination buffer of at least the input
+                              *ReadSize bytes.
+
+  @retval RETURN_SUCCESS            Read succeeded; *ReadSize is the
+                                    number of bytes copied.
+  @retval RETURN_INVALID_PARAMETER  FileHandle, ReadSize, or Buffer was
+                                    NULL.
+**/
+STATIC
+RETURN_STATUS
+EFIAPI
+BoundedImageRead (
+  IN     VOID   *FileHandle,
+  IN     UINTN  FileOffset,
+  IN OUT UINTN  *ReadSize,
+  OUT    VOID   *Buffer
+  )
+{
+  CONST PE_COFF_IMAGE_HANDLE  *Handle;
+  UINTN                       Available;
+
+  if ((FileHandle == NULL) || (ReadSize == NULL) || (Buffer == NULL)) {
+    return RETURN_INVALID_PARAMETER;
+  }
+
+  Handle = (CONST PE_COFF_IMAGE_HANDLE *)FileHandle;
+
+  if (FileOffset >= Handle->BufferSize) {
+    *ReadSize = 0;
+    return RETURN_SUCCESS;
+  }
+
+  Available = Handle->BufferSize - FileOffset;
+  if (*ReadSize > Available) {
+    *ReadSize = Available;
+  }
+
+  CopyMem (Buffer, Handle->Base + FileOffset, *ReadSize);
+  return RETURN_SUCCESS;
+}
+
+/**
+  Locate the EFI_IMAGE_DIRECTORY_ENTRY_SECURITY data directory in the
+  PE/COFF image contained in FileBuffer.
+
+  Caution: This function may receive untrusted input. The PE/COFF image
+  is external input and is bounds-checked by PeCoffLib before any field
+  is dereferenced.
+
+  @param[in]   FileBuffer  Pointer to the in-memory PE/COFF image.
+  @param[in]   FileSize    BufferSize of FileBuffer in bytes.
+  @param[out]  SecDataDir  On success, filled with a copy of the image's
+                           security data directory entry. Zeroed when
+                           the image declares no security directory.
+
+  @retval EFI_SUCCESS            SecDataDir has been populated.
+  @retval EFI_INVALID_PARAMETER  FileBuffer or SecDataDir is NULL.
+  @retval EFI_LOAD_ERROR         FileBuffer does not contain a valid
+                                 PE/COFF image, or PeCoffLib otherwise
+                                 rejected the headers.
+**/
+EFI_STATUS
+GetImageSecurityDataDirectory (
+  IN  VOID                      *FileBuffer,
+  IN  UINTN                     FileSize,
+  OUT EFI_IMAGE_DATA_DIRECTORY  *SecDataDir
+  )
+{
+  RETURN_STATUS                 PeCoffStatus;
+  PE_COFF_LOADER_IMAGE_CONTEXT  ImageContext;
+  PE_COFF_IMAGE_HANDLE          Handle;
+
+  if ((FileBuffer == NULL) || (SecDataDir == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  ZeroMem (SecDataDir, sizeof (*SecDataDir));
+
+  Handle.Base       = (CONST UINT8 *)FileBuffer;
+  Handle.BufferSize = FileSize;
+
+  //
+  // Delegate header parsing, signature validation, optional-header
+  // magic checks, and security-directory bounds checking to PeCoffLib.
+  // PeCoffLib records the validated security data directory entry in the
+  // image context, leaving it zeroed when the image declares no security
+  // directory.
+  //
+  ZeroMem (&ImageContext, sizeof (ImageContext));
+  ImageContext.Handle    = &Handle;
+  ImageContext.ImageRead = BoundedImageRead;
+
+  PeCoffStatus = PeCoffLoaderGetImageInfo (&ImageContext);
+  if (RETURN_ERROR (PeCoffStatus)) {
+    DEBUG ((DEBUG_INFO, "DxeImageVerificationLib: PeImage invalid (0x%lx).\n", (UINT64)PeCoffStatus));
+    return EFI_LOAD_ERROR;
+  }
+
+  *SecDataDir = ImageContext.SecurityDataDirectory;
+  return EFI_SUCCESS;
+}
+
+/**
+  Classify an EFI_SIGNATURE_LIST SignatureType GUID for the database walkers.
+
+  In a single table lookup, reports what a list's entries enroll (Kind) and how they are laid out
+  (OwnerSize): entries of a V1 signature type begin with a 16-byte SignatureOwner
+  (EFI_SIGNATURE_DATA), while V2 entries omit it (EFI_SIGNATURE_V2_DATA). The payload therefore
+  begins OwnerSize bytes into each entry.
+
+  @param[in]   SignatureType  The EFI_SIGNATURE_LIST SignatureType GUID.
+  @param[out]  Kind           On EFI_SUCCESS, the signature kind.
+  @param[out]  OwnerSize      On EFI_SUCCESS, the per-entry SignatureOwner size: 0 for a V2
+                              (EFI_SIGNATURE_V2_DATA) type, sizeof (EFI_GUID) for a V1
+                              (EFI_SIGNATURE_DATA) type.
+
+  @retval EFI_SUCCESS            SignatureType is recognized; Kind and OwnerSize are set.
+  @retval EFI_INVALID_PARAMETER  A required pointer is NULL.
+  @retval EFI_UNSUPPORTED        SignatureType is not a supported signature type.
+**/
+EFI_STATUS
+GetSignatureTypeInfo (
+  IN  CONST EFI_GUID  *SignatureType,
+  OUT SIGNATURE_KIND  *Kind,
+  OUT UINTN           *OwnerSize
+  )
+{
+  UINTN  Index;
+
+  if ((SignatureType == NULL) || (Kind == NULL) || (OwnerSize == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // Full X.509 certificate lists carry a DER certificate and are not tracked in mHashAlgorithms.
+  //
+  if (CompareGuid (SignatureType, &gEfiCertX509Guid)) {
+    *Kind      = SignatureKindX509Cert;
+    *OwnerSize = sizeof (EFI_GUID);
+    return EFI_SUCCESS;
+  }
+
+  if (CompareGuid (SignatureType, &gEfiCertV2X509Guid)) {
+    *Kind      = SignatureKindX509Cert;
+    *OwnerSize = 0;
+    return EFI_SUCCESS;
+  }
+
+  //
+  // Image-hash and X.509 TBS-cert-hash lists carry a digest. One pass over the table checks both
+  // roles across both layouts; a match in a V2 column reports a zero owner size.
+  //
+  for (Index = 0; Index < ARRAY_SIZE (mHashAlgorithms); Index++) {
+    if ((mHashAlgorithms[Index].ImageHashGuid != NULL) &&
+        CompareGuid (SignatureType, mHashAlgorithms[Index].ImageHashGuid))
+    {
+      *Kind      = SignatureKindImageHash;
+      *OwnerSize = sizeof (EFI_GUID);
+      return EFI_SUCCESS;
+    }
+
+    if ((mHashAlgorithms[Index].ImageHashGuidV2 != NULL) &&
+        CompareGuid (SignatureType, mHashAlgorithms[Index].ImageHashGuidV2))
+    {
+      *Kind      = SignatureKindImageHash;
+      *OwnerSize = 0;
+      return EFI_SUCCESS;
+    }
+
+    if ((mHashAlgorithms[Index].X509CertHashGuid != NULL) &&
+        CompareGuid (SignatureType, mHashAlgorithms[Index].X509CertHashGuid))
+    {
+      *Kind      = SignatureKindX509TbsHash;
+      *OwnerSize = sizeof (EFI_GUID);
+      return EFI_SUCCESS;
+    }
+
+    if ((mHashAlgorithms[Index].X509CertHashGuidV2 != NULL) &&
+        CompareGuid (SignatureType, mHashAlgorithms[Index].X509CertHashGuidV2))
+    {
+      *Kind      = SignatureKindX509TbsHash;
+      *OwnerSize = 0;
+      return EFI_SUCCESS;
+    }
+  }
+
+  return EFI_UNSUPPORTED;
+}
+
+/**
+  Populate Authority with a newly allocated V1 EFI_SIGNATURE_DATA that wraps a certificate payload.
+
+  The allocation is a 16-byte SignatureOwner followed by a copy of Payload. It is owned by the
+  caller and released with FreeImageAuthority (). Authority->SignatureType is left unchanged so the
+  caller can record the authorizing list's signature type independently.
+
+  @param[in]   Owner        SignatureOwner GUID to store, or NULL to store a zeroed GUID (used for a
+                            matching V2 EFI_SIGNATURE_V2_DATA entry, which carries no owner).
+  @param[in]   Payload      The certificate (or other signature payload) to copy.
+  @param[in]   PayloadSize  Size of Payload in bytes.
+  @param[out]  Authority    On success, Authority->Data references the allocated EFI_SIGNATURE_DATA
+                            and Authority->Size is its total length.
+
+  @retval EFI_SUCCESS            Authority was populated.
+  @retval EFI_INVALID_PARAMETER  Payload or Authority is NULL, or PayloadSize is 0 or too large.
+  @retval EFI_OUT_OF_RESOURCES   The allocation failed.
+**/
+EFI_STATUS
+BuildImageAuthority (
+  IN  CONST EFI_GUID   *Owner  OPTIONAL,
+  IN  CONST UINT8      *Payload,
+  IN  UINTN            PayloadSize,
+  OUT IMAGE_AUTHORITY  *Authority
+  )
+{
+  EFI_SIGNATURE_DATA  *SigData;
+  UINTN               TotalSize;
+
+  if ((Payload == NULL) || (PayloadSize == 0) || (Authority == NULL)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  //
+  // Reject a payload large enough to overflow the header addition. PayloadSize is derived from
+  // attacker-controlled db/dbx and image data, so the bound is checked before allocation.
+  //
+  if (PayloadSize > MAX_UINTN - OFFSET_OF (EFI_SIGNATURE_DATA, SignatureData)) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  TotalSize = OFFSET_OF (EFI_SIGNATURE_DATA, SignatureData) + PayloadSize;
+
+  SigData = AllocateZeroPool (TotalSize);
+  if (SigData == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  //
+  // A NULL Owner leaves the zeroed SignatureOwner from AllocateZeroPool in place (V2 source entry).
+  //
+  if (Owner != NULL) {
+    CopyGuid (&SigData->SignatureOwner, Owner);
+  }
+
+  CopyMem (SigData->SignatureData, Payload, PayloadSize);
+
+  Authority->Data = SigData;
+  Authority->Size = TotalSize;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Release the allocation owned by an IMAGE_AUTHORITY.
+
+  Frees Authority->Data (if any) and clears Authority->Data / Authority->Size. Authority->SignatureType
+  is left intact. Safe to call on an already-empty authority or a NULL pointer.
+
+  @param[in,out]  Authority  Authority whose owned Data is released.
+**/
+VOID
+FreeImageAuthority (
+  IN OUT IMAGE_AUTHORITY  *Authority
+  )
+{
+  if (Authority == NULL) {
+    return;
+  }
+
+  if (Authority->Data != NULL) {
+    FreePool (Authority->Data);
+    Authority->Data = NULL;
+  }
+
+  Authority->Size = 0;
+}

--- a/SecurityPkg/Library/DxeImageVerificationLib2/Support.h
+++ b/SecurityPkg/Library/DxeImageVerificationLib2/Support.h
@@ -1,0 +1,180 @@
+/** @file
+  Utility functions for DxeImageVerificationLib.
+
+  Copyright (C) Microsoft Corporation. All rights reserved.<BR>
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#pragma once
+
+#include "DxeImageVerificationLib.h"
+
+#include <Library/PeCoffLib.h>
+
+//
+// An enum to specify the type of data being cached in an instance of `DIGEST_CACHE`.
+//
+typedef enum {
+  DigestCacheTypeImage,
+  DigestCacheTypeX509
+} DIGEST_CACHE_TYPE;
+
+//
+// A cached digest slot in `DIGEST_CACHE`. The slot's position within `DIGEST_CACHE::Entries`
+// identifies the hash algorithm (ordering matches `mHashAlgorithms`).
+//
+// BufferSize == 0 marks an empty slot; any non-zero BufferSize identifies a valid cached digest
+// for that particular hash algorithm (based on index compared to `mHashAlgorithms`).
+//
+typedef struct {
+  UINT8    Bytes[MAX_DIGEST_SIZE];
+  UINTN    BufferSize;
+} DIGEST_CACHE_ENTRY;
+
+//
+// Caller-owned digest cache, one fixed slot per supported hash algorithm based on
+// `mHashAlgorithms` order.
+//
+// The structure should be zero-initialized before use as the DigestSize in each entry is used to
+// determine whether the slot contains a valid cached digest.
+//
+typedef struct {
+  DIGEST_CACHE_TYPE     Type;
+  CONST VOID            *Buffer;
+  UINTN                 BufferSize;
+  DIGEST_CACHE_ENTRY    Entries[ARRAY_SIZE (mHashAlgorithms)];
+} DIGEST_CACHE;
+
+/**
+  Get or compute a cached digest for HashType.
+
+  `Cache->Buffer` is the data to be hashed for cache miss while `Cache->Type` indicates how to
+  compute the digest.
+
+  Digest calculations are as follows:
+  - DigestCacheTypeImage: compute using GetAuthenticodeHash() with the specified HashType.
+  - DigestCacheTypeX509: compute using X509GetTbsCertHash() with the specified HashType.
+
+  @param[in]      HashType     Signature-type GUID identifying the hash algorithm to use.
+  @param[in,out]  Cache        Caller-owned digest cache bound to one buffer via Cache->Buffer /
+                               Cache->BufferSize.
+  @param[out]     Digest       On success, receives a pointer to the cached digest bytes. The
+                               pointer is valid for the lifetime of Cache.
+  @param[out]     DigestSize   On success, receives the digest length in bytes.
+
+  @retval EFI_SUCCESS            Digest / DigestSize describe a valid cached digest.
+  @retval EFI_INVALID_PARAMETER  A required pointer is NULL.
+  @retval EFI_UNSUPPORTED        HashType does not map to an entry in mHashAlgorithms compatible
+                                 with Cache->Type.
+  @retval EFI_COMPROMISED_DATA   Cache already holds a digest for this slot but the stored size is invalid.
+  @retval EFI_SECURITY_VIOLATION The hash operation failed.
+  @retval other                  Forwarded from GetAuthenticodeHash or X509GetTbsCertHash.
+**/
+EFI_STATUS
+GetHash (
+  IN     CONST EFI_GUID  *HashType,
+  IN OUT DIGEST_CACHE    *Cache,
+  OUT    CONST UINT8     **Digest,
+  OUT    UINTN           *DigestSize
+  );
+
+/**
+  Locate the EFI_IMAGE_DIRECTORY_ENTRY_SECURITY data directory in the
+  PE/COFF image contained in FileBuffer.
+
+  Caution: This function may receive untrusted input. The PE/COFF image
+  is external input and is bounds-checked by PeCoffLib before any field
+  is dereferenced.
+
+  @param[in]   FileBuffer  Pointer to the in-memory PE/COFF image.
+  @param[in]   FileSize    BufferSize of FileBuffer in bytes.
+  @param[out]  SecDataDir  On success, filled with a copy of the image's
+                           security data directory entry. Zeroed when
+                           the image declares no security directory.
+
+  @retval EFI_SUCCESS            SecDataDir has been populated.
+  @retval EFI_INVALID_PARAMETER  FileBuffer or SecDataDir is NULL.
+  @retval EFI_LOAD_ERROR         FileBuffer does not contain a valid
+                                 PE/COFF image, or PeCoffLib otherwise
+                                 rejected the headers.
+**/
+EFI_STATUS
+GetImageSecurityDataDirectory (
+  IN  VOID                      *FileBuffer,
+  IN  UINTN                     FileSize,
+  OUT EFI_IMAGE_DATA_DIRECTORY  *SecDataDir
+  );
+
+//
+// The kind of subject an EFI_SIGNATURE_LIST enrolls, independent of the entry layout (V1 vs V2)
+// that GetSignatureTypeInfo reports separately.
+//
+typedef enum {
+  SignatureKindImageHash,      // raw image digest           (EFI_CERT_SHA*      / EFI_CERT_V2_SHA*)
+  SignatureKindX509Cert,       // DER X.509 certificate       (EFI_CERT_X509      / EFI_CERT_V2_X509)
+  SignatureKindX509TbsHash     // X.509 TBSCertificate digest (EFI_CERT_X509_SHA* / EFI_CERT_V2_X509_SHA*)
+} SIGNATURE_KIND;
+
+/**
+  Classify an EFI_SIGNATURE_LIST SignatureType GUID for the database walkers.
+
+  In a single table lookup, reports what a list's entries enroll (Kind) and how they are laid out
+  (OwnerSize): entries of a V1 signature type begin with a 16-byte SignatureOwner
+  (EFI_SIGNATURE_DATA), while V2 entries omit it (EFI_SIGNATURE_V2_DATA). The payload therefore
+  begins OwnerSize bytes into each entry.
+
+  @param[in]   SignatureType  The EFI_SIGNATURE_LIST SignatureType GUID.
+  @param[out]  Kind           On EFI_SUCCESS, the signature kind.
+  @param[out]  OwnerSize      On EFI_SUCCESS, the per-entry SignatureOwner size: 0 for a V2
+                              (EFI_SIGNATURE_V2_DATA) type, sizeof (EFI_GUID) for a V1
+                              (EFI_SIGNATURE_DATA) type.
+
+  @retval EFI_SUCCESS            SignatureType is recognized; Kind and OwnerSize are set.
+  @retval EFI_INVALID_PARAMETER  A required pointer is NULL.
+  @retval EFI_UNSUPPORTED        SignatureType is not a supported signature type.
+**/
+EFI_STATUS
+GetSignatureTypeInfo (
+  IN  CONST EFI_GUID  *SignatureType,
+  OUT SIGNATURE_KIND  *Kind,
+  OUT UINTN           *OwnerSize
+  );
+
+/**
+  Populate Authority with a newly allocated V1 EFI_SIGNATURE_DATA that wraps a certificate payload.
+
+  The allocation is a 16-byte SignatureOwner followed by a copy of Payload. It is owned by the
+  caller and released with FreeImageAuthority (). Authority->SignatureType is left unchanged so the
+  caller can record the authorizing list's signature type independently.
+
+  @param[in]   Owner        SignatureOwner GUID to store, or NULL to store a zeroed GUID (used for a
+                            matching V2 EFI_SIGNATURE_V2_DATA entry, which carries no owner).
+  @param[in]   Payload      The certificate (or other signature payload) to copy.
+  @param[in]   PayloadSize  Size of Payload in bytes.
+  @param[out]  Authority    On success, Authority->Data references the allocated EFI_SIGNATURE_DATA
+                            and Authority->Size is its total length.
+
+  @retval EFI_SUCCESS            Authority was populated.
+  @retval EFI_INVALID_PARAMETER  Payload or Authority is NULL, or PayloadSize is 0 or too large.
+  @retval EFI_OUT_OF_RESOURCES   The allocation failed.
+**/
+EFI_STATUS
+BuildImageAuthority (
+  IN  CONST EFI_GUID   *Owner  OPTIONAL,
+  IN  CONST UINT8      *Payload,
+  IN  UINTN            PayloadSize,
+  OUT IMAGE_AUTHORITY  *Authority
+  );
+
+/**
+  Release the allocation owned by an IMAGE_AUTHORITY.
+
+  Frees Authority->Data (if any) and clears Authority->Data / Authority->Size. Authority->SignatureType
+  is left intact. Safe to call on an already-empty authority or a NULL pointer.
+
+  @param[in,out]  Authority  Authority whose owned Data is released.
+**/
+VOID
+FreeImageAuthority (
+  IN OUT IMAGE_AUTHORITY  *Authority
+  );

--- a/SecurityPkg/SecurityPkg.dsc
+++ b/SecurityPkg/SecurityPkg.dsc
@@ -206,6 +206,7 @@
 
 [Components]
   SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.inf
+  SecurityPkg/Library/DxeImageVerificationLib2/DxeImageVerificationLib.inf
   SecurityPkg/Library/DxeImageAuthenticationStatusLib/DxeImageAuthenticationStatusLib.inf
   SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/ImageSecureBootVerificationResultTableLib.inf
 

--- a/SecurityPkg/Test/SecurityPkgHostTest.dsc
+++ b/SecurityPkg/Test/SecurityPkgHostTest.dsc
@@ -64,6 +64,20 @@
 #  }
 # MU_CHANGE - Problems with Consuming OpensslLibFull and UnitTestHostBaseCryptLib from CryptoPkg
 
+SecurityPkg/Library/DxeImageVerificationLib2/GoogleTest/DxeImageVerificationLibGoogleTest.inf {
+    <LibraryClasses>
+      UefiRuntimeServicesTableLib|MdePkg/Test/Mock/Library/GoogleTest/MockUefiRuntimeServicesTableLib/MockUefiRuntimeServicesTableLib.inf
+      UefiBootServicesTableLib|MdePkg/Test/Mock/Library/GoogleTest/MockUefiBootServicesTableLib/MockUefiBootServicesTableLib.inf
+      DevicePathLib|MdePkg/Test/Mock/Library/GoogleTest/MockDevicePathLib/MockDevicePathLib.inf
+      DxeImageVerificationLib|SecurityPkg/Library/DxeImageVerificationLib2/DxeImageVerificationLib.inf
+      BaseCryptLib|CryptoPkg/Test/Mock/Library/GoogleTest/MockBaseCryptLib/MockBaseCryptLib.inf
+      UefiLib|MdePkg/Test/Mock/Library/GoogleTest/MockUefiLib/MockUefiLib.inf
+      SecureBootVariableLib|SecurityPkg/Test/Mock/Library/GoogleTest/MockSecureBootVariableLib/MockSecureBootVariableLib.inf
+      SecurityManagementLib|MdeModulePkg/Test/Mock/Library/GoogleTest/MockSecurityManagementLib/MockSecurityManagementLib.inf
+      PeCoffLib|MdePkg/Library/BasePeCoffLib/BasePeCoffLib.inf
+      PeCoffExtraActionLib|MdePkg/Library/BasePeCoffExtraActionLibNull/BasePeCoffExtraActionLibNull.inf
+      TpmMeasurementLib|MdeModulePkg/Test/Mock/Library/GoogleTest/MockTpmMeasurementLib/MockTpmMeasurementLib.inf
+  }
 
   SecurityPkg/Library/ImageSecureBootVerificationResultTableLib/GoogleTest/ImageSecureBootVerificationResultTableLibGoogleTest.inf {
     <LibraryClasses>


### PR DESCRIPTION
## Description

Adds the initial implementation of the updated DXE Image Verification Lib to the library as a new library. Includes host based unit tests.

For details on how to complete these options and their meaning refer to [CONTRIBUTING.md](https://github.com/microsoft/mu/blob/HEAD/CONTRIBUTING.md).

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Current implementation passes all image verification test app tests.

## Integration Instructions

replace the existing NULL library implementation with this one.
