### PR TITLE
[2608][REBASE & FF] [CHERRY-PICK] Revert SecurityPkg CodeQL and CP From edk2

### DIFF
--- a/SecurityPkg/FvReportPei/FvReportPei.c
+++ b/SecurityPkg/FvReportPei/FvReportPei.c
@@ -71,7 +71,10 @@ InstallPreHashFvPpi (
             + HashSize;
 
   PreHashedFvPpi = AllocatePool (PpiSize);
-  ASSERT (PreHashedFvPpi != NULL);
+  if (PreHashedFvPpi == NULL) {
+    ASSERT (PreHashedFvPpi != NULL);
+    return;
+  }
 
   PreHashedFvPpi->FvBase   = (UINT32)(UINTN)FvBuffer;
   PreHashedFvPpi->FvLength = (UINT32)FvLength;
@@ -83,7 +86,11 @@ InstallPreHashFvPpi (
   CopyMem (HASH_VALUE_PTR (HashInfo), HashValue, HashSize);
 
   FvInfoPpiDescriptor = AllocatePool (sizeof (EFI_PEI_PPI_DESCRIPTOR));
-  ASSERT (FvInfoPpiDescriptor != NULL);
+  if (FvInfoPpiDescriptor == NULL) {
+    ASSERT (FvInfoPpiDescriptor != NULL);
+    FreePool (PreHashedFvPpi);
+    return;
+  }
 
   FvInfoPpiDescriptor->Guid  = &gEdkiiPeiFirmwareVolumeInfoPrehashedFvPpiGuid;
   FvInfoPpiDescriptor->Flags = EFI_PEI_PPI_DESCRIPTOR_PPI | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST;
@@ -202,8 +209,11 @@ VerifyHashedFv (
     // Copy FV to permanent memory to avoid potential TOC/TOU.
     //
     FvBuffer = AllocatePages (EFI_SIZE_TO_PAGES ((UINTN)FvInfo[FvIndex].Length));
-
-    ASSERT (FvBuffer != NULL);
+    if (FvBuffer == NULL) {
+      ASSERT (FvBuffer != NULL);
+      Status = EFI_OUT_OF_RESOURCES;
+      goto Done;
+    }
 
     if (FvShadowPpi != NULL) {
       Status = FvShadowPpi->FirmwareVolumeShadow (

--- a/SecurityPkg/FvReportPei/FvReportPei.c
+++ b/SecurityPkg/FvReportPei/FvReportPei.c
@@ -71,13 +71,7 @@ InstallPreHashFvPpi (
             + HashSize;
 
   PreHashedFvPpi = AllocatePool (PpiSize);
-  // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-  if (PreHashedFvPpi == NULL) {
-    ASSERT (PreHashedFvPpi != NULL);
-    return;
-  }
-
-  // MU_CHANGE End - CodeQL change - unguardednullreturndereference
+  ASSERT (PreHashedFvPpi != NULL);
 
   PreHashedFvPpi->FvBase   = (UINT32)(UINTN)FvBuffer;
   PreHashedFvPpi->FvLength = (UINT32)FvLength;
@@ -89,14 +83,7 @@ InstallPreHashFvPpi (
   CopyMem (HASH_VALUE_PTR (HashInfo), HashValue, HashSize);
 
   FvInfoPpiDescriptor = AllocatePool (sizeof (EFI_PEI_PPI_DESCRIPTOR));
-  // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-  if (FvInfoPpiDescriptor == NULL) {
-    ASSERT (FvInfoPpiDescriptor != NULL);
-    FreePool (PreHashedFvPpi);
-    return;
-  }
-
-  // MU_CHANGE End - CodeQL change - unguardednullreturndereference
+  ASSERT (FvInfoPpiDescriptor != NULL);
 
   FvInfoPpiDescriptor->Guid  = &gEdkiiPeiFirmwareVolumeInfoPrehashedFvPpiGuid;
   FvInfoPpiDescriptor->Flags = EFI_PEI_PPI_DESCRIPTOR_PPI | EFI_PEI_PPI_DESCRIPTOR_TERMINATE_LIST;
@@ -215,14 +202,8 @@ VerifyHashedFv (
     // Copy FV to permanent memory to avoid potential TOC/TOU.
     //
     FvBuffer = AllocatePages (EFI_SIZE_TO_PAGES ((UINTN)FvInfo[FvIndex].Length));
-    // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-    if (FvBuffer == NULL) {
-      ASSERT (FvBuffer != NULL);
-      Status = EFI_OUT_OF_RESOURCES;
-      goto Done;
-    }
 
-    // MU_CHANGE End - CodeQL change - unguardednullreturndereference
+    ASSERT (FvBuffer != NULL);
 
     if (FvShadowPpi != NULL) {
       Status = FvShadowPpi->FirmwareVolumeShadow (
@@ -419,19 +400,12 @@ CheckStoredHashFv (
                       );
   if (!EFI_ERROR (Status) && (StoredHashFvPpi != NULL) && (StoredHashFvPpi->FvNumber > 0)) {
     HashInfo = GetHashInfo (StoredHashFvPpi, BootMode);
-    // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-    if (HashInfo != NULL) {
-      Status = VerifyHashedFv (
+    Status   = VerifyHashedFv (
                  HashInfo,
                  StoredHashFvPpi->FvInfo,
                  StoredHashFvPpi->FvNumber,
                  BootMode
                  );
-    } else {
-      Status = EFI_NOT_FOUND;
-    }
-
-    // MU_CHANGE End - CodeQL change - unguardednullreturndereference
     if (!EFI_ERROR (Status)) {
       DEBUG ((DEBUG_INFO, "OBB verification passed (%r)\r\n", Status));
 

--- a/SecurityPkg/HddPassword/HddPasswordDxe.c
+++ b/SecurityPkg/HddPassword/HddPasswordDxe.c
@@ -149,7 +149,10 @@ BuildHddPasswordDeviceInfo (
     S3InitDevicesExist = FALSE;
   } else if (Status == EFI_BUFFER_TOO_SMALL) {
     S3InitDevices = AllocatePool (S3InitDevicesLength);
-    ASSERT (S3InitDevices != NULL);
+    if (S3InitDevices == NULL) {
+      ASSERT (S3InitDevices != NULL);
+      return;
+    }
 
     Status = RestoreLockBox (
                &gS3StorageDeviceInitListGuid,
@@ -184,7 +187,12 @@ BuildHddPasswordDeviceInfo (
         FreePool (S3InitDevicesBak);
       }
 
-      ASSERT (S3InitDevices != NULL);
+      if (S3InitDevices == NULL) {
+        ASSERT (S3InitDevices != NULL);
+        ZeroMem (DevInfo, DevInfoLength);
+        FreePool (DevInfo);
+        return;
+      }
 
       TempDevInfo = (HDD_PASSWORD_DEVICE_INFO *)((UINTN)TempDevInfo +
                                                  sizeof (HDD_PASSWORD_DEVICE_INFO) +
@@ -2178,7 +2186,11 @@ HddPasswordFormExtractConfig (
 
   Private = HDD_PASSWORD_DXE_PRIVATE_FROM_THIS (This);
   IfrData = AllocateZeroPool (sizeof (HDD_PASSWORD_CONFIG));
-  ASSERT (IfrData != NULL);
+  if (IfrData == NULL) {
+    ASSERT (IfrData != NULL);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
   if (Private->Current != NULL) {
     CopyMem (IfrData, &Private->Current->IfrData, sizeof (HDD_PASSWORD_CONFIG));
   }
@@ -2195,9 +2207,21 @@ HddPasswordFormExtractConfig (
     // followed by "&OFFSET=0&WIDTH=WWWWWWWWWWWWWWWW" followed by a Null-terminator
     //
     ConfigRequestHdr = HiiConstructConfigHdr (&mHddPasswordVendorGuid, mHddPasswordVendorStorageName, Private->DriverHandle);
-    Size             = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
-    ConfigRequest    = AllocateZeroPool (Size);
-    ASSERT (ConfigRequest != NULL);
+    if (ConfigRequestHdr == NULL) {
+      ASSERT (ConfigRequestHdr != NULL);
+      FreePool (IfrData);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    Size          = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
+    ConfigRequest = AllocateZeroPool (Size);
+    if (ConfigRequest == NULL) {
+      ASSERT (ConfigRequest != NULL);
+      FreePool (IfrData);
+      FreePool (ConfigRequestHdr);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
     AllocatedRequest = TRUE;
     UnicodeSPrint (ConfigRequest, Size, L"%s&OFFSET=0&WIDTH=%016LX", ConfigRequestHdr, (UINT64)BufferSize);
     FreePool (ConfigRequestHdr);
@@ -2348,10 +2372,14 @@ HddPasswordFormCallback (
   Private = HDD_PASSWORD_DXE_PRIVATE_FROM_THIS (This);
 
   //
-  // Retrive data from Browser
+  // Retrieve data from Browser
   //
   IfrData = AllocateZeroPool (sizeof (HDD_PASSWORD_CONFIG));
-  ASSERT (IfrData != NULL);
+  if (IfrData == NULL) {
+    ASSERT (IfrData != NULL);
+    return EFI_OUT_OF_RESOURCES;
+  }
+
   if (!HiiGetBrowserData (&mHddPasswordVendorGuid, mHddPasswordVendorStorageName, sizeof (HDD_PASSWORD_CONFIG), (UINT8 *)IfrData)) {
     FreePool (IfrData);
     return EFI_NOT_FOUND;
@@ -2386,7 +2414,11 @@ HddPasswordFormCallback (
           // In case goto the device configuration form, update the device form title.
           //
           ConfigFormEntry = HddPasswordGetConfigFormEntryByIndex ((UINT32)(QuestionId - KEY_HDD_DEVICE_ENTRY_BASE));
-          ASSERT (ConfigFormEntry != NULL);
+          if (ConfigFormEntry == NULL) {
+            ASSERT (ConfigFormEntry != NULL);
+            FreePool (IfrData);
+            return EFI_NOT_FOUND;
+          }
 
           DeviceFormTitleToken = (EFI_STRING_ID)STR_HDD_SECURITY_HD;
           HiiSetString (Private->HiiHandle, DeviceFormTitleToken, ConfigFormEntry->HddString, NULL);

--- a/SecurityPkg/HddPassword/HddPasswordDxe.c
+++ b/SecurityPkg/HddPassword/HddPasswordDxe.c
@@ -149,13 +149,7 @@ BuildHddPasswordDeviceInfo (
     S3InitDevicesExist = FALSE;
   } else if (Status == EFI_BUFFER_TOO_SMALL) {
     S3InitDevices = AllocatePool (S3InitDevicesLength);
-    // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-    if (S3InitDevices == NULL) {
-      ASSERT (S3InitDevices != NULL);
-      return;
-    }
-
-    // MU_CHANGE End - CodeQL change - unguardednullreturndereference
+    ASSERT (S3InitDevices != NULL);
 
     Status = RestoreLockBox (
                &gS3StorageDeviceInitListGuid,
@@ -190,13 +184,7 @@ BuildHddPasswordDeviceInfo (
         FreePool (S3InitDevicesBak);
       }
 
-      // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-      if (S3InitDevices == NULL) {
-        ASSERT (S3InitDevices != NULL);
-        return;
-      }
-
-      // MU_CHANGE End - CodeQL change - unguardednullreturndereference
+      ASSERT (S3InitDevices != NULL);
 
       TempDevInfo = (HDD_PASSWORD_DEVICE_INFO *)((UINTN)TempDevInfo +
                                                  sizeof (HDD_PASSWORD_DEVICE_INFO) +
@@ -2207,16 +2195,8 @@ HddPasswordFormExtractConfig (
     // followed by "&OFFSET=0&WIDTH=WWWWWWWWWWWWWWWW" followed by a Null-terminator
     //
     ConfigRequestHdr = HiiConstructConfigHdr (&mHddPasswordVendorGuid, mHddPasswordVendorStorageName, Private->DriverHandle);
-    // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-    if (ConfigRequestHdr == NULL) {
-      ASSERT (ConfigRequestHdr != NULL);
-      FreePool (IfrData);
-      return EFI_OUT_OF_RESOURCES;
-    }
-
-    // MU_CHANGE End - CodeQL change - unguardednullreturndereference
-    Size          = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
-    ConfigRequest = AllocateZeroPool (Size);
+    Size             = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
+    ConfigRequest    = AllocateZeroPool (Size);
     ASSERT (ConfigRequest != NULL);
     AllocatedRequest = TRUE;
     UnicodeSPrint (ConfigRequest, Size, L"%s&OFFSET=0&WIDTH=%016LX", ConfigRequestHdr, (UINT64)BufferSize);
@@ -2406,14 +2386,7 @@ HddPasswordFormCallback (
           // In case goto the device configuration form, update the device form title.
           //
           ConfigFormEntry = HddPasswordGetConfigFormEntryByIndex ((UINT32)(QuestionId - KEY_HDD_DEVICE_ENTRY_BASE));
-          // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-          if (ConfigFormEntry == NULL) {
-            ASSERT (ConfigFormEntry != NULL);
-            FreePool (IfrData);
-            return EFI_NOT_FOUND;
-          }
-
-          // MU_CHANGE End - CodeQL change - unguardednullreturndereference
+          ASSERT (ConfigFormEntry != NULL);
 
           DeviceFormTitleToken = (EFI_STRING_ID)STR_HDD_SECURITY_HD;
           HiiSetString (Private->HiiHandle, DeviceFormTitleToken, ConfigFormEntry->HddString, NULL);

--- a/SecurityPkg/Library/AuthVariableLib/AuthService.c
+++ b/SecurityPkg/Library/AuthVariableLib/AuthService.c
@@ -557,7 +557,7 @@ CheckSignatureListFormat (
   // Walk through the input signature list and check the data format.
   // If any signature is incorrectly formed, the whole check will fail.
   //
-  while ((SigDataSize > 0) && (SigDataSize >= SigList->SignatureListSize)) {
+  while ((SigDataSize > 0) && (SigDataSize >= (UINTN)SigList->SignatureListSize)) {
     for (Index = 0; Index < (sizeof (mSupportSigItem) / sizeof (EFI_SIGNATURE_ITEM)); Index++ ) {
       if (CompareGuid (&SigList->SignatureType, &mSupportSigItem[Index].SigType)) {
         //

--- a/SecurityPkg/Library/AuthVariableLib/AuthService.c
+++ b/SecurityPkg/Library/AuthVariableLib/AuthService.c
@@ -557,9 +557,7 @@ CheckSignatureListFormat (
   // Walk through the input signature list and check the data format.
   // If any signature is incorrectly formed, the whole check will fail.
   //
-  // MU_CHANGE Start - CodeQL change - comparison-with-wider-type
-  while ((SigDataSize > 0) && (SigDataSize >= (UINTN)SigList->SignatureListSize)) {
-    // MU_CHANGE End - CodeQL change - comparison-with-wider-type
+  while ((SigDataSize > 0) && (SigDataSize >= SigList->SignatureListSize)) {
     for (Index = 0; Index < (sizeof (mSupportSigItem) / sizeof (EFI_SIGNATURE_ITEM)); Index++ ) {
       if (CompareGuid (&SigList->SignatureType, &mSupportSigItem[Index].SigType)) {
         //

--- a/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
+++ b/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
@@ -883,7 +883,7 @@ IsCertHashFoundInDbx (
     return Status;
   }
 
-  while ((DbxSize > 0) && (SignatureListSize >= DbxList->SignatureListSize)) {
+  while ((DbxSize > 0) && (SignatureListSize >= (UINTN)DbxList->SignatureListSize)) {
     //
     // Determine Hash Algorithm of Certificate in the forbidden database.
     //
@@ -1028,7 +1028,7 @@ IsSignatureFoundInDatabase (
   // Enumerate all signature data in SigDB to check if signature exists for executable.
   //
   CertList = (EFI_SIGNATURE_LIST *)Data;
-  while ((DataSize > 0) && (DataSize >= CertList->SignatureListSize)) {
+  while ((DataSize > 0) && (DataSize >= (UINTN)CertList->SignatureListSize)) {
     CertCount = (CertList->SignatureListSize - sizeof (EFI_SIGNATURE_LIST) - CertList->SignatureHeaderSize) / CertList->SignatureSize;
     Cert      = (EFI_SIGNATURE_DATA *)((UINT8 *)CertList + sizeof (EFI_SIGNATURE_LIST) + CertList->SignatureHeaderSize);
     if ((CertList->SignatureSize == sizeof (EFI_SIGNATURE_DATA) - 1 + SignatureSize) && (CompareGuid (&CertList->SignatureType, CertType))) {
@@ -1193,7 +1193,7 @@ PassTimestampCheck (
   }
 
   CertList = (EFI_SIGNATURE_LIST *)DbtData;
-  while ((DbtDataSize > 0) && (DbtDataSize >= CertList->SignatureListSize)) {
+  while ((DbtDataSize > 0) && (DbtDataSize >= (UINTN)CertList->SignatureListSize)) {
     if (CompareGuid (&CertList->SignatureType, &gEfiCertX509Guid)) {
       Cert      = (EFI_SIGNATURE_DATA *)((UINT8 *)CertList + sizeof (EFI_SIGNATURE_LIST) + CertList->SignatureHeaderSize);
       CertCount = (CertList->SignatureListSize - sizeof (EFI_SIGNATURE_LIST) - CertList->SignatureHeaderSize) / CertList->SignatureSize;
@@ -1319,7 +1319,7 @@ IsForbiddenByDbx (
   //
   CertList     = (EFI_SIGNATURE_LIST *)Data;
   CertListSize = DataSize;
-  while ((CertListSize > 0) && (CertListSize >= CertList->SignatureListSize)) {
+  while ((CertListSize > 0) && (CertListSize >= (UINTN)CertList->SignatureListSize)) {
     if (CompareGuid (&CertList->SignatureType, &gEfiCertX509Guid)) {
       CertData  = (EFI_SIGNATURE_DATA *)((UINT8 *)CertList + sizeof (EFI_SIGNATURE_LIST) + CertList->SignatureHeaderSize);
       CertCount = (CertList->SignatureListSize - sizeof (EFI_SIGNATURE_LIST) - CertList->SignatureHeaderSize) / CertList->SignatureSize;
@@ -1524,7 +1524,7 @@ IsAllowedByDb (
   // Find X509 certificate in Signature List to verify the signature in pkcs7 signed data.
   //
   CertList = (EFI_SIGNATURE_LIST *)Data;
-  while ((DataSize > 0) && (DataSize >= CertList->SignatureListSize)) {
+  while ((DataSize > 0) && (DataSize >= (UINTN)CertList->SignatureListSize)) {
     if (CompareGuid (&CertList->SignatureType, &gEfiCertX509Guid)) {
       CertData  = (EFI_SIGNATURE_DATA *)((UINT8 *)CertList + sizeof (EFI_SIGNATURE_LIST) + CertList->SignatureHeaderSize);
       CertCount = (CertList->SignatureListSize - sizeof (EFI_SIGNATURE_LIST) - CertList->SignatureHeaderSize) / CertList->SignatureSize;

--- a/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
+++ b/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c
@@ -883,9 +883,7 @@ IsCertHashFoundInDbx (
     return Status;
   }
 
-  // MU_CHANGE Start - CodeQL change - comparison-with-wider-type
-  while ((DbxSize > 0) && (SignatureListSize >= (UINTN)DbxList->SignatureListSize)) {
-    // MU_CHANGE End - CodeQL change - comparison-with-wider-type
+  while ((DbxSize > 0) && (SignatureListSize >= DbxList->SignatureListSize)) {
     //
     // Determine Hash Algorithm of Certificate in the forbidden database.
     //
@@ -1030,9 +1028,7 @@ IsSignatureFoundInDatabase (
   // Enumerate all signature data in SigDB to check if signature exists for executable.
   //
   CertList = (EFI_SIGNATURE_LIST *)Data;
-  // MU_CHANGE Start - CodeQL change - comparison-with-wider-type
-  while ((DataSize > 0) && (DataSize >= (UINTN)CertList->SignatureListSize)) {
-    // MU_CHANGE End - CodeQL change - comparison-with-wider-type
+  while ((DataSize > 0) && (DataSize >= CertList->SignatureListSize)) {
     CertCount = (CertList->SignatureListSize - sizeof (EFI_SIGNATURE_LIST) - CertList->SignatureHeaderSize) / CertList->SignatureSize;
     Cert      = (EFI_SIGNATURE_DATA *)((UINT8 *)CertList + sizeof (EFI_SIGNATURE_LIST) + CertList->SignatureHeaderSize);
     if ((CertList->SignatureSize == sizeof (EFI_SIGNATURE_DATA) - 1 + SignatureSize) && (CompareGuid (&CertList->SignatureType, CertType))) {
@@ -1197,9 +1193,7 @@ PassTimestampCheck (
   }
 
   CertList = (EFI_SIGNATURE_LIST *)DbtData;
-  // MU_CHANGE Start - CodeQL change - comparison-with-wider-type
-  while ((DbtDataSize > 0) && (DbtDataSize >= (UINTN)CertList->SignatureListSize)) {
-    // MU_CHANGE End - CodeQL change - comparison-with-wider-type
+  while ((DbtDataSize > 0) && (DbtDataSize >= CertList->SignatureListSize)) {
     if (CompareGuid (&CertList->SignatureType, &gEfiCertX509Guid)) {
       Cert      = (EFI_SIGNATURE_DATA *)((UINT8 *)CertList + sizeof (EFI_SIGNATURE_LIST) + CertList->SignatureHeaderSize);
       CertCount = (CertList->SignatureListSize - sizeof (EFI_SIGNATURE_LIST) - CertList->SignatureHeaderSize) / CertList->SignatureSize;
@@ -1325,9 +1319,7 @@ IsForbiddenByDbx (
   //
   CertList     = (EFI_SIGNATURE_LIST *)Data;
   CertListSize = DataSize;
-  // MU_CHANGE Start - CodeQL change - comparison-with-wider-type
-  while ((CertListSize > 0) && (CertListSize >= (UINTN)CertList->SignatureListSize)) {
-    // MU_CHANGE End - CodeQL change - comparison-with-wider-type
+  while ((CertListSize > 0) && (CertListSize >= CertList->SignatureListSize)) {
     if (CompareGuid (&CertList->SignatureType, &gEfiCertX509Guid)) {
       CertData  = (EFI_SIGNATURE_DATA *)((UINT8 *)CertList + sizeof (EFI_SIGNATURE_LIST) + CertList->SignatureHeaderSize);
       CertCount = (CertList->SignatureListSize - sizeof (EFI_SIGNATURE_LIST) - CertList->SignatureHeaderSize) / CertList->SignatureSize;
@@ -1532,9 +1524,7 @@ IsAllowedByDb (
   // Find X509 certificate in Signature List to verify the signature in pkcs7 signed data.
   //
   CertList = (EFI_SIGNATURE_LIST *)Data;
-  // MU_CHANGE Start - CodeQL change - comparison-with-wider-type
-  while ((DataSize > 0) && (DataSize >= (UINTN)CertList->SignatureListSize)) {
-    // MU_CHANGE End - CodeQL change - comparison-with-wider-type
+  while ((DataSize > 0) && (DataSize >= CertList->SignatureListSize)) {
     if (CompareGuid (&CertList->SignatureType, &gEfiCertX509Guid)) {
       CertData  = (EFI_SIGNATURE_DATA *)((UINT8 *)CertList + sizeof (EFI_SIGNATURE_LIST) + CertList->SignatureHeaderSize);
       CertCount = (CertList->SignatureListSize - sizeof (EFI_SIGNATURE_LIST) - CertList->SignatureHeaderSize) / CertList->SignatureSize;
@@ -2071,15 +2061,11 @@ Failed:
   // executable information table in either case.
   //
   NameStr = ConvertDevicePathToText (File, FALSE, TRUE);
-
-  // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
+  AddImageExeInfo (Action, NameStr, File, SignatureList, SignatureListSize);
   if (NameStr != NULL) {
-    AddImageExeInfo (Action, NameStr, File, SignatureList, SignatureListSize);
     DEBUG ((DEBUG_INFO, "The image doesn't pass verification: %s\n", NameStr));
     FreePool (NameStr);
   }
-
-  // MU_CHANGE End - CodeQL change - unguardednullreturndereference
 
   if (SignatureList != NULL) {
     FreePool (SignatureList);

--- a/SecurityPkg/Library/DxeTcg2PhysicalPresenceLib/DxeTcg2PhysicalPresenceLib.c
+++ b/SecurityPkg/Library/DxeTcg2PhysicalPresenceLib/DxeTcg2PhysicalPresenceLib.c
@@ -399,13 +399,7 @@ Tcg2UserConfirm (
   NoPpiInfo   = FALSE;
   BufSize     = CONFIRM_BUFFER_SIZE;
   ConfirmText = AllocateZeroPool (BufSize);
-  // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-  if (ConfirmText == NULL) {
-    ASSERT (ConfirmText != NULL);
-    return FALSE;
-  }
-
-  // MU_CHANGE End - CodeQL change - unguardednullreturndereference
+  ASSERT (ConfirmText != NULL);
 
   mTcg2PpStringPackHandle = HiiAddPackages (&gEfiTcg2PhysicalPresenceGuid, gImageHandle, DxeTcg2PhysicalPresenceLibStrings, NULL);
   ASSERT (mTcg2PpStringPackHandle != NULL);
@@ -419,24 +413,10 @@ Tcg2UserConfirm (
       TmpStr2    = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_CLEAR));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_HEAD_STR));
-      // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
-      // MU_CHANGE End - CodeQL change - unguardednullreturndereference
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_WARNING_CLEAR));
-      // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-      if (TmpStr1 == NULL) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
-      // MU_CHANGE End - CodeQL change - unguardednullreturndereference
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), L" \n\n", (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
@@ -449,35 +429,14 @@ Tcg2UserConfirm (
       TmpStr2    = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_CLEAR));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_PPI_HEAD_STR));
-      // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
-      // MU_CHANGE End - CodeQL change - unguardednullreturndereference
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_NOTE_CLEAR));
-      // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-      if (TmpStr1 == NULL) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
-      // MU_CHANGE End - CodeQL change - unguardednullreturndereference
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_WARNING_CLEAR));
-      // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-      if (TmpStr1 == NULL) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
-      // MU_CHANGE End - CodeQL change - unguardednullreturndereference
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), L" \n\n", (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
@@ -505,35 +464,14 @@ Tcg2UserConfirm (
       TmpStr2    = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_SET_PCR_BANKS));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_HEAD_STR));
-      // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
-      // MU_CHANGE End - CodeQL change - unguardednullreturndereference
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_WARNING_SET_PCR_BANKS_1));
-      // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-      if (TmpStr1 == NULL) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
-      // MU_CHANGE End - CodeQL change - unguardednullreturndereference
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_WARNING_SET_PCR_BANKS_2));
-      // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-      if (TmpStr1 == NULL) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
-      // MU_CHANGE End - CodeQL change - unguardednullreturndereference
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
 
@@ -541,13 +479,7 @@ Tcg2UserConfirm (
       Tcg2FillBufferWithBootHashAlg (TempBuffer2, sizeof (TempBuffer2), CurrentPCRBanks);
 
       TmpStr1 = AllocateZeroPool (BufSize);
-      // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-      if (TmpStr1 == NULL) {
-        ASSERT (TmpStr1 != NULL);
-        return FALSE;
-      }
-
-      // MU_CHANGE End - CodeQL change - unguardednullreturndereference
+      ASSERT (TmpStr1 != NULL);
       UnicodeSPrint (TmpStr1, BufSize, L"Current PCRBanks is 0x%x. (%s)\nNew PCRBanks is 0x%x. (%s)\n", CurrentPCRBanks, TempBuffer2, TpmPpCommandParameter, TempBuffer);
 
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
@@ -561,35 +493,14 @@ Tcg2UserConfirm (
       TmpStr2    = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_CHANGE_EPS));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_HEAD_STR));
-      // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
-      // MU_CHANGE End - CodeQL change - unguardednullreturndereference
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_WARNING_CHANGE_EPS_1));
-      // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-      if (TmpStr1 == NULL) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
-      // MU_CHANGE End - CodeQL change - unguardednullreturndereference
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_WARNING_CHANGE_EPS_2));
-      // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-      if (TmpStr1 == NULL) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
-      // MU_CHANGE End - CodeQL change - unguardednullreturndereference
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
 
@@ -599,13 +510,6 @@ Tcg2UserConfirm (
       TmpStr2 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_ENABLE_BLOCK_SID));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_HEAD_STR));
-      // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
-      // MU_CHANGE End - CodeQL change - unguardednullreturndereference
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
       break;
@@ -614,13 +518,6 @@ Tcg2UserConfirm (
       TmpStr2 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_DISABLE_BLOCK_SID));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_HEAD_STR));
-      // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
-      // MU_CHANGE End - CodeQL change - unguardednullreturndereference
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
       break;
@@ -630,13 +527,6 @@ Tcg2UserConfirm (
       TmpStr2   = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_PP_ENABLE_BLOCK_SID));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_PPI_HEAD_STR));
-      // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
-      // MU_CHANGE End - CodeQL change - unguardednullreturndereference
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
       break;
@@ -646,13 +536,6 @@ Tcg2UserConfirm (
       TmpStr2   = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_PP_DISABLE_BLOCK_SID));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_PPI_HEAD_STR));
-      // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
-      // MU_CHANGE End - CodeQL change - unguardednullreturndereference
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
       break;
@@ -673,25 +556,11 @@ Tcg2UserConfirm (
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_ACCEPT_KEY));
     }
 
-    // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-    if (TmpStr1 == NULL) {
-      FreePool (ConfirmText);
-      return FALSE;
-    }
-
-    // MU_CHANGE End - CodeQL change - unguardednullreturndereference
     StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
     FreePool (TmpStr1);
 
     if (NoPpiInfo) {
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_NO_PPI_INFO));
-      // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-      if (TmpStr1 == NULL) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
-      // MU_CHANGE End - CodeQL change - unguardednullreturndereference
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
     }
@@ -704,39 +573,17 @@ Tcg2UserConfirm (
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_ACCEPT_KEY));
     }
 
-    // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-    if (TmpStr1 == NULL) {
-      FreePool (ConfirmText);
-      return FALSE;
-    }
-
-    // MU_CHANGE End - CodeQL change - unguardednullreturndereference
     StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
     FreePool (TmpStr1);
 
     if (NoPpiInfo) {
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_NO_PPI_INFO));
-      // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-      if (TmpStr1 == NULL) {
-        FreePool (ConfirmText);
-        return FALSE;
-      }
-
-      // MU_CHANGE End - CodeQL change - unguardednullreturndereference
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
     }
 
     TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_REJECT_KEY));
   }
-
-  // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-  if (TmpStr1 == NULL) {
-    FreePool (ConfirmText);
-    return FALSE;
-  }
-
-  // MU_CHANGE End - CodeQL change - unguardednullreturndereference
 
   BufSize -= StrSize (ConfirmText);
   UnicodeSPrint (ConfirmText + StrLen (ConfirmText), BufSize, TmpStr1, TmpStr2);

--- a/SecurityPkg/Library/DxeTcg2PhysicalPresenceLib/DxeTcg2PhysicalPresenceLib.c
+++ b/SecurityPkg/Library/DxeTcg2PhysicalPresenceLib/DxeTcg2PhysicalPresenceLib.c
@@ -394,15 +394,23 @@ Tcg2UserConfirm (
   UINT32                            CurrentPCRBanks;
   EFI_STATUS                        Status;
 
+  TmpStr1     = NULL;
   TmpStr2     = NULL;
   CautionKey  = FALSE;
   NoPpiInfo   = FALSE;
   BufSize     = CONFIRM_BUFFER_SIZE;
   ConfirmText = AllocateZeroPool (BufSize);
-  ASSERT (ConfirmText != NULL);
+  if (ConfirmText == NULL) {
+    ASSERT (ConfirmText != NULL);
+    return FALSE;
+  }
 
   mTcg2PpStringPackHandle = HiiAddPackages (&gEfiTcg2PhysicalPresenceGuid, gImageHandle, DxeTcg2PhysicalPresenceLibStrings, NULL);
-  ASSERT (mTcg2PpStringPackHandle != NULL);
+  if (mTcg2PpStringPackHandle == NULL) {
+    ASSERT (mTcg2PpStringPackHandle != NULL);
+    FreePool (ConfirmText);
+    return FALSE;
+  }
 
   switch (TpmPpCommand) {
     case TCG2_PHYSICAL_PRESENCE_CLEAR:
@@ -413,13 +421,24 @@ Tcg2UserConfirm (
       TmpStr2    = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_CLEAR));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_HEAD_STR));
+      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
+        Result = FALSE;
+        goto Cleanup;
+      }
+
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_WARNING_CLEAR));
+      if (TmpStr1 == NULL) {
+        Result = FALSE;
+        goto Cleanup;
+      }
+
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), L" \n\n", (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
+      TmpStr1 = NULL;
 
       break;
 
@@ -429,17 +448,33 @@ Tcg2UserConfirm (
       TmpStr2    = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_CLEAR));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_PPI_HEAD_STR));
+      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
+        Result = FALSE;
+        goto Cleanup;
+      }
+
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_NOTE_CLEAR));
+      if (TmpStr1 == NULL) {
+        Result = FALSE;
+        goto Cleanup;
+      }
+
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_WARNING_CLEAR));
+      if (TmpStr1 == NULL) {
+        Result = FALSE;
+        goto Cleanup;
+      }
+
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), L" \n\n", (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
+      TmpStr1 = NULL;
 
       break;
 
@@ -464,14 +499,29 @@ Tcg2UserConfirm (
       TmpStr2    = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_SET_PCR_BANKS));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_HEAD_STR));
+      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
+        Result = FALSE;
+        goto Cleanup;
+      }
+
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_WARNING_SET_PCR_BANKS_1));
+      if (TmpStr1 == NULL) {
+        Result = FALSE;
+        goto Cleanup;
+      }
+
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_WARNING_SET_PCR_BANKS_2));
+      if (TmpStr1 == NULL) {
+        Result = FALSE;
+        goto Cleanup;
+      }
+
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
 
@@ -479,12 +529,18 @@ Tcg2UserConfirm (
       Tcg2FillBufferWithBootHashAlg (TempBuffer2, sizeof (TempBuffer2), CurrentPCRBanks);
 
       TmpStr1 = AllocateZeroPool (BufSize);
-      ASSERT (TmpStr1 != NULL);
+      if (TmpStr1 == NULL) {
+        ASSERT (TmpStr1 != NULL);
+        Result = FALSE;
+        goto Cleanup;
+      }
+
       UnicodeSPrint (TmpStr1, BufSize, L"Current PCRBanks is 0x%x. (%s)\nNew PCRBanks is 0x%x. (%s)\n", CurrentPCRBanks, TempBuffer2, TpmPpCommandParameter, TempBuffer);
 
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), L" \n", (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
+      TmpStr1 = NULL;
 
       break;
 
@@ -493,16 +549,32 @@ Tcg2UserConfirm (
       TmpStr2    = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_CHANGE_EPS));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_HEAD_STR));
+      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
+        Result = FALSE;
+        goto Cleanup;
+      }
+
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_WARNING_CHANGE_EPS_1));
+      if (TmpStr1 == NULL) {
+        Result = FALSE;
+        goto Cleanup;
+      }
+
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_WARNING_CHANGE_EPS_2));
+      if (TmpStr1 == NULL) {
+        Result = FALSE;
+        goto Cleanup;
+      }
+
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
+      TmpStr1 = NULL;
 
       break;
 
@@ -510,16 +582,28 @@ Tcg2UserConfirm (
       TmpStr2 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_ENABLE_BLOCK_SID));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_HEAD_STR));
+      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
+        Result = FALSE;
+        goto Cleanup;
+      }
+
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
+      TmpStr1 = NULL;
       break;
 
     case TCG2_PHYSICAL_PRESENCE_DISABLE_BLOCK_SID:
       TmpStr2 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_DISABLE_BLOCK_SID));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_HEAD_STR));
+      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
+        Result = FALSE;
+        goto Cleanup;
+      }
+
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
+      TmpStr1 = NULL;
       break;
 
     case TCG2_PHYSICAL_PRESENCE_SET_PP_REQUIRED_FOR_ENABLE_BLOCK_SID_FUNC_FALSE:
@@ -527,8 +611,14 @@ Tcg2UserConfirm (
       TmpStr2   = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_PP_ENABLE_BLOCK_SID));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_PPI_HEAD_STR));
+      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
+        Result = FALSE;
+        goto Cleanup;
+      }
+
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
+      TmpStr1 = NULL;
       break;
 
     case TCG2_PHYSICAL_PRESENCE_SET_PP_REQUIRED_FOR_DISABLE_BLOCK_SID_FUNC_FALSE:
@@ -536,8 +626,14 @@ Tcg2UserConfirm (
       TmpStr2   = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_PP_DISABLE_BLOCK_SID));
 
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_PPI_HEAD_STR));
+      if ((TmpStr1 == NULL) || (TmpStr2 == NULL)) {
+        Result = FALSE;
+        goto Cleanup;
+      }
+
       UnicodeSPrint (ConfirmText, BufSize, TmpStr1, TmpStr2);
       FreePool (TmpStr1);
+      TmpStr1 = NULL;
       break;
 
     default:
@@ -545,8 +641,8 @@ Tcg2UserConfirm (
   }
 
   if (TmpStr2 == NULL) {
-    FreePool (ConfirmText);
-    return FALSE;
+    Result = FALSE;
+    goto Cleanup;
   }
 
   if (TpmPpCommand < TCG2_PHYSICAL_PRESENCE_STORAGE_MANAGEMENT_BEGIN) {
@@ -556,11 +652,21 @@ Tcg2UserConfirm (
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_ACCEPT_KEY));
     }
 
+    if (TmpStr1 == NULL) {
+      Result = FALSE;
+      goto Cleanup;
+    }
+
     StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
     FreePool (TmpStr1);
 
     if (NoPpiInfo) {
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TPM_NO_PPI_INFO));
+      if (TmpStr1 == NULL) {
+        Result = FALSE;
+        goto Cleanup;
+      }
+
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
     }
@@ -573,16 +679,31 @@ Tcg2UserConfirm (
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_ACCEPT_KEY));
     }
 
+    if (TmpStr1 == NULL) {
+      Result = FALSE;
+      goto Cleanup;
+    }
+
     StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
     FreePool (TmpStr1);
 
     if (NoPpiInfo) {
       TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_NO_PPI_INFO));
+      if (TmpStr1 == NULL) {
+        Result = FALSE;
+        goto Cleanup;
+      }
+
       StrnCatS (ConfirmText, BufSize / sizeof (CHAR16), TmpStr1, (BufSize / sizeof (CHAR16)) - StrLen (ConfirmText) - 1);
       FreePool (TmpStr1);
     }
 
     TmpStr1 = Tcg2PhysicalPresenceGetStringById (STRING_TOKEN (TCG_STORAGE_REJECT_KEY));
+  }
+
+  if (TmpStr1 == NULL) {
+    Result = FALSE;
+    goto Cleanup;
   }
 
   BufSize -= StrSize (ConfirmText);
@@ -597,9 +718,19 @@ Tcg2UserConfirm (
   // }
   Result = PromptForUserConfirmation (ConfirmText);     // JBB TODO: Alter EDKII to call out to a vendor function to do this.
 
-  FreePool (TmpStr1);
-  FreePool (TmpStr2);
-  FreePool (ConfirmText);
+Cleanup:
+  if (TmpStr1 != NULL) {
+    FreePool (TmpStr1);
+  }
+
+  if (TmpStr2 != NULL) {
+    FreePool (TmpStr2);
+  }
+
+  if (ConfirmText != NULL) {
+    FreePool (ConfirmText);
+  }
+
   HiiRemovePackages (mTcg2PpStringPackHandle);
 
   // if (Tcg2ReadUserKey (CautionKey)) {

--- a/SecurityPkg/Library/DxeTcg2PhysicalPresenceMinimumLib/DxeTcg2PhysicalPresenceMinimumLib.inf
+++ b/SecurityPkg/Library/DxeTcg2PhysicalPresenceMinimumLib/DxeTcg2PhysicalPresenceMinimumLib.inf
@@ -9,7 +9,7 @@
 #
 ##
 
-#Override : 00000002 | SecurityPkg/Library/DxeTcg2PhysicalPresenceLib/DxeTcg2PhysicalPresenceLib.inf | 5441f72b0765d487d0c25edda74e5d7d | 2026-08-28T02-05-29 | 77e4b9983033b23d40342dd5f0cd1b2d80efaf05
+#Override : 00000002 | SecurityPkg/Library/DxeTcg2PhysicalPresenceLib/DxeTcg2PhysicalPresenceLib.inf | c8e018a8f552c42f28a97d3c9b6a710e | 2026-08-28T02-05-29 | 77e4b9983033b23d40342dd5f0cd1b2d80efaf05
 
 [Defines]
   INF_VERSION                    = 0x00010005

--- a/SecurityPkg/Library/DxeTcgPhysicalPresenceLib/DxeTcgPhysicalPresenceLib.c
+++ b/SecurityPkg/Library/DxeTcgPhysicalPresenceLib/DxeTcgPhysicalPresenceLib.c
@@ -540,7 +540,7 @@ UserConfirm (
   CHAR16   *TmpStr2;
   UINTN    BufSize;
   BOOLEAN  CautionKey;
-  UINT16   Index;
+  UINTN    Index;
   CHAR16   DstStr[81];
 
   TmpStr2     = NULL;

--- a/SecurityPkg/Library/DxeTcgPhysicalPresenceLib/DxeTcgPhysicalPresenceLib.c
+++ b/SecurityPkg/Library/DxeTcgPhysicalPresenceLib/DxeTcgPhysicalPresenceLib.c
@@ -540,7 +540,7 @@ UserConfirm (
   CHAR16   *TmpStr2;
   UINTN    BufSize;
   BOOLEAN  CautionKey;
-  UINTN    Index; // MU_CHANGE - CodeQL change - comparison-with-wider-type
+  UINT16   Index;
   CHAR16   DstStr[81];
 
   TmpStr2     = NULL;

--- a/SecurityPkg/Library/DxeTpm2MeasureBootLib/DxeTpm2MeasureBootLib.c
+++ b/SecurityPkg/Library/DxeTpm2MeasureBootLib/DxeTpm2MeasureBootLib.c
@@ -650,6 +650,9 @@ GetMeasureBootProtocols (
   @retval EFI_SUCCESS             The file specified by DevicePath and non-NULL
                                   FileBuffer did authenticate, and the platform policy dictates
                                   that the DXE Foundation may use the file.
+
+  @retval EFI_OUT_OF_RESOURCES    A necessary memory buffer could not be allocated.
+
   @retval other error value
 **/
 EFI_STATUS
@@ -743,9 +746,17 @@ DxeTpm2MeasureBootHandler (
             }
           }
 
-          FreePool (OrigDevicePathNode);
+          if (OrigDevicePathNode != NULL) {
+            FreePool (OrigDevicePathNode);
+          }
+
           OrigDevicePathNode = DuplicateDevicePath (File);
-          ASSERT (OrigDevicePathNode != NULL);
+          if (OrigDevicePathNode == NULL) {
+            ASSERT (OrigDevicePathNode != NULL);
+            Status = EFI_OUT_OF_RESOURCES;
+            goto Finish;
+          }
+
           break;
         }
       }

--- a/SecurityPkg/Library/DxeTpm2MeasureBootLib/DxeTpm2MeasureBootLib.c
+++ b/SecurityPkg/Library/DxeTpm2MeasureBootLib/DxeTpm2MeasureBootLib.c
@@ -650,9 +650,6 @@ GetMeasureBootProtocols (
   @retval EFI_SUCCESS             The file specified by DevicePath and non-NULL
                                   FileBuffer did authenticate, and the platform policy dictates
                                   that the DXE Foundation may use the file.
-
-  @retval EFI_OUT_OF_RESOURCES    A necessary memory buffer could not be allocated. // MU_CHANGE - CodeQL Change
-
   @retval other error value
 **/
 EFI_STATUS
@@ -746,22 +743,9 @@ DxeTpm2MeasureBootHandler (
             }
           }
 
-          // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-          if (OrigDevicePathNode != NULL) {
-            FreePool (OrigDevicePathNode);
-          }
-
-          // MU_CHANGE End - CodeQL change - unguardednullreturndereference
-
+          FreePool (OrigDevicePathNode);
           OrigDevicePathNode = DuplicateDevicePath (File);
-          // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-          if (OrigDevicePathNode == NULL) {
-            ASSERT (OrigDevicePathNode != NULL);
-            return EFI_OUT_OF_RESOURCES;
-          }
-
-          // MU_CHANGE End - CodeQL change - unguardednullreturndereference
-
+          ASSERT (OrigDevicePathNode != NULL);
           break;
         }
       }

--- a/SecurityPkg/Library/HashInstanceLibSha1/HashInstanceLibSha1.c
+++ b/SecurityPkg/Library/HashInstanceLibSha1/HashInstanceLibSha1.c
@@ -56,7 +56,10 @@ Sha1HashInit (
 
   CtxSize = Sha1GetContextSize ();
   Sha1Ctx = AllocatePool (CtxSize);
-  ASSERT (Sha1Ctx != NULL);
+  if (Sha1Ctx == NULL) {
+    ASSERT (Sha1Ctx != NULL);
+    return EFI_OUT_OF_RESOURCES;
+  }
 
   Sha1Init (Sha1Ctx);
 

--- a/SecurityPkg/Library/HashInstanceLibSha1/HashInstanceLibSha1.c
+++ b/SecurityPkg/Library/HashInstanceLibSha1/HashInstanceLibSha1.c
@@ -56,13 +56,7 @@ Sha1HashInit (
 
   CtxSize = Sha1GetContextSize ();
   Sha1Ctx = AllocatePool (CtxSize);
-  // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-  if (Sha1Ctx == NULL) {
-    ASSERT (Sha1Ctx != NULL);
-    return EFI_OUT_OF_RESOURCES;
-  }
-
-  // MU_CHANGE End - CodeQL change - unguardednullreturndereference
+  ASSERT (Sha1Ctx != NULL);
 
   Sha1Init (Sha1Ctx);
 

--- a/SecurityPkg/Library/HashInstanceLibSha256/HashInstanceLibSha256.c
+++ b/SecurityPkg/Library/HashInstanceLibSha256/HashInstanceLibSha256.c
@@ -55,7 +55,10 @@ Sha256HashInit (
 
   CtxSize   = Sha256GetContextSize ();
   Sha256Ctx = AllocatePool (CtxSize);
-  ASSERT (Sha256Ctx != NULL);
+  if (Sha256Ctx == NULL) {
+    ASSERT (Sha256Ctx != NULL);
+    return EFI_OUT_OF_RESOURCES;
+  }
 
   Sha256Init (Sha256Ctx);
 

--- a/SecurityPkg/Library/HashInstanceLibSha256/HashInstanceLibSha256.c
+++ b/SecurityPkg/Library/HashInstanceLibSha256/HashInstanceLibSha256.c
@@ -55,13 +55,7 @@ Sha256HashInit (
 
   CtxSize   = Sha256GetContextSize ();
   Sha256Ctx = AllocatePool (CtxSize);
-  // MU_CHANGE - CodeQL Change - unguardednullreturndereference
-  if (Sha256Ctx == NULL) {
-    ASSERT (Sha256Ctx != NULL);
-    return EFI_OUT_OF_RESOURCES;
-  }
-
-  // MU_CHANGE - CodeQL Change - unguardednullreturndereference
+  ASSERT (Sha256Ctx != NULL);
 
   Sha256Init (Sha256Ctx);
 

--- a/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterDxe.c
+++ b/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterDxe.c
@@ -69,6 +69,7 @@ HashStart (
   HASH_HANDLE  *HashCtx;
   UINTN        Index;
   UINT32       HashMask;
+  EFI_STATUS   Status;
 
   if (mHashInterfaceCount == 0) {
     return EFI_UNSUPPORTED;
@@ -85,7 +86,11 @@ HashStart (
   for (Index = 0; Index < mHashInterfaceCount; Index++) {
     HashMask = Tpm2GetHashMaskFromGuid (&mHashInterface[Index].HashGuid);
     if ((HashMask & PcdGet32 (PcdTpm2HashMask)) != 0) {
-      mHashInterface[Index].HashInit (&HashCtx[Index]);
+      Status = mHashInterface[Index].HashInit (&HashCtx[Index]);
+      if (EFI_ERROR (Status)) {
+        FreePool (HashCtx);
+        return Status;
+      }
     }
   }
 
@@ -282,8 +287,16 @@ HashAndExtend (
 
   CheckSupportedHashMaskMismatch ();
 
-  HashStart (&HashHandle);
-  HashUpdate (HashHandle, DataToHash, DataToHashLen);
+  Status = HashStart (&HashHandle);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = HashUpdate (HashHandle, DataToHash, DataToHashLen);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
   Status = HashCompleteAndExtend (HashHandle, PcrIndex, NULL, 0, DigestList);
 
   return Status;

--- a/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterDxe.c
+++ b/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterDxe.c
@@ -77,7 +77,10 @@ HashStart (
   CheckSupportedHashMaskMismatch ();
 
   HashCtx = AllocatePool (sizeof (*HashCtx) * mHashInterfaceCount);
-  ASSERT (HashCtx != NULL);
+  if (HashCtx == NULL) {
+    ASSERT (HashCtx != NULL);
+    return EFI_OUT_OF_RESOURCES;
+  }
 
   for (Index = 0; Index < mHashInterfaceCount; Index++) {
     HashMask = Tpm2GetHashMaskFromGuid (&mHashInterface[Index].HashGuid);

--- a/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterDxe.c
+++ b/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterDxe.c
@@ -1,4 +1,4 @@
-﻿/** @file
+/** @file
   This library is BaseCrypto router. It will redirect hash request to each individual
   hash handler registered, such as SHA1, SHA256.
   Platform can use PcdTpm2HashMask to mask some hash engines.
@@ -77,13 +77,7 @@ HashStart (
   CheckSupportedHashMaskMismatch ();
 
   HashCtx = AllocatePool (sizeof (*HashCtx) * mHashInterfaceCount);
-  // MU_CHANGE - CodeQL Change - unguardednullreturndereference
-  if (HashCtx == NULL) {
-    ASSERT (HashCtx != NULL);
-    return EFI_OUT_OF_RESOURCES;
-  }
-
-  // MU_CHANGE - CodeQL Change - unguardednullreturndereference
+  ASSERT (HashCtx != NULL);
 
   for (Index = 0; Index < mHashInterfaceCount; Index++) {
     HashMask = Tpm2GetHashMaskFromGuid (&mHashInterface[Index].HashGuid);
@@ -285,18 +279,8 @@ HashAndExtend (
 
   CheckSupportedHashMaskMismatch ();
 
-  // MU_CHANGE - CodeQL Change - unguardednullreturndereference
-  Status = HashStart (&HashHandle);
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
-
-  Status = HashUpdate (HashHandle, DataToHash, DataToHashLen);
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
-
-  // MU_CHANGE - CodeQL Change - unguardednullreturndereference
+  HashStart (&HashHandle);
+  HashUpdate (HashHandle, DataToHash, DataToHashLen);
   Status = HashCompleteAndExtend (HashHandle, PcrIndex, NULL, 0, DigestList);
 
   return Status;

--- a/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterPei.c
+++ b/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterPei.c
@@ -142,6 +142,7 @@ HashStart (
   HASH_HANDLE         *HashCtx;
   UINTN               Index;
   UINT32              HashMask;
+  EFI_STATUS          Status;
 
   HashInterfaceHob = InternalGetHashInterfaceHob (&gEfiCallerIdGuid);
   if (HashInterfaceHob == NULL) {
@@ -163,7 +164,11 @@ HashStart (
   for (Index = 0; Index < HashInterfaceHob->HashInterfaceCount; Index++) {
     HashMask = Tpm2GetHashMaskFromGuid (&HashInterfaceHob->HashInterface[Index].HashGuid);
     if ((HashMask & PcdGet32 (PcdTpm2HashMask)) != 0) {
-      HashInterfaceHob->HashInterface[Index].HashInit (&HashCtx[Index]);
+      Status = HashInterfaceHob->HashInterface[Index].HashInit (&HashCtx[Index]);
+      if (EFI_ERROR (Status)) {
+        FreePool (HashCtx);
+        return Status;
+      }
     }
   }
 
@@ -311,8 +316,16 @@ HashAndExtend (
 
   CheckSupportedHashMaskMismatch (HashInterfaceHob);
 
-  HashStart (&HashHandle);
-  HashUpdate (HashHandle, DataToHash, DataToHashLen);
+  Status = HashStart (&HashHandle);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  Status = HashUpdate (HashHandle, DataToHash, DataToHashLen);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
   Status = HashCompleteAndExtend (HashHandle, PcrIndex, NULL, 0, DigestList);
 
   return Status;

--- a/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterPei.c
+++ b/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterPei.c
@@ -106,7 +106,10 @@ CheckSupportedHashMaskMismatch (
   HASH_INTERFACE_HOB  *HashInterfaceHobLast;
 
   HashInterfaceHobLast = InternalGetHashInterfaceHob (&gZeroGuid);
-  ASSERT (HashInterfaceHobLast != NULL);
+  if (HashInterfaceHobLast == NULL) {
+    ASSERT (HashInterfaceHobLast != NULL);
+    return;
+  }
 
   if ((HashInterfaceHobLast->SupportedHashMask != 0) &&
       (HashInterfaceHobCurrent->SupportedHashMask != HashInterfaceHobLast->SupportedHashMask))
@@ -152,7 +155,10 @@ HashStart (
   CheckSupportedHashMaskMismatch (HashInterfaceHob);
 
   HashCtx = AllocatePool (sizeof (*HashCtx) * HashInterfaceHob->HashInterfaceCount);
-  ASSERT (HashCtx != NULL);
+  if (HashCtx == NULL) {
+    ASSERT (HashCtx != NULL);
+    return EFI_OUT_OF_RESOURCES;
+  }
 
   for (Index = 0; Index < HashInterfaceHob->HashInterfaceCount; Index++) {
     HashMask = Tpm2GetHashMaskFromGuid (&HashInterfaceHob->HashInterface[Index].HashGuid);

--- a/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterPei.c
+++ b/SecurityPkg/Library/HashLibBaseCryptoRouter/HashLibBaseCryptoRouterPei.c
@@ -106,13 +106,7 @@ CheckSupportedHashMaskMismatch (
   HASH_INTERFACE_HOB  *HashInterfaceHobLast;
 
   HashInterfaceHobLast = InternalGetHashInterfaceHob (&gZeroGuid);
-  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
-  if (HashInterfaceHobLast == NULL) {
-    ASSERT (HashInterfaceHobLast != NULL);
-    return;
-  }
-
-  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
+  ASSERT (HashInterfaceHobLast != NULL);
 
   if ((HashInterfaceHobLast->SupportedHashMask != 0) &&
       (HashInterfaceHobCurrent->SupportedHashMask != HashInterfaceHobLast->SupportedHashMask))
@@ -158,13 +152,7 @@ HashStart (
   CheckSupportedHashMaskMismatch (HashInterfaceHob);
 
   HashCtx = AllocatePool (sizeof (*HashCtx) * HashInterfaceHob->HashInterfaceCount);
-  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
-  if (HashCtx == NULL) {
-    ASSERT (HashCtx != NULL);
-    return EFI_OUT_OF_RESOURCES;
-  }
-
-  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
+  ASSERT (HashCtx != NULL);
 
   for (Index = 0; Index < HashInterfaceHob->HashInterfaceCount; Index++) {
     HashMask = Tpm2GetHashMaskFromGuid (&HashInterfaceHob->HashInterface[Index].HashGuid);
@@ -317,19 +305,8 @@ HashAndExtend (
 
   CheckSupportedHashMaskMismatch (HashInterfaceHob);
 
-  // MU_CHANGE Start - CodeQL Change - unguardednullreturndereference
-  Status = HashStart (&HashHandle);
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
-
-  Status = HashUpdate (HashHandle, DataToHash, DataToHashLen);
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
-
-  // MU_CHANGE End - CodeQL Change - unguardednullreturndereference
-
+  HashStart (&HashHandle);
+  HashUpdate (HashHandle, DataToHash, DataToHashLen);
   Status = HashCompleteAndExtend (HashHandle, PcrIndex, NULL, 0, DigestList);
 
   return Status;

--- a/SecurityPkg/Library/SecureBootVariableProvisionLib/SecureBootVariableProvisionLib.c
+++ b/SecurityPkg/Library/SecureBootVariableProvisionLib/SecureBootVariableProvisionLib.c
@@ -59,7 +59,11 @@ SecureBootFetchData (
   *SigListOut   = NULL;
   *SigListsSize = 0;
   CertInfo      = AllocatePool (sizeof (SECURE_BOOT_CERTIFICATE_INFO));
-  NewCertInfo   = CertInfo;
+  if (CertInfo == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  NewCertInfo = CertInfo;
   while (1) {
     if (NewCertInfo == NULL) {
       Status = EFI_OUT_OF_RESOURCES;
@@ -93,6 +97,10 @@ SecureBootFetchData (
                       sizeof (SECURE_BOOT_CERTIFICATE_INFO) * (KeyIndex + 1),
                       CertInfo
                       );
+      if (NewCertInfo == NULL) {
+        Status = EFI_OUT_OF_RESOURCES;
+        goto Cleanup;
+      }
     }
 
     if (Status == EFI_NOT_FOUND) {

--- a/SecurityPkg/Library/SecureBootVariableProvisionLib/SecureBootVariableProvisionLib.c
+++ b/SecurityPkg/Library/SecureBootVariableProvisionLib/SecureBootVariableProvisionLib.c
@@ -59,13 +59,7 @@ SecureBootFetchData (
   *SigListOut   = NULL;
   *SigListsSize = 0;
   CertInfo      = AllocatePool (sizeof (SECURE_BOOT_CERTIFICATE_INFO));
-  // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-  if (CertInfo == NULL) {
-    return EFI_OUT_OF_RESOURCES;
-  }
-
-  // MU_CHANGE End - CodeQL change - unguardednullreturndereference
-  NewCertInfo = CertInfo;
+  NewCertInfo   = CertInfo;
   while (1) {
     if (NewCertInfo == NULL) {
       Status = EFI_OUT_OF_RESOURCES;
@@ -99,12 +93,6 @@ SecureBootFetchData (
                       sizeof (SECURE_BOOT_CERTIFICATE_INFO) * (KeyIndex + 1),
                       CertInfo
                       );
-      // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-      if (NewCertInfo == NULL) {
-        goto Cleanup;
-      }
-
-      // MU_CHANGE End - CodeQL change - unguardednullreturndereference
     }
 
     if (Status == EFI_NOT_FOUND) {

--- a/SecurityPkg/Library/TcgEventLogRecordLib/TcgEventLogRecordLib.c
+++ b/SecurityPkg/Library/TcgEventLogRecordLib/TcgEventLogRecordLib.c
@@ -106,7 +106,7 @@ MeasureFirmwareBlob (
   {
     if (Description != NULL) {
       AsciiSPrint ((CHAR8 *)FvBlob2.BlobDescription, sizeof (FvBlob2.BlobDescription), "%a", Description);
-    } else {
+    } else if (FvName != NULL) {
       AsciiSPrint ((CHAR8 *)FvBlob2.BlobDescription, sizeof (FvBlob2.BlobDescription), "Fv(%g)", FvName);
     }
 

--- a/SecurityPkg/Library/TcgEventLogRecordLib/TcgEventLogRecordLib.c
+++ b/SecurityPkg/Library/TcgEventLogRecordLib/TcgEventLogRecordLib.c
@@ -106,9 +106,7 @@ MeasureFirmwareBlob (
   {
     if (Description != NULL) {
       AsciiSPrint ((CHAR8 *)FvBlob2.BlobDescription, sizeof (FvBlob2.BlobDescription), "%a", Description);
-      // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-    } else if (FvName != NULL) {
-      // MU_CHANGE End - CodeQL change - unguardednullreturndereference
+    } else {
       AsciiSPrint ((CHAR8 *)FvBlob2.BlobDescription, sizeof (FvBlob2.BlobDescription), "Fv(%g)", FvName);
     }
 

--- a/SecurityPkg/Library/Tpm12DeviceLibDTpm/Tpm12Tis.c
+++ b/SecurityPkg/Library/Tpm12DeviceLibDTpm/Tpm12Tis.c
@@ -270,7 +270,7 @@ Tpm12TisTpmCommand (
 {
   EFI_STATUS  Status;
   UINT16      BurstCount;
-  UINT32      Index;
+  UINTN       Index;
   UINT32      TpmOutSize;
   UINT16      Data16;
   UINT32      Data32;

--- a/SecurityPkg/Library/Tpm12DeviceLibDTpm/Tpm12Tis.c
+++ b/SecurityPkg/Library/Tpm12DeviceLibDTpm/Tpm12Tis.c
@@ -270,7 +270,7 @@ Tpm12TisTpmCommand (
 {
   EFI_STATUS  Status;
   UINT16      BurstCount;
-  UINTN       Index; // MU_CHANGE - CodeQL change - comparison-with-wider-type
+  UINT32      Index;
   UINT32      TpmOutSize;
   UINT16      Data16;
   UINT32      Data32;

--- a/SecurityPkg/RandomNumberGenerator/RngDxe/Rand/AesCore.c
+++ b/SecurityPkg/RandomNumberGenerator/RngDxe/Rand/AesCore.c
@@ -209,6 +209,7 @@ AesExpandKey (
 
   @retval EFI_SUCCESS            AES Block Encryption succeeded.
   @retval EFI_INVALID_PARAMETER  One or more parameters are invalid.
+  @retval Others                 AesExpandKey failed
 
 **/
 EFI_STATUS
@@ -219,17 +220,18 @@ AesEncrypt (
   OUT UINT8  *OutData
   )
 {
-  AES_KEY  AesKey;
-  UINTN    Nr;
-  UINT32   *Ek;
-  UINT32   State[4];
-  UINT32   TempState[4];
-  UINT32   *StateX;
-  UINT32   *StateY;
-  UINT32   *Temp;
-  UINTN    Index;
-  UINTN    NbIndex;
-  UINTN    Round;
+  AES_KEY     AesKey;
+  UINTN       Nr;
+  UINT32      *Ek;
+  UINT32      State[4];
+  UINT32      TempState[4];
+  UINT32      *StateX;
+  UINT32      *StateY;
+  UINT32      *Temp;
+  UINTN       Index;
+  UINTN       NbIndex;
+  UINTN       Round;
+  EFI_STATUS  Status;
 
   if ((Key == NULL) || (InData == NULL) || (OutData == NULL)) {
     return EFI_INVALID_PARAMETER;
@@ -238,7 +240,10 @@ AesEncrypt (
   //
   // Expands AES Key for encryption.
   //
-  AesExpandKey (Key, 128, &AesKey);
+  Status = AesExpandKey (Key, 128, &AesKey);
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
 
   Nr = AesKey.Nk + 6;
   Ek = AesKey.EncKey;

--- a/SecurityPkg/RandomNumberGenerator/RngDxe/Rand/AesCore.c
+++ b/SecurityPkg/RandomNumberGenerator/RngDxe/Rand/AesCore.c
@@ -231,8 +231,6 @@ AesEncrypt (
   UINTN    NbIndex;
   UINTN    Round;
 
-  EFI_STATUS  Status; // MU_CHANGE - CodeQL Change
-
   if ((Key == NULL) || (InData == NULL) || (OutData == NULL)) {
     return EFI_INVALID_PARAMETER;
   }
@@ -240,13 +238,7 @@ AesEncrypt (
   //
   // Expands AES Key for encryption.
   //
-  // MU_CHANGE Start - CodeQL Change
-  Status = AesExpandKey (Key, 128, &AesKey);
-  if (EFI_ERROR (Status)) {
-    return Status;
-  }
-
-  // MU_CHANGE End - CodeQL Change
+  AesExpandKey (Key, 128, &AesKey);
 
   Nr = AesKey.Nk + 6;
   Ek = AesKey.EncKey;

--- a/SecurityPkg/Tcg/Opal/OpalPassword/OpalDriver.c
+++ b/SecurityPkg/Tcg/Opal/OpalPassword/OpalDriver.c
@@ -2224,7 +2224,7 @@ ProcessOpalRequest (
   //
   TempVariable = Variable;
   while ((VariableSize > sizeof (OPAL_REQUEST_VARIABLE)) &&
-         (VariableSize >= TempVariable->Length) &&
+         (VariableSize >= (UINTN)TempVariable->Length) &&
          (TempVariable->Length > sizeof (OPAL_REQUEST_VARIABLE)))
   {
     DevicePathInVariable     = (EFI_DEVICE_PATH_PROTOCOL *)((UINTN)TempVariable + sizeof (OPAL_REQUEST_VARIABLE));

--- a/SecurityPkg/Tcg/Opal/OpalPassword/OpalDriver.c
+++ b/SecurityPkg/Tcg/Opal/OpalPassword/OpalDriver.c
@@ -2224,9 +2224,7 @@ ProcessOpalRequest (
   //
   TempVariable = Variable;
   while ((VariableSize > sizeof (OPAL_REQUEST_VARIABLE)) &&
-         // MU_CHANGE Start - CodeQL change - comparison-with-wider-type
-         (VariableSize >= (UINTN)TempVariable->Length) &&
-         // MU_CHANGE End - CodeQL change - comparison-with-wider-type
+         (VariableSize >= TempVariable->Length) &&
          (TempVariable->Length > sizeof (OPAL_REQUEST_VARIABLE)))
   {
     DevicePathInVariable     = (EFI_DEVICE_PATH_PROTOCOL *)((UINTN)TempVariable + sizeof (OPAL_REQUEST_VARIABLE));

--- a/SecurityPkg/Tcg/Opal/OpalPassword/OpalHii.c
+++ b/SecurityPkg/Tcg/Opal/OpalPassword/OpalHii.c
@@ -113,7 +113,7 @@ GetSavedOpalRequest (
 
   TempVariable = Variable;
   while ((VariableSize > sizeof (OPAL_REQUEST_VARIABLE)) &&
-         (VariableSize >= TempVariable->Length) &&
+         (VariableSize >= (UINTN)TempVariable->Length) &&
          (TempVariable->Length > sizeof (OPAL_REQUEST_VARIABLE)))
   {
     DevicePathInVariable     = (EFI_DEVICE_PATH_PROTOCOL *)((UINTN)TempVariable + sizeof (OPAL_REQUEST_VARIABLE));
@@ -193,7 +193,7 @@ SaveOpalRequest (
     TempVariable     = Variable;
     TempVariableSize = VariableSize;
     while ((TempVariableSize > sizeof (OPAL_REQUEST_VARIABLE)) &&
-           (TempVariableSize >= TempVariable->Length) &&
+           (TempVariableSize >= (UINTN)TempVariable->Length) &&
            (TempVariable->Length > sizeof (OPAL_REQUEST_VARIABLE)))
     {
       DevicePathInVariable     = (EFI_DEVICE_PATH_PROTOCOL *)((UINTN)TempVariable + sizeof (OPAL_REQUEST_VARIABLE));

--- a/SecurityPkg/Tcg/Opal/OpalPassword/OpalHii.c
+++ b/SecurityPkg/Tcg/Opal/OpalPassword/OpalHii.c
@@ -226,7 +226,12 @@ SaveOpalRequest (
       DevicePathSize  = GetDevicePathSize (DevicePath);
       NewVariableSize = VariableSize + sizeof (OPAL_REQUEST_VARIABLE) + DevicePathSize;
       NewVariable     = AllocatePool (NewVariableSize);
-      ASSERT (NewVariable != NULL);
+      if (NewVariable == NULL) {
+        ASSERT (NewVariable != NULL);
+        FreePool (Variable);
+        return;
+      }
+
       CopyMem (NewVariable, Variable, VariableSize);
       TempVariable         = (OPAL_REQUEST_VARIABLE *)((UINTN)NewVariable + VariableSize);
       TempVariable->Length = (UINT32)(sizeof (OPAL_REQUEST_VARIABLE) + DevicePathSize);
@@ -239,7 +244,11 @@ SaveOpalRequest (
     DevicePathSize  = GetDevicePathSize (DevicePath);
     NewVariableSize = sizeof (OPAL_REQUEST_VARIABLE) + DevicePathSize;
     NewVariable     = AllocatePool (NewVariableSize);
-    ASSERT (NewVariable != NULL);
+    if (NewVariable == NULL) {
+      ASSERT (NewVariable != NULL);
+      return;
+    }
+
     NewVariable->Length = (UINT32)(sizeof (OPAL_REQUEST_VARIABLE) + DevicePathSize);
     CopyMem (&NewVariable->OpalRequest, &OpalRequest, sizeof (OPAL_REQUEST));
     DevicePathInVariable = (EFI_DEVICE_PATH_PROTOCOL *)((UINTN)NewVariable + sizeof (OPAL_REQUEST_VARIABLE));
@@ -1111,9 +1120,15 @@ ExtractConfig (
     //
     DriverHandle     = HiiGetDriverImageHandleCB ();
     ConfigRequestHdr = HiiConstructConfigHdr (&gHiiSetupVariableGuid, OpalPasswordStorageName, DriverHandle);
-    Size             = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
-    ConfigRequest    = AllocateZeroPool (Size);
+    if (ConfigRequestHdr == NULL) {
+      ASSERT (ConfigRequestHdr != NULL);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    Size          = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
+    ConfigRequest = AllocateZeroPool (Size);
     if (ConfigRequest == NULL) {
+      FreePool (ConfigRequestHdr);
       return EFI_OUT_OF_RESOURCES;
     }
 

--- a/SecurityPkg/Tcg/Opal/OpalPassword/OpalHii.c
+++ b/SecurityPkg/Tcg/Opal/OpalPassword/OpalHii.c
@@ -113,9 +113,7 @@ GetSavedOpalRequest (
 
   TempVariable = Variable;
   while ((VariableSize > sizeof (OPAL_REQUEST_VARIABLE)) &&
-         // MU_CHANGE Start - CodeQL change - comparison-with-wider-type
-         (VariableSize >= (UINTN)TempVariable->Length) &&
-         // MU_CHANGE End - CodeQL change - comparison-with-wider-type
+         (VariableSize >= TempVariable->Length) &&
          (TempVariable->Length > sizeof (OPAL_REQUEST_VARIABLE)))
   {
     DevicePathInVariable     = (EFI_DEVICE_PATH_PROTOCOL *)((UINTN)TempVariable + sizeof (OPAL_REQUEST_VARIABLE));
@@ -195,9 +193,7 @@ SaveOpalRequest (
     TempVariable     = Variable;
     TempVariableSize = VariableSize;
     while ((TempVariableSize > sizeof (OPAL_REQUEST_VARIABLE)) &&
-           // MU_CHANGE Start - CodeQL change - comparison-with-wider-type
-           (TempVariableSize >= (UINTN)TempVariable->Length) &&
-           // MU_CHANGE End - CodeQL change - comparison-with-wider-type
+           (TempVariableSize >= TempVariable->Length) &&
            (TempVariable->Length > sizeof (OPAL_REQUEST_VARIABLE)))
     {
       DevicePathInVariable     = (EFI_DEVICE_PATH_PROTOCOL *)((UINTN)TempVariable + sizeof (OPAL_REQUEST_VARIABLE));
@@ -230,13 +226,7 @@ SaveOpalRequest (
       DevicePathSize  = GetDevicePathSize (DevicePath);
       NewVariableSize = VariableSize + sizeof (OPAL_REQUEST_VARIABLE) + DevicePathSize;
       NewVariable     = AllocatePool (NewVariableSize);
-      // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-      if (NewVariable == NULL) {
-        ASSERT (NewVariable != NULL);
-        return;
-      }
-
-      // MU_CHANGE End - CodeQL change - unguardednullreturndereference
+      ASSERT (NewVariable != NULL);
       CopyMem (NewVariable, Variable, VariableSize);
       TempVariable         = (OPAL_REQUEST_VARIABLE *)((UINTN)NewVariable + VariableSize);
       TempVariable->Length = (UINT32)(sizeof (OPAL_REQUEST_VARIABLE) + DevicePathSize);
@@ -249,13 +239,7 @@ SaveOpalRequest (
     DevicePathSize  = GetDevicePathSize (DevicePath);
     NewVariableSize = sizeof (OPAL_REQUEST_VARIABLE) + DevicePathSize;
     NewVariable     = AllocatePool (NewVariableSize);
-    // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-    if (NewVariable == NULL) {
-      ASSERT (NewVariable != NULL);
-      return;
-    }
-
-    // MU_CHANGE End - CodeQL change - unguardednullreturndereference
+    ASSERT (NewVariable != NULL);
     NewVariable->Length = (UINT32)(sizeof (OPAL_REQUEST_VARIABLE) + DevicePathSize);
     CopyMem (&NewVariable->OpalRequest, &OpalRequest, sizeof (OPAL_REQUEST));
     DevicePathInVariable = (EFI_DEVICE_PATH_PROTOCOL *)((UINTN)NewVariable + sizeof (OPAL_REQUEST_VARIABLE));
@@ -1127,15 +1111,8 @@ ExtractConfig (
     //
     DriverHandle     = HiiGetDriverImageHandleCB ();
     ConfigRequestHdr = HiiConstructConfigHdr (&gHiiSetupVariableGuid, OpalPasswordStorageName, DriverHandle);
-    // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-    if (ConfigRequestHdr == NULL) {
-      ASSERT (ConfigRequestHdr != NULL);
-      return EFI_OUT_OF_RESOURCES;
-    }
-
-    // MU_CHANGE End - CodeQL change - unguardednullreturndereference
-    Size          = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
-    ConfigRequest = AllocateZeroPool (Size);
+    Size             = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
+    ConfigRequest    = AllocateZeroPool (Size);
     if (ConfigRequest == NULL) {
       return EFI_OUT_OF_RESOURCES;
     }

--- a/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigDriver.c
+++ b/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigDriver.c
@@ -103,7 +103,11 @@ InitializeTcg2VersionInfo (
                        TCG2_VERSION_NAME,
                        PrivateData->DriverHandle
                        );
-  ASSERT (ConfigRequestHdr != NULL);
+  if (ConfigRequestHdr == NULL) {
+    ASSERT (ConfigRequestHdr != NULL);
+    return;
+  }
+
   DataSize = sizeof (Tcg2Version);
   Status   = gRT->GetVariable (
                     TCG2_VERSION_NAME,

--- a/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigDriver.c
+++ b/SecurityPkg/Tcg/Tcg2Config/Tcg2ConfigDriver.c
@@ -103,13 +103,7 @@ InitializeTcg2VersionInfo (
                        TCG2_VERSION_NAME,
                        PrivateData->DriverHandle
                        );
-  // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-  if (ConfigRequestHdr == NULL) {
-    ASSERT (ConfigRequestHdr != NULL);
-    return;
-  }
-
-  // MU_CHANGE End - CodeQL change - unguardednullreturndereference
+  ASSERT (ConfigRequestHdr != NULL);
   DataSize = sizeof (Tcg2Version);
   Status   = gRT->GetVariable (
                     TCG2_VERSION_NAME,

--- a/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
+++ b/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
@@ -655,7 +655,7 @@ DumpEventLog (
   TCG_PCR_EVENT_HDR         *EventHdr;
   TCG_PCR_EVENT2            *TcgPcrEvent2;
   TCG_EfiSpecIDEventStruct  *TcgEfiSpecIdEventStruct;
-  UINT64                    NumberOfEvents; // MU_CHANGE - CodeQL Change - comparison-with-wider-type
+  UINTN                     NumberOfEvents;
 
   if (!DebugPrintLevelEnabled (DEBUG_SECURITY)) {
     return;
@@ -666,8 +666,7 @@ DumpEventLog (
   switch (EventLogFormat) {
     case EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2:
       EventHdr = (TCG_PCR_EVENT_HDR *)(UINTN)EventLogLocation;
-      while ((EFI_PHYSICAL_ADDRESS)(UINTN)EventHdr <= EventLogLastEntry) {
-        // MU_CHANGE - CodeQL Change
+      while ((UINTN)EventHdr <= EventLogLastEntry) {
         DumpEvent (EventHdr);
         EventHdr = (TCG_PCR_EVENT_HDR *)((UINTN)EventHdr + sizeof (TCG_PCR_EVENT_HDR) + EventHdr->EventSize);
       }
@@ -698,8 +697,7 @@ DumpEventLog (
       DumpTcgEfiSpecIdEventStruct (TcgEfiSpecIdEventStruct);
 
       TcgPcrEvent2 = (TCG_PCR_EVENT2 *)((UINTN)TcgEfiSpecIdEventStruct + GetTcgEfiSpecIdEventStructSize (TcgEfiSpecIdEventStruct));
-      while ((EFI_PHYSICAL_ADDRESS)(UINTN)TcgPcrEvent2 <= EventLogLastEntry) {
-        // MU_CHANGE -  CodeQL
+      while ((UINTN)TcgPcrEvent2 <= EventLogLastEntry) {
         DumpEvent2 (TcgPcrEvent2);
         TcgPcrEvent2 = (TCG_PCR_EVENT2 *)((UINTN)TcgPcrEvent2 + GetPcrEvent2Size (TcgPcrEvent2));
       }

--- a/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
+++ b/SecurityPkg/Tcg/Tcg2Dxe/Tcg2Dxe.c
@@ -655,7 +655,7 @@ DumpEventLog (
   TCG_PCR_EVENT_HDR         *EventHdr;
   TCG_PCR_EVENT2            *TcgPcrEvent2;
   TCG_EfiSpecIDEventStruct  *TcgEfiSpecIdEventStruct;
-  UINTN                     NumberOfEvents;
+  UINT64                    NumberOfEvents;
 
   if (!DebugPrintLevelEnabled (DEBUG_SECURITY)) {
     return;
@@ -666,7 +666,7 @@ DumpEventLog (
   switch (EventLogFormat) {
     case EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2:
       EventHdr = (TCG_PCR_EVENT_HDR *)(UINTN)EventLogLocation;
-      while ((UINTN)EventHdr <= EventLogLastEntry) {
+      while ((EFI_PHYSICAL_ADDRESS)(UINTN)EventHdr <= EventLogLastEntry) {
         DumpEvent (EventHdr);
         EventHdr = (TCG_PCR_EVENT_HDR *)((UINTN)EventHdr + sizeof (TCG_PCR_EVENT_HDR) + EventHdr->EventSize);
       }
@@ -697,7 +697,7 @@ DumpEventLog (
       DumpTcgEfiSpecIdEventStruct (TcgEfiSpecIdEventStruct);
 
       TcgPcrEvent2 = (TCG_PCR_EVENT2 *)((UINTN)TcgEfiSpecIdEventStruct + GetTcgEfiSpecIdEventStructSize (TcgEfiSpecIdEventStruct));
-      while ((UINTN)TcgPcrEvent2 <= EventLogLastEntry) {
+      while ((EFI_PHYSICAL_ADDRESS)(UINTN)TcgPcrEvent2 <= EventLogLastEntry) {
         DumpEvent2 (TcgPcrEvent2);
         TcgPcrEvent2 = (TCG_PCR_EVENT2 *)((UINTN)TcgPcrEvent2 + GetPcrEvent2Size (TcgPcrEvent2));
       }

--- a/SecurityPkg/Tcg/TcgConfigDxe/TcgConfigImpl.c
+++ b/SecurityPkg/Tcg/TcgConfigDxe/TcgConfigImpl.c
@@ -193,9 +193,19 @@ TcgExtractConfig (
     // followed by "&OFFSET=0&WIDTH=WWWWWWWWWWWWWWWW" followed by a Null-terminator
     //
     ConfigRequestHdr = HiiConstructConfigHdr (&gTcgConfigFormSetGuid, mTcgStorageName, PrivateData->DriverHandle);
-    Size             = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
-    ConfigRequest    = AllocateZeroPool (Size);
-    ASSERT (ConfigRequest != NULL);
+    if (ConfigRequestHdr == NULL) {
+      ASSERT (ConfigRequestHdr != NULL);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    Size          = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
+    ConfigRequest = AllocateZeroPool (Size);
+    if (ConfigRequest == NULL) {
+      ASSERT (ConfigRequest != NULL);
+      FreePool (ConfigRequestHdr);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
     AllocatedRequest = TRUE;
     UnicodeSPrint (ConfigRequest, Size, L"%s&OFFSET=0&WIDTH=%016LX", ConfigRequestHdr, sizeof (TCG_CONFIGURATION));
     FreePool (ConfigRequestHdr);

--- a/SecurityPkg/Tcg/TcgConfigDxe/TcgConfigImpl.c
+++ b/SecurityPkg/Tcg/TcgConfigDxe/TcgConfigImpl.c
@@ -193,21 +193,9 @@ TcgExtractConfig (
     // followed by "&OFFSET=0&WIDTH=WWWWWWWWWWWWWWWW" followed by a Null-terminator
     //
     ConfigRequestHdr = HiiConstructConfigHdr (&gTcgConfigFormSetGuid, mTcgStorageName, PrivateData->DriverHandle);
-    // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-    if (ConfigRequestHdr == NULL) {
-      ASSERT (ConfigRequestHdr != NULL);
-      return EFI_OUT_OF_RESOURCES;
-    }
-
-    Size          = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
-    ConfigRequest = AllocateZeroPool (Size);
-    if (ConfigRequest == NULL) {
-      ASSERT (ConfigRequest != NULL);
-      FreePool (ConfigRequestHdr);
-      return EFI_OUT_OF_RESOURCES;
-    }
-
-    // MU_CHANGE End - CodeQL change - unguardednullreturndereference
+    Size             = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
+    ConfigRequest    = AllocateZeroPool (Size);
+    ASSERT (ConfigRequest != NULL);
     AllocatedRequest = TRUE;
     UnicodeSPrint (ConfigRequest, Size, L"%s&OFFSET=0&WIDTH=%016LX", ConfigRequestHdr, sizeof (TCG_CONFIGURATION));
     FreePool (ConfigRequestHdr);

--- a/SecurityPkg/Tcg/TcgDxe/TcgDxe.c
+++ b/SecurityPkg/Tcg/TcgDxe/TcgDxe.c
@@ -286,7 +286,10 @@ TpmCommHashAll (
 
   CtxSize = Sha1GetContextSize ();
   Sha1Ctx = AllocatePool (CtxSize);
-  ASSERT (Sha1Ctx != NULL);
+  if (Sha1Ctx == NULL) {
+    ASSERT (Sha1Ctx != NULL);
+    return EFI_OUT_OF_RESOURCES;
+  }
 
   Sha1Init (Sha1Ctx);
   Sha1Update (Sha1Ctx, Data, DataLen);

--- a/SecurityPkg/Tcg/TcgDxe/TcgDxe.c
+++ b/SecurityPkg/Tcg/TcgDxe/TcgDxe.c
@@ -286,13 +286,7 @@ TpmCommHashAll (
 
   CtxSize = Sha1GetContextSize ();
   Sha1Ctx = AllocatePool (CtxSize);
-  // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-  if (Sha1Ctx == NULL) {
-    ASSERT (Sha1Ctx != NULL);
-    return EFI_OUT_OF_RESOURCES;
-  }
-
-  // MU_CHANGE End - CodeQL change - unguardednullreturndereference
+  ASSERT (Sha1Ctx != NULL);
 
   Sha1Init (Sha1Ctx);
   Sha1Update (Sha1Ctx, Data, DataLen);

--- a/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigFileExplorer.c
+++ b/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigFileExplorer.c
@@ -98,7 +98,11 @@ ExtractFileNameFromDevicePath (
 
   ASSERT (DevicePath != NULL);
 
-  String      = DevicePathToStr (DevicePath);
+  String = DevicePathToStr (DevicePath);
+  if (String == NULL) {
+    return NULL;
+  }
+
   MatchString = String;
   LastMatch   = String;
   FileName    = NULL;

--- a/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigFileExplorer.c
+++ b/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigFileExplorer.c
@@ -98,13 +98,7 @@ ExtractFileNameFromDevicePath (
 
   ASSERT (DevicePath != NULL);
 
-  String = DevicePathToStr (DevicePath);
-  // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-  if (String == NULL) {
-    return NULL;
-  }
-
-  // MU_CHANGE End - CodeQL change - unguardednullreturndereference
+  String      = DevicePathToStr (DevicePath);
   MatchString = String;
   LastMatch   = String;
   FileName    = NULL;

--- a/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.c
+++ b/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.c
@@ -1094,7 +1094,7 @@ IsSignatureFoundInDatabase (
   // Enumerate all signature data in SigDB to check if signature exists for executable.
   //
   CertList = (EFI_SIGNATURE_LIST *)Data;
-  while ((DataSize > 0) && (DataSize >= CertList->SignatureListSize)) {
+  while ((DataSize > 0) && (DataSize >= (UINTN)CertList->SignatureListSize)) {
     CertCount = (CertList->SignatureListSize - sizeof (EFI_SIGNATURE_LIST) - CertList->SignatureHeaderSize) / CertList->SignatureSize;
     Cert      = (EFI_SIGNATURE_DATA *)((UINT8 *)CertList + sizeof (EFI_SIGNATURE_LIST) + CertList->SignatureHeaderSize);
     if ((CertList->SignatureSize == sizeof (EFI_SIGNATURE_DATA) - 1 + SignatureSize) && (CompareGuid (&CertList->SignatureType, &gEfiCertX509Guid))) {
@@ -1263,7 +1263,7 @@ IsCertHashFoundInDbx (
   // Check whether the certificate hash exists in the forbidden database.
   //
   DbxList = (EFI_SIGNATURE_LIST *)Data;
-  while ((DataSize > 0) && (DataSize >= DbxList->SignatureListSize)) {
+  while ((DataSize > 0) && (DataSize >= (UINTN)DbxList->SignatureListSize)) {
     //
     // Determine Hash Algorithm of Certificate in the forbidden database.
     //
@@ -1350,7 +1350,7 @@ GetSignaturelistOffset (
 
   SigList     = Database;
   SiglistSize = DatabaseSize;
-  while ((SiglistSize > 0) && (SiglistSize >= SigList->SignatureListSize)) {
+  while ((SiglistSize > 0) && (SiglistSize >= (UINTN)SigList->SignatureListSize)) {
     if (CompareGuid (&SigList->SignatureType, SignatureType)) {
       *Offset = DatabaseSize - SiglistSize;
       return TRUE;
@@ -2544,7 +2544,7 @@ UpdateDeletePage (
   )
 {
   EFI_STATUS          Status;
-  UINT32              Index;
+  UINTN               Index;
   UINTN               CertCount;
   UINTN               GuidIndex;
   VOID                *StartOpCodeHandle;
@@ -2728,7 +2728,7 @@ DeleteKeyExchangeKey (
   UINT8               *Data;
   UINT8               *OldData;
   UINT32              Attr;
-  UINT32              Index;
+  UINTN               Index;
   EFI_SIGNATURE_LIST  *CertList;
   EFI_SIGNATURE_LIST  *NewCertList;
   EFI_SIGNATURE_DATA  *Cert;
@@ -2932,7 +2932,7 @@ DeleteSignature (
   UINT8               *Data;
   UINT8               *OldData;
   UINT32              Attr;
-  UINT32              Index;
+  UINTN               Index;
   EFI_SIGNATURE_LIST  *CertList;
   EFI_SIGNATURE_LIST  *NewCertList;
   EFI_SIGNATURE_DATA  *Cert;
@@ -3210,7 +3210,7 @@ DeleteSignatureEx (
     //
     //  Traverse to target EFI_SIGNATURE_LIST but others will be skipped.
     //
-    while ((RemainingSize > 0) && (RemainingSize >= ListWalker->SignatureListSize) && ListIndex < PrivateData->ListIndex) {
+    while ((RemainingSize > 0) && (RemainingSize >= (UINTN)ListWalker->SignatureListSize) && ListIndex < PrivateData->ListIndex) {
       CopyMem ((UINT8 *)NewVariableData + Offset, ListWalker, ListWalker->SignatureListSize);
       Offset += ListWalker->SignatureListSize;
 
@@ -3808,7 +3808,7 @@ LoadSignatureList (
 
   RemainingSize = DataSize;
   ListWalker    = (EFI_SIGNATURE_LIST *)VariableData;
-  while ((RemainingSize > 0) && (RemainingSize >= ListWalker->SignatureListSize)) {
+  while ((RemainingSize > 0) && (RemainingSize >= (UINTN)ListWalker->SignatureListSize)) {
     if (CompareGuid (&ListWalker->SignatureType, &gEfiCertRsa2048Guid)) {
       ListType = STRING_TOKEN (STR_LIST_TYPE_RSA2048_SHA256);
     } else if (CompareGuid (&ListWalker->SignatureType, &gEfiCertX509Guid)) {
@@ -4224,7 +4224,7 @@ LoadSignatureData (
   VOID                *EndOpCodeHandle;
   UINTN               DataSize;
   UINTN               RemainingSize;
-  UINT16              Index;
+  UINT64              Index;
   UINT8               *VariableData;
   CHAR16              VariableName[BUFFER_MAX_SIZE];
   CHAR16              NameBuffer[BUFFER_MAX_SIZE];
@@ -4308,7 +4308,7 @@ LoadSignatureData (
   //
   // Skip signature list.
   //
-  while ((RemainingSize > 0) && (RemainingSize >= ListWalker->SignatureListSize) && ListIndex-- > 0) {
+  while ((RemainingSize > 0) && (RemainingSize >= (UINTN)ListWalker->SignatureListSize) && ListIndex-- > 0) {
     RemainingSize -= ListWalker->SignatureListSize;
     ListWalker     = (EFI_SIGNATURE_LIST *)((UINT8 *)ListWalker + ListWalker->SignatureListSize);
   }

--- a/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.c
+++ b/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.c
@@ -1172,7 +1172,10 @@ CalculateCertHash (
   //
   CtxSize = mHash[HashAlg].GetContextSize ();
   HashCtx = AllocatePool (CtxSize);
-  ASSERT (HashCtx != NULL);
+  if (HashCtx == NULL) {
+    ASSERT (HashCtx != NULL);
+    return FALSE;
+  }
 
   //
   // 2. Initialize a hash context.
@@ -1886,7 +1889,10 @@ HashPeImage (
   CtxSize = mHash[HashAlg].GetContextSize ();
 
   HashCtx = AllocatePool (CtxSize);
-  ASSERT (HashCtx != NULL);
+  if (HashCtx == NULL) {
+    ASSERT (HashCtx != NULL);
+    goto Done;
+  }
 
   // 1.  Load the image header into memory.
 
@@ -3511,9 +3517,19 @@ SecureBootExtractConfig (
     // followed by "&OFFSET=0&WIDTH=WWWWWWWWWWWWWWWW" followed by a Null-terminator
     //
     ConfigRequestHdr = HiiConstructConfigHdr (&gSecureBootConfigFormSetGuid, mSecureBootStorageName, PrivateData->DriverHandle);
-    Size             = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
-    ConfigRequest    = AllocateZeroPool (Size);
-    ASSERT (ConfigRequest != NULL);
+    if (ConfigRequestHdr == NULL) {
+      ASSERT (ConfigRequestHdr != NULL);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
+    Size          = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
+    ConfigRequest = AllocateZeroPool (Size);
+    if (ConfigRequest == NULL) {
+      ASSERT (ConfigRequest != NULL);
+      FreePool (ConfigRequestHdr);
+      return EFI_OUT_OF_RESOURCES;
+    }
+
     AllocatedRequest = TRUE;
     UnicodeSPrint (ConfigRequest, Size, L"%s&OFFSET=0&WIDTH=%016LX", ConfigRequestHdr, (UINT64)BufferSize);
     FreePool (ConfigRequestHdr);

--- a/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.c
+++ b/SecurityPkg/VariableAuthenticated/SecureBootConfigDxe/SecureBootConfigImpl.c
@@ -1094,9 +1094,7 @@ IsSignatureFoundInDatabase (
   // Enumerate all signature data in SigDB to check if signature exists for executable.
   //
   CertList = (EFI_SIGNATURE_LIST *)Data;
-  // MU_CHANGE Start - CodeQL change - comparison-with-wider-type
-  while ((DataSize > 0) && (DataSize >= (UINTN)CertList->SignatureListSize)) {
-    // MU_CHANGE End - CodeQL change - comparison-with-wider-type
+  while ((DataSize > 0) && (DataSize >= CertList->SignatureListSize)) {
     CertCount = (CertList->SignatureListSize - sizeof (EFI_SIGNATURE_LIST) - CertList->SignatureHeaderSize) / CertList->SignatureSize;
     Cert      = (EFI_SIGNATURE_DATA *)((UINT8 *)CertList + sizeof (EFI_SIGNATURE_LIST) + CertList->SignatureHeaderSize);
     if ((CertList->SignatureSize == sizeof (EFI_SIGNATURE_DATA) - 1 + SignatureSize) && (CompareGuid (&CertList->SignatureType, &gEfiCertX509Guid))) {
@@ -1174,13 +1172,7 @@ CalculateCertHash (
   //
   CtxSize = mHash[HashAlg].GetContextSize ();
   HashCtx = AllocatePool (CtxSize);
-  // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-  if (HashCtx == NULL) {
-    ASSERT (HashCtx != NULL);
-    return FALSE;
-  }
-
-  // MU_CHANGE End - CodeQL change - unguardednullreturndereference
+  ASSERT (HashCtx != NULL);
 
   //
   // 2. Initialize a hash context.
@@ -1268,9 +1260,7 @@ IsCertHashFoundInDbx (
   // Check whether the certificate hash exists in the forbidden database.
   //
   DbxList = (EFI_SIGNATURE_LIST *)Data;
-  // MU_CHANGE Start - CodeQL change - comparison-with-wider-type
-  while ((DataSize > 0) && (DataSize >= (UINTN)DbxList->SignatureListSize)) {
-    // MU_CHANGE End - CodeQL change - comparison-with-wider-type
+  while ((DataSize > 0) && (DataSize >= DbxList->SignatureListSize)) {
     //
     // Determine Hash Algorithm of Certificate in the forbidden database.
     //
@@ -1357,9 +1347,7 @@ GetSignaturelistOffset (
 
   SigList     = Database;
   SiglistSize = DatabaseSize;
-  // MU_CHANGE Start - CodeQL change - comparison-with-wider-type
-  while ((SiglistSize > 0) && (SiglistSize >= (UINTN)SigList->SignatureListSize)) {
-    // MU_CHANGE End - CodeQL change - comparison-with-wider-type
+  while ((SiglistSize > 0) && (SiglistSize >= SigList->SignatureListSize)) {
     if (CompareGuid (&SigList->SignatureType, SignatureType)) {
       *Offset = DatabaseSize - SiglistSize;
       return TRUE;
@@ -1898,13 +1886,7 @@ HashPeImage (
   CtxSize = mHash[HashAlg].GetContextSize ();
 
   HashCtx = AllocatePool (CtxSize);
-  // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-  if (HashCtx == NULL) {
-    ASSERT (HashCtx != NULL);
-    goto Done;
-  }
-
-  // MU_CHANGE End - CodeQL change - unguardednullreturndereference
+  ASSERT (HashCtx != NULL);
 
   // 1.  Load the image header into memory.
 
@@ -2556,7 +2538,7 @@ UpdateDeletePage (
   )
 {
   EFI_STATUS          Status;
-  UINTN               Index; // MU_CHANGE - CodeQL Change - comparison-with-wider-type
+  UINT32              Index;
   UINTN               CertCount;
   UINTN               GuidIndex;
   VOID                *StartOpCodeHandle;
@@ -2740,7 +2722,7 @@ DeleteKeyExchangeKey (
   UINT8               *Data;
   UINT8               *OldData;
   UINT32              Attr;
-  UINTN               Index; // MU_CHANGE - CodeQL Change - comparison-with-wider-type
+  UINT32              Index;
   EFI_SIGNATURE_LIST  *CertList;
   EFI_SIGNATURE_LIST  *NewCertList;
   EFI_SIGNATURE_DATA  *Cert;
@@ -2944,7 +2926,7 @@ DeleteSignature (
   UINT8               *Data;
   UINT8               *OldData;
   UINT32              Attr;
-  UINTN               Index; // MU_CHANGE - CodeQL Change - comparison-with-wider-type
+  UINT32              Index;
   EFI_SIGNATURE_LIST  *CertList;
   EFI_SIGNATURE_LIST  *NewCertList;
   EFI_SIGNATURE_DATA  *Cert;
@@ -3222,9 +3204,7 @@ DeleteSignatureEx (
     //
     //  Traverse to target EFI_SIGNATURE_LIST but others will be skipped.
     //
-    // MU_CHANGE Start - CodeQL change - comparison-with-wider-type
-    while ((RemainingSize > 0) && (RemainingSize >= (UINTN)ListWalker->SignatureListSize) && ListIndex < PrivateData->ListIndex) {
-      // MU_CHANGE End - CodeQL change - comparison-with-wider-type
+    while ((RemainingSize > 0) && (RemainingSize >= ListWalker->SignatureListSize) && ListIndex < PrivateData->ListIndex) {
       CopyMem ((UINT8 *)NewVariableData + Offset, ListWalker, ListWalker->SignatureListSize);
       Offset += ListWalker->SignatureListSize;
 
@@ -3531,21 +3511,9 @@ SecureBootExtractConfig (
     // followed by "&OFFSET=0&WIDTH=WWWWWWWWWWWWWWWW" followed by a Null-terminator
     //
     ConfigRequestHdr = HiiConstructConfigHdr (&gSecureBootConfigFormSetGuid, mSecureBootStorageName, PrivateData->DriverHandle);
-    // MU_CHANGE Start - CodeQL change - unguardednullreturndereference
-    if (ConfigRequestHdr == NULL) {
-      ASSERT (ConfigRequestHdr != NULL);
-      return EFI_OUT_OF_RESOURCES;
-    }
-
-    Size          = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
-    ConfigRequest = AllocateZeroPool (Size);
-    if (ConfigRequest == NULL) {
-      ASSERT (ConfigRequest != NULL);
-      FreePool (ConfigRequestHdr);
-      return EFI_OUT_OF_RESOURCES;
-    }
-
-    // MU_CHANGE End - CodeQL change - unguardednullreturndereference
+    Size             = (StrLen (ConfigRequestHdr) + 32 + 1) * sizeof (CHAR16);
+    ConfigRequest    = AllocateZeroPool (Size);
+    ASSERT (ConfigRequest != NULL);
     AllocatedRequest = TRUE;
     UnicodeSPrint (ConfigRequest, Size, L"%s&OFFSET=0&WIDTH=%016LX", ConfigRequestHdr, (UINT64)BufferSize);
     FreePool (ConfigRequestHdr);
@@ -3824,9 +3792,7 @@ LoadSignatureList (
 
   RemainingSize = DataSize;
   ListWalker    = (EFI_SIGNATURE_LIST *)VariableData;
-  // MU_CHANGE Start - CodeQL change - comparison-with-wider-type
-  while ((RemainingSize > 0) && (RemainingSize >= (UINTN)ListWalker->SignatureListSize)) {
-    // MU_CHANGE End - CodeQL change - comparison-with-wider-type
+  while ((RemainingSize > 0) && (RemainingSize >= ListWalker->SignatureListSize)) {
     if (CompareGuid (&ListWalker->SignatureType, &gEfiCertRsa2048Guid)) {
       ListType = STRING_TOKEN (STR_LIST_TYPE_RSA2048_SHA256);
     } else if (CompareGuid (&ListWalker->SignatureType, &gEfiCertX509Guid)) {
@@ -4242,7 +4208,7 @@ LoadSignatureData (
   VOID                *EndOpCodeHandle;
   UINTN               DataSize;
   UINTN               RemainingSize;
-  UINT64              Index; // MU_CHANGE - CodeQL Change - comparison-with-wider-type
+  UINT16              Index;
   UINT8               *VariableData;
   CHAR16              VariableName[BUFFER_MAX_SIZE];
   CHAR16              NameBuffer[BUFFER_MAX_SIZE];
@@ -4326,9 +4292,7 @@ LoadSignatureData (
   //
   // Skip signature list.
   //
-  // MU_CHANGE Start - CodeQL change - comparison-with-wider-type
-  while ((RemainingSize > 0) && (RemainingSize >= (UINTN)ListWalker->SignatureListSize) && ListIndex-- > 0) {
-    // MU_CHANGE End - CodeQL change - comparison-with-wider-type
+  while ((RemainingSize > 0) && (RemainingSize >= ListWalker->SignatureListSize) && ListIndex-- > 0) {
     RemainingSize -= ListWalker->SignatureListSize;
     ListWalker     = (EFI_SIGNATURE_LIST *)((UINT8 *)ListWalker + ListWalker->SignatureListSize);
   }


### PR DESCRIPTION
## Description

SecurityPkg CodeQL has been upstreamed to edk2, so this reverts the Mu commit and cps the edk2 commit. Note, the original change that is reverted here caused a regression in edk2 and so part of that change was dropped that was erroneous. That may cause a CodeQL failure; if so, we should add an explicit ignore for it.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

N/A.

## Integration Instructions

N/A.
