### PR TITLE
[Cherry-Pick][202608] MdePkg/CompilerIntrinsicsLib: Fix IA32 with VS202x

### DIFF
--- a/MdePkg/Library/CompilerIntrinsicsLib/memcmp_ms.c
+++ b/MdePkg/Library/CompilerIntrinsicsLib/memcmp_ms.c
@@ -7,7 +7,7 @@
 //
 // ------------------------------------------------------------------------------
 
-typedef unsigned __int64 size_t;
+typedef UINTN size_t;
 
 int
 memcmp (

--- a/MdePkg/Library/CompilerIntrinsicsLib/memcpy_ms.c
+++ b/MdePkg/Library/CompilerIntrinsicsLib/memcpy_ms.c
@@ -7,7 +7,7 @@
 //
 // ------------------------------------------------------------------------------
 
-typedef unsigned __int64 size_t;
+typedef UINTN size_t;
 
 void *
 memcpy (

--- a/MdePkg/Library/CompilerIntrinsicsLib/memmove_ms.c
+++ b/MdePkg/Library/CompilerIntrinsicsLib/memmove_ms.c
@@ -7,7 +7,7 @@
 //
 // ------------------------------------------------------------------------------
 
-typedef unsigned __int64 size_t;
+typedef UINTN size_t;
 
 void *
 memmove (

--- a/MdePkg/Library/CompilerIntrinsicsLib/memset_ms.c
+++ b/MdePkg/Library/CompilerIntrinsicsLib/memset_ms.c
@@ -7,7 +7,7 @@
 //
 // ------------------------------------------------------------------------------
 
-typedef unsigned __int64 size_t;
+typedef UINTN size_t;
 
 void *
 memset (

--- a/MdePkg/MdePkg.ci.yaml
+++ b/MdePkg/MdePkg.ci.yaml
@@ -63,7 +63,8 @@
             "8002", "aligned (",
             "4002", "_ReturnAddress",
             "8005", "__security_cookie",
-            "8006", "__stack_chk_fail"
+            "8006", "__stack_chk_fail",
+            "8002", "size_t"
         ],
         ## Both file path and directory path are accepted.
         "IgnoreFiles": [

--- a/MdePkg/MdePkg.dsc
+++ b/MdePkg/MdePkg.dsc
@@ -165,6 +165,7 @@
   MdePkg/Library/BaseRngLib/BaseRngLib.inf
 
 [Components.IA32, Components.X64]
+  MdePkg/Library/CompilerIntrinsicsLib/CompilerIntrinsicsLib.inf
   MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
   MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsicSev.inf
   MdePkg/Library/BaseMemoryLibMmx/BaseMemoryLibMmx.inf


### PR DESCRIPTION


## Description

CompilerIntrinsicsLib is causing a #UD when used in IA32 mode.

This was tracked back to memcpy using size_t, which locally defined in the file as __int64. When compiling for IA32 target, this results in the memcpy interpreting 64 bits from the calling convention instead of the 32 bits that were passed.

Update the local size_t defines to use UINTN. This matches the functionality from CryptoPkg's Intrinsic functions.

Add CompilerIntrinsics to IA32/X64 component so it is complied as part of CI.

Add size_t as ECC check exclusion to MdePkg.ci.yaml.


(cherry picked from commit fc428a1dab3555d539404b8618a9519fe6105f1b)
- [X] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested
Compiled mu_crypto_release for IA32 and encountered #UD on physical systems
After change, physical system booted

## Integration Instructions
No integration necessary