### PR TITLE
[CHERRY-PICK] MdePkg: Add PeCoffLib and RngLib GoogleTest mocks

### DIFF
--- a/MdePkg/Test/MdePkgHostTest.dsc
+++ b/MdePkg/Test/MdePkgHostTest.dsc
@@ -75,6 +75,7 @@
   MdePkg/Test/Mock/Library/GoogleTest/MockPciLib/MockPciLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockDxeServicesTableLib/MockDxeServicesTableLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockPcdLib/MockPcdLib.inf
+  MdePkg/Test/Mock/Library/GoogleTest/MockPeCoffLib/MockPeCoffLib.inf
   MdePkg/Test/Mock/Library/Cmocka/MockUefiRuntimeServicesTableLib/MockUefiRuntimeServicesTableLib.inf
   MdePkg/Test/Mock/Library/Cmocka/MockUefiBootServicesTableLib/MockUefiBootServicesTableLib.inf
   MdePkg/Test/Mock/Library/Stub/StubHobLib/StubHobLib.inf

--- a/MdePkg/Test/MdePkgHostTest.dsc
+++ b/MdePkg/Test/MdePkgHostTest.dsc
@@ -76,6 +76,7 @@
   MdePkg/Test/Mock/Library/GoogleTest/MockDxeServicesTableLib/MockDxeServicesTableLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockPcdLib/MockPcdLib.inf
   MdePkg/Test/Mock/Library/GoogleTest/MockPeCoffLib/MockPeCoffLib.inf
+  MdePkg/Test/Mock/Library/GoogleTest/MockRngLib/MockRngLib.inf
   MdePkg/Test/Mock/Library/Cmocka/MockUefiRuntimeServicesTableLib/MockUefiRuntimeServicesTableLib.inf
   MdePkg/Test/Mock/Library/Cmocka/MockUefiBootServicesTableLib/MockUefiBootServicesTableLib.inf
   MdePkg/Test/Mock/Library/Stub/StubHobLib/StubHobLib.inf

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockPeCoffLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockPeCoffLib.h
@@ -1,0 +1,61 @@
+/** @file
+  Google Test mocks for PeCoffLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#pragma once
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+extern "C" {
+  #include <Uefi.h>
+  #include <Library/PeCoffLib.h>
+}
+
+struct MockPeCoffLib {
+  MOCK_INTERFACE_DECLARATION (MockPeCoffLib);
+
+  MOCK_FUNCTION_DECLARATION (
+    RETURN_STATUS,
+    PeCoffLoaderGetImageInfo,
+    (IN OUT PE_COFF_LOADER_IMAGE_CONTEXT  *ImageContext)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    RETURN_STATUS,
+    PeCoffLoaderRelocateImage,
+    (IN OUT PE_COFF_LOADER_IMAGE_CONTEXT  *ImageContext)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    RETURN_STATUS,
+    PeCoffLoaderLoadImage,
+    (IN OUT PE_COFF_LOADER_IMAGE_CONTEXT  *ImageContext)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    RETURN_STATUS,
+    PeCoffLoaderImageReadFromMemory,
+    (IN     VOID   *FileHandle,
+     IN     UINTN  FileOffset,
+     IN OUT UINTN  *ReadSize,
+     OUT    VOID   *Buffer)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    VOID,
+    PeCoffLoaderRelocateImageForRuntime,
+    (IN PHYSICAL_ADDRESS  ImageBase,
+     IN PHYSICAL_ADDRESS  VirtImageBase,
+     IN UINTN             ImageSize,
+     IN VOID              *RelocationData)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    RETURN_STATUS,
+    PeCoffLoaderUnloadImage,
+    (IN OUT PE_COFF_LOADER_IMAGE_CONTEXT  *ImageContext)
+    );
+};

--- a/MdePkg/Test/Mock/Include/GoogleTest/Library/MockRngLib.h
+++ b/MdePkg/Test/Mock/Include/GoogleTest/Library/MockRngLib.h
@@ -1,0 +1,49 @@
+/** @file
+  Google Test mocks for RngLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#pragma once
+
+#include <Library/GoogleTestLib.h>
+#include <Library/FunctionMockLib.h>
+extern "C" {
+  #include <Uefi.h>
+  #include <Library/RngLib.h>
+}
+
+struct MockRngLib {
+  MOCK_INTERFACE_DECLARATION (MockRngLib);
+
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    GetRandomNumber16,
+    (OUT UINT16  *Rand)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    GetRandomNumber32,
+    (OUT UINT32  *Rand)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    GetRandomNumber64,
+    (OUT UINT64  *Rand)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    BOOLEAN,
+    GetRandomNumber128,
+    (OUT UINT64  *Rand)
+    );
+
+  MOCK_FUNCTION_DECLARATION (
+    EFI_STATUS,
+    GetRngGuid,
+    (GUID  *RngGuid)
+    );
+};

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockPeCoffLib/MockPeCoffLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockPeCoffLib/MockPeCoffLib.cpp
@@ -1,0 +1,17 @@
+/** @file
+  Google Test mocks for PeCoffLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <GoogleTest/Library/MockPeCoffLib.h>
+
+MOCK_INTERFACE_DEFINITION (MockPeCoffLib);
+
+MOCK_FUNCTION_DEFINITION (MockPeCoffLib, PeCoffLoaderGetImageInfo, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPeCoffLib, PeCoffLoaderRelocateImage, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPeCoffLib, PeCoffLoaderLoadImage, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPeCoffLib, PeCoffLoaderImageReadFromMemory, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPeCoffLib, PeCoffLoaderRelocateImageForRuntime, 4, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockPeCoffLib, PeCoffLoaderUnloadImage, 1, EFIAPI);

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockPeCoffLib/MockPeCoffLib.inf
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockPeCoffLib/MockPeCoffLib.inf
@@ -1,0 +1,33 @@
+## @file
+# Google Test mocks for PeCoffLib
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MockPeCoffLib
+  FILE_GUID                      = E79BBE2D-008E-4831-AACF-4656C4AE99F3
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = PeCoffLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  MockPeCoffLib.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHsc

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockRngLib/MockRngLib.cpp
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockRngLib/MockRngLib.cpp
@@ -1,0 +1,16 @@
+/** @file
+  Google Test mocks for RngLib
+
+  Copyright (c) Microsoft Corporation.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <GoogleTest/Library/MockRngLib.h>
+
+MOCK_INTERFACE_DEFINITION (MockRngLib);
+
+MOCK_FUNCTION_DEFINITION (MockRngLib, GetRandomNumber16, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockRngLib, GetRandomNumber32, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockRngLib, GetRandomNumber64, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockRngLib, GetRandomNumber128, 1, EFIAPI);
+MOCK_FUNCTION_DEFINITION (MockRngLib, GetRngGuid, 1, EFIAPI);

--- a/MdePkg/Test/Mock/Library/GoogleTest/MockRngLib/MockRngLib.inf
+++ b/MdePkg/Test/Mock/Library/GoogleTest/MockRngLib/MockRngLib.inf
@@ -1,0 +1,33 @@
+## @file
+# Google Test mocks for RngLib
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = MockRngLib
+  FILE_GUID                      = 237613B8-9F39-46D3-BD44-52E8C40729D6
+  MODULE_TYPE                    = HOST_APPLICATION
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = RngLib
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = IA32 X64
+#
+
+[Sources]
+  MockRngLib.cpp
+
+[Packages]
+  MdePkg/MdePkg.dec
+  UnitTestFrameworkPkg/UnitTestFrameworkPkg.dec
+
+[LibraryClasses]
+  GoogleTestLib
+
+[BuildOptions]
+  MSFT:*_*_*_CC_FLAGS = /EHsc


### PR DESCRIPTION
## Description

This cherry-picks complete, reusable GoogleTest mocks for the public PeCoffLib and RngLib APIs from edk2 and adds both mock libraries to the MdePkg host-test DSC for CI integration.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

- `stuart_ci_build -c .pytool\CISettings.py -p MdePkg -a IA32,X64 -t NO-TARGET TOOL_CHAIN_TAG=VS2022` — passed all enforced MdePkg static CI checks; SpellCheck remained audit-only with the package's existing dictionary findings.
- `stuart_ci_build -c .pytool\CISettings.py -p MdePkg -a IA32,X64 -t NOOPT TOOL_CHAIN_TAG=VS2022` — passed the MdePkg host build and host-based unit-test run for X64.
- `stuart_ci_build -c .pytool\CISettings.py -p MdePkg -a IA32,X64 -t NO-TARGET TOOL_CHAIN_TAG=VS2022 -d HostUnitTestDscCompleteCheck=run` — passed host-test DSC completeness.
- `py -3 BaseTools\Scripts\PatchCheck.py e5826edfdbe5c97fc5522e18327a17c7423a6841` — code passed all checks; commit-message validation reports the required `[CHERRY-PICK]` prefix and the inherited upstream body line exceeding 75 characters.
- `py -3 BaseTools\Scripts\PatchCheck.py 2f6cd3ed96e2e55806728feff89bb541a460b8ed` — code passed all checks; commit-message validation reports the required `[CHERRY-PICK]` prefix and the inherited upstream body line exceeding 75 characters.

## Integration Instructions

N/A