### PR TITLE
[CHERRY-PICK] StandaloneMmPkg/Core: Return when processing malformed DEPEX

### DIFF
--- a/StandaloneMmPkg/Core/Dependency.c
+++ b/StandaloneMmPkg/Core/Dependency.c
@@ -220,6 +220,7 @@ MmIsSchedulable (
         //
         DEBUG ((DEBUG_DISPATCH, "  RESULT = FALSE (Unexpected BEFORE or AFTER opcode)\n"));
         ASSERT (FALSE);
+        return FALSE;
 
       case EFI_DEP_PUSH:
         //


### PR DESCRIPTION
## Description
For a well-formed Dependency Expression, the code should never get here. The BEFORE and AFTER are processed prior to this routine's invocation. If the code flow arrives at this point, present code only called ASSERT(FALSE),
causing release builds to fall through to the EFI_DEP_SOR case.

Adding an explicit return FALSE after the assertion ensures correct error handling in release and debug build modes.

This commit also addresses the fix for Coverity
issue "MISSING BREAK"

Cc: Sachin Ganesh <sachinganesh@ami.com>

(cherry picked from commit 7e0b85e03bccb56c67a23fc651b449f75126719d)


- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
