### PR TITLE
[Cherry-pick] StandaloneMmPkg Core: Treat no DEPEX as TRUE

### DIFF
--- a/StandaloneMmPkg/Core/Dependency.c
+++ b/StandaloneMmPkg/Core/Dependency.c
@@ -182,12 +182,10 @@ MmIsSchedulable (
 
   if (DriverEntry->Depex == NULL) {
     //
-    // A NULL Depex means that the MM driver is not built correctly.
-    // All MM drivers must have a valid depex expression.
+    // If there is no DEPEX, assume the module can be executed
     //
-    DEBUG ((DEBUG_DISPATCH, "  RESULT = FALSE (Depex is empty)\n"));
-    ASSERT (FALSE);
-    return FALSE;
+    DEBUG ((DEBUG_DISPATCH, "  RESULT = TRUE (No DEPEX)\n"));
+    return TRUE;
   }
 
   //


### PR DESCRIPTION
## Description

Treat no DEPEX as TRUE, then the DEPEX section can be eliminated if a driver can be assured to have no
DEPEX needed.


(cherry picked from commit 37db80097dbe4d1487191422240bdc0a9ad8d963)

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

<_Describe the test(s) that were run to verify the changes._>

## Integration Instructions

<_Describe how these changes should be integrated. Use N/A if nothing is required._>
