### PR TITLE
[CHERRY-PICK] StandaloneMmPkg Core: Check PE section finding status

### DIFF
--- a/StandaloneMmPkg/Core/Dispatcher.c
+++ b/StandaloneMmPkg/Core/Dispatcher.c
@@ -377,9 +377,6 @@ MmGetDepexSectionAndPreProccess (
       //
       DriverEntry->DepexProtocolError = TRUE;
     } else {
-      //
-      // If no Depex assume depend on all architectural protocols
-      //
       DriverEntry->Depex              = NULL;
       DriverEntry->Dependent          = TRUE;
       DriverEntry->DepexProtocolError = FALSE;

--- a/StandaloneMmPkg/Core/FwVol.c
+++ b/StandaloneMmPkg/Core/FwVol.c
@@ -222,7 +222,12 @@ MmCoreFfsFindMmDriver (
       Status = FfsFindSectionData (EFI_SECTION_PE32, FileHeader, &Pe32Data, &Pe32DataSize);
       DEBUG ((DEBUG_INFO, "Find PE data - 0x%x\n", Pe32Data));
       DepexStatus = FfsFindSectionData (EFI_SECTION_MM_DEPEX, FileHeader, &Depex, &DepexSize);
-      if (!EFI_ERROR (DepexStatus)) {
+      if (DepexStatus == EFI_NOT_FOUND) {
+        Depex     = NULL;
+        DepexSize = 0;
+      }
+
+      if (!EFI_ERROR (Status)) {
         MmAddToDriverList (FwVolHeader, Pe32Data, Pe32DataSize, Depex, DepexSize, &FileHeader->Name);
       }
     }


### PR DESCRIPTION
## Description

StandaloneMmPkg Core: Check PE section finding status
The code should check PE section finding status instead of DEPEX section finding status for the driver to be added into list. It is a supplementary patch for 37db800 to support no DEPEX case.

(cherry picked from commit a4a7346cf4502a36ed4181cf45cf2eea1eb66b8f)


- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
